### PR TITLE
ci: add merge_group trigger to security and fossa workflows

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group: {}
 
 permissions:
   contents: read

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group: {}
   workflow_dispatch: {}
   schedule:
     - cron: "0 6 * * 1"  # Weekly Monday 6am UTC


### PR DESCRIPTION
The merge queue creates temporary commits that need all required checks to report. Without `merge_group` triggers, CodeQL (`security.yaml`) and FOSSA (`fossa.yaml`) checks remain queued forever on the merge queue commit, blocking PRs with `AWAITING_CHECKS` state indefinitely.

This was the root cause of PRs #186 and #187 appearing stuck despite all PR-level checks passing. The `code_scanning` branch rule requires CodeQL to report on every commit, including merge queue commits. Since `security.yaml` only triggered on `push` and `pull_request`, CodeQL never ran on the merge queue commit.

### Changes
- Add `merge_group: {}` trigger to `security.yaml` (CodeQL, Trivy, Gitleaks)
- Add `merge_group: {}` trigger to `fossa.yaml` (FOSSA license scan)

### Follow-up
After this merges, the `code_scanning` branch rule (temporarily removed to unblock #186/#187) will be re-added.