### PR TITLE
fix: address 4 GitHub AI code quality findings

### DIFF
--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1307,7 +1307,6 @@ func getConditionMessage(obj unstructured.Unstructured, conditionType string) st
 	return ""
 }
 
-// savingsPercent computes the CPU savings percentage from reduction and total strings.
 // parseDollarCents parses a dollar string like "$12.78" into cents (1278).
 // Returns 0 for empty, dash, or unparseable values.
 func parseDollarCents(s string) int64 {
@@ -1323,6 +1322,7 @@ func parseDollarCents(s string) int64 {
 	return int64(f * 100)
 }
 
+// savingsPercent computes the CPU savings percentage from reduction and total strings.
 func savingsPercent(saved, total string) string {
 	if saved == "-" || saved == "" || total == "" {
 		return "-"

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -60,7 +60,7 @@ wait_for() {
   local timeout="${1:-120}"; shift || true
   echo -ne "${GREEN}▸${RESET} Waiting: ${msg}..."
   local elapsed=0
-  while ! eval "$@" >/dev/null 2>&1; do
+  while ! "$@" >/dev/null 2>&1; do
     sleep 2
     elapsed=$((elapsed + 2))
     if [ "$elapsed" -ge "$timeout" ]; then
@@ -127,7 +127,7 @@ banner "Step 3: Build and deploy attune"
 
 cd "$REPO_ROOT"
 info "Building operator image..."
-run make docker-build IMG="$IMG" 2>/dev/null
+run make docker-build IMG="$IMG"
 
 info "Loading image into cluster..."
 k3d image import "$IMG" -c "$CLUSTER_NAME"

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -97,7 +97,7 @@ func (r *AttunePolicyReconciler) getOrCreateCollectorByKey(cacheKey, description
 	if cached, ok := r.collectors.Load(cacheKey); ok {
 		entry, _ := cached.(*collectorEntry)
 		if entry != nil {
-			r.collectors.Store(cacheKey, &collectorEntry{collector: entry.collector, lastUsed: now})
+			r.collectors.CompareAndSwap(cacheKey, cached, &collectorEntry{collector: entry.collector, lastUsed: now})
 			return entry.collector, nil
 		}
 	}

--- a/internal/resize/engine_test.go
+++ b/internal/resize/engine_test.go
@@ -103,13 +103,21 @@ func TestResizePod_CallsUpdateResize(t *testing.T) {
 			assert.Equal(t, "web-0", updatedPod.Name)
 			assert.Equal(t, "default", updatedPod.Namespace)
 
-			gotCPU := updatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
-			assert.True(t, gotCPU.Equal(resource.MustParse("250m")),
-				"expected cpu request 250m, got %s", gotCPU.String())
+			gotCPUReq := updatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+			assert.True(t, gotCPUReq.Equal(resource.MustParse("250m")),
+				"expected cpu request 250m, got %s", gotCPUReq.String())
 
-			gotMem := updatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
-			assert.True(t, gotMem.Equal(resource.MustParse("1Gi")),
-				"expected memory limit 1Gi, got %s", gotMem.String())
+			gotMemReq := updatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
+			assert.True(t, gotMemReq.Equal(resource.MustParse("512Mi")),
+				"expected memory request 512Mi, got %s", gotMemReq.String())
+
+			gotCPULim := updatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
+			assert.True(t, gotCPULim.Equal(resource.MustParse("500m")),
+				"expected cpu limit 500m, got %s", gotCPULim.String())
+
+			gotMemLim := updatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
+			assert.True(t, gotMemLim.Equal(resource.MustParse("1Gi")),
+				"expected memory limit 1Gi, got %s", gotMemLim.String())
 			break
 		}
 	}


### PR DESCRIPTION
## Summary

Address 4 valid findings from GitHub's AI Code Quality scanner (9 findings reviewed, 4 fixed, 4 false positives, 1 cosmetic skip).

## Changes

- **`internal/controller/prometheus.go`**: Use `CompareAndSwap` instead of `Store` on sync.Map cache hit path to avoid resurrecting evicted entries during concurrent access
- **`cmd/kubectl-attune/main.go`**: Move `savingsPercent` doc comment to the correct function (was attached to `parseDollarCents`)
- **`hack/demo.sh`**: Replace `eval` with direct execution (`"$@"`) in `wait_for`, remove `2>/dev/null` on `docker-build` to surface build errors
- **`internal/resize/engine_test.go`**: Assert all 4 resource fields (CPU/memory request and limit) instead of only CPU request and memory limit

## False Positives (not fixed)

| Finding | Why |
|---------|-----|
| prometheus.go Range count stops early | Count reaches `maxCollectors` before returning false; the capacity check fires correctly |
| prometheus.go CloudWatch cache key pipe collision | AWS ARNs follow `arn:aws:iam::ACCOUNT:role/ROLE_NAME` format and cannot contain `\|` |
| engine_test.go result ordering assumption | `ResizePod` guarantees [cpu, memory] order via deterministic resource iteration |
| CHANGELOG.md missing period | Managed by release-please; manual edits get overwritten |