### PR TITLE
fix: correct hallucinated email in artifacthub-repo.yml

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,4 @@
 repositoryID: attune
 owners:
   - name: SebTardif
-    email: seb@tardif.com
+    email: sebtardif@ncf.ca


### PR DESCRIPTION
Replace hallucinated `seb@tardif.com` with the correct email from git config.