### PR TITLE
feat: make OpenShift RBAC conditional via openshift.enabled Helm value

### DIFF
--- a/charts/attune/README.md
+++ b/charts/attune/README.md
@@ -68,6 +68,8 @@ helm install attune oci://ghcr.io/attune-io/charts/attune \
 | networkPolicy.enabled | bool | `true` | Enable NetworkPolicy for the operator pod |
 | networkPolicy.prometheusPort | int | `9090` | TCP port allowed by NetworkPolicy for Prometheus backend pods |
 | nodeSelector | object | `{}` | Node selector |
+| openshift | object | `{"enabled":false}` | OpenShift integration |
+| openshift.enabled | bool | `false` | Enable OpenShift-specific features (TLS profile auto-detection). When enabled, the ClusterRole includes read access to config.openshift.io/apiservers for TLS security profile detection. |
 | podAnnotations | object | `{}` | Pod annotations |
 | podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod security context |
 | priorityClassName | string | `""` | Priority class name for the operator pod (recommended: system-cluster-critical for production) |

--- a/charts/attune/templates/clusterrole.yaml
+++ b/charts/attune/templates/clusterrole.yaml
@@ -117,6 +117,7 @@ rules:
       - get
       - list
       - watch
+  {{- if .Values.openshift.enabled }}
   # OpenShift TLS profile: read-only (TLS security profile detection)
   - apiGroups:
       - config.openshift.io
@@ -125,6 +126,7 @@ rules:
     verbs:
       - get
       - list
+  {{- end }}
   # Prometheus Operator: read-only (auto-discovery)
   - apiGroups:
       - monitoring.coreos.com

--- a/charts/attune/tests/rbac_test.yaml
+++ b/charts/attune/tests/rbac_test.yaml
@@ -139,7 +139,23 @@ tests:
               - list
               - watch
 
-  - it: should include OpenShift APIServer read permissions for TLS profile detection
+  - it: should not include OpenShift RBAC by default
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - config.openshift.io
+            resources:
+              - apiservers
+            verbs:
+              - get
+              - list
+
+  - it: should include OpenShift RBAC when openshift.enabled is true
+    set:
+      openshift:
+        enabled: true
     asserts:
       - contains:
           path: rules

--- a/charts/attune/values.schema.json
+++ b/charts/attune/values.schema.json
@@ -517,6 +517,18 @@
         }
       }
     },
+    "openshift": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "OpenShift integration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable OpenShift-specific features (TLS profile auto-detection RBAC)"
+        }
+      }
+    },
     "logging": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/attune/values.yaml
+++ b/charts/attune/values.yaml
@@ -252,6 +252,13 @@ fips:
   # because client-go uses X25519 which is not FIPS-approved.
   mode: "on"
 
