### PR TITLE
fix: pin setup-oras to SHA that includes ORAS CLI 1.3.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -302,7 +302,7 @@ jobs:
           helm package charts/attune
           helm push attune-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
 
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+      - uses: oras-project/setup-oras@94695ea835c8fd3d6bb0ffe5fb6d24d8848e72ef # v2 (includes 1.3.2)
         with:
           version: "1.3.2"
 


### PR DESCRIPTION
## Problem

The Helm Chart Release job fails because `setup-oras@v2.0.0` (released April 6) does not recognize ORAS CLI v1.3.2 (released April 18). The action maintains a `releases.json` file with known versions, and v1.3.2 was only added in commit d98226f6e992 (May 5).

Error:
```
official ORAS CLI releases does not contain version 1.3.2
```

## Fix

Pin `setup-oras` to SHA `94695ea835c8` (latest main, which includes the v1.3.2 entry in releases.json) instead of the `v2.0.0` tag.

## Verification

After merge, re-release v0.1.12 to confirm the Helm chart copy to Docker Hub succeeds.

Closes #221