### PR TITLE
docs: add hard rule to never push directly to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,14 @@ someValue: "default"
 Using `# --` on every line causes helm-docs to treat each line as a
 separate parameter description, producing garbled output.
 
+### Hard process rule: Never push directly to main
+
+**All changes — no matter how small — must go through a feature branch and Pull Request.** Direct pushes to `main` (including `git push origin main`, force-pushes, or bypassing the merge queue) are forbidden, even for the repo owner.
+
+This applies to code, CI/workflows, Makefile, scripts, and documentation.
+
+See the "Never Push Directly to Main (HARD RULE)" section in `~/.grok/skills/attune-contrib/SKILL.md` for the full rationale and correct workflow.
+
 ### Pull request titles and commit messages
 
 The repository enforces semantic PR titles via [.github/workflows/pr-title.yaml](.github/workflows/pr-title.yaml) (the `amannn/action-semantic-pull-request` action).


### PR DESCRIPTION
Add explicit hard rule (applies even to the repo owner) that all changes must go through a feature branch + Pull Request.

Direct pushes to main (including `git push origin main`) are forbidden.

This formalizes the standing process rule we established.

See also the corresponding section added to `~/.grok/skills/attune-contrib/SKILL.md`.