### PR TITLE
fix: add observability logging for request clamping and NaN/Inf data quality

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -622,6 +622,49 @@ helm upgrade attune attune/attune \
   --set logging.level=info
 ```
 
+### NaN or Inf values in Prometheus data
+
+**Symptom**: Debug logs (V(1)) show messages like `All CPU samples were
+NaN/Inf` or `All memory samples were NaN/Inf`, and the policy remains in
+`InsufficientData` state despite Prometheus being reachable.
+
+**Cause**: Prometheus queries can return NaN (e.g., 0/0 division in rate
+queries when no samples exist yet) or Inf when scrape data is missing or
+contains malformed values. The operator filters out non-finite values
+before computing recommendations to prevent corrupted percentile
+calculations.
+
+**Fix**:
+
+1. Check if Prometheus has cAdvisor metrics for your namespace:
+
+    ```bash
+    kubectl exec -n monitoring prometheus-0 -- \
+      wget -qO- 'http://localhost:9090/api/v1/query?query=container_cpu_usage_seconds_total{namespace="YOUR_NS"}' \
+      | head -c 200
+    ```
+
+2. If the query returns data but values are NaN, check for recording rules
+   or relabeling that might divide by zero.
+3. Wait for more scrape cycles. NaN values are common during the first few
+   minutes after pod creation when Prometheus has only one data point
+   (rate computation needs at least two).
+
+### Requests clamped to limits
+
+**Symptom**: Debug logs (V(1)) show `Requests clamped to limits` with a
+list of affected resources (e.g., `cpu`, `memory`).
+
+**Cause**: The recommended CPU or memory request exceeds the container's
+current limit. This happens when `controlledValues` is set to
+`RequestsOnly` (limits stay at their current values) and the
+recommendation grows beyond those limits. The operator caps the request
+at the limit to prevent the API server from rejecting the resize.
+
+**Fix**: Either increase the container's limits, or switch to
+`controlledValues: RequestsAndLimits` so the operator can scale limits
+proportionally with requests.
+
 ## Debug commands
 
 Operator logs:

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -7002,7 +7002,7 @@ func TestBuildResizeTarget_OmitsLimitsWhenZero(t *testing.T) {
 			MemoryRequest: resource.MustParse("128Mi"),
 		},
 	}
-	target := buildResizeTarget(rec)
+	target, _ := buildResizeTarget(rec)
 	assert.Equal(t, int64(100), target.Requests.Cpu().MilliValue())
 	wantMem := resource.MustParse("128Mi")
 	assert.Equal(t, wantMem.Value(), target.Requests.Memory().Value())
@@ -7019,7 +7019,7 @@ func TestBuildResizeTarget_IncludesLimitsWhenNonZero(t *testing.T) {
 			MemoryLimit:   resource.MustParse("256Mi"),
 		},
 	}
-	target := buildResizeTarget(rec)
+	target, _ := buildResizeTarget(rec)
 	require.NotNil(t, target.Limits)
 	assert.Equal(t, int64(200), target.Limits.Cpu().MilliValue())
 	wantMemLim := resource.MustParse("256Mi")
@@ -7035,7 +7035,7 @@ func TestBuildResizeTarget_PartialLimits(t *testing.T) {
 			MemoryRequest: resource.MustParse("128Mi"),
 		},
 	}
-	target := buildResizeTarget(rec)
+	target, _ := buildResizeTarget(rec)
 	require.NotNil(t, target.Limits, "Limits should be non-nil when any limit is non-zero")
 	assert.Equal(t, int64(200), target.Limits.Cpu().MilliValue())
 	_, hasMemLimit := target.Limits[corev1.ResourceMemory]
@@ -7052,12 +7052,14 @@ func TestBuildResizeTarget_ClampsRequestsToLimits(t *testing.T) {
 			MemoryLimit:   resource.MustParse("512Mi"), // Limit < Request
 		},
 	}
-	target := buildResizeTarget(rec)
+	target, clamped := buildResizeTarget(rec)
 	// Requests should be clamped to limits.
 	assert.Equal(t, resource.MustParse("500m"), target.Requests[corev1.ResourceCPU],
 		"CPU request should be clamped to limit")
 	assert.Equal(t, resource.MustParse("512Mi"), target.Requests[corev1.ResourceMemory],
 		"Memory request should be clamped to limit")
+	assert.ElementsMatch(t, []string{"cpu", "memory"}, clamped,
+		"both CPU and memory should be reported as clamped")
 }
 
 func TestBuildResizeTarget_NoClampsWhenRequestsBelowLimits(t *testing.T) {
@@ -7070,11 +7072,12 @@ func TestBuildResizeTarget_NoClampsWhenRequestsBelowLimits(t *testing.T) {
 			MemoryLimit:   resource.MustParse("512Mi"),
 		},
 	}
-	target := buildResizeTarget(rec)
+	target, clamped := buildResizeTarget(rec)
 	assert.Equal(t, resource.MustParse("200m"), target.Requests[corev1.ResourceCPU],
 		"CPU request should not be modified when below limit")
 	assert.Equal(t, resource.MustParse("256Mi"), target.Requests[corev1.ResourceMemory],
 		"Memory request should not be modified when below limit")
+	assert.Empty(t, clamped, "no resources should be clamped when requests are below limits")
 }
 
 func TestTryEvictionFallback_EvictsWhenMultipleReplicas(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -1743,6 +1743,34 @@ func TestComputeRecommendations_InsufficientDataPoints(t *testing.T) {
 	assert.Nil(t, rec) // No recommendation because data points are insufficient
 }
 
+func TestComputeRecommendations_AllNaNInfSamplesLogsDataQuality(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	deploy := newTestDeployment("api-server", "default", nil)
+	reconciler := newReconcilerWithClient()
+
+	// Return samples with all NaN values. BuildProfile filters them out,
+	// producing DataPoints == 0 while len(samples) > 0. This exercises
+	// the V(1) "All CPU/memory samples were NaN/Inf" log path added in #171.
+	nanSamples := make([]rsmetrics.Sample, 50)
+	now := time.Now()
+	for i := range nanSamples {
+		nanSamples[i] = rsmetrics.Sample{
+			Timestamp: now.Add(-time.Duration(50-i) * time.Hour),
+			Value:     math.NaN(),
+		}
+	}
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return nanSamples, nil
+		},
+	}
+
+	rec, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, rec, "no recommendation when all samples are NaN")
+}
+
 func TestComputeRecommendations_QueryError(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	deploy := newTestDeployment("api-server", "default", nil)
@@ -7078,6 +7106,25 @@ func TestBuildResizeTarget_NoClampsWhenRequestsBelowLimits(t *testing.T) {
 	assert.Equal(t, resource.MustParse("256Mi"), target.Requests[corev1.ResourceMemory],
 		"Memory request should not be modified when below limit")
 	assert.Empty(t, clamped, "no resources should be clamped when requests are below limits")
+}
+
+func TestBuildResizeTarget_PartialClamping(t *testing.T) {
+	rec := attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Recommended: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("800m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+			CPULimit:      resource.MustParse("500m"),  // Limit < Request (clamped)
+			MemoryLimit:   resource.MustParse("512Mi"), // Limit > Request (not clamped)
+		},
+	}
+	target, clamped := buildResizeTarget(rec)
+	assert.Equal(t, resource.MustParse("500m"), target.Requests[corev1.ResourceCPU],
+		"CPU request should be clamped to limit")
+	assert.Equal(t, resource.MustParse("256Mi"), target.Requests[corev1.ResourceMemory],
+		"Memory request should not be modified when below limit")
+	assert.Equal(t, []string{"cpu"}, clamped,
+		"only CPU should be reported as clamped")
 }
 
 func TestTryEvictionFallback_EvictsWhenMultipleReplicas(t *testing.T) {

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -303,6 +303,18 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 
 		// Check for sufficient data points.
 		if cpuProfile.DataPoints < int(minimumDataPoints) && memProfile.DataPoints < int(minimumDataPoints) {
+			// Distinguish "no data from Prometheus" from "data received but
+			// all values were NaN/Inf" to help debug data quality issues.
+			if len(cpuSamples) > 0 && cpuProfile.DataPoints == 0 {
+				logger.V(1).Info("All CPU samples were NaN/Inf",
+					"container", containerName,
+					"sampleCount", len(cpuSamples))
+			}
+			if len(memSamples) > 0 && memProfile.DataPoints == 0 {
+				logger.V(1).Info("All memory samples were NaN/Inf",
+					"container", containerName,
+					"sampleCount", len(memSamples))
+			}
 			logger.Info("Insufficient data points",
 				"container", containerName,
 				"cpuPoints", cpuProfile.DataPoints,

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -253,7 +253,12 @@ func (r *AttunePolicyReconciler) executeResizes(
 				// Each UpdateResize bumps resourceVersion; using a stale copy
 				// for the next container causes a 409 Conflict.
 				for _, containerRec := range rec.Containers {
-					target := buildResizeTarget(containerRec)
+					target, clamped := buildResizeTarget(containerRec)
+					if len(clamped) > 0 {
+						logger.V(1).Info("Requests clamped to limits",
+							"pod", pod.Name, "container", containerRec.Name,
+							"clampedResources", clamped)
+					}
 					cpuIncrease, memIncrease := budgetIncrease(&pod, containerRec.Name, target)
 
 					// Reserve budget before resizing so concurrent goroutines cannot
@@ -665,7 +670,7 @@ func (r *AttunePolicyReconciler) persistResizeAnnotations(
 // Limits are included when non-zero: for RequestsOnly they equal the current limits (no-op),
 // for RequestsAndLimits they are scaled proportionally. Pods that never had limits produce
 // zero-valued limit fields, which are omitted to avoid Kubernetes rejecting the resize.
-func buildResizeTarget(rec attunev1alpha1.ContainerRecommendation) corev1.ResourceRequirements {
+func buildResizeTarget(rec attunev1alpha1.ContainerRecommendation) (corev1.ResourceRequirements, []string) {
 	target := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    rec.Recommended.CPURequest.DeepCopy(),
@@ -684,8 +689,8 @@ func buildResizeTarget(rec attunev1alpha1.ContainerRecommendation) corev1.Resour
 	// Clamp requests to not exceed limits. When ControlledValues is
 	// RequestsOnly, limits stay at current values and a growing request
 	// can exceed them, causing the API server to reject the resize.
-	clampRequestsToLimits(&target)
-	return target
+	clamped := clampRequestsToLimits(&target)
+	return target, clamped
 }
 
 // clampRequestsToLimits ensures requests do not exceed limits for each resource.


### PR DESCRIPTION
## Summary

Two observability gaps addressed:

1. **Request clamping logging (#169):** `buildResizeTarget` now returns the list of clamped resource names so `executeResizes` can log them at V(1) level. Previously, `clampRequestsToLimits` silently adjusted requests without any log output, making it invisible when limits were hit.

2. **NaN/Inf data quality logging (#171):** `computeRecommendations` now distinguishes between "no data from Prometheus" and "data received but all values were NaN/Inf" with a separate V(1) log line. This helps debug data quality issues where Prometheus returns values but they are all non-finite.

## Changes

- `internal/controller/resize.go`: `buildResizeTarget` returns `(corev1.ResourceRequirements, []string)` instead of just `corev1.ResourceRequirements`. `clampRequestsToLimits` returns the list of clamped resource names. Caller logs clamped resources at V(1).
- `internal/controller/prometheus.go`: Added V(1) log when CPU or memory samples are received but all produce zero data points (NaN/Inf filtering removed them all).
- `internal/controller/attunepolicy_controller_test.go`: Updated 5 test call sites for the new `buildResizeTarget` return type. Added assertions for clamped resource names in existing clamp test. Added no-clamp assertion in the no-clamp test.

Closes #169
Closes #171