### PR TITLE
fix: remove auto-rebase job that silently broke Dependabot CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -2,14 +2,12 @@ name: Dependabot Auto-Merge
 
 on:
   pull_request_target:
-  push:
-    branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
-  group: dependabot-auto-merge-${{ github.event.pull_request.number || github.sha }}
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -48,31 +46,12 @@ jobs:
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: echo "Skipping major version update — requires manual review"
 
-  # When main changes (e.g. another Dependabot PR merges), update all
-  # open Dependabot PRs so they stay current and auto-merge can proceed
-  # without waiting for Dependabot's slow rebase scheduler.
-  rebase-dependabot:
-    name: Rebase open Dependabot PRs
-    permissions:
-      contents: write
-      pull-requests: write
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: github.event_name == 'push'
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Update Dependabot PR branches
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" \
-            --author "app/dependabot" --state open \
-            --json number --jq '.[].number')
-          for pr in $prs; do
-            echo "Updating PR #$pr..."
-            gh pr update-branch "$pr" --repo "$GITHUB_REPOSITORY" --rebase || \
-              echo "  Skipped (already up to date or conflict)"
-          done
+  # NOTE: A rebase-dependabot job was removed here. It updated open
+  # Dependabot PR branches on every push to main, but caused more harm
+  # than good: GITHUB_TOKEN pushes do not trigger other workflows (GitHub
+  # infinite-loop prevention), so the rebase invalidated existing CI
+  # results without starting new ones, leaving PRs stuck in "no required
+  # checks reported" limbo. With strict_required_status_checks_policy
+  # disabled in the branch ruleset, PRs can merge when behind main, so
+  # auto-rebase is unnecessary. Dependabot handles its own rebases when
+  # conflicts arise.


### PR DESCRIPTION
## Problem

The rebase-dependabot job (added in #265) ran on every push to main and rebased all open Dependabot PR branches. This caused PR #260 to get stuck indefinitely:

1. PR merges to main -> rebase job fires -> updates Dependabot branch
2. `GITHUB_TOKEN` pushes don't trigger other workflows (GitHub infinite-loop prevention)
3. The rebase invalidated existing CI results (old HEAD no longer matches)
4. No new CI run starts on the new HEAD
5. Required checks show 'no checks reported' -> auto-merge blocked

Each subsequent PR merging to main repeated the cycle, keeping the PR permanently stuck.

## Fix

Remove the rebase-dependabot job entirely. With `strict_required_status_checks_policy` disabled in the branch ruleset, PRs can merge when behind main. Auto-rebase is unnecessary. Dependabot handles its own rebases when real conflicts arise.

Also simplify the concurrency group key (no longer needs `github.sha` fallback since the push trigger is removed).