### PR TITLE
ci: skip semantic PR title check for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
 
   - package-ecosystem: github-actions
     directory: /
@@ -15,6 +17,8 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
 
   - package-ecosystem: docker
     directory: /
@@ -23,3 +27,5 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   semantic-title:
     name: Semantic PR Title
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Dependabot auto-generates titles with 'Bump' (uppercase), which violates the lowercase-subject rule. Since Dependabot titles are auto-generated and not human-controlled, skip the check for bot PRs.

Also adds `commit-message` prefix to `dependabot.yml` so future PRs use the `chore(deps)` conventional commits prefix.

Unblocks PRs #15 and #16 which are stuck on the Semantic PR Title check.