### PR TITLE
ci: cache tool binaries to improve CI speed and reliability

### DIFF
--- a/.github/actions/install-binary-tool/action.yaml
+++ b/.github/actions/install-binary-tool/action.yaml
@@ -1,0 +1,39 @@
+name: Install Binary Tool (cached)
+description: |
+  Download a pre-built binary and cache it across runs.
+  On cache hit the binary is restored without re-downloading.
+  On cache miss the install-command runs and the result is saved.
+
+inputs:
+  name:
+    description: Tool name used as cache key prefix (e.g. gitleaks, k3d)
+    required: true
+  version:
+    description: Version string for the cache key (e.g. 8.30.1)
+    required: true
+  install-command:
+    description: Shell command that installs the binary into $TOOL_DIR
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore ${{ inputs.name }} from cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      id: tool-cache
+      with:
+        path: ${{ runner.temp }}/bin-tool-cache/${{ inputs.name }}
+        key: bin-tool-${{ inputs.name }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+
+    - name: Install ${{ inputs.name }}
+      if: steps.tool-cache.outputs.cache-hit != 'true'
+      shell: bash -Eeuo pipefail {0}
+      env:
+        TOOL_DIR: ${{ runner.temp }}/bin-tool-cache/${{ inputs.name }}
+      run: |
+        mkdir -p "$TOOL_DIR"
+        ${{ inputs.install-command }}
+
+    - name: Add ${{ inputs.name }} to PATH
+      shell: bash -Eeuo pipefail {0}
+      run: echo "${RUNNER_TEMP}/bin-tool-cache/${{ inputs.name }}" >> "$GITHUB_PATH"

--- a/.github/actions/install-go-tool/action.yaml
+++ b/.github/actions/install-go-tool/action.yaml
@@ -1,0 +1,38 @@
+name: Install Go Tool (cached)
+description: |
+  Install a Go tool binary and cache it across runs.
+  On cache hit the binary is restored from cache without recompilation.
+  On cache miss the tool is compiled via 'go install' and saved for future runs.
+
+inputs:
+  name:
+    description: Binary name produced by go install (e.g. gotestsum, govulncheck)
+    required: true
+  version:
+    description: Version tag (e.g. v1.13.0)
+    required: true
+  package:
+    description: Go module path (e.g. gotest.tools/gotestsum)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore ${{ inputs.name }} from cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      id: tool-cache
+      with:
+        path: ${{ runner.temp }}/go-tool-cache/${{ inputs.name }}
+        key: go-tool-${{ inputs.name }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+
+    - name: Install ${{ inputs.name }}
+      if: steps.tool-cache.outputs.cache-hit != 'true'
+      shell: bash -Eeuo pipefail {0}
+      run: |
+        tool_dir="${RUNNER_TEMP}/go-tool-cache/${{ inputs.name }}"
+        mkdir -p "$tool_dir"
+        GOBIN="$tool_dir" go install "${{ inputs.package }}@${{ inputs.version }}"
+
+    - name: Add ${{ inputs.name }} to PATH
+      shell: bash -Eeuo pipefail {0}
+      run: echo "${RUNNER_TEMP}/go-tool-cache/${{ inputs.name }}" >> "$GITHUB_PATH"

--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -61,15 +61,12 @@ runs:
           /tmp/stress-ng.tar
         key: e2e-images-${{ runner.os }}-cm${{ inputs.cert-manager-version }}-prom${{ inputs.prometheus-chart-version }}-stress0.20.01
 
-    - name: Install k3d
-      shell: bash -Eeuo pipefail -x {0}
-      run: |
-        mkdir -p "$HOME/.local/bin"
-        if command -v k3d &>/dev/null; then
-          echo "k3d already installed: $(k3d version)"
-        else
-          curl -s https://raw.githubusercontent.com/k3d-io/k3d/${{ inputs.k3d-version }}/install.sh | K3D_INSTALL_DIR="$HOME/.local/bin" USE_SUDO=false bash
-        fi
+    - uses: ./.github/actions/install-binary-tool
+      with:
+        name: k3d
+        version: ${{ inputs.k3d-version }}
+        install-command: |
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/${{ inputs.k3d-version }}/install.sh | K3D_INSTALL_DIR="$TOOL_DIR" USE_SUDO=false bash
 
     - name: Prepare isolated kubeconfig
       shell: bash -Eeuo pipefail -x {0}
@@ -78,7 +75,6 @@ runs:
     - name: Cleanup stale k3d clusters and Docker resources
       shell: bash -Eeuo pipefail -x {0}
       run: |
-        export PATH="$HOME/.local/bin:$PATH"
         for cluster in $(k3d cluster list -o json 2>/dev/null | jq -r '.[].name // empty'); do
           started=$(docker inspect --format '{{.State.StartedAt}}' "k3d-${cluster}-server-0" 2>/dev/null) || continue
           started_epoch=$(date -d "$started" +%s 2>/dev/null) || continue
@@ -109,7 +105,6 @@ runs:
     - name: Create k3d cluster
       shell: bash -Eeuo pipefail -x {0}
       run: |
-        export PATH="$HOME/.local/bin:$PATH"
         for attempt in 1 2 3; do
           if k3d cluster create "${{ inputs.cluster-name }}" \
             --image ${{ inputs.k3s-image }} \
@@ -137,7 +132,6 @@ runs:
     - name: Load cert-manager images into cluster
       shell: bash -Eeuo pipefail -x {0}
       run: |
-        export PATH="$HOME/.local/bin:$PATH"
         k3d image import \
           /tmp/cert-manager-controller.tar \
           /tmp/cert-manager-webhook.tar \
@@ -155,7 +149,6 @@ runs:
     - name: Load Prometheus and test images into cluster
       shell: bash -Eeuo pipefail -x {0}
       run: |
-        export PATH="$HOME/.local/bin:$PATH"
         k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar -c "${{ inputs.cluster-name }}"
 
     - name: Install Prometheus
@@ -192,11 +185,15 @@ runs:
           sleep 5
         done
 
+    - uses: ./.github/actions/install-go-tool
+      with:
+        name: ko
+        version: v0.18.0
+        package: github.com/google/ko
+
     - name: Build and load operator image
       shell: bash -Eeuo pipefail -x {0}
       run: |
-        export PATH="$HOME/.local/bin:$PATH"
-        go install github.com/google/ko@v0.18.0
         VERSION=e2e COMMIT=$(git rev-parse --short HEAD) DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
           KO_DOCKER_REPO=attune ko build ./cmd/manager/ \
           --bare --tags=e2e --platform=linux/$(go env GOARCH) \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ env:
   K3S_IMAGE: "rancher/k3s:v1.35.4-k3s1"
   ENVTEST_K8S_VERSION: "1.35.0"
   HELM_UNITTEST_VERSION: "v0.7.2"
+  BENCHSTAT_VERSION: "v0.0.0-20260512194132-3cf34090a3db"
   CERT_MANAGER_VERSION: "v1.17.2"
   PROMETHEUS_IMAGE: "quay.io/prometheus/prometheus:v3.4.1"
   PROMETHEUS_CHART_VERSION: "27.22.0"
@@ -104,17 +105,15 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: golangci-lint
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          package: github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+
       - name: golangci-lint
         shell: bash -Eeuo pipefail {0}
-        run: |
-          lint_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/golangci-lint-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-lint}-XXXXXX")
-          trap 'rm -rf "$lint_root"' EXIT
-          lint_bindir="$lint_root/bin"
-          lint_cachedir="$lint_root/cache"
-          mkdir -p "$lint_bindir" "$lint_cachedir"
-          GOBIN="$lint_bindir" make golangci-lint LOCALBIN="$lint_bindir"
-          GOLANGCI_LINT_CACHE="$lint_cachedir" \
-            "$lint_bindir/golangci-lint-${{ env.GOLANGCI_LINT_VERSION }}" run --timeout 5m --allow-serial-runners
+        run: golangci-lint run --timeout 5m --allow-serial-runners
 
       - name: Check go mod tidy
         shell: bash -Eeuo pipefail {0}
@@ -165,11 +164,14 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.x"
+          cache: pip
+
       - name: Install MkDocs
         shell: bash -Eeuo pipefail {0}
-        run: |
-          python3 -m pip install --user --break-system-packages mkdocs-material==9.7.6
-          echo "$(python3 -m site --user-base)/bin" >> "$GITHUB_PATH"
+        run: pip install mkdocs-material==9.7.6
 
       - name: Build docs site
         shell: bash -Eeuo pipefail {0}
@@ -219,13 +221,17 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.x"
+
+      - name: Install yamllint
+        shell: bash -Eeuo pipefail {0}
+        run: pip install yamllint
+
       - name: YAML lint
         shell: bash -Eeuo pipefail {0}
         run: |
-          if ! command -v yamllint &>/dev/null; then
-            python3 -m pip install --user --break-system-packages yamllint 2>/dev/null
-            export PATH="$(python3 -m site --user-base)/bin:$PATH"
-          fi
           yamllint_config="${RUNNER_TEMP:-/tmp}/yamllint-${GITHUB_RUN_ID}-${GITHUB_JOB}.yaml"
           cat > "$yamllint_config" <<'EOF'
           extends: default
@@ -277,13 +283,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Install gotestsum
-        shell: bash -Eeuo pipefail {0}
-        run: |
-          export GOBIN="${RUNNER_TEMP}/gobin-${GITHUB_RUN_ID}-${GITHUB_JOB}"
-          mkdir -p "$GOBIN"
-          go install gotest.tools/gotestsum@${{ env.GOTESTSUM_VERSION }}
-          echo "${GOBIN}" >> "$GITHUB_PATH"
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: gotestsum
+          version: ${{ env.GOTESTSUM_VERSION }}
+          package: gotest.tools/gotestsum
 
       - name: Run unit tests
         shell: bash -Eeuo pipefail -x {0}
@@ -365,9 +369,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Install benchstat
-        shell: bash -Eeuo pipefail {0}
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: benchstat
+          version: v0.0.0-20260512194132-3cf34090a3db
+          package: golang.org/x/perf/cmd/benchstat
 
       - name: Restore baseline benchmarks
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -428,22 +434,21 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Install gotestsum
-        shell: bash -Eeuo pipefail {0}
-        run: |
-          export GOBIN="${RUNNER_TEMP}/gobin-${GITHUB_RUN_ID}-${GITHUB_JOB}"
-          mkdir -p "$GOBIN"
-          go install gotest.tools/gotestsum@${{ env.GOTESTSUM_VERSION }}
-          echo "${GOBIN}" >> "$GITHUB_PATH"
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: gotestsum
+          version: ${{ env.GOTESTSUM_VERSION }}
+          package: gotest.tools/gotestsum
 
-      - name: Setup envtest
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: setup-envtest
+          version: v0.24.1
+          package: sigs.k8s.io/controller-runtime/tools/setup-envtest
+
+      - name: Setup envtest assets
         shell: bash -Eeuo pipefail -x {0}
-        run: |
-          export GOBIN="${RUNNER_TEMP}/gobin-${GITHUB_RUN_ID}-${GITHUB_JOB}"
-          mkdir -p "$GOBIN"
-          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.24
-          echo "${GOBIN}" >> "$GITHUB_PATH"
-          echo "KUBEBUILDER_ASSETS=$(setup-envtest use ${{ env.ENVTEST_K8S_VERSION }} -p path)" >> "$GITHUB_ENV"
+        run: echo "KUBEBUILDER_ASSETS=$(setup-envtest use ${{ env.ENVTEST_K8S_VERSION }} -p path)" >> "$GITHUB_ENV"
 
       - name: Run integration tests
         shell: bash -Eeuo pipefail -x {0}
@@ -543,7 +548,6 @@ jobs:
         if: always()
         shell: bash -Eeuo pipefail {0}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           k3d cluster delete "$K3D_CLUSTER_NAME" 2>/dev/null || true
           rm -f "$KUBECONFIG"
 
@@ -564,11 +568,15 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: govulncheck
+          version: v1.3.0
+          package: golang.org/x/vuln/cmd/govulncheck
+
       - name: Run govulncheck
         shell: bash -Eeuo pipefail -x {0}
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
-          govulncheck ./...
+        run: govulncheck ./...
 
   crd-freshness:
     name: CRD Freshness Check
@@ -629,40 +637,53 @@ jobs:
               --api-versions cert-manager.io/v1 > /dev/null
           done
 
+      - uses: ./.github/actions/install-binary-tool
+        with:
+          name: helm-unittest
+          version: ${{ env.HELM_UNITTEST_VERSION }}
+          install-command: |
+            # Remove stale helm-unittest plugins that conflict on self-hosted runners
+            rm -rf "$(helm env HELM_PLUGINS)/helm-unittest.git" 2>/dev/null || true
+            ASSET_VERSION="${{ env.HELM_UNITTEST_VERSION }}"
+            ASSET_VERSION="${ASSET_VERSION#v}"
+            case "$(uname -s)" in
+              Linux)  HU_OS=linux  ;;
+              Darwin) HU_OS=macos  ;;
+              *)      echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+            esac
+            case "$(uname -m)" in
+              x86_64)       HU_ARCH=amd64 ;;
+              aarch64|arm64) HU_ARCH=arm64 ;;
+              *)            echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+            esac
+            curl -fsSL "https://github.com/helm-unittest/helm-unittest/releases/download/${{ env.HELM_UNITTEST_VERSION }}/helm-unittest-${HU_OS}-${HU_ARCH}-${ASSET_VERSION}.tgz" \
+              | tar xz -C "$TOOL_DIR"
+
+      - name: Link helm-unittest plugin
+        shell: bash -Eeuo pipefail {0}
+        run: |
+          PLUGINS_DIR="$(helm env HELM_PLUGINS)/unittest"
+          rm -rf "$PLUGINS_DIR"
+          ln -s "${RUNNER_TEMP}/bin-tool-cache/helm-unittest" "$PLUGINS_DIR"
+
       - name: Run chart unit tests
         shell: bash -Eeuo pipefail -x {0}
