### PR TITLE
fix: release pipeline audit fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -203,6 +203,14 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: 1
 
+      - name: Sign SBOM
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          cosign sign-blob --yes \
+            --output-signature sbom.spdx.json.sig \
+            --output-certificate sbom.spdx.json.cert \
+            sbom.spdx.json
+
       - name: Generate install manifest and CRDs bundle
         shell: bash -Eeuo pipefail -x {0}
         run: |
@@ -218,6 +226,8 @@ jobs:
             dist/install.yaml
             dist/crds.yaml
             sbom.spdx.json
+            sbom.spdx.json.sig
+            sbom.spdx.json.cert
 
       # Krew manifest update runs last with continue-on-error so a Krew
       # failure never blocks Docker images, signatures, or provenance.
@@ -265,18 +275,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub (Docker/cosign)
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Docker Hub (Helm)
-        shell: bash -Eeuo pipefail -x {0}
-        run: |
-          echo "${{ secrets.DOCKERHUB_TOKEN }}" | helm registry login registry-1.docker.io \
-            --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-
       - name: Package and push Helm chart
         shell: bash -Eeuo pipefail -x {0}
         run: |
@@ -288,7 +286,6 @@ jobs:
 
           helm package charts/attune
           helm push attune-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
-          helm push attune-${VERSION}.tgz oci://registry-1.docker.io/attuneio
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -301,27 +298,17 @@ jobs:
           cosign sign --yes \
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/attune:${VERSION}
 
-      - name: Sign Helm chart (Docker Hub)
-        shell: bash -Eeuo pipefail -x {0}
-        run: |
-          VERSION="${{ needs.release.outputs.tag }}"
-          VERSION="${VERSION#v}"
-          cosign sign --yes \
-            docker.io/attuneio/attune:${VERSION}
+      - uses: oras-project/setup-oras@v1
+        with:
+          version: "1.3.2"
 
       - name: Push Artifact Hub metadata
         shell: bash -Eeuo pipefail -x {0}
         run: |
-          # Install ORAS CLI
-          ORAS_VERSION="1.3.2"
-          curl -sLO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
-          tar -xzf "oras_${ORAS_VERSION}_linux_amd64.tar.gz" oras
-          chmod +x oras
-
           # Push artifacthub-repo.yml as OCI artifact for Verified Publisher status
-          echo "${{ secrets.GITHUB_TOKEN }}" | ./oras login ${{ env.REGISTRY }} \
+          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ${{ env.REGISTRY }} \
             --username ${{ github.actor }} --password-stdin
-          ./oras push \
+          oras push \
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/attune:artifacthub.io \
             --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
             artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
@@ -342,6 +329,7 @@ jobs:
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true
+      upload-tag-name: ${{ needs.release.outputs.tag }}
 
   # SLSA Level 3 provenance for the container image.
   container-provenance:
@@ -362,17 +350,19 @@ jobs:
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
 
-  # Submit an OLM bundle PR to k8s-operatorhub/community-operators.
-  # Uses continue-on-error so OperatorHub failures never block releases.
+  # Submit OLM bundle PRs to OperatorHub repos.
+  # Step-level continue-on-error keeps the job green while exposing the
+  # actual outcome via outputs for the release-notify job.
   operatorhub-pr:
     name: OperatorHub PR
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [release]
     if: ${{ !cancelled() && needs.release.result == 'success' }}
-    continue-on-error: true
     permissions:
       contents: read
