### PR TITLE
fix: remove stress-ng VM stressor crashing on K8s 1.33+

### DIFF
--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -540,7 +540,11 @@ func TestE2E_RealisticLoad_Overprovisioned(t *testing.T) {
 	ns := uniqueNS("load")
 	createNamespace(t, ns)
 
-	// Deploy a workload using stress-ng to generate known CPU/memory load.
+	// Deploy a workload using stress-ng to generate known CPU load.
+	// Only the --cpu stressor is used; the --vm stressor is omitted because
+	// stress-ng exits with code 2 on K8s 1.33+ k3s builds (containerd/cgroup
+	// incompatibility). cAdvisor still reports memory working set bytes for
+	// the running container, so the operator gets both CPU and memory data.
 	// Moderate requests (150m/64Mi) so the pod schedules on the shared CI
 	// k3d node where 13 parallel E2E tests compete for ~4 CPUs. Burstable QoS
 	// (no limits) lets the container burst to its actual ~200m CPU usage.
@@ -564,7 +568,7 @@ func TestE2E_RealisticLoad_Overprovisioned(t *testing.T) {
 						{
 							Name:  "app",
 							Image: "ghcr.io/alexei-led/stress-ng:0.20.01",
-							Args:  []string{"--cpu", "1", "--cpu-load", "20", "--vm", "1", "--vm-bytes", "100M", "--timeout", "0"},
+							Args:  []string{"--cpu", "1", "--cpu-load", "20", "--timeout", "0"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("150m"),


### PR DESCRIPTION
The `stress-ng` VM stressor (`--vm 1 --vm-bytes 100M`) exits with code 2 on K8s 1.33/1.34/1.35 k3s builds, causing `CrashLoopBackOff`. The operator detects the pod as mid-rollout and skips it, so recommendations are never produced and `TestE2E_RealisticLoad_Overprovisioned` times out.

**Root cause from nightly debug artifacts:**
```
# K8s 1.35 operator logs
Skipping workload mid-rollout  workload=load-app

# K8s 1.34 pod status
load-app-789d64cdf4-s9mxb  0/1  CrashLoopBackOff  Exit Code: 2
```

K8s 1.32 passes because the older k3s containerd/cgroup stack is compatible with stress-ng's VM stressor.

**Fix:** Remove `--vm 1 --vm-bytes 100M` from the stress-ng args. The test only checks CPU recommendations and MaxAllowed bounds. cAdvisor still reports `container_memory_working_set_bytes` for running containers, so the operator gets both CPU and memory data points.

**Impact:** Fixes nightly E2E failures on K8s 1.33, 1.34, and 1.35 (3 out of 4 versions in the matrix).