### PR TITLE
ci: cross-platform plugin build, Codecov PR comments, docs deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -299,6 +299,7 @@ jobs:
         with:
           files: coverage.out
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-bench:
     name: Benchmark Tests (${{ matrix.pkg }})
@@ -716,6 +717,19 @@ jobs:
         run: |
           go build -o bin/manager ./cmd/manager/
           go build -o bin/kubectl-attune ./cmd/kubectl-attune/
+
+      - name: Cross-compile kubectl plugin
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          platforms=("linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64")
+          for platform in "${platforms[@]}"; do
+            os="${platform%/*}"
+            arch="${platform#*/}"
+            ext=""; if [ "$os" = "windows" ]; then ext=".exe"; fi
+            echo "::group::${os}/${arch}"
+            GOOS="$os" GOARCH="$arch" go build -o "bin/kubectl-attune-${os}-${arch}${ext}" ./cmd/kubectl-attune/
+            echo "::endgroup::"
+          done
 
       - name: Build container image (no push)
         shell: bash -Eeuo pipefail -x {0}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install MkDocs

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Changes

### Cross-platform kubectl plugin build test (#71)

Add a cross-compilation step to the Build CI job that verifies `kubectl-attune`
compiles for all supported platforms:

- `linux/amd64`, `linux/arm64`
- `darwin/amd64`, `darwin/arm64`
- `windows/amd64`

This catches platform-specific compilation issues (e.g., `syscall` usage,
missing build tags) before release.

### Codecov coverage diff comments (#64)

- Add `codecov.yml` with project target (80%), patch target (80%), and
  PR comment configuration (`reach,diff,flags,files` layout)
- Pass `CODECOV_TOKEN` secret to the upload action so Codecov can post
  coverage diff comments on PRs

**Setup required:** Add a `CODECOV_TOKEN` repository secret from
[codecov.io](https://app.codecov.io/gh/attune-io/attune/settings).
Without the token, coverage uploads still work but PR comments are
disabled.

### MkDocs GitHub Pages deployment (#74)

- Switch GitHub Pages source from branch to Actions deployment (required
  for `actions/deploy-pages` to work)
- Add `harden-runner` to the docs build job for consistency

The docs workflow (`.github/workflows/docs.yaml`) already existed with
build + deploy jobs. The only missing piece was the Pages source
configuration.

Closes #71
Closes #64
Closes #74