### PR TITLE
fix: skip Docker build on re-release to preserve OLM bundle digest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,10 @@ jobs:
       - name: Check if Docker build is possible
         id: docker-check
         run: |
-          if [ -f Dockerfile.release ]; then
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping Docker build on re-release to preserve OLM bundle digest"
+          elif [ -f Dockerfile.release ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

Re-releases (`workflow_dispatch` with `tag` input) rebuilt the Docker image, overwriting the tag with a new manifest digest. This invalidated the OLM bundle submitted during the original release, causing the community-operators-prod preflight `DeployableByOLM` check to fail with `ImagePullBackOff` on the stale digest.

This blocked PR [redhat-openshift-ecosystem/community-operators-prod#9875](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/9875) through 7+ pipeline restarts.

## Root Cause

The v0.1.13 release pipeline:
1. Built and pushed the Docker image (digest `sha256:143df78c...`)
2. Generated the OLM bundle referencing that digest
3. Submitted the OLM bundle PR to community-operators-prod

Then a re-release (`workflow_dispatch`) attempted to rebuild the image. Even though the step failed, it overwrote the tag with a new manifest (digest `sha256:d27c0569...`). The old digest was garbage-collected, but the OLM bundle PR still referenced it.

## Fix

Skip the Docker build entirely on re-releases (`inputs.tag != ''`). Re-releases are for GoReleaser artifacts (binaries, checksums, signatures) only. The container image is immutable once published during the original release.

Also fixed the community-operators-prod fork branch with the correct digest (already pushed, pipeline passed).