### PR TITLE
fix: replace inline Python with jq in orphan-cleanup E2E test

### DIFF
--- a/test/e2e/configmap-orphan-cleanup/chainsaw-test.yaml
+++ b/test/e2e/configmap-orphan-cleanup/chainsaw-test.yaml
@@ -148,12 +148,7 @@ spec:
                       echo "ConfigMap $cm missing recommendation data"
                       exit 1
                     fi
-                    WL=$(echo "$DATA" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-labels = d.get('metadata', {}).get('labels', {})
-print(labels.get('attune.io/workload', ''))
-" 2>/dev/null)
+                    WL=$(echo "$DATA" | jq -r '.metadata.labels["attune.io/workload"] // ""')
                     if [ -z "$WL" ]; then
                       echo "ConfigMap $cm missing attune.io/workload label (required for orphan cleanup)"
                       exit 1


### PR DESCRIPTION
The embedded Python script in the configmap-orphan-cleanup Chainsaw test
had lines starting at column 1, breaking the YAML literal block scalar.
Chainsaw failed to parse the test file during `Loading tests...` with:

```
yaml: line 153: could not find expected ':'
```

This broke ALL Chainsaw E2E tests on v1.33, v1.34, and v1.35 in the
nightly since PR #149 was merged.

Replace the multi-line `python3 -c` invocation with a single `jq` call
that extracts the same label value without YAML indentation conflicts.

Closes #150