### PR TITLE
fix: rename OLM bundle CSV from attune-operator to attune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,8 +406,8 @@ generate-olm-bundle: manifests ## Generate OLM bundle for OperatorHub submission
 	mkdir -p "$$BUNDLE_DIR/manifests" "$$BUNDLE_DIR/metadata" && \
 	ICON_B64=$$(base64 < docs/logo.svg | tr -d '\n') && \
 	sed "s/__VERSION__/$$VERSION/g; s/__DATE__/$$DATE/g; s/__ICON_BASE64__/$$ICON_B64/g" \
-		config/olm/template/manifests/attune-operator.clusterserviceversion.yaml \
-		> "$$BUNDLE_DIR/manifests/attune-operator.clusterserviceversion.yaml" && \
+		config/olm/template/manifests/attune.clusterserviceversion.yaml \
+		> "$$BUNDLE_DIR/manifests/attune.clusterserviceversion.yaml" && \
 	cp config/olm/template/metadata/annotations.yaml "$$BUNDLE_DIR/metadata/" && \
 	cp config/crd/bases/attune.io_attunepolicies.yaml "$$BUNDLE_DIR/manifests/" && \
 	cp config/crd/bases/attune.io_attunedefaults.yaml "$$BUNDLE_DIR/manifests/" && \

--- a/config/olm/template/manifests/attune.clusterserviceversion.yaml
+++ b/config/olm/template/manifests/attune.clusterserviceversion.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: attune-operator.v__VERSION__
+  name: attune.v__VERSION__
   namespace: placeholder
   annotations:
     alm-examples: |-

--- a/hack/operatorhub-pr.sh
+++ b/hack/operatorhub-pr.sh
@@ -47,7 +47,7 @@ fi
 
 # Verify bundle contents
 for f in \
-    "${BUNDLE_DIR}/manifests/attune-operator.clusterserviceversion.yaml" \
+    "${BUNDLE_DIR}/manifests/attune.clusterserviceversion.yaml" \
     "${BUNDLE_DIR}/manifests/attune.io_attunepolicies.yaml" \
     "${BUNDLE_DIR}/manifests/attune.io_attunedefaults.yaml" \
     "${BUNDLE_DIR}/manifests/attune.io_attunenamespacedefaults.yaml" \


### PR DESCRIPTION
## Problem

The community-operators-prod CI `check_operator_name` test requires the CSV name prefix to match the `operators.operatorframework.io.bundle.package.v1` annotation in `annotations.yaml`. The annotation uses `attune` but the CSV was named `attune-operator.v<VERSION>`, causing the pipeline to fail on [redhat-openshift-ecosystem/community-operators-prod#9871](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/9871).

## Fix

- Rename CSV template from `attune-operator.clusterserviceversion.yaml` to `attune.clusterserviceversion.yaml`
- Update CSV `name` field from `attune-operator.v__VERSION__` to `attune.v__VERSION__`
- Update `Makefile` `generate-olm-bundle` target for the new filename
- Update `hack/operatorhub-pr.sh` bundle verification for the new filename

## Verification

- `make verify-quick` passes (lint, tests, helm, docs)
- Generated bundle: CSV name `attune.v0.1.11` matches annotation package `attune`
- No remaining references to `attune-operator.clusterserviceversion` in the codebase