+    outputs:
+      outcome: ${{ steps.create-pr.outcome }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -393,9 +383,11 @@ jobs:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: attune-io
-          repositories: community-operators
+          repositories: community-operators,community-operators-prod
 
-      - name: Generate OLM bundle and create PR
+      - name: Generate OLM bundle and create PRs
+        id: create-pr
+        continue-on-error: true
         env:
           VERSION: ${{ needs.release.outputs.tag }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -427,3 +419,40 @@ jobs:
           repository: attuneio/attune
           readme-filepath: docker/README.md
           short-description: "Safe, in-place Kubernetes pod resource right-sizing. VPA done right."
+
+  # Create a GitHub Issue if any optional post-release job failed.
+  # This prevents silent failures from going unnoticed.
+  release-notify:
+    name: Release Health Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [release, operatorhub-pr, helm-release]
+    if: always() && needs.release.result == 'success'
+    permissions:
+      issues: write
+    steps:
+      - name: Check for failures and create issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPERATORHUB_OUTCOME: ${{ needs.operatorhub-pr.outputs.outcome }}
+          HELM_RESULT: ${{ needs.helm-release.result }}
+          TAG: ${{ needs.release.outputs.tag }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          FAILURES=""
+          if [ "${OPERATORHUB_OUTCOME}" = "failure" ]; then
+            FAILURES="${FAILURES}- OperatorHub PR creation failed\n"
+          fi
+          if [ "${HELM_RESULT}" = "failure" ]; then
+            FAILURES="${FAILURES}- Helm chart release failed\n"
+          fi
+          if [ -n "${FAILURES}" ]; then
+            BODY="The release ${TAG} succeeded, but some post-release jobs failed:\n\n${FAILURES}\n[View workflow run](${RUN_URL})\n\nThese failures do not affect the core release (container images, binaries, signatures) but may leave the OperatorHub listing or Helm chart out of date."
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "Release ${TAG}: post-release job failures" \
+              --label "bug" \
+              --body "$(echo -e "${BODY}")"
+          else
+            echo "All post-release jobs succeeded."
+          fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,9 @@ builds:
   - id: manager
     main: ./cmd/manager
     binary: manager
+    env:
+      - CGO_ENABLED=0
+      - GOFIPS140=latest
     goos: [linux]
     goarch: [amd64, arm64, arm, ppc64le, s390x]
     goarm: ["7"]
@@ -18,6 +21,9 @@ builds:
   - id: kubectl-attune
     main: ./cmd/kubectl-attune
     binary: kubectl-attune
+    env:
+      - CGO_ENABLED=0
+      - GOFIPS140=latest
     goos: [linux, darwin]
     goarch: [amd64, arm64, arm, ppc64le, s390x]
     goarm: ["7"]

--- a/charts/attune/Chart.yaml
+++ b/charts/attune/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: attune
 description: Safe, in-place Kubernetes pod resource right-sizing operator
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.11
+appVersion: "0.1.11"
 icon: https://raw.githubusercontent.com/attune-io/attune/main/docs/logo.png
 home: https://github.com/attune-io/attune
 sources:

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -64,20 +64,16 @@ cosign-signed independently.
 
 ### 6. Helm chart publishing
 
-The Helm chart is published as an OCI artifact to `ghcr.io/attune-io/charts/attune`.
+The Helm chart is published as an OCI artifact to GHCR at
+`ghcr.io/attune-io/charts/attune`. The chart version in
+`charts/attune/Chart.yaml` is bumped automatically by release-please.
 
-Update the chart version in `charts/attune/Chart.yaml`:
-
-```yaml
-version: 0.2.0
-appVersion: "0.2.0"
-```
-
-The CI pipeline packages and pushes the chart automatically:
+The CI pipeline packages, pushes, and cosign-signs the chart:
 
 ```bash
 helm package charts/attune
 helm push attune-0.2.0.tgz oci://ghcr.io/attune-io/charts
+cosign sign --yes ghcr.io/attune-io/charts/attune:0.2.0
 ```
 
 ### 7. Static install manifest

--- a/hack/operatorhub-pr.sh
+++ b/hack/operatorhub-pr.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
-# Create or update a PR to k8s-operatorhub/community-operators for a new Attune release.
+# Create or update PRs to OperatorHub repos for a new Attune release.
+# Submits to both k8s-operatorhub/community-operators (operatorhub.io)
+# and redhat-openshift-ecosystem/community-operators-prod (OpenShift catalog).
 #
 # Usage: VERSION=0.1.7 GH_TOKEN=<token> hack/operatorhub-pr.sh
 #
 # Required env vars:
 #   VERSION         - Release version without 'v' prefix (e.g., 0.1.7)
-#   GH_TOKEN        - GitHub App token for pushing to the fork repo
+#   GH_TOKEN        - GitHub App token for pushing to the fork repos
 #
 # Optional env vars:
 #   UPSTREAM_GH_TOKEN - PAT with public_repo scope for creating PRs on
-#                       k8s-operatorhub/community-operators. Required because
-#                       GitHub App tokens can only act on repos where the app
-#                       is installed (our fork), not the upstream repo.
+#                       upstream repos. Required because GitHub App tokens
+#                       can only act on repos where the app is installed.
 #                       Falls back to GH_TOKEN if not set.
-#   FORK_OWNER      - GitHub user owning the fork (default: SebTardif)
+#   FORK_OWNER      - GitHub org owning the forks (default: attune-io)
 #   GIT_USER_NAME   - Git commit author name (default: github-actions[bot])
 #   GIT_USER_EMAIL  - Git commit author email (default: 41898282+github-actions[bot]@users.noreply.github.com)
 #   BUNDLE_DIR      - Pre-generated bundle path (default: generates via make)
@@ -26,14 +27,16 @@ set -Eeuo pipefail
 FORK_OWNER="${FORK_OWNER:-attune-io}"
 GIT_USER_NAME="${GIT_USER_NAME:-github-actions[bot]}"
 GIT_USER_EMAIL="${GIT_USER_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
-UPSTREAM_REPO="k8s-operatorhub/community-operators"
-FORK_REPO="${FORK_OWNER}/community-operators"
 BRANCH="attune-v${VERSION}"
 OPERATOR_DIR="operators/attune"
 
-# Save checkout root before any cd operations (OLDPWD is unreliable
-# after multiple cd commands).
+# Save checkout root before any cd operations.
 CHECKOUT_DIR="$(pwd)"
+
+# Collect temp dirs for cleanup.
+CLEANUP_DIRS=()
+cleanup() { for d in "${CLEANUP_DIRS[@]}"; do rm -rf "$d"; done; }
+trap cleanup EXIT
 
 # Generate the OLM bundle if not pre-generated
 BUNDLE_DIR="${BUNDLE_DIR:-dist/olm-bundle/${VERSION}}"
@@ -56,47 +59,73 @@ for f in \
 done
 echo "Bundle verified: ${BUNDLE_DIR}"
 
-# Clone the fork (shallow is fine here since we reset to upstream/main)
-WORK_DIR=$(mktemp -d)
-trap 'rm -rf "${WORK_DIR}"' EXIT
+# ── Submit bundle to one upstream repo ──────────────────────────────
+# Args: upstream_repo [openshift_versions]
+#   upstream_repo      - e.g. k8s-operatorhub/community-operators
+#   openshift_versions - e.g. v4.19 (only for community-operators-prod)
+submit_bundle() {
+    local upstream_repo="$1"
+    local openshift_versions="${2:-}"
+    local repo_name="${upstream_repo##*/}"
+    local fork_repo="${FORK_OWNER}/${repo_name}"
 
-echo "Cloning fork ${FORK_REPO}..."
-cd "${WORK_DIR}"
-git clone --depth=1 "https://x-access-token:${GH_TOKEN}@github.com/${FORK_REPO}.git" community-operators
-cd community-operators
+    echo ""
+    echo "=== Submitting to ${upstream_repo} ==="
 
-git config user.name "${GIT_USER_NAME}"
-git config user.email "${GIT_USER_EMAIL}"
+    local work_dir
+    work_dir=$(mktemp -d)
+    CLEANUP_DIRS+=("${work_dir}")
 
-# Reset to upstream main for a clean base
-git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
-git fetch upstream main --depth=1
-git checkout -B "${BRANCH}" upstream/main
+    echo "Cloning fork ${fork_repo}..."
+    git clone --depth=1 \
+        "https://x-access-token:${GH_TOKEN}@github.com/${fork_repo}.git" \
+        "${work_dir}/${repo_name}"
+    cd "${work_dir}/${repo_name}"
 
-# Copy the bundle
-mkdir -p "${OPERATOR_DIR}/${VERSION}/manifests" "${OPERATOR_DIR}/${VERSION}/metadata"
-cp "${CHECKOUT_DIR}/${BUNDLE_DIR}/manifests/"* "${OPERATOR_DIR}/${VERSION}/manifests/"
-cp "${CHECKOUT_DIR}/${BUNDLE_DIR}/metadata/"* "${OPERATOR_DIR}/${VERSION}/metadata/"
+    git config user.name "${GIT_USER_NAME}"
+    git config user.email "${GIT_USER_EMAIL}"
 
-# Ensure ci.yaml exists at the operator root with reviewers for auto-merge
-cat > "${OPERATOR_DIR}/ci.yaml" <<'EOF'
+    # Reset to upstream main for a clean base
+    git remote add upstream "https://github.com/${upstream_repo}.git"
+    git fetch upstream main --depth=1
+    git checkout -B "${BRANCH}" upstream/main
+
+    # Copy the bundle
+    mkdir -p "${OPERATOR_DIR}/${VERSION}/manifests" "${OPERATOR_DIR}/${VERSION}/metadata"
+    cp "${CHECKOUT_DIR}/${BUNDLE_DIR}/manifests/"* "${OPERATOR_DIR}/${VERSION}/manifests/"
+    cp "${CHECKOUT_DIR}/${BUNDLE_DIR}/metadata/"* "${OPERATOR_DIR}/${VERSION}/metadata/"
+
+    # Inject OpenShift version annotation if specified
+    if [ -n "${openshift_versions}" ]; then
+        sed -i '/^annotations:/a\  com.redhat.openshift.versions: "'"${openshift_versions}"'"' \
+            "${OPERATOR_DIR}/${VERSION}/metadata/annotations.yaml"
+    fi
+
+    # Ensure ci.yaml exists at the operator root with reviewers
+    cat > "${OPERATOR_DIR}/ci.yaml" <<'CIEOF'
 updateGraph: semver-mode
 reviewers:
   - SebTardif
   - attune-release-bot[bot]
-EOF
+CIEOF
 
-# Commit with DCO sign-off
-git add "${OPERATOR_DIR}/"
-git commit -s -m "operator attune (${VERSION})"
+    # Commit with DCO sign-off
+    git add "${OPERATOR_DIR}/"
+    git commit -s -m "operator attune (${VERSION})"
 
-# Force-push (creates or updates the branch)
-git push --force origin "${BRANCH}"
-echo "Pushed branch ${BRANCH} to ${FORK_REPO}"
+    # Force-push (creates or updates the branch)
+    git push --force origin "${BRANCH}"
+    echo "Pushed branch ${BRANCH} to ${fork_repo}"
 
-# Create or update the PR
-PR_TITLE="operator [U] [CI] attune (${VERSION})"
-PR_BODY="### New Submission
+    # Detect new vs update: check if operator dir exists on upstream/main
+    local pr_tag="[U]"
+    if ! git ls-tree --name-only upstream/main -- "${OPERATOR_DIR}" | grep -q .; then
+        pr_tag="[N]"
+    fi
+
+    local pr_title="operator ${pr_tag} [CI] attune (${VERSION})"
+    local pr_body
+    pr_body="### New Submission
 
 **Operator:** attune
 **Version:** ${VERSION}
@@ -108,33 +137,40 @@ See [release notes](https://github.com/attune-io/attune/releases/tag/v${VERSION}
 ---
 *This PR was automatically created by the Attune release workflow.*"
 
-# Switch to a token that can create PRs on the upstream public repo.
-# GitHub App tokens only work on repos where the app is installed (our fork).
-# Creating cross-fork PRs requires a PAT with public_repo scope.
-PR_TOKEN="${UPSTREAM_GH_TOKEN:-${GH_TOKEN}}"
+    # Switch to a token that can create PRs on the upstream public repo.
+    local pr_token="${UPSTREAM_GH_TOKEN:-${GH_TOKEN}}"
 
-# Check if a PR already exists for this branch
-EXISTING_PR=$(GH_TOKEN="${PR_TOKEN}" gh pr list \
-    --repo "${UPSTREAM_REPO}" \
-    --head "${FORK_OWNER}:${BRANCH}" \
-    --state open \
-    --json number \
-    --jq '.[0].number // empty' 2>/dev/null || true)
-
-if [ -n "${EXISTING_PR}" ]; then
-    echo "Updating existing PR #${EXISTING_PR}"
-    GH_TOKEN="${PR_TOKEN}" gh pr edit "${EXISTING_PR}" \
-        --repo "${UPSTREAM_REPO}" \
-        --title "${PR_TITLE}" \
-        --body "${PR_BODY}"
-    echo "PR updated: https://github.com/${UPSTREAM_REPO}/pull/${EXISTING_PR}"
-else
-    echo "Creating new PR..."
-    PR_URL=$(GH_TOKEN="${PR_TOKEN}" gh pr create \
-        --repo "${UPSTREAM_REPO}" \
+    # Check if a PR already exists for this branch
+    local existing_pr
+    existing_pr=$(GH_TOKEN="${pr_token}" gh pr list \
+        --repo "${upstream_repo}" \
         --head "${FORK_OWNER}:${BRANCH}" \
-        --base main \
-        --title "${PR_TITLE}" \
-        --body "${PR_BODY}")
-    echo "PR created: ${PR_URL}"
-fi
+        --state open \
+        --json number \
+        --jq '.[0].number // empty' 2>/dev/null || true)
+
+    if [ -n "${existing_pr}" ]; then
+        echo "Updating existing PR #${existing_pr}"
+        GH_TOKEN="${pr_token}" gh pr edit "${existing_pr}" \
+            --repo "${upstream_repo}" \
+            --title "${pr_title}" \
+            --body "${pr_body}"
+        echo "PR updated: https://github.com/${upstream_repo}/pull/${existing_pr}"
+    else
+        echo "Creating new PR..."
+        local pr_url
+        pr_url=$(GH_TOKEN="${pr_token}" gh pr create \
+            --repo "${upstream_repo}" \
+            --head "${FORK_OWNER}:${BRANCH}" \
+            --base main \
+            --title "${pr_title}" \
+            --body "${pr_body}")
+        echo "PR created: ${pr_url}"
+    fi
+
+    cd "${CHECKOUT_DIR}"
+}
+
+# ── Submit to both OperatorHub repos ────────────────────────────────
+submit_bundle "k8s-operatorhub/community-operators"
+submit_bundle "redhat-openshift-ecosystem/community-operators-prod" "v4.19"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,19 @@
       "release-type": "go",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "charts/attune/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/attune/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Addresses 9 issues found during a comprehensive release pipeline audit.

### Changes

| Issue | Fix |
|-------|-----|
| #199 (Critical) | SLSA binary provenance: add `upload-tag-name` so the generator can find the GitHub Release |
| #200 (High) | Silent failures: add `release-notify` job that creates a GitHub Issue when OperatorHub or Helm jobs fail |
| #204 (High) | OpenShift catalog: refactor `operatorhub-pr.sh` to submit to both `community-operators` and `community-operators-prod` |
| #198 (Medium) | Docker Hub collision: stop pushing Helm charts to Docker Hub (GHCR only, matching industry convention) |
| #201 (Medium) | GOFIPS140 parity: add `GOFIPS140=latest` to GoReleaser so CLI binaries match container FIPS crypto |
| #205 (Medium) | Chart.yaml version: add `extra-files` to release-please config so it bumps Chart.yaml automatically |
| #203 (Medium) | Stale secret: deleted unused `APP_ID` secret |
| #202 (Low) | SBOM signing: add `cosign sign-blob` step, attach `.sig` and `.cert` to release |
| #206 (Low) | ORAS pinning: replace inline curl download with `oras-project/setup-oras` action |

### Files changed

- `.github/workflows/release.yaml` - SLSA fix, SBOM signing, ORAS action, Docker Hub Helm removal, notify job, community-operators-prod scope
- `.goreleaser.yaml` - GOFIPS140=latest on both builds
- `hack/operatorhub-pr.sh` - Refactored to `submit_bundle()` function, submits to both OperatorHub repos
- `release-please-config.json` - extra-files for Chart.yaml
- `charts/attune/Chart.yaml` - Version updated to 0.1.11 (was stale at 0.1.0)
- `docs/contributing/releasing.md` - Updated Helm chart section

### Manual cleanup (not in this PR)

Docker Hub still has 11 stale Helm chart tags (`0.1.0` through `0.1.11`) in `attuneio/attune`. These should be deleted via the Docker Hub API after this PR merges. They are harmless but confusing.

### Verification

- `make verify-quick` passes (lint, tests, helm-unittest, doc-defaults, RBAC check)
- All 96 Helm unit tests pass
- Release artifacts generate cleanly

Closes #198, #199, #200, #201, #202, #203, #204, #205, #206