### PR TITLE
test(e2e): add diagnostic logging to waitForPolicyDiscovered and waitForResize

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -215,6 +215,7 @@ runs:
           --set metrics.enabled=true \
           --set leaderElection.enabled=false \
           --set maxConcurrentReconciles=4 \
+          --set logging.level=1 \
           --set resources.limits.memory=512Mi \
           --set resources.requests.memory=256Mi \
           --wait --timeout 3m

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -482,7 +482,7 @@ jobs:
           echo "=== cert-manager pods ==="
           kubectl get pods -n cert-manager
           echo "=== Operator logs ==="
-          kubectl logs -n attune-system -l app.kubernetes.io/name=attune --tail=100 || true
+          kubectl logs -n attune-system -l app.kubernetes.io/name=attune --tail=300 || true
           echo "=== Pod status ==="
           kubectl get pods -A
           echo "=== Events ==="
@@ -533,7 +533,7 @@ jobs:
           echo "=== cert-manager pods ==="
           kubectl get pods -n cert-manager
           echo "=== Operator logs ==="
-          kubectl logs -n attune-system -l app.kubernetes.io/name=attune --tail=100 || true
+          kubectl logs -n attune-system -l app.kubernetes.io/name=attune --tail=300 || true
           echo "=== Pod status ==="
           kubectl get pods -A
           echo "=== Events ==="

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -330,6 +330,7 @@ jobs:
             --set metrics.enabled=true \
             --set leaderElection.enabled=false \
             --set maxConcurrentReconciles=4 \
+            --set logging.level=1 \
             --set resources.limits.memory=512Mi \
             --set resources.requests.memory=256Mi \
             --wait --timeout 3m

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -262,24 +262,62 @@ func podRestartCount(pod corev1.Pod) int32 {
 
 func waitForPolicyDiscovered(t *testing.T, name, namespace string, timeout time.Duration) {
 	t.Helper()
+	start := time.Now()
+	lastDiag := time.Time{}
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		var policy attunev1alpha1.AttunePolicy
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &policy); err != nil {
 			return false, nil
 		}
-		return policy.Status.Workloads.Discovered > 0, nil
-	}))
+		if policy.Status.Workloads.Discovered > 0 {
+			return true, nil
+		}
+		if elapsed := time.Since(start); elapsed > 30*time.Second && time.Since(lastDiag) > 30*time.Second {
+			lastDiag = time.Now()
+			t.Logf("waitForPolicyDiscovered(%s/%s): discovered=%d after %s",
+				namespace, name, policy.Status.Workloads.Discovered, elapsed.Round(time.Second))
+			for _, c := range policy.Status.Conditions {
+				t.Logf("  condition %s: status=%s reason=%s", c.Type, c.Status, c.Reason)
+			}
+		}
+		return false, nil
+	}), "policy %s/%s workloads.discovered still 0 after %s", namespace, name, timeout)
 }
 
 func waitForResize(t *testing.T, policyName, namespace string, timeout time.Duration) {
 	t.Helper()
+	start := time.Now()
+	lastDiag := time.Time{}
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		var policy attunev1alpha1.AttunePolicy
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: namespace}, &policy); err != nil {
 			return false, nil
 		}
-		return policy.Status.Workloads.Resized > 0, nil
-	}))
+		if policy.Status.Workloads.Resized > 0 {
+			return true, nil
+		}
+		if elapsed := time.Since(start); elapsed > 30*time.Second && time.Since(lastDiag) > 30*time.Second {
+			lastDiag = time.Now()
+			w := policy.Status.Workloads
+			t.Logf("waitForResize(%s/%s): discovered=%d recommendations=%d pending=%d resized=%d after %s",
+				namespace, policyName, w.Discovered, w.WithRecommendations, w.Pending, w.Resized, elapsed.Round(time.Second))
+			for _, c := range policy.Status.Conditions {
+				t.Logf("  condition %s: status=%s reason=%s", c.Type, c.Status, c.Reason)
+			}
+			for _, rec := range policy.Status.Recommendations {
+				for _, cr := range rec.Containers {
+					t.Logf("  recommendation %s/%s: currentCPU=%s recCPU=%s currentMem=%s recMem=%s",
+						rec.Workload, cr.Name,
+						cr.Current.CPURequest.String(), cr.Recommended.CPURequest.String(),
+						cr.Current.MemoryRequest.String(), cr.Recommended.MemoryRequest.String())
+				}
+			}
+			for _, we := range policy.Status.WorkloadErrors {
+				t.Logf("  workloadError %s: %s", we.Workload, we.Error)
+			}
+		}
+		return false, nil
+	}), "policy %s/%s workloads.resized still 0 after %s", namespace, policyName, timeout)
 }
 
 func forcePolicyReconcile(t *testing.T, name, namespace string, timeout time.Duration) {


### PR DESCRIPTION
Both helpers now log policy status (conditions, workload counts, recommendations, workload errors) every 30s during the poll loop. This matches the pattern already used by `waitForDeploymentReady` and makes E2E timeout failures diagnosable from CI logs.

**What changed:**
- `waitForPolicyDiscovered`: logs `discovered` count and all conditions every 30s
- `waitForResize`: logs full workload summary (`discovered`, `withRecommendations`, `pending`, `resized`), conditions, per-container recommendation values (current vs recommended CPU/memory), and workload errors every 30s
- Both now include the policy namespace/name and elapsed time in the failure message

Closes #84