### PR TITLE
feat: migrate cosign signing from deprecated flags to --bundle format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,18 +180,43 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract legacy .sig and .pem from Sigstore bundle
+        shell: bash -Eeuo pipefail {0}
+        run: |
+          # GoReleaser now signs with --bundle, producing a .sigstore.json.
+          # Extract separate .sig and .pem files for backward compatibility
+          # with downstream verification scripts.
+          BUNDLE="goreleaser-dist/checksums.txt.sigstore.json"
+          if [ -f "$BUNDLE" ] && [ ! -f "goreleaser-dist/checksums.txt.sig" ]; then
+            echo "Extracting .sig and .pem from Sigstore bundle"
+            jq -r '.messageSignature.signature' "$BUNDLE" \
+              > goreleaser-dist/checksums.txt.sig
+            jq -r '.verificationMaterial.certificate.rawBytes' "$BUNDLE" \
+              | base64 -d | openssl x509 -inform DER -outform PEM \
+              > goreleaser-dist/checksums.txt.pem
+            gh release upload "${{ steps.tag.outputs.name }}" \
+              goreleaser-dist/checksums.txt.sig \
+              goreleaser-dist/checksums.txt.pem \
+              --repo "${{ github.repository }}" --clobber
+          elif [ -f "goreleaser-dist/checksums.txt.sig" ]; then
+            echo "Legacy .sig already exists (produced by GoReleaser directly)"
+          else
+            echo "No bundle or signatures found; fallback step will handle this"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Sign checksums (fallback for older tags without signs config)
         if: inputs.tag != ''
         shell: bash
         run: |
-          # If GoReleaser's .goreleaser.yaml at this tag lacks the signs
-          # section, the signature files won't exist. Sign them manually.
-          if [ ! -f goreleaser-dist/checksums.txt.sig ]; then
+          # If GoReleaser's .goreleaser.yaml at this tag lacks any signs
+          # config, neither .sigstore.json nor .sig will exist. Sign manually.
+          if [ ! -f goreleaser-dist/checksums.txt.sig ] && [ ! -f goreleaser-dist/checksums.txt.sigstore.json ]; then
             echo "GoReleaser did not produce signatures; signing checksums manually"
             cosign sign-blob --yes \
               --bundle goreleaser-dist/checksums.txt.bundle \
               goreleaser-dist/checksums.txt
-            # Extract .sig and .pem from the Sigstore bundle for backward compatibility
             jq -r '.messageSignature.signature' goreleaser-dist/checksums.txt.bundle \
               > goreleaser-dist/checksums.txt.sig
             jq -r '.verificationMaterial.certificate.rawBytes' goreleaser-dist/checksums.txt.bundle \
@@ -199,7 +224,8 @@ jobs:
               > goreleaser-dist/checksums.txt.pem
             gh release upload "${{ steps.tag.outputs.name }}" \
               goreleaser-dist/checksums.txt.sig \
-              goreleaser-dist/checksums.txt.pem
+              goreleaser-dist/checksums.txt.pem \
+              --repo "${{ github.repository }}" --clobber
           else
             echo "GoReleaser already produced signatures"
           fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,14 +48,12 @@ checksum:
 signs:
   - cmd: cosign
     artifacts: checksum
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - "--yes"
-      - "--new-bundle-format=false"
-      - "--use-signing-config=false"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
+      - "--bundle=${signature}"
       - "${artifact}"
-    certificate: '${artifact}.pem'
+      - "--yes"
+    output: true
 changelog:
   use: github-native


### PR DESCRIPTION
## Summary

Migrate GoReleaser signing from deprecated `--output-signature`/`--output-certificate` flags to the `--bundle` flag, which is the recommended approach since cosign v2 and will be required in cosign v3+.

## Changes

### `.goreleaser.yaml`
- Replace `--output-signature=${signature}`, `--output-certificate=${certificate}`, `--new-bundle-format=false`, `--use-signing-config=false` with `--bundle=${signature}`
- Set `signature: "${artifact}.sigstore.json"` so GoReleaser produces a Sigstore bundle
- Add `output: true` for signing step visibility in logs

### `.github/workflows/release.yaml`
- **New step: "Extract legacy .sig and .pem from Sigstore bundle"** runs after GoReleaser for all releases. Extracts the signature and certificate from the `.sigstore.json` bundle and uploads them as separate `.sig`/`.pem` release assets for backward compatibility.
- **Updated fallback step:** now checks for both `.sigstore.json` and `.sig` before deciding to sign manually (covers re-releases of tags that predate any signing config).

## Release assets (unchanged from user perspective)

| Asset | Source |
|-------|--------|
| `checksums.txt` | GoReleaser |
| `checksums.txt.sigstore.json` | GoReleaser (new, modern verification) |
| `checksums.txt.sig` | Extracted from bundle (backward compat) |
| `checksums.txt.pem` | Extracted from bundle (backward compat) |

Both verification methods work:
```bash
# Modern (bundle)
cosign verify-blob --bundle checksums.txt.sigstore.json checksums.txt

# Legacy (separate files, still works)
cosign verify-blob --signature checksums.txt.sig --certificate checksums.txt.pem checksums.txt
```

## Why

The `--output-signature` and `--output-certificate` flags are deprecated in cosign v2 and scheduled for removal in v3. GoReleaser's official `example-secure` repo already uses `--bundle`. This migration ensures our release pipeline does not break when cosign v3 is released.

Related: [goreleaser/goreleaser#6195](https://github.com/goreleaser/goreleaser/discussions/6643), [goreleaser/goreleaser#6643](https://github.com/goreleaser/goreleaser/discussions/6643)