### PR TITLE
ci: add workflow_dispatch and concurrency group to fossa.yaml

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [main]
   merge_group: {}
+  workflow_dispatch: {}
 
 permissions:
   contents: read
+
+concurrency:
+  group: fossa-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   FOSSA_CLI_VERSION: "3.17.10"


### PR DESCRIPTION
Add missing `workflow_dispatch` trigger and `concurrency` group to the FOSSA license compliance workflow, matching the pattern established across all other CI workflows.

**Changes:**
- Added `workflow_dispatch:` trigger for manual runs
- Added `concurrency` group with `cancel-in-progress: true` to prevent duplicate runs

Found during multi-perspective improvement rotation (Ops/SRE perspective).