### PR TITLE
feat: publish container image to Docker Hub for discoverability

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
@@ -82,6 +88,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            docker.io/attuneio/attune:${{ github.ref_name }}
+            docker.io/attuneio/attune:latest
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
@@ -94,11 +102,17 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Sign container image
+      - name: Sign GHCR image
         shell: bash -Eeuo pipefail -x {0}
         run: |
           cosign sign --yes \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+
+      - name: Sign Docker Hub image
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          cosign sign --yes \
+            docker.io/attuneio/attune@${{ steps.build.outputs.digest }}
 
       - name: Attest container image
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
@@ -219,3 +233,24 @@ jobs:
       registry-username: ${{ github.actor }}
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  # Sync docker/README.md to the Docker Hub repository description.
+  dockerhub-readme:
+    name: Docker Hub README
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [release]
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: attuneio/attune
+          readme-filepath: docker/README.md
+          short-description: "Safe, in-place Kubernetes pod resource right-sizing. VPA done right."

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Go Version](https://img.shields.io/badge/go-1.26-blue)](go.mod)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12998/badge)](https://www.bestpractices.dev/projects/12998)
+[![Docker Hub](https://img.shields.io/docker/pulls/attuneio/attune)](https://hub.docker.com/r/attuneio/attune)
 
 **Safe, in-place Kubernetes pod resource right-sizing. VPA done right.**
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,69 @@
+# Attune
+
+Safe, in-place Kubernetes pod resource right-sizing. VPA done right.
+
+## Quick reference
+
+- **Source**: [github.com/attune-io/attune](https://github.com/attune-io/attune)
+- **Documentation**: [github.com/attune-io/attune#documentation](https://github.com/attune-io/attune#documentation)
+- **Issues**: [github.com/attune-io/attune/issues](https://github.com/attune-io/attune/issues)
+- **License**: Apache 2.0
+
+## What is Attune?
+
+Attune is a Kubernetes operator that automatically right-sizes pod resource
+requests and limits using In-Place Pod Resize (beta in Kubernetes 1.33+, alpha
+with feature gate in 1.32). No pod restarts, no HPA conflicts, no outages.
+
+## Supported tags
+
+- `latest` - latest stable release
+- `vX.Y.Z` - specific version (e.g., `v0.1.1`)
+
+## Supported architectures
+
+- `linux/amd64`
+- `linux/arm64`
+
+## How to use this image
+
+> **Recommended registry**: For production use, pull from GHCR to avoid
+> Docker Hub rate limits:
+> ```bash
+> ghcr.io/attune-io/attune:latest
+> ```
+
+### Install with Helm (recommended)
+
+```bash
+helm install attune oci://ghcr.io/attune-io/charts/attune \
+  --namespace attune-system --create-namespace
+```
+
+### Pull from Docker Hub
+
+```bash
+docker pull attuneio/attune:latest
+```
+
+### Verify image signature
+
+All images are signed with cosign (keyless, Sigstore):
+
+```bash
+cosign verify \
+  --certificate-identity-regexp="https://github.com/attune-io/attune" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  attuneio/attune:latest
+```
+
+## Security
+
+- Runs as non-root (UID 65532)
+- Distroless base image (no shell, no package manager)
+- Signed with cosign + SLSA Level 3 provenance
+- Trivy-scanned on every release
+
+## Source
+
+[https://github.com/attune-io/attune](https://github.com/attune-io/attune)

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -53,7 +53,16 @@ cosign verify \
   ghcr.io/attune-io/attune:v0.2.0
 ```
 
-### 5. Helm chart publishing
+### 5. Docker Hub publishing
+
+The release workflow also pushes the same multi-arch image to Docker Hub
+at `docker.io/attuneio/attune`. The Docker Hub README is synced from
+`docker/README.md` on each release.
+
+Both the GHCR and Docker Hub images share the same digest and are
+cosign-signed independently.
+
+### 6. Helm chart publishing
 
 The Helm chart is published as an OCI artifact to `ghcr.io/attune-io/charts/attune`.
 
@@ -71,7 +80,7 @@ helm package charts/attune
 helm push attune-0.2.0.tgz oci://ghcr.io/attune-io/charts
 ```
 
-### 6. Static install manifest
+### 7. Static install manifest
 
 Generate the combined install manifest for users who do not use Helm:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,6 +39,11 @@ helm install attune \
     (`prometheus-server`, `prometheus-kube-prometheus-prometheus`) in
     common namespaces.
 
+!!! info "Also available on Docker Hub"
+    The container image is also published to Docker Hub at
+    `docker.io/attuneio/attune` for discoverability. For production
+    use, GHCR is recommended (no rate limits on public packages).
+
 ### Upgrading
 
 !!! important "CRDs are not updated by `helm upgrade`"

--- a/lychee.toml
+++ b/lychee.toml
@@ -4,6 +4,7 @@ exclude = [
   "0\\.0\\.0\\.0",
   "example\\.com",
   "medium\\.com",
+  "hub\\.docker\\.com",
 ]
 exclude_loopback = true
 max_concurrency = 8


### PR DESCRIPTION
## Summary

Adds Docker Hub as a second push target in the release workflow for discoverability. GHCR remains the primary registry for all documentation, Helm chart defaults, and install manifests.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yaml` | Docker Hub login, image tags, cosign signing, README sync job |
| `docker/README.md` | New Docker Hub-specific README (shorter, pull-focused) |
| `README.md` | Docker Hub pulls badge |
| `docs/getting-started/installation.md` | "Also available on Docker Hub" note |
| `docs/contributing/releasing.md` | Docker Hub section in release process |

## What stays the same

- Helm chart `image.repository` stays `ghcr.io/attune-io/attune`
- All install docs default to GHCR
- `config/manager/kustomization.yaml` stays GHCR
- `dist/install.yaml` stays GHCR

## Prerequisites before next release

Two repo secrets must be configured:
- `DOCKERHUB_USERNAME`: Docker Hub username or bot account for `attuneio` org
- `DOCKERHUB_TOKEN`: Docker Hub access token (read/write scope)

## Verification

After the first tagged release with this workflow:
1. `docker pull attuneio/attune:vX.Y.Z` works
2. `cosign verify` passes for both GHCR and Docker Hub
3. Docker Hub repo page shows the README from `docker/README.md`

Closes #12