### PR TITLE
ci: add test summary, link checker, semantic PR titles, stale bot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,6 +173,29 @@ jobs:
         shell: bash -Eeuo pipefail {0}
         run: bash hack/verify-doc-tool-versions.sh
 
+  link-check:
+    name: Link Check
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: >-
+            --no-progress
+            'README.md'
+            'CONTRIBUTING.md'
+            'SECURITY.md'
+            'docs/**/*.md'
+            'charts/attune/README.md'
+          fail: true
+
   yaml-lint:
     name: YAML Lint
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
@@ -262,6 +285,12 @@ jobs:
           path: test-results/
           retention-days: 7
 
+      - name: Test summary
+        if: always()
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
+        with:
+          paths: test-results/unit.xml
+
       - name: Upload coverage
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         continue-on-error: true
@@ -341,6 +370,12 @@ jobs:
           name: integration-test-results
           path: test-results/
           retention-days: 7
+
+      - name: Test summary
+        if: always()
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
+        with:
+          paths: test-results/integration.xml
 
   # Single-version E2E on every push/PR. Full K8s version matrix runs nightly.
   # Skipped for Dockerfile-only and workflow-only changes (e.g. Dependabot
@@ -737,6 +772,7 @@ jobs:
     needs:
       - lint
       - docs-check
+      - link-check
       - yaml-lint
       - test-unit
       - test-bench
@@ -752,6 +788,7 @@ jobs:
           results=( \
             "${{ needs.lint.result }}" \
             "${{ needs.docs-check.result }}" \
+            "${{ needs.link-check.result }}" \
             "${{ needs.yaml-lint.result }}" \
             "${{ needs.test-unit.result }}" \
             "${{ needs.test-bench.result }}" \

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,35 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-title:
+    name: Semantic PR Title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            ci
+            refactor
+            test
+            chore
+            perf
+            build
+            revert
+          requireScope: false
+          subjectPattern: ^[a-z].+$
+          subjectPatternError: >
+            The PR title subject must start with a lowercase letter.
+            Example: "feat: add memory ratio support"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,40 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Close stale issues and PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 14 days if
+            no further activity occurs. If this issue is still relevant,
+            please comment to keep it open.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 14 days if
+            no further activity occurs. If this PR is still relevant,
+            please comment or push updates to keep it open.
+          close-issue-message: >
+            This issue was closed because it has been stale for 14 days
+            with no activity. Feel free to reopen if it is still relevant.
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: "bug,security,milestone,pinned"
+          exempt-pr-labels: "pinned,dependencies"
+          exempt-all-milestones: true
+          operations-per-run: 50

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,10 @@
+exclude = [
+  "localhost",
+  "127\\.0\\.0\\.1",
+  "0\\.0\\.0\\.0",
+  "example\\.com",
+]
+exclude_loopback = true
+max_concurrency = 8
+timeout = 30
+max_retries = 3


### PR DESCRIPTION
## Summary

Add four CI improvements (Wave 1: quick wins).

### Changes

1. **Test summary in workflow UI** (#19): Adds `test-summary/action` to unit and integration test jobs. JUnit XML results render as formatted tables in the Actions summary tab, eliminating the need to download artifacts to see test failures.

2. **Link checker** (#21): Adds `lychee-action` as a CI job that runs on docs changes. Configured with `.lychee.toml` to exclude localhost/example.com. Added to the ci-gate aggregator so broken links block PRs.

3. **Semantic PR title enforcement** (#24): New `pr-title.yaml` workflow using `amannn/action-semantic-pull-request` to enforce conventional commit prefixes (`feat:`, `fix:`, `docs:`, `ci:`, etc.). Uses `pull_request_target` to work on fork PRs.

4. **Stale issue/PR bot** (#23): New `stale.yaml` workflow that labels issues/PRs as stale after 60 days of inactivity and closes them after 14 more days. Exempts bug, security, milestoned, and pinned items.

All actions are SHA-pinned per project convention.

Closes #19
Closes #21
Closes #24
Closes #23