### PR TITLE
fix(e2e): resolve recommend-mode Chainsaw intermittent timeout

### DIFF
--- a/.github/workflows/pr-size.yaml
+++ b/.github/workflows/pr-size.yaml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   size-label:
@@ -43,11 +44,13 @@ jobs:
 
           echo "PR #${PR_NUMBER}: +${ADDITIONS} -${DELETIONS} = ${TOTAL} lines -> ${SIZE}"
 
-          # Remove any existing size labels, then add the correct one
-          for label in size/xs size/s size/m size/l size/xl; do
-            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --remove-label "$label" 2>/dev/null || true
-          done
-          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-label "$SIZE"
+          # Fetch current labels, swap the size/* label in one API call
+          REPO="${{ github.repository }}"
+          KEEP=$(gh api "repos/${REPO}/issues/${PR_NUMBER}" --jq \
+            '[.labels[].name | select(startswith("size/") | not)]')
+          FINAL=$(echo "$KEEP" | jq --arg s "$SIZE" '. + [$s]')
+          echo "$FINAL" | jq '{labels: .}' | \
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" --method PUT --input -
 
           # Post a warning comment for XL PRs
           if [ "$SIZE" = "size/xl" ]; then

--- a/test/e2e/recommend-mode/chainsaw-test.yaml
+++ b/test/e2e/recommend-mode/chainsaw-test.yaml
@@ -95,6 +95,32 @@ spec:
                 readyReplicas: 1
     - name: verify-status
       try:
+        - script:
+            timeout: 3m
+            content: |
+              # The operator may transition quickly from InsufficientData to Monitoring
+              # when minimumDataPoints is 1 and Prometheus scrapes fast. Accept either
+              # state as valid — both prove the policy discovered the workload and
+              # the controller reconciled it.
+              for i in $(seq 1 36); do
+                reason=$(kubectl get attunepolicy recommend-test -n e2e-recommend-mode \
+                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' 2>/dev/null)
+                discovered=$(kubectl get attunepolicy recommend-test -n e2e-recommend-mode \
+                  -o jsonpath='{.status.workloads.discovered}' 2>/dev/null)
+                if [ "$discovered" = "1" ]; then
+                  if [ "$reason" = "InsufficientData" ] || [ "$reason" = "Monitoring" ]; then
+                    echo "OK: workloads discovered=$discovered, Ready reason=$reason"
+                    exit 0
+                  fi
+                fi
+                echo "Waiting... discovered=$discovered reason=$reason"
+                sleep 5
+              done
+              echo "FAIL: timed out waiting for policy to discover workloads"
+              kubectl get attunepolicy recommend-test -n e2e-recommend-mode -o yaml
+              exit 1
+    - name: verify-no-resizes
+      try:
         - assert:
             resource:
               apiVersion: attune.io/v1alpha1
@@ -103,10 +129,8 @@ spec:
                 name: recommend-test
                 namespace: e2e-recommend-mode
               status:
-                conditions:
-                  - type: Ready
-                    status: "False"
-                    reason: InsufficientData
+                workloads:
+                  resized: 0
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1


### PR DESCRIPTION
## Problem

The `recommend-mode` Chainsaw test intermittently times out during the `verify-status` assertion step. The static assert waits for `Ready=False, reason=InsufficientData`, but with `minimumDataPoints: 1` and a 15s Prometheus scrape interval, the operator can transition to `Ready=True, reason=Monitoring` within seconds of policy creation. The assert then spends the full 2-minute timeout waiting for a state that already passed.

From the [failing nightly run](https://github.com/attune-io/attune/actions/runs/26496301834) on K8s v1.35:

```
status.conditions[0].reason: Invalid value: "Monitoring": Expected value: "InsufficientData"
status.conditions[0].status: Invalid value: "True": Expected value: "False"
```

## Root Cause

The test asserted a **transient** state (`InsufficientData`) rather than a **stable** state. With `minimumDataPoints: 1`, the operator only needs one Prometheus scrape to have enough data. The race between "assert polls for InsufficientData" and "operator transitions to Monitoring" is timing-dependent. On 5 consecutive nightly passes (20 K8s-version runs), the timing was favorable. On the next run, it was not.

## Fix

- Replace the static Chainsaw assert with a script-based poll that accepts **either** `InsufficientData` or `Monitoring` as valid states (both prove the policy discovered the workload and the controller reconciled it)
- Add a `verify-no-resizes` step that asserts `workloads.resized: 0`, confirming Recommend mode does not apply changes (stronger test coverage than before)

Closes #87