### PR TITLE
ci: cache Docker build layers with GitHub Actions cache

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,6 +162,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.name }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
Adds `cache-from: type=gha` and `cache-to: type=gha,mode=max` to the multi-arch Docker build step in the release workflow.

**Problem:** Every release downloads all Go dependencies from scratch inside the Docker build. The `go mod download` layer runs for each of the 5 target platforms (amd64, arm64, armv7, ppc64le, s390x), wasting several minutes of build time on every release.

**Fix:** GitHub Actions cache backend for BuildKit persists Docker layers across workflow runs. When `go.mod`/`go.sum` haven't changed, the cached `go mod download` layer is reused instead of re-downloading all packages.

`mode=max` caches all intermediate layers (including the dependency download layer), not just the final image layer.