### PR TITLE
fix: replace deprecated archives.builds with archives.ids

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,7 +35,7 @@ builds:
       - -X main.version={{.Version}}
 archives:
   - id: kubectl-plugin
-    builds: [kubectl-attune]
+    ids: [kubectl-attune]
     name_template: "kubectl-attune_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
GoReleaser v2.8+ renamed `archives.builds` to `archives.ids`. The old key still works but logs a deprecation warning on every release run.

Spotted in https://github.com/attune-io/attune/actions/runs/26703736857/job/78701103245#logs