### PR TITLE
ci: pin pip install by hash and add OpenSSF Best Practices badge

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install MkDocs
         run: |
-          python3 -m pip install --user --break-system-packages mkdocs-material==9.7.6
+          python3 -m pip install --user --break-system-packages --require-hashes -r docs/requirements.txt
           echo "$(python3 -m site --user-base)/bin" >> "$GITHUB_PATH"
 
       - name: Build site

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Security](https://github.com/attune-io/attune/actions/workflows/security.yaml/badge.svg)](https://github.com/attune-io/attune/actions/workflows/security.yaml)
 [![Go Version](https://img.shields.io/badge/go-1.26-blue)](go.mod)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12998/badge)](https://www.bestpractices.dev/projects/12998)
 
 **Safe, in-place Kubernetes pod resource right-sizing. VPA done right.**
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+# Hash-pinned for OpenSSF Scorecard PinnedDependencies compliance.
+# To update: pip download <pkg>==<ver> --no-deps -d /tmp && pip hash /tmp/<whl>
+mkdocs-material==9.7.6 --hash=sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba


### PR DESCRIPTION
## Summary

Two Scorecard-related improvements:

### 1. Pin pip install by hash (Scorecard #15 PinnedDependencies)

Creates `docs/requirements.txt` with SHA-256 hash-pinned `mkdocs-material==9.7.6` and updates the docs workflow to use `--require-hashes`. This was the only remaining unpinned dependency (Scorecard score was 9/10).

### 2. OpenSSF Best Practices badge (Scorecard #8 CII-Best-Practices)

Registered the project at [bestpractices.dev](https://www.bestpractices.dev/projects/12998) and completed the full self-assessment questionnaire. Achieved **100% passing** across all 67 criteria:

| Section | Score |
|---------|-------|
| Basics | 13/13 |
| Change Control | 9/9 |
| Reporting | 8/8 |
| Quality | 13/13 |
| Security | 16/16 |
| Analysis | 8/8 |

Adds the badge to the README.

Closes #77
Closes #79