### PR TITLE
test: add budget increase tests, mixed NaN coverage, and partial NaN/Inf diagnostic log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,31 @@ is distinguishable from zero/false. Update all 7 locations:
 If the field also belongs in `AttuneDefaults`, add it to
 `api/v1alpha1/attunedefaults_types.go` as well.
 
+### Adding a new Prometheus operator metric
+
+When adding a new metric to `internal/operatormetrics/metrics.go`,
+update all 5 locations:
+
+1. `internal/operatormetrics/metrics.go` - Define the metric var and
+   register it in `init()`
+2. The emitting call site (e.g., `internal/controller/`) - Increment
+   or observe the metric at the right code path
+3. `docs/reference/metrics.md` - Add the metric definition with labels
+   table and an example PromQL query
+4. `docs/guides/troubleshooting.md` - If the metric surfaces a user-visible
+   condition (NaN data, clamped requests), add a reference and PromQL
+   alert example in the relevant troubleshooting section
+5. `charts/attune/files/grafana-dashboard.json` - Add a panel (or update
+   an existing row) so the metric is visible in Grafana
+6. `charts/attune/templates/prometheusrule.yaml` + `values.yaml` - If the
+   metric indicates a condition worth alerting on, add an opt-in
+   PrometheusRule alert with configurable threshold
+
+This checklist was added after PR #177 added `attune_request_clamped_total`
+and `attune_nan_inf_samples_total` to the code but missed locations 3-6.
+The doc gap was caught in the cycle 18 post-cycle gate; the dashboard and
+alert gaps became issues #179 and #181.
+
 ### Helm values.yaml comments (helm-docs format)
 
 `helm-docs` reads `# --` comments from `values.yaml` to generate README

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -650,6 +650,14 @@ calculations.
    minutes after pod creation when Prometheus has only one data point
    (rate computation needs at least two).
 
+The `attune_nan_inf_samples_total` counter increments each time this
+happens, broken down by container and metric type (`cpu` or `memory`).
+Use it to alert on persistent data quality issues:
+
+```promql
+rate(attune_nan_inf_samples_total[1h]) > 0
+```
+
 ### Requests clamped to limits
 
 **Symptom**: Debug logs (V(1)) show `Requests clamped to limits` with a
@@ -664,6 +672,14 @@ at the limit to prevent the API server from rejecting the resize.
 **Fix**: Either increase the container's limits, or switch to
 `controlledValues: RequestsAndLimits` so the operator can scale limits
 proportionally with requests.
+
+The `attune_request_clamped_total` counter increments each time a request
+is capped, broken down by container and resource. Use it to detect
+policies where limits are consistently too tight:
+
+```promql
+rate(attune_request_clamped_total[1h]) > 0
+```
 
 ## Debug commands
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -122,6 +122,33 @@ Total times recommendations were marked stale due to Prometheus data gaps.
 | `namespace` | Policy namespace |
 | `policy` | Policy name |
 
