### PR TITLE
fix: use spec.targetRef.selector in orphan-cleanup E2E test

### DIFF
--- a/test/e2e/configmap-orphan-cleanup/chainsaw-test.yaml
+++ b/test/e2e/configmap-orphan-cleanup/chainsaw-test.yaml
@@ -85,11 +85,13 @@ spec:
                 name: orphan-test
                 namespace: e2e-configmap-orphan
               spec:
-                selector:
-                  matchExpressions:
-                    - key: tier
-                      operator: In
-                      values: ["api", "worker"]
+                targetRef:
+                  kind: Deployment
+                  selector:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values: ["api", "worker"]
                 metricsSource:
                   prometheus:
                     address: http://prometheus-server.monitoring:80
@@ -175,9 +177,11 @@ spec:
                 name: orphan-test
                 namespace: e2e-configmap-orphan
               spec:
-                selector:
-                  matchLabels:
-                    tier: api
+                targetRef:
+                  kind: Deployment
+                  selector:
+                    matchLabels:
+                      tier: api
 
     - name: verify-orphaned-configmap-deleted
       try:


### PR DESCRIPTION
## Problem

The `configmap-orphan-cleanup` Chainsaw E2E test placed `selector` directly under `spec` instead of under `spec.targetRef.selector`, which is where the AttunePolicy CRD defines it. This caused strict decoding errors on all K8s versions (1.32, 1.33, 1.34, 1.35) in the nightly E2E matrix:

```
AttunePolicy in version "v1alpha1" cannot be handled as a AttunePolicy:
strict decoding error: unknown field "spec.selector"
```

## Fix

- Move `selector` under `spec.targetRef.selector` (matching the CRD schema)
- Add the required `targetRef.kind: Deployment` field
- Applied to both the initial create step and the patch step that narrows the selector

## Testing

- Chainsaw lint: passes
- YAML structure validated programmatically
- Will be verified by E2E CI on this PR