### PR TITLE
ci: use pre-built GoReleaser binaries in release Docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,24 +158,38 @@ jobs:
         run: |
           echo "hashes=$(cat goreleaser-dist/checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare release image context
+        shell: bash -Eeuo pipefail {0}
+        run: |
+          # Map GoReleaser output dirs to Docker TARGETARCH layout.
+          # GoReleaser names dirs like manager_linux_{arch}_{variant},
+          # e.g. manager_linux_amd64_v1, manager_linux_arm_7, manager_linux_s390x.
+          for dir in goreleaser-dist/manager_linux_*/; do
+            arch=$(basename "$dir" | sed 's/^manager_linux_//' | sed 's/_.*//')
+            mkdir -p ".release-image/${arch}"
+            cp "${dir}manager" ".release-image/${arch}/manager"
+          done
+          # Verify all target platforms have a binary
+          for arch in amd64 arm64 arm ppc64le s390x; do
+            if [ ! -f ".release-image/${arch}/manager" ]; then
+              echo "ERROR: missing manager binary for ${arch}" >&2
+              exit 1
+            fi
+          done
+
       - name: Build and push multi-arch image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         id: build
         with:
-          context: .
+          context: .release-image
+          file: Dockerfile.release
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.name }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             docker.io/attuneio/attune:${{ steps.tag.outputs.name }}
             docker.io/attuneio/attune:latest
-          build-args: |
-            VERSION=${{ steps.tag.outputs.name }}
-            COMMIT=${{ github.sha }}
-            DATE=${{ steps.build_date.outputs.date }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ audit-findings.md
 
 # GoReleaser output
 goreleaser-dist/
+
+# Release image build context (generated from goreleaser-dist/)
+.release-image/

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,19 @@
+# Release Dockerfile: copies pre-built binaries from GoReleaser output.
+# Used only by the CI release workflow (.github/workflows/release.yaml).
+# For local development builds, use Dockerfile.
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
+
+ARG TARGETARCH
+
+LABEL org.opencontainers.image.source="https://github.com/attune-io/attune"
+LABEL org.opencontainers.image.title="attune"
+LABEL org.opencontainers.image.description="Kubernetes operator for in-place pod resource right-sizing"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+WORKDIR /
+
+COPY ${TARGETARCH}/manager .
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Problem

The release workflow builds the `manager` binary **twice**:

1. **GoReleaser** cross-compiles it for 5 Linux architectures (~6 min)
2. **docker/build-push-action** runs the full Dockerfile, which does `go mod download` + `go build` for the same 5 architectures (~7 min)

This redundant compilation accounts for ~7 of the ~15 minute release job.

## Solution

Add a `Dockerfile.release` that copies pre-built binaries from GoReleaser output instead of compiling from source:

- A `Prepare release image context` step maps GoReleaser's output layout (`manager_linux_{arch}_{variant}`) to Docker's `TARGETARCH` convention
- `Dockerfile.release` does a single `COPY ${TARGETARCH}/manager .` into the same distroless base
- Verification loop ensures all 5 target platforms have a binary before building

The existing `Dockerfile` is unchanged and continues to be used for local dev builds (`make docker-build`).

## Expected impact

| Step | Before | After |
|------|--------|-------|
| GoReleaser | ~6 min | ~6 min (unchanged) |
| Docker build + push | ~7 min (full go build) | ~1 min (COPY + push) |
| **Release job total** | **~15 min** | **~9 min** |

## Changes

| File | What |
|------|------|
| `Dockerfile.release` | New. Copy-only Dockerfile for release builds |
| `.github/workflows/release.yaml` | Add prep step, switch to `Dockerfile.release`, remove unused `build-args` |
| `.gitignore` | Add `.release-image/` (generated build context) |