### PR TITLE
ci: pre-import stress-ng image into k3d clusters

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -26,6 +26,9 @@ inputs:
   prometheus-chart-version:
     description: Prometheus Helm chart version
     required: true
+  stress-ng-image:
+    description: stress-ng container image for E2E load tests
+    required: true
 
 runs:
   using: composite
@@ -55,7 +58,8 @@ runs:
           /tmp/cert-manager-webhook.tar
           /tmp/cert-manager-cainjector.tar
           /tmp/prometheus.tar
-        key: e2e-images-${{ runner.os }}-cm${{ inputs.cert-manager-version }}-prom${{ inputs.prometheus-chart-version }}
+          /tmp/stress-ng.tar
+        key: e2e-images-${{ runner.os }}-cm${{ inputs.cert-manager-version }}-prom${{ inputs.prometheus-chart-version }}-stress0.20.01
 
     - name: Install k3d
       shell: bash -Eeuo pipefail -x {0}
@@ -100,6 +104,7 @@ runs:
         pull_and_save "quay.io/jetstack/cert-manager-webhook:${{ inputs.cert-manager-version }}" /tmp/cert-manager-webhook.tar
         pull_and_save "quay.io/jetstack/cert-manager-cainjector:${{ inputs.cert-manager-version }}" /tmp/cert-manager-cainjector.tar
         pull_and_save "${{ inputs.prometheus-image }}" /tmp/prometheus.tar
+        pull_and_save "${{ inputs.stress-ng-image }}" /tmp/stress-ng.tar
 
     - name: Create k3d cluster
       shell: bash -Eeuo pipefail -x {0}
@@ -147,11 +152,11 @@ runs:
         kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
         kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
 
-    - name: Load Prometheus image into cluster
+    - name: Load Prometheus and test images into cluster
       shell: bash -Eeuo pipefail -x {0}
       run: |
         export PATH="$HOME/.local/bin:$PATH"
