### PR TITLE
Fix release workflow and move fuzz tests to nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -269,10 +269,10 @@ jobs:
           files: coverage.out
           fail_ci_if_error: false
 
-  test-fuzz-bench:
-    name: Fuzz & Benchmark Tests
+  test-bench:
+    name: Benchmark Tests
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 20
+    timeout-minutes: 10
     needs: changes
     if: needs.changes.outputs.go == 'true'
     steps:
@@ -285,12 +285,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-
-      - name: Run fuzz tests (fixed execution budget)
-        shell: bash -Eeuo pipefail -x {0}
-        run: |
-          go test ./internal/recommendation/... -run='^$' -fuzz=FuzzPercentileEstimator -fuzztime=1000000x
-          go test ./internal/recommendation/... -run='^$' -fuzz=FuzzRecommendationEngine -fuzztime=1000000x
 
       - name: Run benchmark tests
         shell: bash -Eeuo pipefail -x {0}
@@ -745,7 +739,7 @@ jobs:
       - docs-check
       - yaml-lint
       - test-unit
-      - test-fuzz-bench
+      - test-bench
       - test-integration
       - test-e2e
       - crd-freshness
@@ -760,7 +754,7 @@ jobs:
             "${{ needs.docs-check.result }}" \
             "${{ needs.yaml-lint.result }}" \
             "${{ needs.test-unit.result }}" \
-            "${{ needs.test-fuzz-bench.result }}" \
+            "${{ needs.test-bench.result }}" \
             "${{ needs.test-integration.result }}" \
             "${{ needs.test-e2e.result }}" \
             "${{ needs.crd-freshness.result }}" \

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -369,11 +369,33 @@ jobs:
           k3d cluster delete "$CLUSTER_NAME" 2>/dev/null || true
           rm -f "$KUBECONFIG"
 
+  fuzz:
+    name: Fuzz Tests
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Run fuzz tests (1M iterations per target)
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          go test ./internal/recommendation/... -run='^$' -fuzz=FuzzPercentileEstimator -fuzztime=1000000x
+          go test ./internal/recommendation/... -run='^$' -fuzz=FuzzRecommendationEngine -fuzztime=1000000x
+
   report:
     name: Nightly Results
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
-    needs: test-e2e
+    needs: [test-e2e, fuzz]
     if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -381,13 +403,21 @@ jobs:
       - name: Summary
         shell: bash -Eeuo pipefail {0}
         run: |
-          result="${{ needs.test-e2e.result }}"
-          if [[ "$result" == "success" ]]; then
-            echo "All K8s version E2E tests passed"
-          else
-            echo "::error::E2E nightly failed (result: $result)"
+          e2e_result="${{ needs.test-e2e.result }}"
+          fuzz_result="${{ needs.fuzz.result }}"
+          failed=0
+          if [[ "$e2e_result" != "success" && "$e2e_result" != "skipped" ]]; then
+            echo "::error::E2E nightly failed (result: $e2e_result)"
+            failed=1
+          fi
+          if [[ "$fuzz_result" != "success" && "$fuzz_result" != "skipped" ]]; then
+            echo "::error::Fuzz nightly failed (result: $fuzz_result)"
+            failed=1
+          fi
+          if (( failed )); then
             exit 1
           fi
+          echo "All nightly tests passed (E2E: $e2e_result, Fuzz: $fuzz_result)"
 
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'
@@ -401,15 +431,16 @@ jobs:
             echo "Open nightly failure issue already exists, skipping creation"
             exit 0
           fi
-          body=$(cat <<'EOF'
-          The [E2E nightly run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed.
+          body=$(cat <<EOF
+          The [nightly run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed.
 
-          Result: `${{ needs.test-e2e.result }}`
+          - E2E result: \`${{ needs.test-e2e.result }}\`
+          - Fuzz result: \`${{ needs.fuzz.result }}\`
 
-          Check the workflow run for details on which K8s version(s) failed.
+          Check the workflow run for details.
           EOF
           )
           gh issue create \
-            --title "E2E nightly failed on $(date -u +%Y-%m-%d)" \
+            --title "Nightly failed on $(date -u +%Y-%m-%d)" \
             --label e2e-nightly-failure \
             --body "$body"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,14 @@ jobs:
         id: build_date
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push multi-arch image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         id: build
@@ -93,14 +101,6 @@ jobs:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           severity: HIGH,CRITICAL
           exit-code: 1
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
-        with:
-          version: "~> v2"
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate install manifest and CRDs bundle
         shell: bash -Eeuo pipefail -x {0}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ charts/attune/charts/
 
 # Local audit symlink
 audit-findings.md
+
+# GoReleaser output
+goreleaser-dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 ---
 version: 2
+dist: goreleaser-dist
 builds:
   - id: manager
     main: ./cmd/manager


### PR DESCRIPTION
## Changes

### Fix release workflow GoReleaser dirty state
- Use `goreleaser-dist/` output directory instead of the default `dist/` to avoid conflict with tracked `dist/crds.yaml` and `dist/install.yaml`
- Reorder release steps: GoReleaser now runs before SBOM/Trivy generation so it operates on a clean checkout
- Root cause of v0.1.0 release failure

### Move fuzz tests from CI to nightly
- Fuzz tests run 1M iterations per target (~15 min) but have zero historical bug findings
- Removing from per-push CI saves ~15 min on every push/PR
- CI job renamed from `test-fuzz-bench` to `test-bench` (only benchmarks remain)
- Fuzz tests added to `e2e-nightly.yaml` with auto-issue creation on failure
- Nightly report job now aggregates both E2E and fuzz results