### PR TITLE
docs: add hyperlinks to source citations and fix broken URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ resource requests and limits using [In-Place Pod Resize](https://kubernetes.io/b
 
 | Problem | Impact |
 |---------|--------|
-| Average CPU utilization is **8%** | Billions wasted industry-wide (CAST AI 2026) |
-| **70%** cite overprovisioning as #1 cost driver | Resources allocated "just in case" never reclaimed (CNCF 2023) |
-| **<1%** run VPA fully automated | VPA evicts pods, conflicts with HPA, causes outages (ScaleOps 2026) |
+| Average CPU utilization is **8%** | Billions wasted industry-wide ([CAST AI 2026](https://cast.ai/reports/state-of-kubernetes-optimization/)) |
+| **70%** cite overprovisioning as #1 cost driver | Resources allocated "just in case" never reclaimed ([CNCF 2023](https://www.cncf.io/blog/2023/12/20/cncf-cloud-native-finops-cloud-financial-management-microsurvey/)) |
+| **<1%** run VPA fully automated | VPA evicts pods, conflicts with HPA, causes outages ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)) |
 | In-Place Pod Resize is **beta** (K8s 1.33+, alpha in 1.32) | The foundation for non-disruptive right-sizing now exists |
 
 ## How It's Different

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -31,8 +31,8 @@
 ### Problem
 
 99.94% of Kubernetes clusters are over-provisioned. Average CPU utilization is 8%, memory 20%
-(CAST AI 2026). VPA, the tool designed to fix this, is universally feared: fewer than 1% of
-organizations run it fully automated (ScaleOps 2026). VPA evicts pods, conflicts with HPA, and
+([CAST AI 2026](https://cast.ai/reports/state-of-kubernetes-optimization/)). VPA, the tool designed to fix this, is universally feared: fewer than 1% of
+organizations run it fully automated ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)). VPA evicts pods, conflicts with HPA, and
 has caused cluster-wide outages.
 
 In 2025, In-Place Pod Resize graduated to beta in Kubernetes 1.33 (KEP-1287,

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,12 +12,12 @@ optional eviction fallback for infeasible resizes, and no HPA conflicts.
 
 Average Kubernetes CPU utilization is **8%**. That means 92% of the compute
 you're paying for is idle. Industry-wide, this adds up to
-**$44.5 billion** in projected cloud waste (Harness 2025), and **70%** of
-organizations cite overprovisioning as their #1 cost driver (CNCF 2023).
+**$44.5 billion** in projected cloud waste ([Harness 2025](https://www.harness.io/finops-in-focus)), and **70%** of
+organizations cite overprovisioning as their #1 cost driver ([CNCF 2023](https://www.cncf.io/blog/2023/12/20/cncf-cloud-native-finops-cloud-financial-management-microsurvey/)).
 
 The existing tool for this, VPA, evicts pods to resize them. It conflicts
 with HPA, causes cascading failures, and fewer than **1%** of teams run
-it fully automated (ScaleOps 2026). Recommendation-only tools like
+it fully automated ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)). Recommendation-only tools like
 Goldilocks show you the numbers but leave you with hundreds of YAML edits
 that sit in the backlog for months.
 

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -9,10 +9,10 @@ The numbers are staggering:
 | Stat | Source |
 |------|--------|
 | **8%** average CPU utilization across K8s clusters | [CAST AI 2026 State of K8s Optimization](https://cast.ai/reports/state-of-kubernetes-optimization/) |
-| **99.94%** of clusters are overprovisioned | [CAST AI 2025 Cost Benchmark](https://cast.ai/blog/kubernetes-cost-report/) |
+| **99.94%** of clusters are overprovisioned | [CAST AI 2025 Cost Benchmark](https://cast.ai/reports/kubernetes-cost-benchmark/) |
 | **83%** of container costs are idle resources | [Datadog State of Cloud Costs 2024](https://www.datadoghq.com/state-of-cloud-costs/) |
-| **$44.5 billion** in projected cloud infrastructure waste for 2025 | [Harness FinOps in Focus 2025](https://www.harness.io/blog/finops-in-focus-report) |
-| **70%** cite overprovisioning as the #1 cost driver | [CNCF FinOps Microsurvey 2023](https://www.cncf.io/reports/cncf-finops-microsurvey-2023/) |
+| **$44.5 billion** in projected cloud infrastructure waste for 2025 | [Harness FinOps in Focus 2025](https://www.harness.io/finops-in-focus) |
+| **70%** cite overprovisioning as the #1 cost driver | [CNCF FinOps Microsurvey 2023](https://www.cncf.io/blog/2023/12/20/cncf-cloud-native-finops-cloud-financial-management-microsurvey/) |
 
 Here's what's happening: your developers set `resources.requests` to "something
 that works," add a generous safety margin because they don't want 3 AM pages,


### PR DESCRIPTION
## What

Link plain-text source references to their reports and fix broken URLs across documentation.

## Changes

**Added hyperlinks** to 8 unlinked citations across 3 files:

| File | References linked |
|------|-------------------|
| `README.md` | CAST AI 2026, CNCF 2023, ScaleOps 2026 |
| `docs/SPEC.md` | CAST AI 2026, ScaleOps 2026 |
| `docs/index.md` | Harness 2025, CNCF 2023, ScaleOps 2026 |

**Fixed 3 broken URLs** (HTTP 404) in `docs/why-attune.md`, `docs/index.md`, and `README.md`:

| Source | Old URL (404) | New URL (200) |
|--------|--------------|---------------|
| CNCF FinOps Microsurvey 2023 | `cncf.io/reports/cncf-finops-microsurvey-2023/` | `cncf.io/blog/2023/12/20/cncf-cloud-native-finops-...` |
| Harness FinOps in Focus 2025 | `harness.io/blog/finops-in-focus-report` | `harness.io/finops-in-focus` |
| CAST AI 2025 Cost Benchmark | `cast.ai/blog/kubernetes-cost-report/` | `cast.ai/reports/kubernetes-cost-benchmark/` |

All 4 distinct URLs verified live with HTTP 200 before committing.