### PR TITLE
fix: dependabot auto-merge signature verification and rebase method

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-commit-verification: true
 
       - name: Approve and enable auto-merge (patch/minor only)
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
@@ -72,6 +73,6 @@ jobs:
             --json number --jq '.[].number')
           for pr in $prs; do
             echo "Updating PR #$pr..."
-            gh pr update-branch "$pr" --repo "$GITHUB_REPOSITORY" || \
+            gh pr update-branch "$pr" --repo "$GITHUB_REPOSITORY" --rebase || \
               echo "  Skipped (already up to date or conflict)"
           done


### PR DESCRIPTION
## Problem

When a Dependabot PR branch gets rebased (manually or via the auto-rebase job), two issues occur:

1. **Signature verification failure**: `dependabot/fetch-metadata` rejects the rebased commit because the original Dependabot signature is stripped during rebase. The error: `Dependabot's commit signature is not verified, refusing to proceed.`

2. **DCO failure from merge commits**: `gh pr update-branch` defaults to merge strategy, creating merge commits authored by the API caller (not `dependabot[bot]`). These merge commits lack DCO sign-off, failing the DCO check.

## Fix

- Add `skip-commit-verification: true` to `dependabot/fetch-metadata` so rebased Dependabot commits are still recognized
- Add `--rebase` flag to `gh pr update-branch` so branches stay linear (no merge commits)

## Context

This was discovered while debugging why approved PRs were not auto-merging. PR #260 (Dependabot go-minor) was stuck because a prior `Update branch` click created a merge commit that failed DCO, and the subsequent rebase invalidated the Dependabot signature.