### PR TITLE
fix: remove untrusted code checkout from pr-size workflow

### DIFF
--- a/.github/workflows/pr-size.yaml
+++ b/.github/workflows/pr-size.yaml
@@ -17,17 +17,17 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+      # No checkout needed: this workflow only reads event payload data and
+      # calls the GitHub API.  Removing the checkout eliminates the
+      # "untrusted code in privileged context" code-scanning alert.
       - name: Calculate diff size and apply label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          ADDITIONS: ${{ github.event.pull_request.additions }}
+          DELETIONS: ${{ github.event.pull_request.deletions }}
+          REPO: ${{ github.repository }}
         run: |
-          ADDITIONS=${{ github.event.pull_request.additions }}
-          DELETIONS=${{ github.event.pull_request.deletions }}
           TOTAL=$((ADDITIONS + DELETIONS))
 
           if [ "$TOTAL" -lt 10 ]; then
@@ -45,7 +45,6 @@ jobs:
           echo "PR #${PR_NUMBER}: +${ADDITIONS} -${DELETIONS} = ${TOTAL} lines -> ${SIZE}"
 
           # Fetch current labels, swap the size/* label in one API call
-          REPO="${{ github.repository }}"
           KEEP=$(gh api "repos/${REPO}/issues/${PR_NUMBER}" --jq \
             '[.labels[].name | select(startswith("size/") | not)]')
           FINAL=$(echo "$KEEP" | jq --arg s "$SIZE" '. + [$s]')
@@ -54,7 +53,7 @@ jobs:
 
           # Post a warning comment for XL PRs
           if [ "$SIZE" = "size/xl" ]; then
-            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" \
+            gh pr comment "$PR_NUMBER" --repo "${REPO}" \
               --body "> **Large PR** (+${ADDITIONS} -${DELETIONS} = ${TOTAL} lines). Consider splitting into smaller, focused PRs for easier review." \
               2>/dev/null || true
           fi


### PR DESCRIPTION
The pr-size workflow uses `pull_request_target` (privileged context with write tokens) and checked out the PR head ref via `ref: ${{ github.event.pull_request.head.sha }}`, triggering critical/high code-scanning alerts for untrusted code execution in a privileged context.

The checkout was unnecessary since the workflow only reads event payload data (`additions`/`deletions`) and calls the GitHub API to set labels.

**Changes:**
- Remove the `actions/checkout` step entirely
- Move inline `${{ }}` expressions from the `run:` block to the `env:` block to follow best practices for `pull_request_target` workflows

**Also dismissed 3 unfixable alerts:**
- **#22, #23** (medium): SLSA reusable workflows require tag refs for self-verification; SHA pinning breaks the provenance chain
- **#18** (high): Branch protection maximality; solo-maintainer repo where enforcing admin restrictions would block all merges

Fixes code-scanning alerts #16 and #17.