### PR TITLE
ci: add workflow_dispatch tag input for release re-runs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,12 @@ name: Release
 on:
   push:
     branches: [main]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Re-release an existing tag (e.g., v0.1.12). Leave empty for normal release-please flow."
+        required: false
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
@@ -25,7 +30,8 @@ jobs:
   # do not trigger separate tag-push workflows.
   release-please:
     name: Release Please
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # Skip release-please when manually re-releasing an existing tag.
+    if: inputs.tag == '' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -56,15 +62,17 @@ jobs:
   release:
     name: Release
     needs: [release-please]
-    # Run when release-please created a release, OR on manual workflow_dispatch
-    # with a tag ref. always() is needed because release-please is skipped on
+    # Run when release-please created a release, on manual workflow_dispatch
+    # with a tag ref, or when re-releasing via the tag input.
+    # always() is needed because release-please is skipped on
     # workflow_dispatch, which would otherwise skip this job too.
     if: |-
       always() &&
       !failure() &&
       !cancelled() &&
       (needs.release-please.outputs.release_created == 'true' ||
-       (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/')))
+       (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/')) ||
+       (github.event_name == 'workflow_dispatch' && inputs.tag != ''))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: release
@@ -86,8 +94,9 @@ jobs:
         id: tag
         shell: bash
         run: |
-          # On release-please: use its output. On workflow_dispatch: use the ref.
-          TAG="${{ needs.release-please.outputs.tag_name || github.ref_name }}"
+          # On release-please: use its output. On re-release: use the input tag.
+          # On workflow_dispatch with tag ref: use ref_name.
+          TAG="${{ needs.release-please.outputs.tag_name || inputs.tag || github.ref_name }}"
           echo "name=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Releasing: ${TAG}"
 


### PR DESCRIPTION
Adds an optional `tag` input to the release workflow's `workflow_dispatch` trigger, enabling re-releases of existing tags from the Actions UI.

**When a tag is provided:**
- Release Please is skipped (unnecessary for re-releases)
- The release job runs using the specified tag
- All downstream jobs (Helm, SLSA provenance, OperatorHub) run normally

**Why this is needed:**
v0.1.12's release workflow failed at the SBOM signing step (fixed in #213). The release was created with GoReleaser binaries but is missing install.yaml, crds.yaml, SBOM, Helm chart, and SLSA provenance. Previously, there was no way to re-run the release for an existing tag because `workflow_dispatch` required a tag ref (which would use the old, broken workflow file from the tag commit).

With this change, you can go to Actions > Release > Run workflow, enter `v0.1.12` in the tag field, and re-run the full release pipeline using the latest workflow code from main.

The existing 'Clean existing release assets' step ensures idempotent re-runs.