### PR TITLE
ci: migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
@@ -390,7 +390,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: attune-io
           repositories: community-operators


### PR DESCRIPTION
## Summary

Migrate `actions/create-github-app-token` from the deprecated `app-id` input to the new `client-id` input.

## What changed

- **Release workflow**: both `create-github-app-token` steps (release-please and operatorhub-pr) now use `client-id: ${{ vars.APP_CLIENT_ID }}` instead of `app-id: ${{ secrets.APP_ID }}`
- **Repo variable**: added `APP_CLIENT_ID` variable with the attune-release-bot Client ID

## Why

`actions/create-github-app-token@v3` deprecated the `app-id` input. Every release workflow run emits:
> Input 'app-id' has been deprecated with message: Use 'client-id' instead.

The old input will stop working when Node.js 24 becomes the default runner (June 16, 2026).

## Migration details

| Before | After |
|--------|-------|
| `app-id: ${{ secrets.APP_ID }}` (numeric) | `client-id: ${{ vars.APP_CLIENT_ID }}` (string, `Iv23...`) |
| `private-key: ${{ secrets.APP_PRIVATE_KEY }}` | unchanged |

The Client ID is not sensitive (it identifies the app publicly), so it is stored as a repository variable rather than a secret.