### PR TITLE
Fix Helm chart cosign signing auth

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,11 +131,18 @@ jobs:
         with:
           version: v4.1.4
 
-      - name: Login to GHCR
+      - name: Login to GHCR (Helm)
         shell: bash -Eeuo pipefail -x {0}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} \
             --username ${{ github.actor }} --password-stdin
+
+      - name: Login to GHCR (Docker/cosign)
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package and push Helm chart
         shell: bash -Eeuo pipefail -x {0}


### PR DESCRIPTION
The v0.1.0 Helm Chart Release job failed because cosign cannot authenticate to GHCR.

The Helm job uses `helm registry login` to push the chart, but cosign needs Docker-level credentials to read the OCI manifest before signing. This adds a `docker/login-action` step (same one used in the main Release job) so cosign can access the pushed chart.

The main Release job succeeded (GoReleaser, Docker image, cosign sign, SBOM, Trivy). Only Helm chart signing failed.