### PR TITLE
fix: docs, CI consistency, and demo script fixes from multi-perspective review

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -20,6 +20,9 @@ jobs:
     timeout-minutes: 5
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,6 +53,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           stale-issue-message: >

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -47,7 +47,7 @@ import (
 var version = "dev"
 
 const (
-	structuredOutputUsage = "Output raw AttunePolicy objects as json or yaml (status only)"
+	structuredOutputUsage = "Output raw AttunePolicy objects as json or yaml (status and diff)"
 	sourcePolicy          = "policy"
 	sourceNamespace       = "namespace default"
 	sourceCluster         = "cluster default"

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -208,7 +208,7 @@ kubectl get rsp
 ```
 
 ```text
-NAME     MODE        WORKLOADS   RECS   RESIZED   READY   AGE
+NAME     TYPE        WORKLOADS   RECS   RESIZED   READY   AGE
 ```
 
 Pass `-o wide` to include `CPU Saved` and `Mem Saved` columns.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -230,8 +230,9 @@ kubectl attune version
 
 ## Structured output
 
-`--output` / `-o` is supported only with the `status` command and prints the
-raw `AttunePolicy` objects returned by the cluster as JSON or YAML.
+`--output` / `-o` is supported with the `status` command (JSON or YAML) and the
+`diff` command (YAML only). It prints the raw `AttunePolicy` objects returned by
+the cluster.
 
 ```bash
 kubectl attune status -o json
@@ -248,7 +249,7 @@ with `kubectl get attunepolicy -o json|yaml`.
 | `--namespace` | `-n` | Target namespace (defaults to current context) |
 | `--all-namespaces` | `-A` | List across all namespaces |
 | `--kubeconfig` | | Path to kubeconfig file |
-| `--output` | `-o` | Output raw `AttunePolicy` objects as `json` or `yaml` (`status` only) |
+| `--output` | `-o` | Output raw `AttunePolicy` objects as `json` or `yaml` (`status` and `diff`) |
 | `--watch` | `-w` | Continuously refresh status every 10 seconds (`status` only) |
 | `--sort-by` | | Sort output: `name`, `namespace`, `savings`, `age` (`status` and `savings` only) |
 | `--filter` | | Filter by condition: `degraded`, `pending`, `collecting`, `ready`, `noworkloads` (`status` only) |

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -183,23 +183,20 @@ spec:
   metricsSource:
     prometheus:
       address: http://prometheus-server.monitoring:80
+    historyWindow: 15m
+    minimumDataPoints: 3
   cpu:
     percentile: 95
     overhead: "20"
-    bounds:
-      min: "50m"
-      max: "2000m"
+    minAllowed: "50m"
+    maxAllowed: "2000m"
   memory:
     percentile: 99
     overhead: "30"
-    bounds:
-      min: "64Mi"
-      max: "4Gi"
-  confidence:
-    minimumDataPoints: 3
-  historyWindow: 15m
+    minAllowed: "64Mi"
+    maxAllowed: "4Gi"
   updateStrategy:
-    mode: Recommend
+    type: Recommend
     reconcileInterval: 30s
 EOF
 echo
@@ -254,7 +251,7 @@ banner "Step 7: Promote to Auto mode (in-place resize)"
 
 info "Switching from Recommend to Auto mode..."
 run kubectl patch attunepolicies web-api -n demo-app --type merge \
-  -p '{"spec":{"updateStrategy":{"mode":"Auto","autoRevert":true}}}'
+  -p '{"spec":{"updateStrategy":{"type":"Auto","autoRevert":true}}}'
 echo
 
 info "Waiting for the operator to resize pods in-place..."


### PR DESCRIPTION
## Changes

8 fixes found across Cycles 2-4 of the multi-perspective improvement rotation (7 cycles total, 14 perspectives each, converged at Cycle 5 with 3 consecutive zero-finding cycles).

### Documentation (3 fixes)
- **api.md**: Fix print column example output from `MODE` to `TYPE` to match the CRD definition (`+kubebuilder:printcolumn:name="Type"`)
- **cli.md**: Fix `-o` flag documentation to reflect that both `status` (JSON/YAML) and `diff` (YAML) support structured output
- **kubectl-attune**: Fix `structuredOutputUsage` constant from `(status only)` to `(status and diff)` to match actual behavior

### CI Consistency (4 fixes)
- **stale.yaml**: Add `step-security/harden-runner`
- **docs.yaml**: Add `step-security/harden-runner` to the `deploy` job (build job already had it)
- **dependabot-auto-merge.yaml**: Add `step-security/harden-runner` (`pull_request_target` trigger)
- **pr-title.yaml**: Add `step-security/harden-runner` (`pull_request_target` trigger)

All 15 workflows now have `step-security/harden-runner` in every job.

### Demo Script (1 fix)
- **hack/demo.sh**: Update to use current API field names (from pre-v0.1.0 renames):
  - `bounds.min/max` to `minAllowed/maxAllowed`
  - `confidence.minimumDataPoints` to `metricsSource.minimumDataPoints`
  - spec-level `historyWindow` to `metricsSource.historyWindow`
  - `updateStrategy.mode` to `updateStrategy.type`

  The stale fields were silently ignored (`omitempty`), causing the demo to use all defaults instead of the fast demo settings.