### PR TITLE
docs: extend NaN/Inf guidance to cover runtime query boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,13 @@ with NaN return false, silently disabling any threshold or guardrail that uses
 the parsed value. Always check `math.IsNaN(v) || math.IsInf(v, 0)` after
 `strconv.ParseFloat` in validation code.
 
+The same guard applies at **runtime query boundaries**, not just parse-time.
+Prometheus queries, API responses, and external computations can return NaN
+(e.g., `0/0` in PromQL) or Inf without any string parsing involved. Any
+`float64` received from an external system must be checked before comparison.
+Example: `internal/safety/monitor.go` SLO query values (PR #167),
+`internal/metrics/collector.go` `GetThrottleRatio` (line 349).
+
 ### Webhooks
 
 controller-runtime v0.24.x uses typed generic interfaces. Register webhooks with:


### PR DESCRIPTION
The Float parsing section in AGENTS.md only covered `strconv.ParseFloat`. The SLO monitor bug (PR #167) showed that Prometheus queries and other external systems can return NaN/Inf at runtime without any string parsing involved. This broadens the rule to cover all `float64` values received from external boundaries.

Examples already in the codebase:
- `internal/safety/monitor.go` SLO query values (PR #167)
- `internal/metrics/collector.go` `GetThrottleRatio` (line 349)