### PR TITLE
fix: use explicit checkout path in operatorhub-pr.sh instead of OLDPWD

### DIFF
--- a/hack/operatorhub-pr.sh
+++ b/hack/operatorhub-pr.sh
@@ -26,6 +26,10 @@ FORK_REPO="${FORK_OWNER}/community-operators"
 BRANCH="attune-v${VERSION}"
 OPERATOR_DIR="operators/attune"
 
+# Save checkout root before any cd operations (OLDPWD is unreliable
+# after multiple cd commands).
+CHECKOUT_DIR="$(pwd)"
+
 # Generate the OLM bundle if not pre-generated
 BUNDLE_DIR="${BUNDLE_DIR:-dist/olm-bundle/${VERSION}}"
 if [ ! -d "${BUNDLE_DIR}/manifests" ]; then
@@ -66,8 +70,8 @@ git checkout -B "${BRANCH}" upstream/main
 
 # Copy the bundle
 mkdir -p "${OPERATOR_DIR}/${VERSION}/manifests" "${OPERATOR_DIR}/${VERSION}/metadata"
-cp "${OLDPWD}/${BUNDLE_DIR}/manifests/"* "${OPERATOR_DIR}/${VERSION}/manifests/"
-cp "${OLDPWD}/${BUNDLE_DIR}/metadata/"* "${OPERATOR_DIR}/${VERSION}/metadata/"
+cp "${CHECKOUT_DIR}/${BUNDLE_DIR}/manifests/"* "${OPERATOR_DIR}/${VERSION}/manifests/"
+cp "${CHECKOUT_DIR}/${BUNDLE_DIR}/metadata/"* "${OPERATOR_DIR}/${VERSION}/metadata/"
 
 # Ensure ci.yaml exists at the operator root with reviewers for auto-merge
 cat > "${OPERATOR_DIR}/ci.yaml" <<'EOF'


### PR DESCRIPTION
## Problem

The OperatorHub PR job in the release workflow fails on every release with:

```
cp: cannot stat '/tmp/tmp.xxx/dist/olm-bundle/0.1.10/manifests/*': No such file or directory
```

## Root Cause

`hack/operatorhub-pr.sh` performs two consecutive `cd` operations:
1. `cd "${WORK_DIR}"` (OLDPWD = checkout dir)
2. `cd community-operators` (OLDPWD = WORK_DIR, not checkout dir)

The `cp` command then uses `${OLDPWD}/${BUNDLE_DIR}/manifests/*`, which resolves to the temp directory instead of the original checkout where the OLM bundle was generated.

## Fix

Save the checkout directory in `CHECKOUT_DIR` before any `cd` operations and use it explicitly instead of relying on `OLDPWD`, which only tracks the last directory change.

## Verification

Tested locally: `VERSION=0.1.10 make generate-olm-bundle` succeeds and all 5 expected bundle files are present.