### PR TITLE
fix: add cosign signing to release artifacts for Scorecard improvement

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,6 +141,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
@@ -177,9 +180,6 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.tag.outputs.name }}
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign GHCR image
         shell: bash -Eeuo pipefail -x {0}

--- a/.github/workflows/sign-old-releases.yaml
+++ b/.github/workflows/sign-old-releases.yaml
@@ -1,0 +1,50 @@
+name: Sign Old Releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: "Space-separated tags to sign (e.g., v0.1.8 v0.1.9 v0.1.10 v0.1.11)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sign:
+    name: Sign Releases
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign each release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAGS: ${{ inputs.tags }}
+        run: |
+          for TAG in ${TAGS}; do
+            echo "::group::Signing ${TAG}"
+            mkdir -p "/tmp/${TAG}" && cd "/tmp/${TAG}"
+            gh release download "${TAG}" \
+              --repo "${{ github.repository }}" \
+              --pattern checksums.txt
+            cosign sign-blob --yes \
+              --output-signature checksums.txt.sig \
+              --output-certificate checksums.txt.pem \
+              checksums.txt
+            gh release upload "${TAG}" \
+              checksums.txt.sig checksums.txt.pem \
+              --repo "${{ github.repository }}" \
+              --clobber
+            echo "Signed ${TAG}"
+            echo "::endgroup::"
+          done

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,5 +45,15 @@ archives:
     name_template: "kubectl-attune_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: checksums.txt
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    args:
+      - sign-blob
+      - "--yes"
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+    certificate: '${artifact}.pem'
 changelog:
   use: github-native


### PR DESCRIPTION
## What

Add cosign keyless signing of GoReleaser checksums to every release, and a one-time workflow to retroactively sign older releases.

## Why

The OpenSSF Scorecard Signed-Releases check scores 2/10 because only 1 of the last 5 releases (v0.1.12) has signed artifacts (SLSA provenance). Older releases (v0.1.8-v0.1.11) have no signatures or provenance.

## Changes

- **`.goreleaser.yaml`**: Add `signs` section to sign `checksums.txt` with cosign (keyless via Sigstore Fulcio). Produces `checksums.txt.sig` and `checksums.txt.pem` as release artifacts.
- **`.github/workflows/release.yaml`**: Move `cosign-installer` before GoReleaser so cosign is available for signing during the release build.
- **`.github/workflows/sign-old-releases.yaml`**: New `workflow_dispatch` workflow to retroactively sign checksums on older releases. Run once with `v0.1.8 v0.1.9 v0.1.10 v0.1.11` after merge.

## Expected Scorecard impact

After retroactive signing + next release: Signed-Releases check goes from 2/10 to 10/10 (all 5 recent releases will have signed artifacts).