-        run: |
-          # Remove stale helm-unittest plugins that conflict on self-hosted runners
-          rm -rf "$(helm env HELM_PLUGINS)/helm-unittest.git" 2>/dev/null || true
-          PLUGINS_DIR="$(helm env HELM_PLUGINS)/unittest"
-          mkdir -p "$PLUGINS_DIR"
-          HELM_UNITTEST_ASSET_VERSION="${HELM_UNITTEST_VERSION#v}"
-          case "$(uname -s)" in
-            Linux)  HU_OS=linux  ;;
-            Darwin) HU_OS=macos  ;;
-            *)      echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
-          esac
-          case "$(uname -m)" in
-            x86_64)       HU_ARCH=amd64 ;;
-            aarch64|arm64) HU_ARCH=arm64 ;;
-            *)            echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
-          esac
-          curl -fsSL "https://github.com/helm-unittest/helm-unittest/releases/download/${HELM_UNITTEST_VERSION}/helm-unittest-${HU_OS}-${HU_ARCH}-${HELM_UNITTEST_ASSET_VERSION}.tgz" \
-            | tar xz -C "$PLUGINS_DIR"
-          helm unittest charts/attune
+        run: helm unittest charts/attune
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: helm-docs
+          version: v1.14.2
+          package: github.com/norwoodj/helm-docs/cmd/helm-docs
+
       - name: Helm docs freshness
         shell: bash -Eeuo pipefail {0}
         run: |
