### PR TITLE
ci: replace Codecov with GitHub native code coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ env:
   K3S_IMAGE: "rancher/k3s:v1.35.4-k3s1"
   ENVTEST_K8S_VERSION: "1.35.0"
   HELM_UNITTEST_VERSION: "v0.7.2"
+  GOCOVER_COBERTURA_VERSION: "v1.5.0"
   BENCHSTAT_VERSION: "v0.0.0-20260512194132-3cf34090a3db"
   CERT_MANAGER_VERSION: "v1.17.2"
   PROMETHEUS_IMAGE: "quay.io/prometheus/prometheus:v3.4.1"
@@ -272,11 +273,16 @@ jobs:
     timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.go == 'true'
+    permissions:
+      contents: read
+      code-quality: write
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -288,6 +294,12 @@ jobs:
           name: gotestsum
           version: ${{ env.GOTESTSUM_VERSION }}
           package: gotest.tools/gotestsum
+
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: gocover-cobertura
+          version: ${{ env.GOCOVER_COBERTURA_VERSION }}
+          package: github.com/boumenot/gocover-cobertura
 
       - name: Run unit tests
         shell: bash -Eeuo pipefail -x {0}
@@ -325,13 +337,21 @@ jobs:
         with:
           paths: test-results/unit.xml
 
+      - name: Convert coverage to Cobertura XML
+        if: always() && hashFiles('coverage.out') != ''
+        shell: bash -Eeuo pipefail {0}
+        run: gocover-cobertura < coverage.out > coverage.xml
+
       - name: Upload coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
-        continue-on-error: true
+        if: >-
+          always() &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
         with:
-          files: coverage.out
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+          file: coverage.xml
+          language: Go
+          label: code-coverage/go
 
   test-bench:
     name: Benchmark Tests (${{ matrix.pkg }})


### PR DESCRIPTION
Replace `codecov/codecov-action` (requires `CODECOV_TOKEN` secret) with GitHub's native `actions/upload-code-coverage@v1` (zero external dependencies).

## What changes

| Before | After |
|--------|-------|
| Codecov third-party action | GitHub native `actions/upload-code-coverage@v1` |
| Requires `CODECOV_TOKEN` secret | No secret needed |
| Coverage on external codecov.io dashboard | Coverage on PR diffs in GitHub UI |
| Go native `coverage.out` format | Cobertura XML via `gocover-cobertura` |

## Details

- Adds `gocover-cobertura` v1.5.0 (cached via `install-go-tool` action) to convert Go's coverage profile to Cobertura XML
- Adds `code-quality: write` permission to the test-unit job (required by the action; new permission scope as of April 2026)
- Uses PR head SHA checkout so coverage is attributed to the correct commit
- Fork PRs are skipped gracefully (they lack write permission to the base repo)
- Conversion and upload steps use `always()` so coverage is available even when the 80% threshold check fails

## Follow-up

After merge, delete the `CODECOV_TOKEN` secret from Settings > Secrets and variables > Actions.