### PR TITLE
fix(e2e): replace stress-ng with busybox CPU burn and update SECURITY.md

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -42,6 +42,7 @@ env:
   PROMETHEUS_IMAGE: "quay.io/prometheus/prometheus:v3.4.1"
   PROMETHEUS_CHART_VERSION: "27.22.0"
   STRESS_NG_IMAGE: "ghcr.io/alexei-led/stress-ng:0.20.01"
+  CPU_BURN_IMAGE: "docker.io/library/busybox:1.37"
 
 jobs:
   prepare-matrix:
@@ -134,7 +135,8 @@ jobs:
             /tmp/cert-manager-cainjector.tar
             /tmp/prometheus.tar
             /tmp/stress-ng.tar
-          key: e2e-images-${{ runner.os }}-cm${{ env.CERT_MANAGER_VERSION }}-prom${{ env.PROMETHEUS_CHART_VERSION }}-stress0.20.01
+            /tmp/busybox.tar
+          key: e2e-images-${{ runner.os }}-cm${{ env.CERT_MANAGER_VERSION }}-prom${{ env.PROMETHEUS_CHART_VERSION }}-stress0.20.01-busybox1.37
 
       - name: Install k3d
         shell: bash -Eeuo pipefail -x {0}
@@ -182,6 +184,7 @@ jobs:
           pull_and_save "quay.io/jetstack/cert-manager-cainjector:${{ env.CERT_MANAGER_VERSION }}" /tmp/cert-manager-cainjector.tar
           pull_and_save "${{ env.PROMETHEUS_IMAGE }}" /tmp/prometheus.tar
           pull_and_save "${{ env.STRESS_NG_IMAGE }}" /tmp/stress-ng.tar
+          pull_and_save "${{ env.CPU_BURN_IMAGE }}" /tmp/busybox.tar
 
       - name: Create k3d cluster
         shell: bash -Eeuo pipefail -x {0}
@@ -269,7 +272,7 @@ jobs:
         shell: bash -Eeuo pipefail -x {0}
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar -c "$CLUSTER_NAME"
+          k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar /tmp/busybox.tar -c "$CLUSTER_NAME"
 
       - name: Install Prometheus
         shell: bash -Eeuo pipefail -x {0}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,10 +20,42 @@ feature: [Report a vulnerability](https://github.com/attune-io/attune/security/a
 
 ## Security Practices
 
-- Container images are signed with [cosign](https://github.com/sigstore/cosign)
-  using keyless signing (Sigstore OIDC)
-- SBOMs are generated for every release (SPDX format)
-- Dependencies are scanned weekly with Trivy and govulncheck
+### Supply Chain
+
+- Container images and binaries are signed with
+  [cosign](https://github.com/sigstore/cosign) using keyless signing
+  (Sigstore OIDC)
+- [SLSA Level 3](https://slsa.dev) provenance is generated for both
+  binary artifacts and container images
+- SBOMs are generated for every release (SPDX format) and attached to
+  the GitHub release
+- [FOSSA](https://fossa.com) license compliance scanning runs on every push
+
+### Vulnerability Scanning
+
+- [Trivy](https://trivy.dev) filesystem and container image scans run
+  weekly
+- [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
+  runs weekly for known Go vulnerabilities
+- [Gitleaks](https://gitleaks.io) secret detection runs on every push
+- [CodeQL](https://codeql.github.com) static analysis runs weekly
+- [GitHub secret scanning](https://docs.github.com/en/code-security/secret-scanning)
+  is enabled at the organization level
+
+### CI Hardening
+
+- [StepSecurity harden-runner](https://github.com/step-security/harden-runner)
+  is enabled on all CI workflows
+- [OpenSSF Scorecard](https://securityscorecards.dev) monitors the
+  repository's security posture
+- [Dependabot](https://docs.github.com/en/code-security/dependabot)
+  monitors Go modules, GitHub Actions, and Docker base images weekly
 - Static analysis via golangci-lint (50+ linters) runs on every push
-- The operator runs as non-root with a read-only root filesystem
+
+### Runtime
+
+- The operator runs as non-root (`runAsUser: 65532`) with a read-only
+  root filesystem
+- All Linux capabilities are dropped (`drop: ALL`); privilege escalation
+  is disabled
 - RBAC permissions follow least-privilege principles

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -51,6 +51,7 @@ import (
 )
 
 const defaultStressNGImage = "ghcr.io/alexei-led/stress-ng:0.20.01"
+const cpuBurnImage = "docker.io/library/busybox:1.37"
 
 var (
 	k8sClient  client.Client
@@ -590,11 +591,11 @@ func TestE2E_RealisticLoad_Overprovisioned(t *testing.T) {
 	ns := uniqueNS("load")
 	createNamespace(t, ns)
 
-	// Deploy a workload using stress-ng to generate CPU load.
-	// Only --cpu is used; --cpu-load exits with code 2 on stress-ng
-	// 0.20.01, and --vm exits with code 2 on K8s 1.33+ k3s builds.
-	// Running at 100% on 1 worker still produces a recommendation
-	// capped by MaxAllowed (80m), which is what the test validates.
+	// Deploy a workload that generates CPU load via a busybox shell loop.
+	// stress-ng --cpu exits with code 2 on certain k3s builds (v1.33, v1.35)
+	// due to containerd/seccomp differences, so we use a simple busy loop
+	// instead. The loop burns CPU, which shows up in cAdvisor/Prometheus
+	// metrics. The recommendation gets capped by MaxAllowed (80m).
 	// Low requests (100m/32Mi) reduce scheduling pressure on the shared CI
 	// k3d node where parallel E2E tests compete for ~4 CPUs. The request
 	// must stay above MaxAllowed (80m) so the workload is "overprovisioned"
@@ -618,9 +619,9 @@ func TestE2E_RealisticLoad_Overprovisioned(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "app",
-							Image: stressNGImage,
-							Args:  []string{"--cpu", "1", "--timeout", "86400"},
+							Name:    "app",
+							Image:   cpuBurnImage,
+							Command: []string{"sh", "-c", "while true; do :; done"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("100m"),


### PR DESCRIPTION
## What

- Replace stress-ng with busybox `while true; do :; done` in the `TestE2E_RealisticLoad_Overprovisioned` E2E test
- Add busybox image to the nightly workflow's pre-pull/import pipeline
- Update SECURITY.md with the full security tooling inventory

## Why

stress-ng `--cpu` stressor exits with code 2 on k3s v1.33.11 and v1.35.4 due to containerd/seccomp compatibility. The test only needs CPU consumption visible in Prometheus metrics; a busybox shell busy loop is more reliable across all K8s versions.

SECURITY.md was missing entries for Gitleaks, CodeQL, Trivy image scanning, SLSA Level 3 provenance, StepSecurity harden-runner, Dependabot, FOSSA, OpenSSF Scorecard, and GitHub secret scanning.

## Proof

5 consecutive E2E nightly passes on this branch across all 4 K8s versions (1.32, 1.33, 1.34, 1.35):

| Run | Result |
|-----|--------|
| [26493377049](https://github.com/attune-io/attune/actions/runs/26493377049) | PASS |
| [26493954983](https://github.com/attune-io/attune/actions/runs/26493954983) | PASS |
| [26494550370](https://github.com/attune-io/attune/actions/runs/26494550370) | PASS |
| [26495233441](https://github.com/attune-io/attune/actions/runs/26495233441) | PASS |
| [26495901686](https://github.com/attune-io/attune/actions/runs/26495901686) | PASS |
