### PR TITLE
fix: replace last direct AttunePolicyReconciler struct literal with constructor

### DIFF
--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -8440,10 +8440,9 @@ func TestExportRecommendationConfigMaps_OrphanCleanup(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, activeCM, orphanCM).Build()
-	r := &AttunePolicyReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
-	}
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
 
 	recs := []attunev1alpha1.WorkloadRecommendation{
 		{


### PR DESCRIPTION
## Summary

Replace the last remaining direct `AttunePolicyReconciler{}` struct literal in the test suite with `NewAttunePolicyReconciler()`, completing the migration tracked in #141.

## Problem

`TestExportRecommendationConfigMaps_OrphanCleanup` used a direct struct literal:
```go
r := &AttunePolicyReconciler{
    Client: fakeClient,
    Scheme: scheme,
}
```

This bypasses `eventDedup` initialization. The test accidentally worked because `Recorder` is nil (making `emitEventOnce` return early at line 217 before touching `eventDedup`), but adding a `Recorder` or refactoring `emitEventOnce` would cause a nil pointer panic.

## Fix

```go
r := NewAttunePolicyReconciler()
r.Client = fakeClient
r.Scheme = scheme
```

Closes #141