### PR TITLE
test: make configmap-export ownerReference assertion fail on mismatch

### DIFF
--- a/test/e2e/configmap-export/chainsaw-test.yaml
+++ b/test/e2e/configmap-export/chainsaw-test.yaml
@@ -94,11 +94,13 @@ spec:
                   DATA=$(kubectl get configmap "$CM" -n e2e-configmap-export -o json)
                   if echo "$DATA" | grep -q "confidence"; then
                     echo "ConfigMap contains recommendation data"
-                    # Verify owner reference
-                    OWNER=$(echo "$DATA" | python3 -c "import sys,json; d=json.load(sys.stdin); refs=d.get('metadata',{}).get('ownerReferences',[]); print(refs[0]['kind'] if refs else '')" 2>/dev/null)
-                    if [ "$OWNER" = "AttunePolicy" ]; then
-                      echo "OwnerReference set correctly"
+                    # Verify owner reference is set to AttunePolicy
+                    OWNER=$(echo "$DATA" | jq -r '.metadata.ownerReferences[0].kind // ""')
+                    if [ "$OWNER" != "AttunePolicy" ]; then
+                      echo "FAIL: expected ownerReference kind=AttunePolicy, got '$OWNER'"
+                      exit 1
                     fi
+                    echo "OwnerReference set correctly"
                     exit 0
                   fi
                 fi


### PR DESCRIPTION
## Problem

The `configmap-export` E2E test's owner reference check was cosmetic: it printed a success message but never failed if the ownerReference was wrong or missing. The test exited 0 at line 102 regardless of the owner reference result. This is a false-pass pattern where the test claims to verify something but does not actually fail if it is wrong.

## Fix

- Changed the check to exit 1 if the ownerReference kind is not `AttunePolicy`
- Replaced inline Python JSON parsing with `jq` for consistency with PR #153's established pattern

## Testing

- Chainsaw lint: passes
- YAML structure validated