### PR TITLE
fix: docker Hub chart separation + nightly E2E install-binary-tool PATH fix

### DIFF
--- a/.github/actions/install-binary-tool/action.yaml
+++ b/.github/actions/install-binary-tool/action.yaml
@@ -32,6 +32,7 @@ runs:
         TOOL_DIR: ${{ runner.temp }}/bin-tool-cache/${{ inputs.name }}
       run: |
         mkdir -p "$TOOL_DIR"
+        export PATH="$TOOL_DIR:$PATH"
         ${{ inputs.install-command }}
 
     - name: Add ${{ inputs.name }} to PATH

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -268,12 +268,24 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} \
             --username ${{ github.actor }} --password-stdin
 
+      - name: Login to Docker Hub (Helm)
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | helm registry login registry-1.docker.io \
+            --username "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
       - name: Login to GHCR (Docker/cosign)
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub (Docker/cosign)
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Package and push Helm chart
         shell: bash -Eeuo pipefail -x {0}
@@ -286,6 +298,7 @@ jobs:
 
           helm package charts/attune
           helm push attune-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
+          helm push attune-${VERSION}.tgz oci://registry-1.docker.io/attuneio/attune-chart
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -297,6 +310,14 @@ jobs:
           VERSION="${VERSION#v}"
           cosign sign --yes \
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/attune:${VERSION}
+
+      - name: Sign Helm chart (Docker Hub)
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          VERSION="${{ needs.release.outputs.tag }}"
+          VERSION="${VERSION#v}"
+          cosign sign --yes \
+            docker.io/attuneio/attune-chart:${VERSION}
 
       - uses: oras-project/setup-oras@v1
         with:

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -64,9 +64,12 @@ cosign-signed independently.
 
 ### 6. Helm chart publishing
 
-The Helm chart is published as an OCI artifact to GHCR at
-`ghcr.io/attune-io/charts/attune`. The chart version in
-`charts/attune/Chart.yaml` is bumped automatically by release-please.
+The Helm chart is published as an OCI artifact to two registries:
+
+- **GHCR:** `ghcr.io/attune-io/charts/attune` (primary)
+- **Docker Hub:** `docker.io/attuneio/attune-chart` (separate from the container image repo)
+
+The chart version in `charts/attune/Chart.yaml` is bumped automatically by release-please.
 
 The CI pipeline packages, pushes, and cosign-signs the chart:
 


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Push Helm chart to separate Docker Hub repo

PR #207 fixed the Docker Hub chart/image collision by removing chart publishing entirely. This restores Docker Hub chart publishing to a **dedicated repo** (`attuneio/attune-chart`), separate from the container image repo (`attuneio/attune`).

- Docker Hub Helm registry login + `helm push` to `oci://registry-1.docker.io/attuneio/attune-chart`
- Cosign signing for the Docker Hub chart
- Updated `docs/contributing/releasing.md` with dual-registry documentation

| Registry | Repository | Content |
|----------|-----------|---------|
| GHCR | `ghcr.io/attune-io/charts/attune` | Helm chart |
| GHCR | `ghcr.io/attune-io/attune` | Container image |
| Docker Hub | `docker.io/attuneio/attune-chart` | Helm chart |
| Docker Hub | `docker.io/attuneio/attune` | Container image |

Ref #198

### 2. Fix nightly E2E install-binary-tool PATH

The `install-binary-tool` composite action (introduced in #186) only added `$TOOL_DIR` to `$GITHUB_PATH` in step 3, after the install command in step 2. The k3d install script runs a post-install verification (`k3d` on PATH?), which failed on cache miss because `$TOOL_DIR` wasn't on PATH yet. This broke the nightly E2E across all 4 K8s versions.

Fix: `export PATH="$TOOL_DIR:$PATH"` before running the install command.

Closes #194