### PR TITLE
ci: add auto-approve workflow, branch protection, and workflow hygiene fixes

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -1,0 +1,35 @@
+name: Auto Approve
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-approve-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-approve:
+    name: Auto Approve
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event.pull_request.user.login == 'SebTardif'
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Auto Approve
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: backport-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   backport:
     name: Backport

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
   merge_group: {}
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   fossa:
     name: FOSSA License Scan
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -45,7 +45,7 @@ jobs:
 
   fossa-test:
     name: FOSSA License Check
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: fossa

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -7,6 +7,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   label:
     name: Auto-label PR

--- a/.github/workflows/pr-size.yaml
+++ b/.github/workflows/pr-size.yaml
@@ -8,6 +8,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: pr-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   size-label:
     name: Label PR size

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -7,6 +7,10 @@ on:
 permissions:
   pull-requests: read
 
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   semantic-title:
     name: Semantic PR Title

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -302,7 +302,7 @@ jobs:
           helm package charts/attune
           helm push attune-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
 
-      - uses: oras-project/setup-oras@v1
+      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
         with:
           version: "1.3.2"
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -9,6 +9,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scorecard:
     name: Scorecard

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -19,24 +19,48 @@ concurrency:
 
 jobs:
   codeql:
-    name: CodeQL
+    name: CodeQL (${{ matrix.language }})
     permissions:
+      actions: read
       contents: read
       security-events: write
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: manual
+          - language: actions
+            build-mode: none
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        if: matrix.language == 'go'
+        with:
+          go-version: "1.26"
+          cache: true
+
       - uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          languages: go, actions
-      - uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+          dependency-caching: true
+
+      - name: Build (Go)
+        if: matrix.build-mode == 'manual'
+        run: go build ./...
+
       - uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           upload: always
+          category: "/language:${{ matrix.language }}"
 
   govulncheck:
     name: Govulncheck

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,6 +9,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: stale
+  cancel-in-progress: true
+
 jobs:
   stale:
     name: Close stale issues and PRs


### PR DESCRIPTION
## Summary

Implements branch protection best practices for a solo-maintainer repo,
following the ci-workflow-hygiene skill (Option B+C: Rulesets + Auto-Approve Bot).

### Branch protection (ruleset update, already applied)

- Added `pull_request` rule requiring 1 approval with dismiss-stale-reviews
- Admin bypass actor (mode: always) for `gh pr merge --admin`
- Updated CodeQL required check names from `CodeQL` to `CodeQL (go)` / `CodeQL (actions)` to match the new matrix job names
- Created `vars.AUTO_APPROVE_CLIENT_ID` (reuses existing release bot app)

### Auto-approve workflow (new)

- `.github/workflows/auto-approve.yaml` using `actions/create-github-app-token@v3` with `client-id` (not deprecated `app-id`)
- Only triggers for PRs authored by `SebTardif`
- Uses `github.event.pull_request.user.login` (not `github.actor`)
- Permissions: `contents: read` only (Scorecard TokenPermissions compliant)

### Workflow audit fixes

| Fix | Workflows |
|-----|-----------|
| Add concurrency groups | scorecard, pr-size, pr-title, labeler, stale, backport |
| Fix `github.actor` to `user.login` | dependabot-auto-merge, fossa |
| Add `workflow_dispatch` | dco |
| CodeQL: autobuild to manual build | security (100% vs ~45% Go file coverage) |
| CodeQL: add `security-and-quality` queries | security |
| CodeQL: add `actions: read` permission | security |
| CodeQL: add `dependency-caching` | security |
| Upgrade `setup-oras` v1 to v2.0.0 | release (fixes #218: v1 does not recognize ORAS CLI 1.3.2) |

### Dependabot

Already fully configured with gomod, github-actions, pip, docker ecosystems,
dependency grouping (k8s separate, minor/patch together), and auto-merge workflow.

### Merge command

Since bot approvals do not satisfy ruleset approval requirements:
```bash
gh pr merge <number> --squash --admin
```

Closes #218