+# -- OpenShift integration
+openshift:
+  # -- Enable OpenShift-specific features (TLS profile auto-detection).
+  # When enabled, the ClusterRole includes read access to
+  # config.openshift.io/apiservers for TLS security profile detection.
+  enabled: false
+
 # -- Logging configuration
 logging:
   # -- Log level (debug, info, warn, error)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -68,7 +68,8 @@ installed, you can install Attune directly from
 [OperatorHub.io](https://operatorhub.io/operator/attune).
 
 **On OpenShift**, search for "Attune" in the built-in OperatorHub catalog and
-click Install.
+click Install. See the [OpenShift guide](../guides/openshift.md) for
+TLS profile integration and OpenShift-specific configuration.
 
 **On other clusters with OLM**, install the operator by creating a
 `Subscription`:

--- a/docs/guides/openshift.md
+++ b/docs/guides/openshift.md
@@ -1,0 +1,139 @@
+# OpenShift
+
+Attune runs on OpenShift 4.x clusters with Kubernetes 1.32+. This guide
+covers OpenShift-specific installation, TLS profile integration, and
+security considerations.
+
+## Installation
+
+### Via OperatorHub (recommended for OpenShift)
+
+OpenShift includes a built-in OperatorHub catalog. Search for "Attune"
+in the web console under **Operators > OperatorHub** and click Install.
+The OLM bundle includes all CRDs, RBAC, and the operator deployment.
+
+### Via Helm
+
+```bash
+kubectl create namespace attune-system
+
+helm install attune \
+  oci://ghcr.io/attune-io/charts/attune \
+  --namespace attune-system \
+  --set openshift.enabled=true
+```
+
+The `openshift.enabled=true` flag adds OpenShift-specific RBAC (read
+access to `config.openshift.io/apiservers`) and enables TLS profile
+auto-detection. Without it, the operator runs with vanilla Kubernetes
+RBAC only.
+
+## TLS profile auto-detection
+
+OpenShift clusters enforce a cluster-wide TLS security profile via the
+`APIServer` resource at `config.openshift.io/v1`. This profile controls
+the minimum TLS version and cipher suites for API server connections.
+
+When `openshift.enabled=true`, Attune reads this profile at startup and
+configures its outbound Prometheus connections to match. This prevents
+TLS handshake failures when the cluster enforces a stricter profile than
+Go's defaults.
+
+| OpenShift TLS Profile | Minimum TLS Version | Go equivalent |
+|----------------------|---------------------|---------------|
+| Modern | TLS 1.3 | `tls.VersionTLS13` |
+| Intermediate (default) | TLS 1.2 | `tls.VersionTLS12` |
+| Old | TLS 1.0 | `tls.VersionTLS10` |
+| Custom | Depends on configuration | Mapped from profile |
+
+### How it works
+
+1. On startup, the operator checks if the `config.openshift.io/v1` API
+   group exists via API discovery
+2. If found, it reads the `APIServer/cluster` resource to extract the
+   TLS security profile type
+3. The detected minimum TLS version is applied to all outbound
+   Prometheus HTTP connections
+4. If the API is not found (vanilla Kubernetes) or the read fails, the
+   operator falls back to Go defaults (TLS 1.2)
+
+### Verifying TLS profile detection
+
+Check the operator logs at startup:
+
+```bash
+kubectl logs -n attune-system deploy/attune -c manager | grep -i tls
+```
+
+On OpenShift with an Intermediate profile:
+
+```json
+{"level":"info","msg":"Detected OpenShift TLS profile","profile":"Intermediate","tlsMinVersion":"0x0303"}
+```
+
+On vanilla Kubernetes:
+
+```json
+{"level":"info","msg":"OpenShift config API not found, using Go TLS defaults"}
+```
+
+## Security Context Constraints
+
+The Attune Helm chart sets a restrictive security context by default:
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+```
+
+These settings are compatible with the OpenShift `restricted-v2` SCC
+(the default for non-privileged workloads). No custom SCC is required.
+
+## RBAC differences
+
+When `openshift.enabled=false` (default), the ClusterRole contains only
+standard Kubernetes API permissions. When `openshift.enabled=true`, one
+additional rule is added:
+
+```yaml
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - apiservers
+  verbs:
+    - get
+    - list
+```
+
+This is read-only access to the cluster TLS configuration. The operator
+never writes to OpenShift API resources.
+
+!!! note "OLM installations"
+    When installing via OperatorHub/OLM, the ClusterServiceVersion (CSV)
+    bundle always includes the OpenShift RBAC rule. OLM manages the RBAC
+    lifecycle automatically.
+
+## Combining with other features
+
+OpenShift integration works alongside all other Attune features:
+
+- **FIPS 140-3 mode** (`fips.enabled=true`): Common on OpenShift
+  clusters in regulated environments. The TLS profile detection respects
+  the FIPS-approved cipher suites.
+- **Prometheus Operator**: OpenShift clusters typically include the
+  Prometheus Operator. Enable `metrics.serviceMonitor.enabled=true` for
+  automatic scrape target registration.
+- **NetworkPolicy**: The default NetworkPolicy allows egress to
+  Prometheus and the Kubernetes API. No OpenShift-specific changes are
+  needed.

--- a/hack/verify-helm-rbac.sh
+++ b/hack/verify-helm-rbac.sh
@@ -34,8 +34,10 @@ normalize_rules() {
 kustomize_rules=$(yq -o=json '.rules' "$KUSTOMIZE_ROLE" | normalize_rules)
 
 # Render Helm template and extract ClusterRole rules.
+# Enable all conditional features so the rendered rules match the full kustomize set.
 helm_rules=$(helm template rbac-check "$HELM_CHART" \
   --set webhooks.enabled=false \
+  --set openshift.enabled=true \
   --show-only templates/clusterrole.yaml \
   --kube-version v1.32.0 \
   | yq -o=json '.rules' | normalize_rules)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Istio Integration: guides/istio-integration.md
       - GitOps Integration: guides/gitops-integration.md
       - Migrating from VPA: guides/migrating-from-vpa.md
+      - OpenShift: guides/openshift.md
       - FIPS 140-3 Compliance: guides/fips-compliance.md
       - Scaling: guides/scaling.md
       - Troubleshooting: guides/troubleshooting.md


### PR DESCRIPTION
## Summary

Makes the OpenShift-specific RBAC rule (`config.openshift.io/apiservers`) conditional in the Helm chart via a new `openshift.enabled` value (default: `false`).

Non-OpenShift users no longer see unnecessary RBAC rules in their ClusterRole, satisfying principle of least privilege and avoiding compliance tool noise.

## Changes

| File | Change |
|---|---|
| `charts/attune/values.yaml` | Add `openshift.enabled: false` |
| `charts/attune/values.schema.json` | Add `openshift` schema entry |
| `charts/attune/templates/clusterrole.yaml` | Wrap OpenShift RBAC in `{{- if .Values.openshift.enabled }}` |
| `charts/attune/tests/rbac_test.yaml` | Add tests for both enabled and disabled states |
| `hack/verify-helm-rbac.sh` | Render with `--set openshift.enabled=true` for full comparison |
| `internal/controller/attunepolicy_controller.go` | Add kubebuilder RBAC marker |
| `config/rbac/role.yaml` | Regenerated from marker |
| `charts/attune/README.md` | Regenerated by helm-docs |

## Notes

- The kustomize deployment (`config/rbac/role.yaml`) always includes the rule since it is auto-generated from kubebuilder markers. Kubernetes silently ignores RBAC for non-existent API groups, so this is harmless on vanilla K8s.
- The runtime code in `DetectOpenShiftTLSProfile()` already handles non-OpenShift gracefully (API discovery, returns Go TLS defaults when the API group is absent). If the RBAC is missing on OpenShift, the discovery call gets a 403 and falls back to defaults.
- This PR also includes the RBAC marker from PR #270; once this merges, #270 can be rebased or its RBAC changes dropped.

Closes #271