### PR TITLE
docs: add guides for Datadog and CloudWatch metrics sources

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,7 +17,7 @@ recommendations, and promoting to Canary mode, all in about five minutes.
 
 !!! info "Prerequisites"
     - **Kubernetes 1.32+** — 1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33+ has it enabled by default.
-    - **Prometheus** — the operator queries `container_cpu_usage_seconds_total` and `container_memory_working_set_bytes`.
+    - **A metrics source** — Prometheus (default), Datadog, or CloudWatch Container Insights. This guide uses Prometheus; see [Datadog Setup](../guides/datadog-setup.md) or [CloudWatch Setup](../guides/cloudwatch-setup.md) for alternatives.
     - **Attune installed** — see [Installation](installation.md) for Helm and raw manifest options.
 
 ## 1. Create an AttunePolicy in Recommend mode

--- a/docs/guides/cloudwatch-setup.md
+++ b/docs/guides/cloudwatch-setup.md
@@ -1,0 +1,257 @@
+# CloudWatch Setup
+
+Attune can use Amazon CloudWatch Container Insights as its metrics source
+instead of Prometheus. This guide covers prerequisites, IAM configuration,
+policy setup, and verification for EKS clusters.
+
+## Prerequisites
+
+- **Amazon EKS cluster** with
+  [Container Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html)
+  enabled. Container Insights publishes container-level metrics to the
+  `ContainerInsights` CloudWatch namespace.
+- **IAM permissions** for the operator's pod to call
+  `cloudwatch:GetMetricData` (see [IAM setup](#step-1-configure-iam-permissions) below).
+- **Attune installed** (see [Installation](../getting-started/installation.md)).
+
+## Required CloudWatch metrics
+
+Container Insights publishes these metrics to the `ContainerInsights`
+namespace with dimensions `ClusterName`, `Namespace`, `PodName`, and
+`ContainerName`:
+
+| Metric | What it measures |
+|--------|-----------------|
+| `container_cpu_usage_total` | CPU usage in nanocores per container (converted to cores internally) |
+| `container_memory_working_set` | Memory actively used per container in bytes |
+
+The operator uses CloudWatch
+[SEARCH expressions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-search-expressions.html)
+to find all matching containers within a namespace and pod prefix, then
+groups results by `ContainerName`.
+
+!!! note
+    Container Insights must be enabled for both `ContainerName`-level and
+    `PodName`-level dimensions. The default "enhanced observability" mode
+    in EKS provides these. If you use the basic Container Insights mode,
+    only cluster and node-level metrics are available.
+
+## Step 1: Configure IAM permissions
+
+The operator needs `cloudwatch:GetMetricData` permission. There are two
+approaches:
+
+=== "IRSA (IAM Roles for Service Accounts)"
+
+    Create an IAM policy:
+
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "cloudwatch:GetMetricData",
+          "Resource": "*"
+        }
+      ]
+    }
+    ```
+
+    Create an IAM role with the IRSA trust policy and attach the policy:
+
+    ```bash
+    # Create the IAM policy
+    aws iam create-policy \
+      --policy-name AttuneCWReadOnly \
+      --policy-document file://attune-cw-policy.json
+
+    # Create the IRSA role
+    eksctl create iamserviceaccount \
+      --cluster my-eks-cluster \
+      --namespace attune-system \
+      --name attune-controller-manager \
+      --attach-policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/AttuneCWReadOnly \
+      --approve
+    ```
+
+    Or annotate the existing ServiceAccount via Helm:
+
+    ```bash
+    helm upgrade attune oci://ghcr.io/attune-io/charts/attune \
+      --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::<ACCOUNT_ID>:role/AttuneCWRole
+    ```
+
+=== "EKS Pod Identity"
+
+    If your cluster uses [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html),
+    create a Pod Identity association:
+
+    ```bash
+    aws eks create-pod-identity-association \
+      --cluster-name my-eks-cluster \
+      --namespace attune-system \
+      --service-account attune-controller-manager \
+      --role-arn arn:aws:iam::<ACCOUNT_ID>:role/AttuneCWRole
+    ```
+
+=== "Cross-account access"
+
+    For centralized monitoring where CloudWatch data is in a different
+    account, specify `roleArn` in the policy to assume a cross-account
+    IAM role:
+
+    ```yaml
+    spec:
+      metricsSource:
+        cloudwatch:
+          region: us-east-1
+          clusterName: my-eks-cluster
+          roleArn: arn:aws:iam::123456789012:role/CloudWatchReadOnly
+    ```
+
+    The operator uses STS `AssumeRole` to obtain temporary credentials.
+    The target role must trust the operator's IAM role/identity.
+
+## Step 2: Create an AttunePolicy
+
+```yaml
+apiVersion: attune.io/v1alpha1
+kind: AttunePolicy
+metadata:
+  name: my-app
+  namespace: production
+spec:
+  targetRef:
+    kind: Deployment
+    name: my-app
+  metricsSource:
+    cloudwatch:
+      region: us-east-1
+      clusterName: my-eks-cluster
+  cpu: {}
+  memory: {}
+```
+
+### Configuration fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `region` | string | (required) | AWS region where CloudWatch metrics are stored (e.g., `us-east-1`) |
+| `clusterName` | string | (required) | EKS cluster name, used as the `ClusterName` dimension filter |
+| `roleArn` | string | (optional) | IAM role ARN to assume for cross-account access |
+
+## Step 3: Verify the integration
+
+### Check policy conditions
+
+```bash
+kubectl get attunepolicy my-app -n production -o wide
+```
+
+| Condition | Meaning |
+|-----------|---------|
+| `Ready: True, Reason: Monitoring` | CloudWatch reachable, recommendations computed |
+| `Ready: False, Reason: InsufficientData` | CloudWatch reachable but not enough history yet |
+
+Check the operator logs for CloudWatch-specific messages:
+
+```bash
+kubectl logs -n attune-system deployment/attune-controller-manager \
+  --tail=50 | grep -i cloudwatch
+```
+
+### Verify Container Insights metrics exist
+
+Confirm that Container Insights is publishing container-level metrics for
+your workload:
+
+```bash
+aws cloudwatch list-metrics \
+  --namespace ContainerInsights \
+  --metric-name container_cpu_usage_total \
+  --dimensions Name=ClusterName,Value=my-eks-cluster \
+               Name=Namespace,Value=production \
+  --region us-east-1
+```
+
+If this returns no results, Container Insights is not enabled or not
+publishing container-level dimensions. See the
+[Container Insights troubleshooting guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-troubleshooting.html).
+
+### Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `loading AWS config` | No AWS credentials available | Configure IRSA, Pod Identity, or an instance profile for the operator pod |
+| `CloudWatch GetMetricData failed: AccessDeniedException` | Missing IAM permission | Add `cloudwatch:GetMetricData` to the operator's IAM role |
+| `empty result from CloudWatch instant query` | No metrics for the workload | Verify Container Insights is enabled and publishing container-level dimensions |
+| `creating CloudWatch collector: operation error STS: AssumeRole` | Cross-account role assumption failed | Check the trust policy on the target role |
+
+## Rate limiting
+
+The operator rate-limits CloudWatch API calls to **5 QPS** with a burst
+of 10, well within CloudWatch's default quota of 50 transactions per
+second for `GetMetricData`.
+
+Collectors are cached by `region + clusterName + roleARN`, so multiple
+policies targeting the same cluster share a single API client.
+
+## Using CloudWatch as the cluster default
+
+Instead of configuring CloudWatch on every policy, set it in
+`AttuneDefaults`:
+
+```yaml
+apiVersion: attune.io/v1alpha1
+kind: AttuneDefaults
+metadata:
+  name: cluster-defaults
+spec:
+  metricsSource:
+    cloudwatch:
+      region: us-east-1
+      clusterName: my-eks-cluster
+```
+
+With defaults configured, policies only need `targetRef`:
+
+```yaml
+apiVersion: attune.io/v1alpha1
+kind: AttunePolicy
+metadata:
+  name: my-app
+  namespace: production
+spec:
+  targetRef:
+    kind: Deployment
+    name: my-app
+  cpu: {}
+  memory: {}
+```
+
+Unlike Datadog (which requires a Secret per namespace), CloudWatch
+authentication uses IAM roles attached to the pod's ServiceAccount.
+A single `AttuneDefaults` resource works for all namespaces without
+additional Secrets.
+
+## Limitations
+
+- **EKS only.** Container Insights metrics are only available on Amazon
+  EKS clusters. Self-managed Kubernetes on EC2 can use Container Insights
+  if the CloudWatch Agent is deployed manually, but EKS is the tested
+  configuration.
+- **No auto-discovery.** The `region` and `clusterName` fields are
+  always required. The operator does not auto-detect the EKS cluster.
+- **One metrics source per policy.** A policy cannot combine CloudWatch
+  and Prometheus data. Set `metricsSource.cloudwatch` or
+  `metricsSource.prometheus`, not both.
+- **Safety monitor throttle detection** uses the same metrics source as
+  recommendations. CloudWatch Container Insights does not expose CFS
+  throttle metrics (`container_cpu_cfs_throttled_periods_total`), so
+  CPU throttle-based auto-revert is not available when using CloudWatch.
+  OOMKill detection, restart monitoring, and pod readiness checks still
+  work.
+- **Metric resolution.** CloudWatch Container Insights publishes metrics
+  at 1-minute intervals (60-second period minimum). The operator clamps
+  the query period to a minimum of 60 seconds.

--- a/docs/guides/datadog-setup.md
+++ b/docs/guides/datadog-setup.md
@@ -1,0 +1,216 @@
+# Datadog Setup
+
+Attune can use Datadog as its metrics source instead of Prometheus.
+This guide covers prerequisites, authentication, policy configuration,
+and verification.
+
+## Prerequisites
+
+- **Datadog Agent** running in your cluster with the Kubernetes integration
+  enabled. The Agent must be collecting `kubernetes.cpu.usage.total` and
+  `kubernetes.memory.working_set` metrics.
+- **Datadog API key** (required) and optionally an **Application key**
+  (recommended for higher rate limits).
+- **Attune installed** (see [Installation](../getting-started/installation.md)).
+
+## Required Datadog metrics
+
+The operator queries these Container-level metrics from the Datadog
+`/api/v1/query` endpoint:
+
+| Metric | What it measures |
+|--------|-----------------|
+| `kubernetes.cpu.usage.total` | CPU usage in nanocores per container (converted to cores internally) |
+| `kubernetes.memory.working_set` | Memory actively used per container in bytes |
+
+These metrics are collected automatically by the Datadog Agent's
+Kubernetes integration when it has access to the kubelet. No custom
+metric configuration or DogStatsD setup is needed.
+
+!!! note
+    Results are grouped by the `kube_container_name` tag. If your Datadog
+    Agent relabels or drops this tag, the operator cannot distinguish
+    between containers in multi-container pods.
+
+## Step 1: Create the API key Secret
+
+Create a Kubernetes Secret containing your Datadog API key. The Secret
+must live in the same namespace as the AttunePolicy that references it.
+
+```bash
+kubectl create secret generic datadog-keys \
+  --from-literal=api-key=<YOUR_DATADOG_API_KEY> \
+  --from-literal=app-key=<YOUR_DATADOG_APP_KEY> \
+  -n production
+```
+
+The `app-key` key is optional but recommended. The Datadog API enforces
+lower rate limits for API-key-only authentication.
+
+| Secret key | Required | Purpose |
+|------------|----------|---------|
+| `api-key` | Yes | Authenticates against the Datadog API (`DD-API-KEY` header) |
+| `app-key` | No | Authenticates for higher rate limits (`DD-APPLICATION-KEY` header) |
+
+!!! warning "Secret namespace"
+    The Secret must be in the **same namespace** as the AttunePolicy.
+    Cross-namespace Secret references are not supported.
+
+## Step 2: Create an AttunePolicy
+
+```yaml
+apiVersion: attune.io/v1alpha1
+kind: AttunePolicy
+metadata:
+  name: my-app
+  namespace: production
+spec:
+  targetRef:
+    kind: Deployment
+    name: my-app
+  metricsSource:
+    datadog:
+      site: datadoghq.com
+      apiKeySecretRef:
+        name: datadog-keys
+        key: api-key
+  cpu: {}
+  memory: {}
+```
+
+### Configuration fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `site` | string | `datadoghq.com` | Datadog site domain. Use `datadoghq.eu` for EU, `us5.datadoghq.com` for US5, etc. |
+| `apiKeySecretRef.name` | string | (required) | Name of the Secret containing the API key |
+| `apiKeySecretRef.key` | string | (required) | Key within the Secret that holds the API key value |
+
+??? note "Datadog sites"
+    Datadog operates in multiple regions. Set `site` to match your account:
+
+    | Region | Site value |
+    |--------|-----------|
+    | US1 (default) | `datadoghq.com` |
+    | US3 | `us3.datadoghq.com` |
+    | US5 | `us5.datadoghq.com` |
+    | EU1 | `datadoghq.eu` |
+    | AP1 | `ap1.datadoghq.com` |
+    | US1-FED | `ddog-gov.com` |
+
+## Step 3: Verify the integration
+
+### Check policy conditions
+
+```bash
+kubectl get attunepolicy my-app -n production -o wide
+```
+
+| Condition | Meaning |
+|-----------|---------|
+| `Ready: True, Reason: Monitoring` | Datadog reachable, recommendations computed |
+| `Ready: False, Reason: InsufficientData` | Datadog reachable but not enough history yet |
+
+If the condition message mentions a Datadog API error, check the
+operator logs:
+
+```bash
+kubectl logs -n attune-system deployment/attune-controller-manager \
+  --tail=50 | grep -i datadog
+```
+
+### Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `cannot read Datadog API key` | Secret not found or missing key | Verify the Secret exists in the policy namespace with the correct key name |
+| `datadog API returned 403` | Invalid API key or insufficient permissions | Regenerate the API key in the Datadog console |
+| `datadog API returned 429` | Rate limited | Add an `app-key` to the Secret for higher limits; the operator rate-limits to ~0.08 QPS per collector |
+| `empty result from Datadog instant query` | No metrics for the workload | Verify the Datadog Agent is collecting Kubernetes metrics for the target namespace and pods |
+
+## Rate limiting
+
+The operator rate-limits Datadog API calls to approximately **0.08 QPS**
+(~300 requests/hour) with a burst of 3, well within Datadog's default
+rate limit of 300 requests/hour for API-key-only authentication and
+3600 requests/hour with an Application key.
+
+If you have many policies using Datadog, consider:
+
+- Adding an Application key to increase the rate limit
+- Using cluster-wide or namespace defaults to share the collector across
+  policies (the operator caches collectors by site + API key)
+
+## Using Datadog as the cluster default
+
+Instead of configuring Datadog on every policy, set it in
+`AttuneDefaults` or `AttuneNamespaceDefaults`:
+
+=== "Cluster-wide"
+
+    ```yaml
+    apiVersion: attune.io/v1alpha1
+    kind: AttuneDefaults
+    metadata:
+      name: cluster-defaults
+    spec:
+      metricsSource:
+        datadog:
+          site: datadoghq.com
+          apiKeySecretRef:
+            name: datadog-keys
+            key: api-key
+    ```
+
+    !!! warning
+        The Secret referenced in `AttuneDefaults` must exist in **every
+        namespace** that has an AttunePolicy, since Secret access is
+        namespace-scoped. Consider using a namespace defaults object
+        per namespace instead.
+
+=== "Per-namespace"
+
+    ```yaml
+    apiVersion: attune.io/v1alpha1
+    kind: AttuneNamespaceDefaults
+    metadata:
+      name: team-defaults
+      namespace: production
+    spec:
+      metricsSource:
+        datadog:
+          site: datadoghq.com
+          apiKeySecretRef:
+            name: datadog-keys
+            key: api-key
+    ```
+
+With defaults configured, policies only need `targetRef`:
+
+```yaml
+apiVersion: attune.io/v1alpha1
+kind: AttunePolicy
+metadata:
+  name: my-app
+  namespace: production
+spec:
+  targetRef:
+    kind: Deployment
+    name: my-app
+  cpu: {}
+  memory: {}
+```
+
+## Limitations
+
+- **No auto-discovery.** Unlike Prometheus, Datadog has no in-cluster
+  service to discover automatically. The `apiKeySecretRef` is always
+  required.
+- **One metrics source per policy.** A policy cannot combine Datadog and
+  Prometheus data. Set `metricsSource.datadog` or
+  `metricsSource.prometheus`, not both.
+- **Safety monitor throttle detection** uses the same metrics source as
+  recommendations. Datadog does not expose CFS throttle metrics
+  (`container_cpu_cfs_throttled_periods_total`), so CPU throttle-based
+  auto-revert is not available when using Datadog. OOMKill detection,
+  restart monitoring, and pod readiness checks still work.

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,17 @@ the full story.
 - [Quick Start](getting-started/quickstart.md) -- Create your first policy
 - [Migrating from VPA](guides/migrating-from-vpa.md) -- Step-by-step replacement
 
+## Metrics Sources
+
+Attune works with multiple metrics backends. One source is configured per
+policy:
+
+| Backend | Guide | Use case |
+|---------|-------|----------|
+| **Prometheus** (+ Thanos, Mimir, VictoriaMetrics) | [Prometheus Setup](guides/prometheus-setup.md) | Default for most clusters; auto-discovery available |
+| **Datadog** | [Datadog Setup](guides/datadog-setup.md) | Teams already using Datadog for Kubernetes monitoring |
+| **CloudWatch** Container Insights | [CloudWatch Setup](guides/cloudwatch-setup.md) | EKS clusters using AWS-native observability |
+
 ## Reference
 
 - [API Reference](reference/api.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,8 @@ nav:
       - Startup Boost: guides/startup-boost.md
       - HPA Coexistence: guides/hpa-coexistence.md
       - Prometheus Setup: guides/prometheus-setup.md
+      - Datadog Setup: guides/datadog-setup.md
+      - CloudWatch Setup: guides/cloudwatch-setup.md
       - Istio Integration: guides/istio-integration.md
       - GitOps Integration: guides/gitops-integration.md
       - Migrating from VPA: guides/migrating-from-vpa.md


### PR DESCRIPTION
Add dedicated setup guides for Datadog and CloudWatch Container Insights metrics backends, mirroring the existing Prometheus setup guide structure.

## New files

- **docs/guides/datadog-setup.md**: API key Secret setup, Datadog site configuration, rate limiting, defaults inheritance, and limitations (CFS throttle detection unavailable)
- **docs/guides/cloudwatch-setup.md**: IAM/IRSA/Pod Identity/cross-account setup, EKS Container Insights prerequisites, verification steps, and limitations

## Updated files

- **docs/index.md**: added a Metrics Sources section with a table linking all three backend guides
- **docs/getting-started/quickstart.md**: updated prerequisites to mention Datadog and CloudWatch as alternatives to Prometheus
- **mkdocs.yml**: added new guides to the nav under Guides, between Prometheus Setup and Istio Integration

## Verification

- `make verify-quick` passes (lint, tests, helm, doc-defaults, RBAC sync)
- `mkdocs build --strict` passes (no broken links)

Closes #227