### PR TITLE
fix: parse Custom TLS profile minTLSVersion on OpenShift clusters

### DIFF
--- a/docs/guides/openshift.md
+++ b/docs/guides/openshift.md
@@ -44,7 +44,7 @@ Go's defaults.
 | Modern | TLS 1.3 | `tls.VersionTLS13` |
 | Intermediate (default) | TLS 1.2 | `tls.VersionTLS12` |
 | Old | TLS 1.0 | `tls.VersionTLS10` |
-| Custom | Depends on configuration | Mapped from profile |
+| Custom | Parsed from `custom.minTLSVersion` | e.g. `VersionTLS13` -> `tls.VersionTLS13` |
 
 ### How it works
 

--- a/internal/metrics/tlsprofile.go
+++ b/internal/metrics/tlsprofile.go
@@ -53,13 +53,40 @@ func TLSMinVersionForProfile(profile string) uint16 {
 
 // openshiftAPIServer is a minimal representation of the OpenShift
 // apiserver.config.openshift.io/v1 resource, enough to extract the
-// TLS profile type.
+// TLS profile type and custom profile settings.
 type openshiftAPIServer struct {
 	Spec struct {
-		TLSSecurityProfile *struct {
-			Type string `json:"type"`
-		} `json:"tlsSecurityProfile"`
+		TLSSecurityProfile *openshiftTLSSecurityProfile `json:"tlsSecurityProfile"`
 	} `json:"spec"`
+}
+
+// openshiftTLSSecurityProfile represents the tlsSecurityProfile block.
+type openshiftTLSSecurityProfile struct {
+	Type   string                     `json:"type"`
+	Custom *openshiftCustomTLSProfile `json:"custom,omitempty"`
+}
+
+// openshiftCustomTLSProfile holds the explicit TLS settings for Custom profiles.
+type openshiftCustomTLSProfile struct {
+	MinTLSVersion string `json:"minTLSVersion"`
+}
+
+// parseOpenShiftTLSVersion converts an OpenShift version string
+// (e.g. "VersionTLS12", "VersionTLS13") to a Go tls.Config MinVersion.
+// Returns 0 for unrecognized strings (caller should use Go defaults).
+func parseOpenShiftTLSVersion(s string) uint16 {
+	switch s {
+	case "VersionTLS10":
+		return tls.VersionTLS10 //nolint:gosec // mirrors OpenShift Custom profile
+	case "VersionTLS11":
+		return tls.VersionTLS11 //nolint:gosec // mirrors OpenShift Custom profile
+	case "VersionTLS12":
+		return tls.VersionTLS12
+	case "VersionTLS13":
+		return tls.VersionTLS13
+	default:
+		return 0
+	}
 }
 
 // DetectOpenShiftTLSProfile reads the OpenShift APIServer cluster config
@@ -121,6 +148,27 @@ func DetectOpenShiftTLSProfile(clientset *kubernetes.Clientset, logger logr.Logg
 	}
 
 	profileType := apiServer.Spec.TLSSecurityProfile.Type
+
+	// Custom profiles carry an explicit minTLSVersion string instead of
+	// using the predefined Old/Intermediate/Modern mapping.
+	if profileType == TLSProfileCustom {
+		custom := apiServer.Spec.TLSSecurityProfile.Custom
+		if custom == nil || custom.MinTLSVersion == "" {
+			logger.Info("OpenShift Custom TLS profile has no minTLSVersion, using Intermediate defaults")
+			return tls.VersionTLS12
+		}
+		minVer := parseOpenShiftTLSVersion(custom.MinTLSVersion)
+		if minVer == 0 {
+			logger.Info("Unrecognized OpenShift Custom TLS version, using Intermediate defaults",
+				"minTLSVersion", custom.MinTLSVersion)
+			return tls.VersionTLS12
+		}
+		logger.Info("Detected OpenShift Custom TLS profile",
+			"minTLSVersion", custom.MinTLSVersion,
+			"tlsMinVersionHex", fmt.Sprintf("0x%04x", minVer))
+		return minVer
+	}
+
 	minVer := TLSMinVersionForProfile(profileType)
 	logger.Info("Detected OpenShift TLS profile",
 		"profile", profileType,

--- a/internal/metrics/tlsprofile_test.go
+++ b/internal/metrics/tlsprofile_test.go
@@ -228,3 +228,104 @@ func TestDetectOpenShiftTLSProfile_UnreachableAPI(t *testing.T) {
 	result := DetectOpenShiftTLSProfile(cs, logr.Discard())
 	assert.Equal(t, uint16(0), result, "unreachable API should return 0 (Go defaults)")
 }
+
+// fakeAPIServerCustomTLS builds an httptest.Server that simulates an OpenShift
+// cluster with a Custom TLS security profile containing an explicit minTLSVersion.
+func fakeAPIServerCustomTLS(t *testing.T, minTLSVersion string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(metav1.APIVersions{Versions: []string{"v1"}})
+	})
+	mux.HandleFunc("/apis", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(metav1.APIGroupList{Groups: []metav1.APIGroup{{
+			Name: "config.openshift.io",
+			Versions: []metav1.GroupVersionForDiscovery{
+				{GroupVersion: "config.openshift.io/v1", Version: "v1"},
+			},
+		}}})
+	})
+	mux.HandleFunc("/apis/config.openshift.io/v1", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(metav1.APIResourceList{
+			GroupVersion: "config.openshift.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "apiservers", Kind: "APIServer", Namespaced: false},
+			},
+		})
+	})
+	mux.HandleFunc("/apis/config.openshift.io/v1/apiservers/cluster", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		spec := map[string]interface{}{
+			"tlsSecurityProfile": map[string]interface{}{
+				"type": "Custom",
+				"custom": map[string]interface{}{
+					"minTLSVersion": minTLSVersion,
+				},
+			},
+		}
+		resp := map[string]interface{}{
+			"apiVersion": "config.openshift.io/v1",
+			"kind":       "APIServer",
+			"metadata":   map[string]string{"name": "cluster"},
+			"spec":       spec,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestDetectOpenShiftTLSProfile_CustomTLS13(t *testing.T) {
+	server := fakeAPIServerCustomTLS(t, "VersionTLS13")
+	defer server.Close()
+
+	result := DetectOpenShiftTLSProfile(clientsetForServer(t, server), logr.Discard())
+	assert.Equal(t, uint16(tls.VersionTLS13), result, "Custom profile with VersionTLS13 should return TLS 1.3")
+}
+
+func TestDetectOpenShiftTLSProfile_CustomTLS12(t *testing.T) {
+	server := fakeAPIServerCustomTLS(t, "VersionTLS12")
+	defer server.Close()
+
+	result := DetectOpenShiftTLSProfile(clientsetForServer(t, server), logr.Discard())
+	assert.Equal(t, uint16(tls.VersionTLS12), result, "Custom profile with VersionTLS12 should return TLS 1.2")
+}
+
+func TestDetectOpenShiftTLSProfile_CustomUnrecognizedVersion(t *testing.T) {
+	server := fakeAPIServerCustomTLS(t, "VersionTLS99")
+	defer server.Close()
+
+	result := DetectOpenShiftTLSProfile(clientsetForServer(t, server), logr.Discard())
+	assert.Equal(t, uint16(tls.VersionTLS12), result, "Custom profile with unrecognized version should fall back to TLS 1.2")
+}
+
+func TestDetectOpenShiftTLSProfile_CustomNoMinVersion(t *testing.T) {
+	// Custom profile without the minTLSVersion field.
+	server := fakeAPIServer(t, true, "Custom")
+	defer server.Close()
+
+	result := DetectOpenShiftTLSProfile(clientsetForServer(t, server), logr.Discard())
+	assert.Equal(t, uint16(tls.VersionTLS12), result, "Custom profile without minTLSVersion should fall back to TLS 1.2")
+}
+
+func TestParseOpenShiftTLSVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    uint16
+	}{
+		{"VersionTLS10", tls.VersionTLS10},
+		{"VersionTLS11", tls.VersionTLS11},
+		{"VersionTLS12", tls.VersionTLS12},
+		{"VersionTLS13", tls.VersionTLS13},
+		{"VersionTLS99", 0},
+		{"", 0},
+		{"TLS13", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseOpenShiftTLSVersion(tt.version))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

On OpenShift clusters with a Custom TLS security profile, the operator ignored the explicit `minTLSVersion` field and fell back to Go's default TLS version (1.2). This meant clusters configured with `VersionTLS13` in their Custom profile would negotiate connections at TLS 1.2 instead of enforcing the cluster-mandated minimum.

## Root Cause

`DetectOpenShiftTLSProfile()` only handled named profiles (Old, Intermediate, Modern) via `TLSMinVersionForProfile()`. When the profile type was `Custom`, `TLSMinVersionForProfile("Custom")` returned 0, causing the TLS config to use Go's default (TLS 1.2).

The Custom profile struct contains an explicit `minTLSVersion` field (e.g. `VersionTLS13`) that was never parsed.

## Fix

- Added `parseOpenShiftTLSVersion()` to map OpenShift version strings (`VersionTLS10` through `VersionTLS13`) to Go `crypto/tls` constants
- Extended the `openshiftAPIServer` struct to include the `custom.minTLSVersion` JSON path
- Added a Custom profile branch in `DetectOpenShiftTLSProfile()` that parses the explicit version
- Updated docs/guides/openshift.md Custom profile description to reflect the new behavior
- Added 4 tests: Custom with TLS 1.3, Custom with TLS 1.2, Custom with empty minTLSVersion, and a table-driven test for the version parser

## Testing

```
make verify-quick  # all checks pass
go test ./internal/metrics/... -race -count=1  # 4 new tests pass
```