### PR TITLE
ci: improve lychee link check resilience

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -6,9 +6,14 @@ exclude = [
   "medium\\.com",
   "hub\\.docker\\.com",
   "securityscorecards\\.dev",
+  "twitter\\.com",
+  "x\\.com",
+  "linkedin\\.com",
+  "facebook\\.com",
+  "instagram\\.com",
 ]
 exclude_loopback = true
 max_concurrency = 8
 timeout = 30
-max_retries = 3
+max_retries = 4
 retry_wait_time = 5


### PR DESCRIPTION
Improve resilience of the Link Check job:

- Increase `max_retries` from 3 → 4
- Add common flaky social domains (`twitter.com`, `linkedin.com`, etc.) to the exclude list

This should reduce transient failures we saw on recent main pushes without significantly increasing worst-case runtime.

Refs recent Link Check flakes on main (e.g. run 26686437145).