### PR TITLE
fix: add --use-signing-config=false for cosign old bundle format

### DIFF
--- a/.github/workflows/sign-old-releases.yaml
+++ b/.github/workflows/sign-old-releases.yaml
@@ -39,11 +39,12 @@ jobs:
               --repo "${{ github.repository }}" \
               --pattern checksums.txt \
               --dir "${WORKDIR}"
-            # --new-bundle-format=false required: cosign defaults to new bundle
-            # format which ignores --output-signature. Scorecard only recognizes
-            # .sig files, not .bundle files.
+            # --new-bundle-format=false and --use-signing-config=false required:
+            # cosign defaults both to true, but use-signing-config requires
+            # new-bundle-format. Scorecard only recognizes .sig files.
             cosign sign-blob --yes \
               --new-bundle-format=false \
+              --use-signing-config=false \
               --output-signature "${WORKDIR}/checksums.txt.sig" \
               --output-certificate "${WORKDIR}/checksums.txt.pem" \
               "${WORKDIR}/checksums.txt"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,7 @@ signs:
       - sign-blob
       - "--yes"
       - "--new-bundle-format=false"
+      - "--use-signing-config=false"
       - "--output-signature=${signature}"
       - "--output-certificate=${certificate}"
       - "${artifact}"


### PR DESCRIPTION
Follow-up to PR #231. Cosign's `--use-signing-config` defaults to `true` and requires either `--new-bundle-format` or `--bundle`. Since we need `--new-bundle-format=false` to produce `.sig` files that scorecard recognizes, we must also set `--use-signing-config=false`.

Error from run 26730968126:
```
Error: must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config
```