### PR TITLE
ci: exclude cast.ai from lychee link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -11,6 +11,7 @@ exclude = [
   "linkedin\\.com",
   "facebook\\.com",
   "instagram\\.com",
+  "cast\\.ai",
 ]
 exclude_loopback = true
 max_concurrency = 8


### PR DESCRIPTION
cast.ai returns 415 Unsupported Media Type to automated link checkers, causing the Link Check CI job to fail on every main push. The links are valid when accessed from a browser; the site blocks bot user agents.

Adds `cast\.ai` to the lychee exclusion list alongside other sites that reject automated requests (medium.com, hub.docker.com, social media platforms).