-          export GOBIN="${RUNNER_TEMP}/gobin-${GITHUB_RUN_ID}-${GITHUB_JOB}"
-          mkdir -p "$GOBIN"
-          go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
-          export PATH="${GOBIN}:${PATH}"
           helm-docs --chart-search-root charts/
           if ! git diff --quiet --exit-code charts/attune/README.md; then
             echo "::error::Helm README is stale. Run 'make helm-docs-gen' and commit."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -663,6 +663,7 @@ jobs:
         shell: bash -Eeuo pipefail {0}
         run: |
           PLUGINS_DIR="$(helm env HELM_PLUGINS)/unittest"
+          mkdir -p "$(dirname "$PLUGINS_DIR")"
           rm -rf "$PLUGINS_DIR"
           ln -s "${RUNNER_TEMP}/bin-tool-cache/helm-unittest" "$PLUGINS_DIR"
 

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -138,20 +138,16 @@ jobs:
             /tmp/busybox.tar
           key: e2e-images-${{ runner.os }}-cm${{ env.CERT_MANAGER_VERSION }}-prom${{ env.PROMETHEUS_CHART_VERSION }}-stress0.20.01-busybox1.37
 
-      - name: Install k3d
-        shell: bash -Eeuo pipefail -x {0}
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          if command -v k3d &>/dev/null; then
-            echo "k3d already installed: $(k3d version)"
-          else
-            curl -s https://raw.githubusercontent.com/k3d-io/k3d/${{ env.K3D_VERSION }}/install.sh | K3D_INSTALL_DIR="$HOME/.local/bin" USE_SUDO=false bash
-          fi
+      - uses: ./.github/actions/install-binary-tool
+        with:
+          name: k3d
+          version: ${{ env.K3D_VERSION }}
+          install-command: |
+            curl -s https://raw.githubusercontent.com/k3d-io/k3d/${{ env.K3D_VERSION }}/install.sh | K3D_INSTALL_DIR="$TOOL_DIR" USE_SUDO=false bash
 
       - name: Cleanup stale k3d clusters and Docker resources
         shell: bash -Eeuo pipefail -x {0}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           # Delete any k3d cluster that has been running for more than 1 hour.
           # Stale clusters from crashed/cancelled jobs waste Docker resources
           # and cause container name conflicts during creation.
