### PR TITLE
ci: add workflow_dispatch to Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   schedule:
     - cron: "0 6 * * 1"
+  workflow_dispatch: {}
 
 permissions: read-all
 


### PR DESCRIPTION
Enables manual Scorecard runs for debugging SAST coverage gaps.

The SAST alert (28/30 commits covered) was caused by two historical commits
(`c269cdf` and `747042f`) missing CodeQL check run associations. The
security workflow ran successfully on both, but the codeql-action at the time
did not create the check run annotation. Re-running those security workflows
fixed the check run gap.

This PR adds `workflow_dispatch` to the Scorecard workflow so future
coverage gaps can be verified immediately instead of waiting for the next
push to main or the weekly schedule.

Closes #78