### PR TITLE
chore: add DCO requirement for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,12 +168,47 @@ To check queued or in-progress CI runs:
 make ci-runner-status
 ```
 
+## Developer Certificate of Origin (DCO)
+
+All contributions must be signed off under the
+[Developer Certificate of Origin](DCO) (DCO v1.1). This certifies that
+you wrote the contribution or otherwise have the right to submit it under
+the project's Apache 2.0 license.
+
+Add the sign-off by passing `-s` to `git commit`:
+
+```bash
+git commit -s -m "feat: add time-of-day-aware algorithm"
+```
+
+This appends a `Signed-off-by` trailer with your name and email:
+
+```
+Signed-off-by: Your Name <your@email.com>
+```
+
+The name and email must match your `git config user.name` and
+`git config user.email`. The [DCO GitHub App](https://github.com/apps/dco)
+checks every commit on pull requests and will block merging if any commit
+is missing the sign-off.
+
+If you forgot to sign off, amend your commits:
+
+```bash
+# Amend the last commit
+git commit --amend -s --no-edit
+
+# Sign off all commits on a branch
+git rebase --signoff main
+```
+
 ## Pull Request Process
 
 1. Fork the repository and create a branch from `main`
 2. Make your changes with tests
-3. Run `make verify` to run all CI checks locally
-4. Submit a pull request
+3. Sign off every commit (`git commit -s`)
+4. Run `make verify` to run all CI checks locally
+5. Submit a pull request
 
 ### Commit Messages
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
## What

Add the Developer Certificate of Origin (DCO) requirement, aligning with CNCF project standards.

## Changes

- **`DCO`**: Standard DCO v1.1 file (same text used by Flux, cert-manager, etcd, containerd, Helm, and all CNCF projects)
- **`CONTRIBUTING.md`**: New "Developer Certificate of Origin" section explaining how to sign off commits, how to fix missing sign-offs, and updated PR process checklist

## Manual step required

Install the [DCO GitHub App](https://github.com/apps/dco) on the `attune-io/attune` repository. This adds a PR status check that blocks merging if any commit lacks a `Signed-off-by` trailer.