@@ -189,7 +185,6 @@ jobs:
       - name: Create k3d cluster
         shell: bash -Eeuo pipefail -x {0}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           rm -f "$KUBECONFIG"
           # Retry cluster creation up to 3 times. k3d can fail transiently
           # when Docker containers vanish mid-creation due to daemon
@@ -253,7 +248,6 @@ jobs:
       - name: Load cert-manager images into cluster
         shell: bash -Eeuo pipefail -x {0}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           k3d image import \
             /tmp/cert-manager-controller.tar \
             /tmp/cert-manager-webhook.tar \
@@ -270,9 +264,7 @@ jobs:
 
       - name: Load Prometheus and test images into cluster
         shell: bash -Eeuo pipefail -x {0}
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar /tmp/busybox.tar -c "$CLUSTER_NAME"
+        run: k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar /tmp/busybox.tar -c "$CLUSTER_NAME"
 
       - name: Install Prometheus
         shell: bash -Eeuo pipefail -x {0}
@@ -308,13 +300,17 @@ jobs:
             sleep 5
           done
 
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: ko
+          version: v0.18.0
+          package: github.com/google/ko
+
       - name: Build and load operator image
         shell: bash -Eeuo pipefail -x {0}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           # Use ko to build the image as an OCI tarball. This bypasses the
           # Docker daemon entirely, avoiding containerd storage races.
