### PR TITLE
ci: make link-check non-blocking in CI gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -689,6 +689,8 @@ jobs:
   # Gate job: always runs, aggregates all conditional job results.
   # This is the ONLY required status check for branch protection,
   # so docs-only PRs (where Go jobs are skipped) can still merge.
+  # Note: link-check is excluded from the gate because external sites
+  # (e.g. kubernetes.io) have transient connectivity issues on CI runners.
   ci-gate:
     name: CI Gate
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
@@ -697,7 +699,6 @@ jobs:
     needs:
       - lint
       - docs-check
-      - link-check
       - yaml-lint
       - test-unit
       - test-bench
@@ -714,7 +715,6 @@ jobs:
           results=( \
             "${{ needs.lint.result }}" \
             "${{ needs.docs-check.result }}" \
-            "${{ needs.link-check.result }}" \
             "${{ needs.yaml-lint.result }}" \
             "${{ needs.test-unit.result }}" \
             "${{ needs.test-bench.result }}" \

--- a/lychee.toml
+++ b/lychee.toml
@@ -9,3 +9,4 @@ exclude_loopback = true
 max_concurrency = 8
 timeout = 30
 max_retries = 3
+retry_wait_time = 5


### PR DESCRIPTION
External link checks are inherently flaky because sites like kubernetes.io intermittently refuse connections from CI runners (run [26479145584](https://github.com/attune-io/attune/actions/runs/26479145584) failed due to transient kubernetes.io connection errors).

**Changes:**
- Remove `link-check` from the CI gate dependencies so transient network failures do not block merging
- The link-check job still runs and reports broken links visually
- Add `retry_wait_time = 5` to lychee config to space out retries for better transient failure recovery