### PR TITLE
ci: fix FOSSA and link check failures on PRs

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   fossa:
     name: FOSSA License Scan
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -25,6 +26,7 @@ jobs:
 
   fossa-test:
     name: FOSSA License Check
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: fossa

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -3,6 +3,7 @@ exclude = [
   "127\\.0\\.0\\.1",
   "0\\.0\\.0\\.0",
   "example\\.com",
+  "medium\\.com",
 ]
 exclude_loopback = true
 max_concurrency = 8


### PR DESCRIPTION
## Problem

Two CI issues are causing failures across multiple open PRs:

1. **FOSSA License Scan** fails on all Dependabot PRs (#34, #35, #36, #37) because the `FOSSA_API_KEY` secret is not available to Dependabot. Since Dependabot PRs only change action versions (not Go dependencies), FOSSA scanning is unnecessary.

2. **Link Check** fails on PRs #33 and #38 because a Medium article URL returns 403. Medium blocks automated crawlers, so this is a false positive.

## Changes

- `.github/workflows/fossa.yaml`: Skip both FOSSA jobs when `github.actor == 'dependabot[bot]'`
- `.lychee.toml`: Add `medium.com` to the exclusion list

## Impact

Fixes CI failures on 6 open PRs (#33, #34, #35, #36, #37, #38).