-          go install github.com/google/ko@v0.18.0
           VERSION=e2e COMMIT=$(git rev-parse --short HEAD) DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
             KO_DOCKER_REPO=attune ko build ./cmd/manager/ \
             --bare --tags=e2e --platform=linux/$(go env GOARCH) \
@@ -396,7 +392,6 @@ jobs:
         if: always()
         shell: bash -Eeuo pipefail {0}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           k3d cluster delete "$CLUSTER_NAME" 2>/dev/null || true
           rm -f "$KUBECONFIG"
 

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FOSSA_CLI_VERSION: "3.17.10"
+
 jobs:
   fossa:
     name: FOSSA License Scan
@@ -20,9 +23,19 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+
+      - uses: ./.github/actions/install-binary-tool
         with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
+          name: fossa
+          version: ${{ env.FOSSA_CLI_VERSION }}
+          install-command: |
+            curl -sfL "https://github.com/fossas/fossa-cli/releases/download/v${{ env.FOSSA_CLI_VERSION }}/fossa_${{ env.FOSSA_CLI_VERSION }}_linux_amd64.tar.gz" \
+              | tar xz -C "$TOOL_DIR" fossa
+
+      - name: Run FOSSA analysis
+        run: fossa analyze
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   fossa-test:
     name: FOSSA License Check
@@ -35,7 +48,16 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+
+      - uses: ./.github/actions/install-binary-tool
         with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          run-tests: true
+          name: fossa
+          version: ${{ env.FOSSA_CLI_VERSION }}
+          install-command: |
+            curl -sfL "https://github.com/fossas/fossa-cli/releases/download/v${{ env.FOSSA_CLI_VERSION }}/fossa_${{ env.FOSSA_CLI_VERSION }}_linux_amd64.tar.gz" \
+              | tar xz -C "$TOOL_DIR" fossa
+
+      - name: Run FOSSA license check
+        run: fossa test
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -52,11 +52,15 @@ jobs:
           go-version: "1.26"
           cache: true
 
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: govulncheck
+          version: v1.3.0
+          package: golang.org/x/vuln/cmd/govulncheck
+
       - name: Run govulncheck
         shell: bash -Eeuo pipefail -x {0}
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
-          govulncheck ./...
+        run: govulncheck ./...
 
   trivy:
     name: Trivy
