### PR TITLE
docs: improve ExportConfig godoc with data format and cleanup behavior

### DIFF
--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -511,11 +511,24 @@ type SLOGuardrail struct {
 }
 
 // ExportConfig controls recommendation export to external systems.
+//
+// When ConfigMap is true, the operator creates one ConfigMap per workload
+// named "<policy>-<workload>-recommendations" in the policy's namespace,
+// labeled with attune.io/policy and attune.io/workload.
+//
+// Data keys use the format "<container>.<resource>" (e.g. "app.cpu-request",
+// "app.memory-limit"), plus "workload", "kind", "last-updated", and
+// "<container>.confidence".
+//
+// Updates use merge-patch to avoid conflicts with GitOps tools (ArgoCD, Flux)
+// that may annotate the same ConfigMap.
+//
+// Cleanup:
+//   - Owner reference: ConfigMaps are garbage-collected when the AttunePolicy is deleted.
+//   - Orphan cleanup: when a workload leaves the policy's selector scope, the operator
+//     deletes its recommendation ConfigMap on the next reconcile.
 type ExportConfig struct {
 	// ConfigMap enables exporting recommendations to ConfigMaps.
-	// One ConfigMap per workload is created, named
-	// "<policy>-<workload>-recommendations", with an owner reference
-	// to the policy for automatic cleanup.
 	// +optional
 	ConfigMap bool `json:"configMap,omitempty"`
 }

--- a/charts/attune/crds/attune.io_attunedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunedefaults.yaml
@@ -529,11 +529,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:

--- a/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
@@ -530,11 +530,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -608,11 +608,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:

--- a/config/crd/bases/attune.io_attunedefaults.yaml
+++ b/config/crd/bases/attune.io_attunedefaults.yaml
@@ -529,11 +529,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:

--- a/config/crd/bases/attune.io_attunenamespacedefaults.yaml
+++ b/config/crd/bases/attune.io_attunenamespacedefaults.yaml
@@ -530,11 +530,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -608,11 +608,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -529,11 +529,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:
@@ -1245,11 +1242,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:
@@ -2039,11 +2033,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -528,11 +528,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:
@@ -1244,11 +1241,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:
@@ -2038,11 +2032,8 @@ spec:
                       consumption (e.g. GitOps workflows with ArgoCD or Flux).
                     properties:
                       configMap:
-                        description: |-
-                          ConfigMap enables exporting recommendations to ConfigMaps.
-                          One ConfigMap per workload is created, named
-                          "<policy>-<workload>-recommendations", with an owner reference
-                          to the policy for automatic cleanup.
+                        description: ConfigMap enables exporting recommendations to
+                          ConfigMaps.
                         type: boolean
                     type: object
                   initialSizing:


### PR DESCRIPTION
Moves detailed ConfigMap export documentation from the inline field comment to the struct-level godoc where it belongs, and adds previously undocumented details:

- **Data format**: documents the key naming convention (`<container>.<resource>`) and metadata keys
- **Update strategy**: notes merge-patch usage to avoid 409 conflicts with GitOps tools
- **Cleanup behavior**: documents both owner-reference GC (policy deletion) and orphan cleanup (workload leaves selector scope)

Regenerated CRD manifests to match the simplified field description.

Recovered from a stash left by a previous session.