### PR TITLE
ci: split controller-scale into 2 shards and reduce max scale

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,9 +312,12 @@ jobs:
           - pkg: controller-core
             path: ./internal/controller/...
             bench: '^Benchmark(BuildPrometheusQuery|Reconcile$|ComputeRecommendations)'
-          - pkg: controller-scale
+          - pkg: controller-workloads
             path: ./internal/controller/...
-            bench: '^BenchmarkReconcile_(Many|Concurrent)'
+            bench: '^BenchmarkReconcile_ManyWorkloads'
+          - pkg: controller-policies
+            path: ./internal/controller/...
+            bench: '^BenchmarkReconcile_(ManyPolicies|Concurrent)'
           - pkg: metrics
             path: ./internal/metrics/...
             bench: '.'

--- a/internal/controller/benchmark_test.go
+++ b/internal/controller/benchmark_test.go
@@ -100,7 +100,7 @@ func BenchmarkComputeRecommendations(b *testing.B) {
 // matching N deployments. Exercises processWorkloads, conflict detection,
 // recommendation computation, and status updates at scale.
 func BenchmarkReconcile_ManyWorkloads(b *testing.B) {
-	for _, n := range []int{10, 100, 500, 1000} {
+	for _, n := range []int{10, 50, 100, 250} {
 		b.Run(fmt.Sprintf("%d_workloads", n), func(b *testing.B) {
 			objects := make([]client.Object, 0, 2*n+1)
 
@@ -200,7 +200,7 @@ func BenchmarkReconcile_ManyWorkloads(b *testing.B) {
 // a different deployment. Measures per-policy overhead and shared state
 // (gauge keys, collector cache) performance.
 func BenchmarkReconcile_ManyPolicies(b *testing.B) {
-	for _, n := range []int{10, 100, 500, 1000} {
+	for _, n := range []int{10, 50, 100, 250} {
 		b.Run(fmt.Sprintf("%d_policies", n), func(b *testing.B) {
 			objects := make([]client.Object, 0, 3*n)
 			reqs := make([]ctrl.Request, n)


### PR DESCRIPTION
Follow-up to PR #54. Further split the controller-scale shard (8m06s) into two parallel shards and reduce the max benchmark scale.

**Shard split:**
| Shard | Benchmarks | Expected time |
|-------|-----------|--------------|
| controller-workloads | ManyWorkloads (10, 50, 100, 250) | ~1 min |
| controller-policies | ManyPolicies (10, 50, 100, 250) + ConcurrentPolicies | ~2-3 min |

**Scale reduction:**
- Before: {10, 100, 500, 1000}
- After: {10, 50, 100, 250}

250 catches the same O(n^2) scaling regressions at 1/12th the cost of 1000 (1.6s vs 20s per iteration locally). The intermediate 50 step improves curve resolution.

**Total benchmark shards: 5** (controller-core, controller-workloads, controller-policies, metrics, recommendation). Expected wall-clock: ~3 min (was ~10 min before PR #54, ~8 min after).