@@ -149,31 +153,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install gitleaks
-        shell: bash -Eeuo pipefail -x {0}
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          VER="8.30.1"
-          # Verify the cached binary actually runs (catches arch mismatch)
-          if command -v gitleaks &>/dev/null && gitleaks version &>/dev/null; then
-            echo "gitleaks already installed: $(gitleaks version)"
-          else
-            mkdir -p "$HOME/.local/bin"
+      - uses: ./.github/actions/install-binary-tool
+        with:
+          name: gitleaks
+          version: "8.30.1"
+          install-command: |
             OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
             ARCH="$(uname -m)"
             case "$ARCH" in
               x86_64)  ARCH="x64" ;;
               aarch64|arm64) ARCH="arm64" ;;
             esac
-            curl -sfL "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_${OS}_${ARCH}.tar.gz" \
-              | tar xz -C "$HOME/.local/bin" gitleaks
-          fi
+            curl -sfL "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_${OS}_${ARCH}.tar.gz" \
+              | tar xz -C "$TOOL_DIR" gitleaks
 
       - name: Detect secrets
         shell: bash -Eeuo pipefail -x {0}
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          gitleaks detect --source . --exit-code 1
+        run: gitleaks detect --source . --exit-code 1
 
   dependency-review:
     name: Dependency Review


### PR DESCRIPTION
## Summary

Adds `actions/cache`-backed caching for all CI tool installations. Fixes the FOSSA CLI transient download failure from PR #184 and eliminates unnecessary recompilation/re-downloading of ~12 tools on every CI run.

## What changed

### New composite actions

| Action | Purpose |
|--------|---------|
| `.github/actions/install-go-tool` | Cache Go tool binaries compiled via `go install`. On cache hit, restores the binary without recompilation. |
| `.github/actions/install-binary-tool` | Cache pre-built binaries downloaded via curl. On cache hit, restores without re-downloading. |

### Tools now cached

| Tool | Type | Previously | Now |
|------|------|-----------|-----|
| golangci-lint | Go | Recompiled every run (~30-60s) | Cached by version |
| gotestsum | Go | Recompiled every run | Cached by version |
| govulncheck | Go | Recompiled every run | Cached by version |
| benchstat | Go | Recompiled every run (`@latest`) | Pinned + cached |
| controller-gen | Go | Recompiled every run | Cached by version |
| helm-docs | Go | Recompiled every run | Cached by version |
| setup-envtest | Go | Recompiled every run | Cached by version |
| ko | Go | Recompiled every run | Cached by version |
| gitleaks | Binary | curl download every run | Cached by version |
| k3d | Binary | curl install script every run | Cached by version |
| helm-unittest | Binary | curl download every run | Cached by version |
| FOSSA CLI | Binary | Downloaded by `fossas/fossa-action` (CDN failure risk) | Pinned to v3.17.10 + cached |

### pip packages

- `mkdocs-material`: now uses `actions/setup-python` with managed Python
- `yamllint`: now uses `actions/setup-python` with managed Python

### Cleanup

- Removed all `$HOME/.local/bin` PATH manipulation (tools are now on `$GITHUB_PATH` via the composite actions)
- Removed per-run temp directory pattern (`GOBIN="${RUNNER_TEMP}/gobin-${GITHUB_RUN_ID}-${GITHUB_JOB}"`) that defeated caching

## Cache design

- Each tool gets its own cache entry: `go-tool-{name}-{os}-{arch}-{version}` or `bin-tool-{name}-{os}-{arch}-{version}`
- Version bumps only invalidate the affected tool's cache
- On cache miss: install normally, save for future runs
- On cache hit: restore binary, skip installation entirely

## Motivation

The FOSSA CLI download failed in PR #184 due to a transient CDN issue (`Unable to locate executable file: fossa`). The broader investigation revealed that every CI run was recompiling ~10 Go tools from source and re-downloading ~3 binaries, wasting both time and creating unnecessary fragility.

Closes #185