### PR TITLE
fix: use cosign --bundle flag for SBOM signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -207,8 +207,7 @@ jobs:
         shell: bash -Eeuo pipefail -x {0}
         run: |
           cosign sign-blob --yes \
-            --output-signature sbom.spdx.json.sig \
-            --output-certificate sbom.spdx.json.cert \
+            --bundle sbom.spdx.json.bundle \
             sbom.spdx.json
 
       - name: Generate install manifest and CRDs bundle
@@ -226,8 +225,7 @@ jobs:
             dist/install.yaml
             dist/crds.yaml
             sbom.spdx.json
-            sbom.spdx.json.sig
-            sbom.spdx.json.cert
+            sbom.spdx.json.bundle
 
       # Krew manifest update runs last with continue-on-error so a Krew
       # failure never blocks Docker images, signatures, or provenance.


### PR DESCRIPTION
Fixes the red X on the latest release workflow run.

## Problem

cosign v2+ deprecated `--output-signature` and `--output-certificate` in favor of `--bundle`. The deprecated flags are silently ignored under the new bundle format, causing:

```
Error: signing sbom.spdx.json: create bundle file: open : no such file or directory
```

The error occurs because no `--bundle` path is specified, so cosign tries to open an empty string as a file path.

## Fix

- Replace `--output-signature` and `--output-certificate` with `--bundle sbom.spdx.json.bundle`
- Update the release asset attachment list to use `.bundle` instead of `.sig` and `.cert`

## Failing run

https://github.com/attune-io/attune/actions/runs/26718534167