### PR TITLE
fix: use oras cp for Docker Hub Helm chart push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -277,12 +277,6 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} \
             --username ${{ github.actor }} --password-stdin
 
-      - name: Login to Docker Hub (Helm)
-        shell: bash -Eeuo pipefail -x {0}
-        run: |
-          echo "${{ secrets.DOCKERHUB_TOKEN }}" | helm registry login registry-1.docker.io \
-            --username "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-
       - name: Login to GHCR (Docker/cosign)
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -307,7 +301,24 @@ jobs:
 
           helm package charts/attune
           helm push attune-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
-          helm push attune-${VERSION}.tgz oci://registry-1.docker.io/attuneio/attune-chart
+
+      - uses: oras-project/setup-oras@v1
+        with:
+          version: "1.3.2"
+
+      - name: Copy Helm chart to Docker Hub
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          # helm push appends the chart name, creating a 3-level path
+          # (attuneio/attune-chart/attune) that Docker Hub rejects.
+          # Use oras cp to copy from GHCR to the exact 2-level path.
+          VERSION="${{ needs.release.outputs.tag }}"
+          VERSION="${VERSION#v}"
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | oras login registry-1.docker.io \
+            --username "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+          oras cp \
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/attune:${VERSION} \
+            registry-1.docker.io/attuneio/attune-chart:${VERSION}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -327,10 +338,6 @@ jobs:
           VERSION="${VERSION#v}"
           cosign sign --yes \
             docker.io/attuneio/attune-chart:${VERSION}
-
-      - uses: oras-project/setup-oras@v1
-        with:
-          version: "1.3.2"
 
       - name: Push Artifact Hub metadata
         shell: bash -Eeuo pipefail -x {0}

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -71,12 +71,15 @@ The Helm chart is published as an OCI artifact to two registries:
 
 The chart version in `charts/attune/Chart.yaml` is bumped automatically by release-please.
 
-The CI pipeline packages, pushes, and cosign-signs the chart:
+The CI pipeline packages, pushes to GHCR, mirrors to Docker Hub via `oras cp`,
+and cosign-signs both copies:
 
 ```bash
 helm package charts/attune
 helm push attune-0.2.0.tgz oci://ghcr.io/attune-io/charts
+oras cp ghcr.io/attune-io/charts/attune:0.2.0 registry-1.docker.io/attuneio/attune-chart:0.2.0
 cosign sign --yes ghcr.io/attune-io/charts/attune:0.2.0
+cosign sign --yes docker.io/attuneio/attune-chart:0.2.0
 ```
 
 ### 7. Static install manifest


### PR DESCRIPTION
Replaces `helm push` to Docker Hub with `oras cp` from GHCR.

**Problem:** `helm push` always appends the chart name from Chart.yaml to the OCI registry path. With the target `oci://registry-1.docker.io/attuneio/attune-chart`, Helm creates a 3-level path `attuneio/attune-chart/attune` that Docker Hub rejects with 401 (Docker Hub only supports 2-level paths).

**Fix:** `oras cp` copies the OCI artifact byte-for-byte from GHCR to the exact 2-level path `attuneio/attune-chart:VERSION` without appending anything. Push once to GHCR with `helm push`, then mirror to Docker Hub with `oras cp`.

**Verified locally:**
```
oras cp ghcr.io/attune-io/charts/attune:0.1.11 registry-1.docker.io/attuneio/attune-chart:0.1.11
Copied [registry] ghcr.io/attune-io/charts/attune:0.1.11 => [registry] registry-1.docker.io/attuneio/attune-chart:0.1.11
Digest: sha256:50854105ad7ec8a84d10e6aff0890b329a6130cd8baf086a2806164938892695
```

Closes #218