-        k3d image import /tmp/prometheus.tar -c "${{ inputs.cluster-name }}"
+        k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar -c "${{ inputs.cluster-name }}"
 
     - name: Install Prometheus
       shell: bash -Eeuo pipefail -x {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ env:
   CERT_MANAGER_VERSION: "v1.17.2"
   PROMETHEUS_IMAGE: "quay.io/prometheus/prometheus:v3.4.1"
   PROMETHEUS_CHART_VERSION: "27.22.0"
+  STRESS_NG_IMAGE: "ghcr.io/alexei-led/stress-ng:0.20.01"
 
 jobs:
   # Detect which files changed so downstream jobs can skip irrelevant work.
@@ -467,6 +468,7 @@ jobs:
           cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
           prometheus-image: ${{ env.PROMETHEUS_IMAGE }}
           prometheus-chart-version: ${{ env.PROMETHEUS_CHART_VERSION }}
+          stress-ng-image: ${{ env.STRESS_NG_IMAGE }}
 
       - name: Install Chainsaw
         uses: kyverno/action-install-chainsaw@1223ef75bedeb59c4e7b5455463d4316e76dff01 # v0.2.15
@@ -518,6 +520,7 @@ jobs:
           cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
           prometheus-image: ${{ env.PROMETHEUS_IMAGE }}
           prometheus-chart-version: ${{ env.PROMETHEUS_CHART_VERSION }}
+          stress-ng-image: ${{ env.STRESS_NG_IMAGE }}
 
       - name: Run Go E2E tests
         shell: bash -Eeuo pipefail -x {0}

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -41,6 +41,7 @@ env:
   CERT_MANAGER_VERSION: "v1.17.2"
   PROMETHEUS_IMAGE: "quay.io/prometheus/prometheus:v3.4.1"
   PROMETHEUS_CHART_VERSION: "27.22.0"
+  STRESS_NG_IMAGE: "ghcr.io/alexei-led/stress-ng:0.20.01"
 
 jobs:
   prepare-matrix:
@@ -132,7 +133,8 @@ jobs:
             /tmp/cert-manager-webhook.tar
             /tmp/cert-manager-cainjector.tar
             /tmp/prometheus.tar
-          key: e2e-images-${{ runner.os }}-cm${{ env.CERT_MANAGER_VERSION }}-prom${{ env.PROMETHEUS_CHART_VERSION }}
+            /tmp/stress-ng.tar
+          key: e2e-images-${{ runner.os }}-cm${{ env.CERT_MANAGER_VERSION }}-prom${{ env.PROMETHEUS_CHART_VERSION }}-stress0.20.01
 
       - name: Install k3d
         shell: bash -Eeuo pipefail -x {0}
@@ -179,6 +181,7 @@ jobs:
           pull_and_save "quay.io/jetstack/cert-manager-webhook:${{ env.CERT_MANAGER_VERSION }}" /tmp/cert-manager-webhook.tar
           pull_and_save "quay.io/jetstack/cert-manager-cainjector:${{ env.CERT_MANAGER_VERSION }}" /tmp/cert-manager-cainjector.tar
           pull_and_save "${{ env.PROMETHEUS_IMAGE }}" /tmp/prometheus.tar
+          pull_and_save "${{ env.STRESS_NG_IMAGE }}" /tmp/stress-ng.tar
 
       - name: Create k3d cluster
         shell: bash -Eeuo pipefail -x {0}
@@ -240,11 +243,11 @@ jobs:
           kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
 
-      - name: Load Prometheus image into cluster
+      - name: Load Prometheus and test images into cluster
         shell: bash -Eeuo pipefail -x {0}
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          k3d image import /tmp/prometheus.tar -c "$CLUSTER_NAME"
+          k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar -c "$CLUSTER_NAME"
 
       - name: Install Prometheus
         shell: bash -Eeuo pipefail -x {0}

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -48,6 +48,8 @@ import (
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
 
+const defaultStressNGImage = "ghcr.io/alexei-led/stress-ng:0.20.01"
+
 var (
 	k8sClient  client.Client
 	clientset  *kubernetes.Clientset
@@ -55,10 +57,16 @@ var (
 	ctx        context.Context
 	cancel     context.CancelFunc
 	promAddr   = "http://prometheus-server.monitoring:80"
+	stressNGImage string
 )
 
 func TestMain(m *testing.M) {
 	ctx, cancel = context.WithTimeout(context.Background(), 20*time.Minute)
+
+	stressNGImage = os.Getenv("STRESS_NG_IMAGE")
+	if stressNGImage == "" {
+		stressNGImage = defaultStressNGImage
+	}
 
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {
@@ -567,7 +575,7 @@ func TestE2E_RealisticLoad_Overprovisioned(t *testing.T) {
 					Containers: []corev1.Container{
 						{
 							Name:  "app",
-							Image: "ghcr.io/alexei-led/stress-ng:0.20.01",
+							Image: stressNGImage,
 							Args:  []string{"--cpu", "1", "--cpu-load", "20", "--timeout", "0"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
@@ -1091,7 +1099,7 @@ func TestE2E_OOMKill_TriggersRevert(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:    "app",
-						Image:   "ghcr.io/alexei-led/stress-ng:0.20.01",
+						Image:   stressNGImage,
 						Command: []string{"/stress-ng", "--sleep", "1", "--timeout", "3600"},
 						ResizePolicy: []corev1.ContainerResizePolicy{
 							{ResourceName: corev1.ResourceCPU, RestartPolicy: corev1.NotRequired},


### PR DESCRIPTION
The stress-ng container image was pulled at test time by the kubelet inside k3d. This is unreliable on CI runners where 13 parallel tests compete for network bandwidth, causing `waitForDeploymentReady` to time out randomly (K8s 1.32/1.34 failed while 1.33/1.35 passed in the same nightly run).

**Fix:** Pre-pull the image on the host and import it into the k3d cluster before tests run, matching the existing pattern for cert-manager and prometheus images.

**Changes:**
- `.github/actions/setup-e2e-cluster/action.yaml`: Add stress-ng to cache, pre-pull, and k3d import
- `.github/workflows/e2e-nightly.yaml`: Same changes for the nightly's independent setup

This eliminates the last source of image-pull flakiness in the E2E test suite.