### PR TITLE
fix: add fallback cosign signing for re-releases of older tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,8 +110,18 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - name: Check if Docker build is possible
+        id: docker-check
+        run: |
+          if [ -f Dockerfile.release ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Dockerfile.release not found at this tag; skipping Docker image build"
+          fi
+
       - name: Login to GHCR
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -119,29 +129,42 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Capture build date
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         id: build_date
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Clean existing release assets (idempotent re-runs)
-        if: inputs.tag == ''
         shell: bash
         run: |
           TAG="${{ steps.tag.outputs.name }}"
           for asset in $(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null || true); do
-            echo "Deleting existing asset: $asset"
-            gh release delete-asset "$TAG" "$asset" -y || true
+            if [ -n "${{ inputs.tag }}" ]; then
+              # Re-release: only delete GoReleaser-produced assets so install.yaml,
+              # crds.yaml, SBOM, and provenance are preserved.
+              case "$asset" in
+                kubectl-attune_*.tar.gz|checksums.txt|checksums.txt.sig|checksums.txt.pem)
+                  echo "Deleting GoReleaser asset: $asset"
+                  gh release delete-asset "$TAG" "$asset" -y || true
+                  ;;
+                *)
+                  echo "Preserving: $asset"
+                  ;;
+              esac
+            else
+              echo "Deleting existing asset: $asset"
+              gh release delete-asset "$TAG" "$asset" -y || true
+            fi
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,7 +187,7 @@ jobs:
           echo "hashes=$(cat goreleaser-dist/checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release image context
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         shell: bash -Eeuo pipefail {0}
         run: |
           # Map GoReleaser output dirs to Docker TARGETARCH layout.
@@ -184,7 +207,7 @@ jobs:
           done
 
       - name: Compute image tags
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         id: image-tags
         shell: bash
         run: |
@@ -202,7 +225,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push multi-arch image
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         id: build
         with:
@@ -217,21 +240,21 @@ jobs:
             org.opencontainers.image.version=${{ steps.tag.outputs.name }}
 
       - name: Sign GHCR image
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         shell: bash -Eeuo pipefail -x {0}
         run: |
           cosign sign --yes \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
       - name: Sign Docker Hub image
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         shell: bash -Eeuo pipefail -x {0}
         run: |
           cosign sign --yes \
             docker.io/attuneio/attune@${{ steps.build.outputs.digest }}
 
       - name: Attest container image
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -239,7 +262,7 @@ jobs:
           push-to-registry: true
 
       - name: Generate SBOM
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
@@ -247,7 +270,7 @@ jobs:
           output-file: sbom.spdx.json
 
       - name: Trivy scan released image
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
@@ -255,7 +278,7 @@ jobs:
           exit-code: 1
 
       - name: Sign SBOM
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         shell: bash -Eeuo pipefail -x {0}
         run: |
           cosign sign-blob --yes \
@@ -263,14 +286,14 @@ jobs:
             sbom.spdx.json
 
       - name: Generate install manifest and CRDs bundle
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         shell: bash -Eeuo pipefail -x {0}
         run: |
           make build-installer IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.name }}
           make build-crds
 
       - name: Attach install manifest, CRDs, and SBOM to release
-        if: inputs.tag == ''
+        if: steps.docker-check.outputs.enabled == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ steps.tag.outputs.name }}
@@ -418,8 +441,8 @@ jobs:
   container-provenance:
     name: Container Provenance
     needs: [release]
-    # Skip on re-releases: no Docker image is built, so there is no digest.
-    if: ${{ !cancelled() && needs.release.result == 'success' && inputs.tag == '' }}
+    # Only runs when Docker built an image (digest is non-empty).
+    if: ${{ !cancelled() && needs.release.result == 'success' && needs.release.outputs.digest != '' }}
     permissions:
       actions: read
       id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,6 +180,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Sign checksums (fallback for older tags without signs config)
+        if: inputs.tag != ''
+        shell: bash
+        run: |
+          # If GoReleaser's .goreleaser.yaml at this tag lacks the signs
+          # section, the signature files won't exist. Sign them manually.
+          if [ ! -f goreleaser-dist/checksums.txt.sig ]; then
+            echo "GoReleaser did not produce signatures; signing checksums manually"
+            cosign sign-blob --yes \
+              --output-signature goreleaser-dist/checksums.txt.sig \
+              --output-certificate goreleaser-dist/checksums.txt.pem \
+              goreleaser-dist/checksums.txt
+            gh release upload "${{ steps.tag.outputs.name }}" \
+              goreleaser-dist/checksums.txt.sig \
+              goreleaser-dist/checksums.txt.pem
+          else
+            echo "GoReleaser already produced signatures"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate provenance subjects
         id: hash
         shell: bash -Eeuo pipefail {0}


### PR DESCRIPTION
## Problem

The v0.1.12 re-release (PR #245) ran GoReleaser successfully but produced no `checksums.txt.sig`/`.pem` because the `.goreleaser.yaml` at the v0.1.12 tag predates the `signs:` section. GoReleaser reads its config from the checked-out tag, not from main.

Additionally, the first failed re-release attempt (run #1) deleted all release assets via the clean step, but the Docker build failed before install.yaml, crds.yaml, and SBOM could be re-uploaded. These assets are now permanently lost from v0.1.12.

## Fix

Add a fallback signing step after GoReleaser that only runs on re-releases (`inputs.tag != ''`):

1. Check if `goreleaser-dist/checksums.txt.sig` exists (produced by GoReleaser if the tag's config has `signs:`)
2. If missing, run `cosign sign-blob` manually to produce the signature and certificate
3. Upload both files to the release via `gh release upload`

This handles all re-release scenarios:
- **Old tag (no signs config)**: fallback produces signatures
- **New tag (has signs config)**: GoReleaser already produced them, fallback is a no-op

## After merge

```bash
gh workflow run release.yaml --repo attune-io/attune -f tag=v0.1.12
```

Closes #241