+### attune_request_clamped_total
+
+Total times a recommended resource request was capped at the container's
+current limit. Fires when `controlledValues` is `RequestsOnly` and the
+recommendation exceeds the limit. See [Troubleshooting: Requests clamped
+to limits](../guides/troubleshooting.md#requests-clamped-to-limits).
+
+| Label | Description |
+|-------|-------------|
+| `namespace` | Policy namespace |
+| `policy` | Policy name |
+| `container` | Container name |
+| `resource` | `cpu` or `memory` |
+
+### attune_nan_inf_samples_total
+
+Total times all Prometheus samples for a container metric were non-finite
+(NaN or Inf), making the metric unusable for recommendations. See
+[Troubleshooting: NaN or Inf values](../guides/troubleshooting.md#nan-or-inf-values-in-prometheus-data).
+
+| Label | Description |
+|-------|-------------|
+| `namespace` | Policy namespace |
+| `policy` | Policy name |
+| `container` | Container name |
+| `metric_type` | `cpu` or `memory` |
+
 ## Gauges
 
 ### attune_recommendation_cpu_cores
@@ -357,4 +384,16 @@ Reconcile enqueue rate (items added to queue per second):
 
 ```promql
 rate(workqueue_adds_total{name="attunepolicy"}[5m])
+```
+
+Containers with persistent NaN/Inf data quality issues:
+
+```promql
+rate(attune_nan_inf_samples_total[1h]) > 0
+```
+
+Policies where requests are frequently clamped to limits:
+
+```promql
+sum by (namespace, policy) (rate(attune_request_clamped_total[1h])) > 0
 ```

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -1771,6 +1771,52 @@ func TestComputeRecommendations_AllNaNInfSamplesLogsDataQuality(t *testing.T) {
 	assert.Nil(t, rec, "no recommendation when all samples are NaN")
 }
 
+func TestComputeRecommendations_CPUAllNaNMemoryValid(t *testing.T) {
+	// CPU samples are all NaN, but memory samples are valid.
+	// The recommendation should still be produced using memory data,
+	// with CPU staying at the current value.
+	policy := newTestPolicy("test-policy", "default")
+	deploy := newTestDeployment("api-server", "default", nil)
+	deploy.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+	reconciler := newReconcilerWithClient()
+
+	nanSamples := make([]rsmetrics.Sample, 50)
+	now := time.Now()
+	for i := range nanSamples {
+		nanSamples[i] = rsmetrics.Sample{
+			Timestamp: now.Add(-time.Duration(50-i) * time.Hour),
+			Value:     math.NaN(),
+		}
+	}
+
+	mc := &mockCollector{
+		queryRangeGroupedFunc: func(_ context.Context, query string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
+			if strings.Contains(query, "memory_working_set_bytes") {
+				// Valid memory samples (~256Mi usage).
+				return map[string][]rsmetrics.Sample{"main": generateSamples(200, 256*1024*1024)}, nil
+			}
+			// CPU: all NaN.
+			return map[string][]rsmetrics.Sample{"main": nanSamples}, nil
+		},
+	}
+
+	rec, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, rec, "recommendation should be produced from memory data even when CPU is all NaN")
+	require.Len(t, rec.Containers, 1)
+	// CPU should stay at current because CPU had no valid data points.
+	assert.Equal(t, resource.MustParse("100m"), rec.Containers[0].Recommended.CPURequest,
+		"CPU should stay at current when CPU samples are all NaN")
+	// Memory should differ from current (recommendations engine processes valid memory data).
+	assert.NotEqual(t, resource.MustParse("128Mi"), rec.Containers[0].Recommended.MemoryRequest,
+		"Memory recommendation should change when memory samples are valid")
+}
+
 func TestComputeRecommendations_QueryError(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	deploy := newTestDeployment("api-server", "default", nil)
@@ -7332,6 +7378,59 @@ func TestResizeContainer_InfeasiblePodSkippedWithInPlaceOnly(t *testing.T) {
 			t.Error("should NOT have attempted eviction with InPlaceOnly")
 		}
 	}
+}
+
+func TestBudgetIncrease_PositiveIncrease(t *testing.T) {
+	pod := newResizePod("api-server", "200m", "256Mi", "0", "0")
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	cpu, mem := budgetIncrease(pod, "main", target)
+	assert.Equal(t, int64(300), cpu, "CPU increase should be 300m")
+	assert.Equal(t, int64(256*1024*1024), mem, "Memory increase should be 256Mi")
+}
+
+func TestBudgetIncrease_DecreaseClampsToZero(t *testing.T) {
+	pod := newResizePod("api-server", "500m", "512Mi", "0", "0")
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+	cpu, mem := budgetIncrease(pod, "main", target)
+	assert.Equal(t, int64(0), cpu, "CPU decrease should not count as budget increase")
+	assert.Equal(t, int64(0), mem, "Memory decrease should not count as budget increase")
+}
+
+func TestBudgetIncrease_ContainerNotFound(t *testing.T) {
+	pod := newResizePod("api-server", "200m", "256Mi", "0", "0")
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	cpu, mem := budgetIncrease(pod, "nonexistent", target)
+	assert.Equal(t, int64(0), cpu, "should return 0 for missing container")
+	assert.Equal(t, int64(0), mem, "should return 0 for missing container")
+}
+
+func TestBudgetIncrease_MixedDirections(t *testing.T) {
+	// CPU increases, memory decreases.
+	pod := newResizePod("api-server", "200m", "512Mi", "0", "0")
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+	cpu, mem := budgetIncrease(pod, "main", target)
+	assert.Equal(t, int64(300), cpu, "CPU increase should be 300m")
+	assert.Equal(t, int64(0), mem, "Memory decrease should be clamped to 0")
 }
 
 func TestExecuteResizes_BudgetCapsDefersExcessiveIncrease(t *testing.T) {

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -323,6 +323,21 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 			continue
 		}
 
+		// Log per-resource NaN/Inf data quality issues even when the
+		// container has enough data from the other resource to produce a
+		// recommendation. Without this, a user sees CPU unchanged with no
+		// explanation when only CPU samples are non-finite.
+		if len(cpuSamples) > 0 && cpuProfile.DataPoints == 0 {
+			logger.V(1).Info("All CPU samples were NaN/Inf, using current CPU request",
+				"container", containerName,
+				"sampleCount", len(cpuSamples))
+		}
+		if len(memSamples) > 0 && memProfile.DataPoints == 0 {
+			logger.V(1).Info("All memory samples were NaN/Inf, using current memory request",
+				"container", containerName,
+				"sampleCount", len(memSamples))
+		}
+
 		// Get current resource values.
 		currentCPUReq := container.Resources.Requests.Cpu().DeepCopy()
 		currentCPULim := container.Resources.Limits.Cpu().DeepCopy()


### PR DESCRIPTION
## Changes

### Tests (5 new unit tests)
- `TestBudgetIncrease_PositiveIncrease`: verifies CPU/memory increase calculation for budget tracking
- `TestBudgetIncrease_DecreaseClampsToZero`: verifies decreases return (0, 0) and do not consume budget
- `TestBudgetIncrease_ContainerNotFound`: verifies nil container returns (0, 0) without panic
- `TestBudgetIncrease_MixedDirections`: verifies CPU increase with memory decrease correctly returns (increase, 0)
- `TestComputeRecommendations_CPUAllNaNMemoryValid`: verifies recommendation is still produced from memory data when CPU samples are all NaN

### Observability fix
When CPU samples are all NaN/Inf but memory has valid data (or vice versa), the container is not skipped and a partial recommendation is produced. Previously, the NaN/Inf diagnostic V(1) log only fired when BOTH metric types had insufficient data. A user debugging "why is CPU not resizing?" would see CPU unchanged with no explanation at V(1) level. This adds a V(1) log that fires for the single-resource NaN/Inf case, explaining that the current value is being used.

## Testing
- All new tests pass with `-race -count=1`
- `make verify-quick` passes