### PR TITLE
ci: exclude cast.ai from link checker (returns 415)

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -11,6 +11,7 @@ exclude = [
   "linkedin\\.com",
   "facebook\\.com",
   "instagram\\.com",
+  "cast\\.ai",
 ]
 exclude_loopback = true
 max_concurrency = 8


### PR DESCRIPTION
cast.ai report URLs return 415 Unsupported Media Type due to bot detection, causing persistent CI link check failures on main (3 consecutive runs). The URLs are valid industry report references that do not need automated crawl validation.

Affected files: README.md, docs/SPEC.md, docs/savings-calculator.md, docs/why-attune.md