### PR TITLE
fix(ci): handle transient API failures in E2E lint/unit gate polling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -483,7 +483,8 @@ jobs:
           echo "Waiting for lint and test-unit jobs to complete..."
           for i in $(seq 1 60); do
             jobs_json=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.name == "Lint" or .name == "Unit Tests") | {name: .name, status: .status, conclusion: .conclusion}]')
+              --jq '[.jobs[] | select(.name == "Lint" or .name == "Unit Tests") | {name: .name, status: .status, conclusion: .conclusion}]') || { echo "API call failed, retrying..."; sleep 5; continue; }
+            echo "$jobs_json" | jq empty 2>/dev/null || { echo "Malformed JSON from API, retrying..."; sleep 5; continue; }
 
             all_done=true
             any_failed=false


### PR DESCRIPTION
The 'Wait for lint and unit gate' step polls the GitHub API to check job status before running E2E tests. If the API returns truncated JSON, jq parse fails and `set -Eeuo pipefail` kills the step immediately.

**Fix:** Validate the API response with `jq empty` before parsing, and continue the poll loop on transient failures instead of aborting the entire E2E job.

**Root cause:** PR #132 CI run [26617885011](https://github.com/attune-io/attune/actions/runs/26617885011) failed because `gh api` returned an unfinished JSON string, causing `jq: parse error: Unfinished string at EOF`.