### PR TITLE
fix: cosign fallback signing uses --bundle for newer cosign versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -189,9 +189,14 @@ jobs:
           if [ ! -f goreleaser-dist/checksums.txt.sig ]; then
             echo "GoReleaser did not produce signatures; signing checksums manually"
             cosign sign-blob --yes \
-              --output-signature goreleaser-dist/checksums.txt.sig \
-              --output-certificate goreleaser-dist/checksums.txt.pem \
+              --bundle goreleaser-dist/checksums.txt.bundle \
               goreleaser-dist/checksums.txt
+            # Extract .sig and .pem from the Sigstore bundle for backward compatibility
+            jq -r '.messageSignature.signature' goreleaser-dist/checksums.txt.bundle \
+              > goreleaser-dist/checksums.txt.sig
+            jq -r '.verificationMaterial.certificate.rawBytes' goreleaser-dist/checksums.txt.bundle \
+              | base64 -d | openssl x509 -inform DER -outform PEM \
+              > goreleaser-dist/checksums.txt.pem
             gh release upload "${{ steps.tag.outputs.name }}" \
               goreleaser-dist/checksums.txt.sig \
               goreleaser-dist/checksums.txt.pem


### PR DESCRIPTION
The `--output-signature` and `--output-certificate` flags are deprecated in cosign v2+ when `--new-bundle-format` is the default. The runner's cosign version now ignores these flags and fails with `create bundle file: open : no such file or directory`.

The fallback signing step now uses `--bundle` and extracts the `.sig` and `.pem` files from the Sigstore bundle JSON for backward compatibility.

**Root cause from run [#26771088138](https://github.com/attune-io/attune/actions/runs/26771088138):**
```
WARNING: --output-signature is deprecated when using --new-bundle-format and will be ignored
WARNING: --output-certificate is deprecated when using --new-bundle-format and will be ignored
Error: signing goreleaser-dist/checksums.txt: create bundle file: open : no such file or directory
```

Ref: #241