### PR TITLE
test: add regression tests for name length validation and isNoResourceMatch

### DIFF
--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -2889,5 +2889,45 @@ func TestWorkloadFromConfigMap(t *testing.T) {
 	}
 }
 
+func TestIsNoResourceMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "server could not find the requested resource",
+			err:      fmt.Errorf("the server could not find the requested resource"),
+			expected: true,
+		},
+		{
+			name:     "no matches for kind",
+			err:      fmt.Errorf("no matches for kind \"AttunePolicy\" in version \"attune.io/v1alpha1\""),
+			expected: true,
+		},
+		{
+			name:     "wrapped error with resource not found",
+			err:      fmt.Errorf("failed to list: %w", fmt.Errorf("the server could not find the requested resource")),
+			expected: true,
+		},
+		{
+			name:     "unrelated error",
+			err:      fmt.Errorf("connection refused"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isNoResourceMatch(tt.err))
+		})
+	}
+}
+
 func ptrInt32(v int32) *int32 { return &v }
 func ptrBool(v bool) *bool    { return &v }

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -8471,6 +8471,51 @@ func TestExportRecommendationConfigMaps_OrphanCleanup(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "orphaned ConfigMap should be deleted")
 }
 
+func TestExportRecommendationConfigMaps_SkipsLongName(t *testing.T) {
+	scheme := testScheme()
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "default",
+			UID:       "abc-123",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.SetNowFunc(func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) })
+
+	// Build a workload name that makes the ConfigMap name exceed 253 chars.
+	// Format: "test-policy-<workload>-recommendations" = 12 + len(workload) + 16 = 28 + len(workload)
+	// Need 28 + len(workload) > 253, so len(workload) >= 226
+	longWorkload := strings.Repeat("x", 226)
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: longWorkload,
+			Kind:     "Deployment",
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{Name: "main", Confidence: 0.9, Recommended: attunev1alpha1.ResourceValues{
+					CPURequest:    resource.MustParse("100m"),
+					MemoryRequest: resource.MustParse("128Mi"),
+				}},
+			},
+		},
+	}
+
+	r.exportRecommendationConfigMaps(context.Background(), policy, recs)
+
+	// ConfigMap should NOT have been created because the name exceeds 253 chars.
+	cmName := fmt.Sprintf("test-policy-%s-recommendations", longWorkload)
+	assert.Greater(t, len(cmName), 253)
+	var cm corev1.ConfigMap
+	err := fakeClient.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      cmName,
+	}, &cm)
+	assert.True(t, apierrors.IsNotFound(err), "ConfigMap with name >253 chars should not be created")
+}
+
 func TestAdjustHPATargets_ScalesTargetUtilization(t *testing.T) {
 	scheme := testScheme()
 	oldTarget := int32(80)


### PR DESCRIPTION
Add missing test coverage for two behaviors introduced in PR #154:

- **`TestExportRecommendationConfigMaps_SkipsLongName`**: verifies that ConfigMap names exceeding the Kubernetes 253-character limit are skipped instead of causing API errors. Uses a 254-char name (policy=12 + workload=226 + suffix=16) and asserts no ConfigMap is created.

- **`TestIsNoResourceMatch`**: table-driven tests for the error-matching function covering nil, both string patterns (`the server could not find the requested resource` and `no matches for kind`), wrapped errors, and unrelated errors.

Found during session-improve review of PR #154 changes.