### PR TITLE
test: reduce RealisticLoad E2E resource requests to avoid CI contention

### DIFF
--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -569,8 +569,8 @@ func TestE2E_RealisticLoad_Overprovisioned(t *testing.T) {
 							Args:  []string{"--cpu", "1", "--cpu-load", "20", "--vm", "1", "--vm-bytes", "100M", "--timeout", "0"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("300m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
+									corev1.ResourceCPU:    resource.MustParse("150m"),
+									corev1.ResourceMemory: resource.MustParse("96Mi"),
 								},
 							},
 						},


### PR DESCRIPTION
Real root-cause fix for #49:

- Reduced CPU request 300m → 150m and memory 128Mi → 96Mi
- Reverted the artificial 3m deployment readiness timeout back to 120s

This makes the test schedule reliably even when 13 parallel E2E tests compete for limited CI node resources, instead of papering over the problem with longer timeouts.