### PR TITLE
fix: cosign signing with --new-bundle-format=false for scorecard

### DIFF
--- a/.github/workflows/sign-old-releases.yaml
+++ b/.github/workflows/sign-old-releases.yaml
@@ -39,15 +39,17 @@ jobs:
               --repo "${{ github.repository }}" \
               --pattern checksums.txt \
               --dir "${WORKDIR}"
+            # --new-bundle-format=false required: cosign defaults to new bundle
+            # format which ignores --output-signature. Scorecard only recognizes
+            # .sig files, not .bundle files.
             cosign sign-blob --yes \
+              --new-bundle-format=false \
               --output-signature "${WORKDIR}/checksums.txt.sig" \
               --output-certificate "${WORKDIR}/checksums.txt.pem" \
-              --bundle "${WORKDIR}/checksums.txt.bundle" \
               "${WORKDIR}/checksums.txt"
             gh release upload "${TAG}" \
               "${WORKDIR}/checksums.txt.sig" \
               "${WORKDIR}/checksums.txt.pem" \
-              "${WORKDIR}/checksums.txt.bundle" \
               --repo "${{ github.repository }}" \
               --clobber
             echo "Signed ${TAG}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,6 +51,7 @@ signs:
     args:
       - sign-blob
       - "--yes"
+      - "--new-bundle-format=false"
       - "--output-signature=${signature}"
       - "--output-certificate=${certificate}"
       - "${artifact}"


### PR DESCRIPTION
## What

Fix cosign signing to produce `.sig` files that OpenSSF Scorecard recognizes, and tighten branch protection for higher scorecard rating.

## Why

- Cosign v2.4+ defaults `--new-bundle-format` to `true`, which causes `sign_blob.go` to take an early-return path (line 131-137) that writes only to `--bundle` and **never executes** the `--output-signature` code. This is why the retroactive signing workflow kept failing.
- OpenSSF Scorecard's `releasesAreSigned` probe only recognizes: `.asc`, `.minisig`, `.sig`, `.sign`, `.sigstore`, `.sigstore.json`. It does **not** recognize `.bundle` files.
- Branch-Protection score was 4/10 due to two missing Tier 2 sub-checks.

## Changes

### Cosign signing fix
- Add `--new-bundle-format=false` to both `.goreleaser.yaml` and `sign-old-releases.yaml`
- Remove `--bundle` flag from sign-old-releases (was causing `--output-signature` to be ignored)
- Upload only `.sig` and `.pem` files (scorecard-recognized formats)

### Branch protection (via API, not in this diff)
- `strict_required_status_checks_policy: true` (require up-to-date branches)
- `require_last_push_approval: true` (last pusher cannot self-approve)

## Expected scorecard impact

| Check | Before | After |
|-------|--------|-------|
| Signed-Releases | 2/10 | 10/10 (after signing old releases) |
| Branch-Protection | 4/10 | 8/10 |