### PR TITLE
ci: enable merge queue and release environment approval gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group: {}
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: release
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Changes

### Migrate to repository rulesets (#75)

Replaced legacy branch protection rules on `main` with a repository
ruleset (`main-branch-protection`, ID 16941636):

| Setting | Legacy | Ruleset |
|---------|--------|---------|
| Required checks | CI Gate, DCO | CI Gate, DCO |
| Linear history | Yes | Yes |
| Force push | Blocked | Blocked (non_fast_forward) |
| Deletions | Blocked | Blocked |
| Admin bypass | No | Yes (RepositoryRole: Admin) |
| Merge queue | N/A | Enabled (new) |

Legacy branch protection rules have been deleted.

### Enable merge queue (#61)

Merge queue is configured in the ruleset with:
- **Merge method:** squash
- **Grouping:** ALLGREEN (all PRs in group must pass checks)
- **Build concurrency:** 5
- **Min entries:** 1 (no batching delay for solo PRs)
- **Wait time:** 1 min before merging below min threshold
- **Check timeout:** 30 min

Added `merge_group: {}` trigger to `ci.yaml` so CI runs on merge queue
events.

### Release environment with approval gate (#67)

Created a `release` environment with:
- **Required reviewer:** @SebTardif
- **Deployment policy:** restricted to `v*` tags only
- **Admin bypass:** enabled

The release workflow now declares `environment: release`, so pushing a
`v*` tag will pause the release job until approved in the GitHub UI.

Closes #75
Closes #61
Closes #67