### PR TITLE
test: add nil UpdateStrategy webhook validation regression test

### DIFF
--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -114,6 +114,41 @@ func TestValidate_ValidPolicy(t *testing.T) {
 	assert.Empty(t, warnings)
 }
 
+func TestValidate_NilUpdateStrategy(t *testing.T) {
+	validator := &AttunePolicyValidator{}
+	name := "my-app"
+	policy := &attunev1alpha1.AttunePolicy{
+		Spec: attunev1alpha1.AttunePolicySpec{
+			TargetRef: attunev1alpha1.TargetRef{
+				Kind: "Deployment",
+				Name: &name,
+			},
+			CPU: attunev1alpha1.ResourceConfig{
+				Percentile: 95,
+				Overhead:   "20",
+			},
+			Memory: attunev1alpha1.ResourceConfig{
+				Percentile: 99,
+				Overhead:   "30",
+			},
+			// UpdateStrategy intentionally nil: the defaulting webhook does not
+			// set it (deferred to controller's ApplyBuiltInDefaults). Validation
+			// must handle nil without panicking.
+		},
+	}
+	require.Nil(t, policy.Spec.UpdateStrategy, "precondition: UpdateStrategy must be nil")
+
+	warnings, err := validator.ValidateCreate(context.Background(), policy)
+
+	assert.NoError(t, err, "nil UpdateStrategy should pass validation")
+	assert.Empty(t, warnings)
+
+	// Also verify UpdateUpdate path.
+	warnings, err = validator.ValidateUpdate(context.Background(), policy, policy)
+	assert.NoError(t, err, "nil UpdateStrategy should pass update validation")
+	assert.Empty(t, warnings)
+}
+
 func TestValidate_CPUBoundsInvalid(t *testing.T) {
 	validator := &AttunePolicyValidator{}
 	policy := validPolicy()


### PR DESCRIPTION
## Summary

Add regression test for nil `UpdateStrategy` webhook validation, guarding
the nil initialization added in PR #255 (`internal/webhook/validation.go:64-66`).

## Changes

- `internal/webhook/validation_test.go`: New `TestValidate_NilUpdateStrategy`
  test that creates an AttunePolicy with intentionally nil `UpdateStrategy`
  and verifies webhook validation succeeds without panicking.

## Context

Multi-perspective improvement cycle 26 (Test Auditor perspective). The nil
guard in PR #255 had no dedicated test; a future refactor could accidentally
remove it without any test catching the regression.

## Verification

- `make verify-quick` passes
- All existing tests pass