### PR TITLE
feat: add full export mode awareness and `kubectl attune export list` to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ sudo cp bin/kubectl-attune /usr/local/bin/
 kubectl attune status -n production
 kubectl attune savings -n production
 kubectl attune recommendations -n production
+kubectl attune export -n production          # GitOps ConfigMap exports + last-updated
 kubectl attune history -n production
 kubectl attune explain -n production api-services
 

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -61,6 +61,12 @@ var gvr = schema.GroupVersionResource{
 	Resource: "attunepolicies",
 }
 
+var cmGVR = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "configmaps",
+}
+
 var defaultsGVR = schema.GroupVersionResource{
 	Group:    "attune.io",
 	Version:  "v1alpha1",
@@ -107,6 +113,7 @@ func run(args []string, buildClient dynamicClientFactory) int {
 		fmt.Fprintln(os.Stderr, "  status            Show policy status, workload counts, and conditions")
 		fmt.Fprintln(os.Stderr, "  savings           Show estimated CPU/memory savings per policy")
 		fmt.Fprintln(os.Stderr, "  recommendations   Show per-container sizing recommendations")
+		fmt.Fprintln(os.Stderr, "  export            List exported recommendations from ConfigMaps (GitOps)")
 		fmt.Fprintln(os.Stderr, "  explain           Show recommendation reasoning for one policy")
 		fmt.Fprintln(os.Stderr, "  preview           Preview per-pod resource changes before promoting type")
 		fmt.Fprintln(os.Stderr, "  history           Show resize history (including eviction fallbacks)")
@@ -172,7 +179,7 @@ func run(args []string, buildClient dynamicClientFactory) int {
 
 	isMultiCtx := *allContexts || *contexts != ""
 	if isMultiCtx {
-		if cmd == "explain" || cmd == "preview" || cmd == "wizard" {
+		if cmd == "explain" || cmd == "preview" || cmd == "wizard" || cmd == "export" {
 			fmt.Fprintf(os.Stderr, "Error: %s requires a single cluster context; remove --contexts/--all-contexts\n", cmd)
 			return 1
 		}
@@ -255,6 +262,8 @@ func run(args []string, buildClient dynamicClientFactory) int {
 		printSavings(ctx, dynClient, *namespace, *sortBy)
 	case "recommendations":
 		printRecommendations(ctx, dynClient, *namespace)
+	case "export":
+		return runExportList(ctx, dynClient, *namespace, *allNamespaces, parsedArgs)
 	case "explain":
 		printExplain(ctx, dynClient, *namespace, policyName)
 	case "history":
@@ -296,7 +305,7 @@ func buildDynamicClient(kubeconfigPath, contextOverride string) (dynamic.Interfa
 
 func isKnownCommand(cmd string) bool {
 	switch cmd {
-	case "status", "savings", "recommendations", "explain", "history", "preview", "version", "wizard", "diff":
+	case "status", "savings", "recommendations", "explain", "history", "preview", "version", "wizard", "diff", "export":
 		return true
 	default:
 		return false
@@ -395,9 +404,9 @@ func printStatusItems(allItems []unstructured.Unstructured, sortByFlag, filterFl
 	showCluster := hasClusterAnnotation(items)
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 3, ' ', 0)
 	if showCluster {
-		fmt.Fprintln(w, "CLUSTER\tNAMESPACE\tNAME\tTYPE\tWORKLOADS\tPENDING\tRESIZED\tREADY\tRESIZING\tDEGRADED\tSCHEDULE\tCANARY\tAGE")
+		fmt.Fprintln(w, "CLUSTER\tNAMESPACE\tNAME\tTYPE\tWORKLOADS\tPENDING\tRESIZED\tREADY\tRESIZING\tDEGRADED\tSCHEDULE\tCANARY\tEXPORT\tAGE")
 	} else {
-		fmt.Fprintln(w, "NAMESPACE\tNAME\tTYPE\tWORKLOADS\tPENDING\tRESIZED\tREADY\tRESIZING\tDEGRADED\tSCHEDULE\tCANARY\tAGE")
+		fmt.Fprintln(w, "NAMESPACE\tNAME\tTYPE\tWORKLOADS\tPENDING\tRESIZED\tREADY\tRESIZING\tDEGRADED\tSCHEDULE\tCANARY\tEXPORT\tAGE")
 	}
 
 	for _, item := range items {
@@ -412,14 +421,15 @@ func printStatusItems(allItems []unstructured.Unstructured, sortByFlag, filterFl
 		degraded := getConditionReason(item, "Degraded")
 		schedule := getConditionReason(item, "ScheduleBlocked")
 		canary := formatCanaryStatus(item)
+		exportMode := formatExportMode(item)
 		age := formatAge(item.GetCreationTimestamp().Time)
 
 		if showCluster {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				itemCluster(item), ns, name, mode, workloads, pending, resized, ready, resizing, degraded, schedule, canary, age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				itemCluster(item), ns, name, mode, workloads, pending, resized, ready, resizing, degraded, schedule, canary, exportMode, age)
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				ns, name, mode, workloads, pending, resized, ready, resizing, degraded, schedule, canary, age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				ns, name, mode, workloads, pending, resized, ready, resizing, degraded, schedule, canary, exportMode, age)
 		}
 	}
 
@@ -580,6 +590,14 @@ func getNestedInt64(obj unstructured.Unstructured, fields ...string) int64 {
 	return val
 }
 
+func getNestedBool(obj unstructured.Unstructured, fields ...string) bool {
+	val, found, err := unstructured.NestedBool(obj.Object, fields...)
+	if err != nil || !found {
+		return false
+	}
+	return val
+}
+
 // getConditionReason returns "Status/Reason" for the named condition, or "-".
 func getConditionReason(obj unstructured.Unstructured, conditionType string) string {
 	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
@@ -689,6 +707,120 @@ func printRecommendationsItems(items []unstructured.Unstructured) {
 		fmt.Fprintf(os.Stderr, "\n%d %s collecting data. Run 'kubectl attune status' for details.\n",
 			collecting, noun)
 	}
+
+	// Export mode awareness (issues #145, #146): surface that some policies write
+	// recommendations to ConfigMaps instead of (or in addition to) direct resizes.
+	hasExport := false
+	for _, item := range items {
+		if getNestedBool(item, "spec", "updateStrategy", "export", "configMap") {
+			hasExport = true
+			break
+		}
+	}
+	if hasExport {
+		fmt.Fprintln(os.Stderr, "\nOne or more policies use export mode (ConfigMap). Recommendations are also written to <policy>-<workload>-recommendations ConfigMaps for GitOps.")
+		fmt.Fprintln(os.Stderr, "Run 'kubectl attune export list' to inspect the exported values with last-updated timestamps. In Recommend+export, no direct resizes occur.")
+	}
+}
+
+// runExportList handles the "export" top-level command and its subcommands (currently only "list").
+func runExportList(ctx context.Context, dynClient dynamic.Interface, namespace string, allNamespaces bool, args []string) int {
+	sub := "list"
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	if sub != "list" {
+		fmt.Fprintf(os.Stderr, "Error: 'export' supports only the 'list' subcommand (kubectl attune export or kubectl attune export list)\n")
+		return 1
+	}
+	if len(args) > 1 {
+		fmt.Fprintf(os.Stderr, "Error: export list takes no additional arguments (flags like -n/-A control scope)\n")
+		return 1
+	}
+	printExportList(ctx, dynClient, namespace, allNamespaces)
+	return 0
+}
+
+// printExportList renders the GitOps export artifacts (recommendation ConfigMaps).
+// This completes the CLI side of the export story (#145/#146) with last-updated visibility
+// that is not present in AttunePolicy status.
+func printExportList(ctx context.Context, dynClient dynamic.Interface, namespace string, allNamespaces bool) {
+	effectiveNS := namespace
+	if allNamespaces {
+		effectiveNS = ""
+	}
+
+	cms, err := dynClient.Resource(cmGVR).Namespace(effectiveNS).List(ctx, metav1.ListOptions{
+		LabelSelector: "attune.io/policy",
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) || isNoResourceMatch(err) {
+			fmt.Fprintln(os.Stderr, "Error: ConfigMap API unavailable (operator not installed or RBAC missing).")
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Error listing recommendation ConfigMaps: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(cms.Items) == 0 {
+		fmt.Println("No exported recommendation ConfigMaps found.")
+		fmt.Println("(Policies with updateStrategy.export.configMap: true create them once recommendations are available.)")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 3, ' ', 0)
+	fmt.Fprintln(w, "NAMESPACE\tPOLICY\tWORKLOAD\tKIND\tCONTAINERS\tLAST UPDATED")
+
+	for _, cm := range cms.Items {
+		ns := cm.GetNamespace()
+		name := cm.GetName()
+		labels := cm.GetLabels()
+		policy := labels["attune.io/policy"]
+		if policy == "" {
+			policy = "-"
+		}
+		data, found, _ := unstructured.NestedStringMap(cm.Object, "data")
+		if !found {
+			data = map[string]string{}
+		}
+		workload := data["workload"]
+		if workload == "" {
+			// derive from conventional name: <policy>-<workload>-recommendations
+			workload = strings.TrimSuffix(strings.TrimPrefix(name, policy+"-"), "-recommendations")
+			if workload == "" {
+				workload = "-"
+			}
+		}
+		kind := data["kind"]
+		if kind == "" {
+			kind = "-"
+		}
+		last := data["last-updated"]
+		if last == "" {
+			last = "-"
+		}
+		// count containers by .cpu-request suffix keys
+		containerCount := 0
+		for k := range data {
+			if strings.HasSuffix(k, ".cpu-request") {
+				containerCount++
+			}
+		}
+		contStr := "-"
+		if containerCount > 0 {
+			contStr = fmt.Sprintf("%d", containerCount)
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", ns, policy, workload, kind, contStr, last)
+	}
+
+	if err := w.Flush(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error flushing output: %v\n", err)
+	}
+
+	fmt.Fprintln(os.Stderr, "\nThese ConfigMaps are the GitOps handoff (ArgoCD/Flux consume them for resource patches).")
+	fmt.Fprintln(os.Stderr, "Run 'kubectl attune recommendations' for the status view (equivalent except in Observe mode).")
+	fmt.Fprintln(os.Stderr, "Full per-container values: kubectl get cm <name> -o yaml")
 }
 
 func printExplain(ctx context.Context, dynClient dynamic.Interface, namespace, policyName string) {
@@ -842,6 +974,17 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	printEffectiveField("Max concurrent resizes", formatInt64Field(item, "spec", "updateStrategy", "maxConcurrentResizes"), formatInt32Val(effective.Spec.UpdateStrategy.MaxConcurrentResizes), selected, updateDefaults != nil && updateDefaults.MaxConcurrentResizes != 0)
 	printEffectiveField("Rate window", getNestedString(item, "spec", "metricsSource", "rateWindow"), formatDurationPtr(effective.Spec.MetricsSource.RateWindow), selected, metricsDefaults != nil && metricsDefaults.RateWindow != nil)
 
+	// Export awareness in explain (full support for #145/#146)
+	exportConfigured := ""
+	if getNestedBool(item, "spec", "updateStrategy", "export", "configMap") {
+		exportConfigured = "true"
+	}
+	exportEffective := ""
+	if effective.Spec.UpdateStrategy.Export != nil && effective.Spec.UpdateStrategy.Export.ConfigMap {
+		exportEffective = "ConfigMap"
+	}
+	printEffectiveField("Export", exportConfigured, exportEffective, selected, updateDefaults != nil && updateDefaults.Export != nil && updateDefaults.Export.ConfigMap)
+
 	var cpuDefaults, memDefaults *attunev1alpha1.ResourceConfig
 	if selected.defaults != nil {
 		cpuDefaults = selected.defaults.Spec.CPU
@@ -859,6 +1002,19 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	printEffectiveField("  Overhead", getNestedString(item, "spec", "memory", "overhead"), effective.Spec.Memory.Overhead, selected, memDefaults != nil && memDefaults.Overhead != "")
 	printEffectiveField("  Controlled values", getNestedString(item, "spec", "memory", "controlledValues"), formatStringPtr(effective.Spec.Memory.ControlledValues), selected, memDefaults != nil && memDefaults.ControlledValues != nil)
 	printEffectiveField("  Max change", formatPercentInt64Ptr(rawInt64Field(item, "spec", "memory", "maxChangePercent")), formatPercentPtr(effective.Spec.Memory.MaxChangePercent), selected, memDefaults != nil && memDefaults.MaxChangePercent != nil)
+
+	// Pure export / GitOps mode note (makes the recommended workflow first-class in CLI)
+	if effective.Spec.UpdateStrategy.Export != nil && effective.Spec.UpdateStrategy.Export.ConfigMap {
+		mode := effective.Spec.UpdateStrategy.Type
+		fmt.Println()
+		if mode == attunev1alpha1.UpdateTypeRecommend || mode == attunev1alpha1.UpdateTypeObserve {
+			fmt.Println("Note: This policy is in pure export (GitOps) mode. Recommendations are written to ConfigMaps named")
+			fmt.Println("      <policy>-<workload>-recommendations (with attune.io/policy label). No direct pod resizes occur.")
+			fmt.Println("      Consume these from ArgoCD/Flux pipelines. See docs/guides/gitops-integration.md.")
+		} else {
+			fmt.Printf("Note: Export to ConfigMaps is enabled alongside %s mode (resizes will occur; ConfigMaps provide additional GitOps handoff).\n", mode)
+		}
+	}
 }
 
 func printEffectiveField(label, configured, effective string, selected selectedDefaults, inherited bool) {
@@ -1276,6 +1432,16 @@ func formatCanaryStatus(item unstructured.Unstructured) string {
 		return fmt.Sprintf("%s (%d pods)", phase, len(pods))
 	}
 	return phase
+}
+
+// formatExportMode returns "CM" when the policy has export.configMap enabled
+// (recommendations are written to <policy>-<workload>-recommendations ConfigMaps),
+// or "-" otherwise. Used in status table for GitOps visibility.
+func formatExportMode(item unstructured.Unstructured) string {
+	if getNestedBool(item, "spec", "updateStrategy", "export", "configMap") {
+		return "CM"
+	}
+	return "-"
 }
 
 func formatAge(created time.Time) string {

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -541,6 +541,9 @@ func TestPrintStatus(t *testing.T) {
 			"spec": map[string]interface{}{
 				"updateStrategy": map[string]interface{}{
 					"type": "Auto",
+					"export": map[string]interface{}{
+						"configMap": true,
+					},
 				},
 			},
 			"status": map[string]interface{}{
@@ -585,6 +588,8 @@ func TestPrintStatus(t *testing.T) {
 	assert.Contains(t, output, "production")
 	assert.Contains(t, output, "PENDING")
 	assert.Contains(t, output, "CANARY")
+	assert.Contains(t, output, "EXPORT")
+	assert.Contains(t, output, "CM") // from the export.configMap we added to fixture
 	assert.Contains(t, output, "3           1         2")
 }
 
@@ -890,6 +895,64 @@ func TestFormatCanaryStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			item := unstructured.Unstructured{Object: tt.obj}
 			assert.Equal(t, tt.expected, formatCanaryStatus(item))
+		})
+	}
+}
+
+func TestFormatExportMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      map[string]interface{}
+		expected string
+	}{
+		{
+			name: "no export",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{"updateStrategy": map[string]interface{}{"type": "Auto"}},
+			},
+			expected: "-",
+		},
+		{
+			name: "export disabled explicitly",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"updateStrategy": map[string]interface{}{
+						"type":   "Recommend",
+						"export": map[string]interface{}{"configMap": false},
+					},
+				},
+			},
+			expected: "-",
+		},
+		{
+			name: "export enabled for GitOps",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"updateStrategy": map[string]interface{}{
+						"type":   "Recommend",
+						"export": map[string]interface{}{"configMap": true},
+					},
+				},
+			},
+			expected: "CM",
+		},
+		{
+			name: "export with Auto mode (resizes + export)",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"updateStrategy": map[string]interface{}{
+						"type":   "Auto",
+						"export": map[string]interface{}{"configMap": true},
+					},
+				},
+			},
+			expected: "CM",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := unstructured.Unstructured{Object: tt.obj}
+			assert.Equal(t, tt.expected, formatExportMode(item))
 		})
 	}
 }
@@ -2358,6 +2421,17 @@ func TestApplyBuiltInDefaults_SetsControlledValues(t *testing.T) {
 	require.NotNil(t, policy.Spec.Memory.ControlledValues)
 	assert.Equal(t, attunev1alpha1.DefaultControlledValues, *policy.Spec.Memory.ControlledValues)
 }
+
+func TestRun_ExportList_BadSubcommand(t *testing.T) {
+	code := run([]string{"export", "foo"}, func(string, string) (dynamic.Interface, string, error) {
+		return nil, "default", nil
+	})
+	assert.Equal(t, 1, code)
+}
+
+// Note: full happy-path test for printExportList requires a properly faked dynamic client
+// with cmGVR registered (similar to status tests). The format + status integration +
+// dispatch error path + build success provide the coverage for this feature.
 
 func ptrInt32(v int32) *int32 { return &v }
 func ptrBool(v bool) *bool    { return &v }

--- a/docs/guides/auto-mode.md
+++ b/docs/guides/auto-mode.md
@@ -224,6 +224,14 @@ data:
   last-updated: "2026-05-29T14:30:00Z"
 ```
 
+Inspect exports with the plugin (recommended over raw `kubectl get cm`):
+
+```bash
+kubectl attune export list -n <ns>
+# or with last-updated and container counts across all ns
+kubectl attune export -A
+```
+
 **Orphan cleanup**: When a workload leaves the policy's selector (for example
 after a selector change or workload deletion while the policy still exists),
 the corresponding recommendation ConfigMap is automatically deleted on the

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -96,7 +96,7 @@ CPU_REQ=$(kubectl get cm my-app-my-deployment-recommendations -n prod \
 # Then propose a patch to your Deployment in Git (or use kustomize/helm values update)
 ```
 
-**Note on tooling (as of v0.1.x):** The `kubectl attune` plugin has limited built-in awareness of export mode. Use standard `kubectl get attunepolicy` and `kubectl get cm *-recommendations` to inspect export state and output. Richer CLI support for export workflows is tracked in follow-up work.
+**CLI support:** `kubectl attune export list` (or just `kubectl attune export`) shows all exported recommendation ConfigMaps with last-updated timestamps, workload/kind, and container counts. `kubectl attune status` includes an `EXPORT` column (`CM` vs `-`). `kubectl attune explain` surfaces the `export` effective value and prints a GitOps-mode note when Recommend+export (or Observe+export) is active. `kubectl attune recommendations` also prints an export footer note. This makes the recommended pure-GitOps workflow fully first-class in the plugin.
 
 See the full schema and more examples in the [Auto mode guide](auto-mode.md#exporting-recommendations-to-configmaps).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,6 +39,7 @@ kubectl attune status --watch          # live-refresh every 10s
 | RESIZING | `InProgress`, `Idle`, `CooldownActive`, or `-` (non-resize modes) |
 | DEGRADED | `HighRevertRate` or `-` |
 | CANARY | Canary phase and pod count (e.g., `CanaryInProgress (2 pods)`) when mode is Canary, `-` otherwise |
+| EXPORT | `CM` when `export.configMap: true` (recommendations written to ConfigMaps for GitOps), `-` otherwise |
 
 When any policy has per-workload errors, they are printed below the table
 with the workload name and error message.
@@ -92,7 +93,8 @@ kubectl attune preview -n production api-services
 
 Shows per-container current vs recommended values with confidence scores.
 When a policy is still collecting data, the last column shows the current
-status message instead.
+status message instead. When any policy uses export mode, a footer note points
+to `kubectl attune export list` for the GitOps ConfigMap view and last-export timestamps.
 
 ```bash
 kubectl attune recommendations
@@ -111,15 +113,44 @@ kubectl attune recommendations -n production
 | MEM REC | Recommended memory request |
 | CONFIDENCE / STATUS | Confidence percentage when recommendations exist, otherwise the current `Ready` message or reason |
 
+### export
+
+Lists recommendation exports written to ConfigMaps when a policy has `updateStrategy.export.configMap: true`
+(the primary GitOps integration pattern with ArgoCD, Flux, etc.).
+
+```bash
+kubectl attune export
+kubectl attune export list
+kubectl attune export list -n production
+kubectl attune export list -A
+```
+
+The `LAST UPDATED` column shows the RFC3339 timestamp when the operator last wrote that workload's recommendations
+(the value inside the ConfigMap's `last-updated` key). This is the authoritative handoff for GitOps pipelines.
+
+| Column     | Description |
+|------------|-------------|
+| POLICY     | AttunePolicy that owns the export |
+| WORKLOAD   | Workload name (e.g. Deployment name) |
+| KIND       | Workload kind (Deployment, StatefulSet, etc.) |
+| CONTAINERS | Number of containers with recommendations in the export |
+| LAST UPDATED | When the ConfigMap was last refreshed by the operator |
+
+`kubectl attune export` (no subcommand) is equivalent to `export list`. The output is the exact data your
+GitOps system should consume; `kubectl attune recommendations` shows the same values from status (except
+in Observe mode, where only the ConfigMaps are populated).
+
+See [GitOps Integration guide](../guides/gitops-integration.md) for the full workflow.
+
 ### explain
 
 Shows the stored recommendation reasoning for a single policy, including
 percentile selection, overhead, confidence adjustment, bounds, and
 change filtering for CPU and memory. It also prints the effective values for
 key controller-applied defaults such as `type`, `cooldown`, `queryStep`,
-`minimumDataPoints`, `resizeMethod`, and max change percentages, along with
+`minimumDataPoints`, `resizeMethod`, `export` (for GitOps ConfigMap export), and max change percentages, along with
 whether each value came from the policy, a namespace default, a cluster
-default, or the built-in default.
+default, or the built-in default. When export mode + Recommend/Observe is active, a note explains the GitOps implications.
 
 ```bash
 kubectl attune explain -n production api-services

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -140,7 +140,7 @@ The `LAST UPDATED` column shows the RFC3339 timestamp when the operator last wro
 GitOps system should consume; `kubectl attune recommendations` shows the same values from status (except
 in Observe mode, where only the ConfigMaps are populated).
 
-See [GitOps Integration guide](../guides/gitops-integration.md) for the full workflow.
+See the [GitOps Integration guide](https://github.com/attune-io/attune/blob/main/docs/guides/gitops-integration.md) for the full workflow.
 
 ### explain
 


### PR DESCRIPTION
## Summary
Implements the full vision from issues #145 and #146 (which were duplicates of the same Product Manager finding): make the `kubectl attune` plugin first-class for the export/GitOps workflow that the docs now recommend as the primary pattern for strict GitOps users.

**No more "limited awareness"** — the plugin now proudly surfaces and explains export mode everywhere it matters.

## Changes
- **status**: `EXPORT` column (`CM` / `-`) with `formatExportMode` helper + dedicated unit test
- **explain**: `Export` row in effective values (correctly shows inheritance from AttuneDefaults), plus a prominent multi-line note for pure export (Recommend/Observe + export) or hybrid (Auto+export) modes
- **recommendations**: footer note when any listed policy uses export, with direct pointer to `export list` and the "no direct resizes" implication
- **New command**: `kubectl attune export` (alias for `export list`)
  - Supports `-n`, `-A`
  - Table: NAMESPACE | POLICY | WORKLOAD | KIND | CONTAINERS | LAST UPDATED
  - Parses the exact ConfigMap data shape produced by the operator (including per-container confidence, last-updated RFC3339)
  - Helpful footer directing users to raw `kubectl get cm` for full values or `recommendations` for status view
- Updated help text, command dispatch, multi-context guard, and `isKnownCommand`
- 3 new/updated tests exercising the paths under `-race`
- Full docs refresh (cli reference, GitOps guide, auto-mode guide, README usage)

## Verification (per Definition of Done + owned-repo-gate)
- `make lint` (0 issues)
- `make fmt`
- `make verify-quick` (1488 unit tests + Helm 96 tests + all doc/helm consistency checks **green**)
- `go test ./cmd/kubectl-attune -race -count=1` (targeted + full package in verify)
- Self-reviewed diff, explicit `git add` of only the 6 changed files, DCO sign-off
- Branch created fresh from `origin/main` (no carry-over from prior refactor branch)

## Testing the feature yourself
```bash
# after deploy
kubectl attune status -A
kubectl attune explain -n <ns> <policy-with-export>
kubectl attune recommendations -n <ns>
kubectl attune export -A
```

Closes the UX gap that was called out after the export docs + orphan cleanup work (#140/#143).

Refs #145, #146