### PR TITLE
ci: increase fuzz timeout to 45s in E2E Nightly to reduce flakes

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -387,14 +387,14 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Run fuzz tests (coverage-guided, 30s per target)
+      - name: Run fuzz tests (coverage-guided, 45s per target)
         shell: bash -Eeuo pipefail -x {0}
         run: |
-          # Time-based limits let Go's coverage-guided engine focus on
-          # inputs that explore new code paths. 30s per target achieves
-          # full branch coverage faster than 1M random iterations.
-          go test ./internal/recommendation/... -run='^$' -fuzz=FuzzPercentileEstimator -fuzztime=30s
-          go test ./internal/recommendation/... -run='^$' -fuzz=FuzzRecommendationEngine -fuzztime=30s
+           # Time-based limits let Go's coverage-guided engine focus on
+           # inputs that explore new code paths. 45s per target in nightly
+           # gives more coverage than the 30s used for local `make test-fuzz`.
+           go test ./internal/recommendation/... -run='^$' -fuzz=FuzzPercentileEstimator -fuzztime=45s
+           go test ./internal/recommendation/... -run='^$' -fuzz=FuzzRecommendationEngine -fuzztime=45s
 
   report:
     name: Nightly Results


### PR DESCRIPTION
Increases the coverage-guided fuzz budget from 30s → 45s for both fuzz targets in the nightly workflow.

This should significantly reduce the 'context deadline exceeded' flakes we see on FuzzRecommendationEngine.

Refs #47