### PR TITLE
fix: guard SLO guardrail query values against NaN and Inf

### DIFF
--- a/internal/safety/monitor.go
+++ b/internal/safety/monitor.go
@@ -261,6 +261,11 @@ func (m *Monitor) checkSLOGuardrails(ctx context.Context, record ResizeRecord, n
 				"guardrail", g.Name, "pod", record.PodName, "namespace", record.Namespace)
 			continue
 		}
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			m.logger.Info("SLO guardrail query returned non-finite value, skipping",
+				"guardrail", g.Name, "value", value, "pod", record.PodName, "namespace", record.Namespace)
+			continue
+		}
 
 		threshold, err := strconv.ParseFloat(g.Threshold, 64)
 		if err != nil || math.IsNaN(threshold) || math.IsInf(threshold, 0) {

--- a/internal/safety/monitor_test.go
+++ b/internal/safety/monitor_test.go
@@ -18,6 +18,7 @@ package safety
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -1599,6 +1600,81 @@ func TestCheckPod_SLOInfThresholdSkipped(t *testing.T) {
 
 	verdict, err := monitor.CheckPod(context.Background(), record, time.Now())
 	require.NoError(t, err)
+	assert.True(t, verdict.Safe)
+}
+
+func TestCheckPod_SLONaNValueSkipped(t *testing.T) {
+	// When Prometheus returns NaN (e.g. 0/0 in a rate query), the guardrail
+	// must be skipped rather than silently treated as "safe". Without the
+	// NaN guard, both NaN > threshold and NaN < threshold evaluate to false
+	// (IEEE 754), making an indeterminate result pass as safe.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-0", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 0},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(pod)
+	monitor := NewMonitor(clientset, testr.New(t))
+	querier := &mockSLOQuerier{value: math.NaN()}
+	monitor.WithSLOChecker(querier, []attunev1alpha1.SLOGuardrail{
+		{Name: "latency", Query: "up", Threshold: "0.99", Comparison: "above"},
+	})
+
+	record := ResizeRecord{
+		PodName:   "web-0",
+		Namespace: "default",
+		Container: "app",
+		ResizedAt: time.Now().Add(-6 * time.Minute),
+	}
+
+	verdict, err := monitor.CheckPod(context.Background(), record, time.Now())
+	require.NoError(t, err)
+	// NaN value is skipped (logged), so verdict is safe.
+	assert.True(t, verdict.Safe)
+}
+
+func TestCheckPod_SLOInfValueSkipped(t *testing.T) {
+	// Inf query values must be detected and skipped. Without the guard,
+	// Inf > 0.99 = true = breach = unsafe, which is incorrect because
+	// the value is non-finite and should not trigger a revert.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-0", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 0},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(pod)
+	monitor := NewMonitor(clientset, testr.New(t))
+	querier := &mockSLOQuerier{value: math.Inf(1)}
+	monitor.WithSLOChecker(querier, []attunev1alpha1.SLOGuardrail{
+		{Name: "latency", Query: "up", Threshold: "0.99", Comparison: "above"},
+	})
+
+	record := ResizeRecord{
+		PodName:   "web-0",
+		Namespace: "default",
+		Container: "app",
+		ResizedAt: time.Now().Add(-6 * time.Minute),
+	}
+
+	verdict, err := monitor.CheckPod(context.Background(), record, time.Now())
+	require.NoError(t, err)
+	// Inf value is skipped (logged), so verdict is safe.
 	assert.True(t, verdict.Safe)
 }
 


### PR DESCRIPTION
IEEE 754 makes NaN comparisons silently evaluate to false, so a Prometheus query returning NaN (e.g. `0/0` in a rate query) would cause `checkSLOGuardrails` to treat an indeterminate result as safe. Similarly, Inf could trigger spurious breaches.

The threshold was already guarded (`strconv.ParseFloat` NaN/Inf check on line 266), but the query value returned by `m.sloQuerier.Query()` was not checked. This adds the same guard for query results and logs a warning when non-finite values are encountered.

### Changes

- `internal/safety/monitor.go`: Add NaN/Inf check after SLO query, skip with info-level log
- `internal/safety/monitor_test.go`: Add `TestCheckPod_SLONaNValueSkipped` and `TestCheckPod_SLOInfValueSkipped` regression tests