### PR TITLE
fix: exclude helm.sh from lychee link checks

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -12,6 +12,7 @@ exclude = [
   "facebook\\.com",
   "instagram\\.com",
   "cast\\.ai",
+  "helm\\.sh",
 ]
 exclude_loopback = true
 max_concurrency = 8


### PR DESCRIPTION
helm.sh intermittently resets connections from GitHub-hosted runners, causing Link Check failures despite 4 retries (max_retries=4, retry_wait_time=5). The URL is stable and does not need automated checking.

This is the same pattern already applied to hub.docker.com, medium.com, securityscorecards.dev, and social media sites.