### PR TITLE
ci: use PR author instead of actor for Dependabot skip

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   semantic-title:
     name: Semantic PR Title
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Problem

The semantic PR title check skips Dependabot PRs using `github.actor != 'dependabot[bot]'`. However, `github.actor` changes to the maintainer when branch updates are triggered via `gh pr update-branch`, causing the check to run on Dependabot PRs and fail on uppercase 'Bump' in the title.

## Fix

Switch to `github.event.pull_request.user.login` which always reflects the original PR author, regardless of who triggers synchronize events.