### PR TITLE
fix: add missing RBAC for OpenShift TLS profile detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,22 @@ After changing RBAC markers, update **three places**:
 - `config/rbac/role.yaml` (run `make manifests`)
 - `charts/attune/templates/clusterrole.yaml` + its test
 
+**Kubebuilder RBAC markers must be in `internal/controller/`.** `controller-gen`
+only scans packages specified in its invocation (typically
+`internal/controller/...`). Placing a `+kubebuilder:rbac` marker in a utility
+package (e.g., `internal/metrics/`, `internal/safety/`) has no effect; the marker
+is silently ignored because controller-gen never reads that package. If a utility
+function accesses a new API resource, add the RBAC marker to
+`internal/controller/attunepolicy_controller.go` (where all other RBAC markers
+live), not to the file that contains the function.
+
+Learned from PR #269/PR #270 where `DetectClusterTLSProfile()` in
+`internal/metrics/tlsprofile.go` reads `apiservers.config.openshift.io/v1`, but
+the RBAC marker was initially placed in `internal/metrics/tlsprofile.go`. Running
+`make manifests` produced no change because controller-gen never scanned that
+package. Moving the marker to `internal/controller/attunepolicy_controller.go`
+fixed it.
+
 Currently, Secrets are the only resource in `DisableFor` (get-only is safe).
 All other resources accessed via the client need `list`/`watch`.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![OperatorHub](https://img.shields.io/badge/OperatorHub.io-Attune-brightgreen?logo=kubernetes)](https://operatorhub.io/operator/attune)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/attune)](https://artifacthub.io/packages/helm/attune/attune)
 [![Docker Hub](https://img.shields.io/docker/pulls/attuneio/attune)](https://hub.docker.com/r/attuneio/attune)
-[![GHCR](https://ghcr-badge.egpl.dev/attune-io/attune/latest_tag?trim=major&label=ghcr.io)](https://github.com/attune-io/attune/pkgs/container/attune)
+[![GHCR](https://img.shields.io/badge/ghcr.io-attune-blue?logo=github)](https://github.com/attune-io/attune/pkgs/container/attune)
 [![kubectl plugin](https://img.shields.io/badge/kubectl_plugin-krew-blue)](https://krew.sigs.k8s.io/plugins/)
 
 **Safe, in-place Kubernetes pod resource right-sizing. VPA done right.**

--- a/charts/attune/templates/clusterrole.yaml
+++ b/charts/attune/templates/clusterrole.yaml
@@ -117,6 +117,14 @@ rules:
       - get
       - list
       - watch
+  # OpenShift TLS profile: read-only (TLS security profile detection)
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - apiservers
+    verbs:
+      - get
+      - list
   # Prometheus Operator: read-only (auto-discovery)
   - apiGroups:
       - monitoring.coreos.com

--- a/charts/attune/tests/rbac_test.yaml
+++ b/charts/attune/tests/rbac_test.yaml
@@ -139,6 +139,19 @@ tests:
               - list
               - watch
 
+  - it: should include OpenShift APIServer read permissions for TLS profile detection
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - config.openshift.io
+            resources:
+              - apiservers
+            verbs:
+              - get
+              - list
+
   - it: should include secret get-only permissions for bearer token
     asserts:
       - contains:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -126,6 +126,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3096,6 +3096,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -123,6 +123,7 @@ const (
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=resourcequotas;limitranges,verbs=get;list;watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list
 
 // AttunePolicyReconciler reconciles an AttunePolicy object.
 type AttunePolicyReconciler struct {


### PR DESCRIPTION
## Summary

Two fixes that missed the merge window of PR #269.

### 1. Missing RBAC for OpenShift TLS profile detection

`DetectOpenShiftTLSProfile` reads `apiservers.config.openshift.io/v1` but no RBAC was generated for the `config.openshift.io` API group. Without this, the operator's service account gets a 403 on OpenShift clusters and silently falls back to Go TLS defaults, making the `tls-profiles: "true"` CSV annotation inaccurate.

**Files:**
- `internal/controller/attunepolicy_controller.go`: added kubebuilder RBAC marker
- `config/rbac/role.yaml`: regenerated via `make manifests`
- `charts/attune/templates/clusterrole.yaml`: added `config.openshift.io/apiservers` rule
- `charts/attune/tests/rbac_test.yaml`: added test for the new rule
- `dist/install.yaml`: regenerated via `make build-installer`

### 2. Shorten GHCR badge in README

Replaced the dynamic `ghcr-badge.egpl.dev` badge (renders full version tag, visually long) with a compact shields.io badge. The version is already shown by the Release badge.