### PR TITLE
fix: resolve tech-debt issues #278-#281

### DIFF
--- a/config/olm/template/manifests/attune.clusterserviceversion.yaml
+++ b/config/olm/template/manifests/attune.clusterserviceversion.yaml
@@ -55,8 +55,8 @@ metadata:
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "true"
-    features.operators.openshift.io/token-auth-gcp: "true"
-    features.operators.openshift.io/token-auth-azure: "true"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/disconnected: "true"
 spec:
   displayName: Attune

--- a/config/olm/template/manifests/attune.clusterserviceversion.yaml
+++ b/config/olm/template/manifests/attune.clusterserviceversion.yaml
@@ -55,8 +55,8 @@ metadata:
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "true"
-    features.operators.openshift.io/token-auth-gcp: "false"
-    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "true"
+    features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/disconnected: "true"
 spec:
   displayName: Attune

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -713,7 +713,18 @@ func (r *AttunePolicyReconciler) updateStatusWithRetry(ctx context.Context, poli
 func (r *AttunePolicyReconciler) newSafetyMonitor(logger logr.Logger, collector rsmetrics.MetricsCollector, guardrails ...[]attunev1alpha1.SLOGuardrail) *safety.Monitor {
 	monitor := safety.NewMonitor(r.Clientset, logger)
 	if tc, ok := collector.(safety.ThrottleChecker); ok {
-		monitor.WithThrottleChecker(tc, safety.DefaultThrottleThreshold)
+		// RateLimitedCollector always satisfies ThrottleChecker, but the
+		// inner collector may not support throttle queries (e.g. Datadog,
+		// CloudWatch). Check before registering to avoid false safety
+		// clearance from the silent 0.0 return.
+		register := true
+		if rl, ok := collector.(*rsmetrics.RateLimitedCollector); ok && !rl.SupportsThrottle() {
+			register = false
+			logger.V(1).Info("Throttle safety check disabled: metrics backend does not support CPU throttle queries")
+		}
+		if register {
+			monitor.WithThrottleChecker(tc, safety.DefaultThrottleThreshold)
+		}
 	}
 	if len(guardrails) > 0 && len(guardrails[0]) > 0 {
 		if sq, ok := collector.(safety.SLOQuerier); ok {

--- a/internal/metrics/ratelimit.go
+++ b/internal/metrics/ratelimit.go
@@ -61,8 +61,17 @@ func (c *RateLimitedCollector) Query(ctx context.Context, query string, ts time.
 	return c.inner.Query(ctx, query, ts)
 }
 
+// SupportsThrottle reports whether the inner collector supports CPU
+// throttle ratio queries. Callers should check this before registering
+// the RateLimitedCollector as a ThrottleChecker, since GetThrottleRatio
+// returns 0 (no throttling) when the inner does not support it.
+func (c *RateLimitedCollector) SupportsThrottle() bool {
+	_, ok := c.inner.(throttle.Checker)
+	return ok
+}
+
 // GetThrottleRatio delegates to the inner collector if it implements
-// safety.ThrottleChecker. Returns 0.0 if the inner collector does not
+// throttle.Checker. Returns 0.0 if the inner collector does not
 // support throttle queries.
 func (c *RateLimitedCollector) GetThrottleRatio(ctx context.Context, namespace, pod, container string, ts time.Time) (float64, error) {
 	if tc, ok := c.inner.(throttle.Checker); ok {

--- a/internal/safety/monitor.go
+++ b/internal/safety/monitor.go
@@ -101,6 +101,7 @@ type Monitor struct {
 	throttleThreshold float64
 	sloQuerier        SLOQuerier
 	sloGuardrails     []attunev1alpha1.SLOGuardrail
+	sloTemplates      map[string]*template.Template // cached parsed templates keyed by query string
 }
 
 // NewMonitor creates a Monitor backed by the given Kubernetes client.
@@ -122,10 +123,21 @@ func (m *Monitor) WithThrottleChecker(checker ThrottleChecker, threshold float64
 }
 
 // WithSLOChecker adds application-level SLO guardrail checking. The querier
-// is used to execute instant PromQL queries for each guardrail.
+// is used to execute instant PromQL queries for each guardrail. Templates are
+// parsed once and cached for the lifetime of the Monitor.
 func (m *Monitor) WithSLOChecker(querier SLOQuerier, guardrails []attunev1alpha1.SLOGuardrail) *Monitor {
 	m.sloQuerier = querier
 	m.sloGuardrails = guardrails
+	m.sloTemplates = make(map[string]*template.Template, len(guardrails))
+	for _, g := range guardrails {
+		tmpl, err := template.New(g.Name).Parse(g.Query)
+		if err != nil {
+			m.logger.Error(err, "Failed to parse SLO query template, will retry per-invocation",
+				"guardrail", g.Name)
+			continue
+		}
+		m.sloTemplates[g.Query] = tmpl
+	}
 	return m
 }
 
@@ -248,7 +260,7 @@ func (m *Monitor) checkSLOGuardrails(ctx context.Context, record ResizeRecord, n
 			continue // evaluation window not yet elapsed
 		}
 
-		query, err := interpolateSLOQuery(g.Query, record)
+		query, err := interpolateSLOQuery(g.Query, record, m.sloTemplates[g.Query])
 		if err != nil {
 			m.logger.Error(err, "SLO guardrail query interpolation failed, skipping",
 				"guardrail", g.Name, "pod", record.PodName, "namespace", record.Namespace)
@@ -301,10 +313,16 @@ func (m *Monitor) checkSLOGuardrails(ctx context.Context, record ResizeRecord, n
 
 // interpolateSLOQuery renders Go template variables in a PromQL query string.
 // Supported variables: {{ .Namespace }}, {{ .WorkloadName }}, {{ .PodName }}.
-func interpolateSLOQuery(queryTemplate string, record ResizeRecord) (string, error) {
-	tmpl, err := template.New("slo").Parse(queryTemplate)
-	if err != nil {
-		return "", fmt.Errorf("parsing SLO query template: %w", err)
+// If a pre-parsed template is provided (from the cache), it is used directly;
+// otherwise the template is parsed on the fly.
+func interpolateSLOQuery(queryTemplate string, record ResizeRecord, cached *template.Template) (string, error) {
+	tmpl := cached
+	if tmpl == nil {
+		var err error
+		tmpl, err = template.New("slo").Parse(queryTemplate)
+		if err != nil {
+			return "", fmt.Errorf("parsing SLO query template: %w", err)
+		}
 	}
 	data := sloTemplateData{
 		Namespace:    record.Namespace,

--- a/internal/safety/monitor_test.go
+++ b/internal/safety/monitor_test.go
@@ -1520,7 +1520,7 @@ func TestInterpolateSLOQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := interpolateSLOQuery(tt.template, tt.record)
+			got, err := interpolateSLOQuery(tt.template, tt.record, nil)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/internal/webhook/defaults_validation.go
+++ b/internal/webhook/defaults_validation.go
@@ -156,6 +156,45 @@ func validateDefaultsSpec(spec attunev1alpha1.AttuneDefaultsSpec) (admission.War
 		}
 	}
 
+	// Validate budget caps are non-negative.
+	if spec.UpdateStrategy != nil {
+		if q := spec.UpdateStrategy.MaxTotalCPUIncrease; q != nil && q.MilliValue() < 0 {
+			return warnings, fmt.Errorf("updateStrategy.maxTotalCpuIncrease must be non-negative, got %s", q)
+		}
+		if q := spec.UpdateStrategy.MaxTotalMemoryIncrease; q != nil && q.Value() < 0 {
+			return warnings, fmt.Errorf("updateStrategy.maxTotalMemoryIncrease must be non-negative, got %s", q)
+		}
+	}
+
+	// Validate safetyObservationPeriod has a minimum floor.
+	if spec.UpdateStrategy != nil && spec.UpdateStrategy.SafetyObservationPeriod != nil {
+		sop := spec.UpdateStrategy.SafetyObservationPeriod.Duration
+		if sop < 0 {
+			return warnings, fmt.Errorf("updateStrategy.safetyObservationPeriod must be non-negative, got %s", sop)
+		}
+		if sop > 0 && sop < time.Minute {
+			return warnings, fmt.Errorf("updateStrategy.safetyObservationPeriod must be at least 1m, got %s", sop)
+		}
+	}
+
+	// Validate canary observation period has a minimum floor.
+	if spec.UpdateStrategy != nil && spec.UpdateStrategy.Canary != nil {
+		op := spec.UpdateStrategy.Canary.ObservationPeriod.Duration
+		if op < 0 {
+			return warnings, fmt.Errorf("updateStrategy.canary.observationPeriod must be non-negative, got %s", op)
+		}
+		if op > 0 && op < time.Minute {
+			return warnings, fmt.Errorf("updateStrategy.canary.observationPeriod must be at least 1m, got %s", op)
+		}
+	}
+
+	// Validate SLO guardrails.
+	if spec.UpdateStrategy != nil {
+		if err := validateSLOGuardrails(spec.UpdateStrategy.SLOGuardrails); err != nil {
+			return warnings, err
+		}
+	}
+
 	// Validate historyWindow bounds.
 	if spec.MetricsSource != nil && spec.MetricsSource.HistoryWindow != nil {
 		hw := spec.MetricsSource.HistoryWindow.Duration
@@ -164,6 +203,21 @@ func validateDefaultsSpec(spec attunev1alpha1.AttuneDefaultsSpec) (admission.War
 		}
 		if hw > 720*time.Hour {
 			return warnings, fmt.Errorf("metricsSource.historyWindow must be at most 720h (30d), got %s", hw)
+		}
+	}
+
+	// Validate rateWindow bounds (30s to historyWindow).
+	if spec.MetricsSource != nil && spec.MetricsSource.RateWindow != nil {
+		rw := spec.MetricsSource.RateWindow.Duration
+		if rw < 30*time.Second {
+			return warnings, fmt.Errorf("metricsSource.rateWindow must be at least 30s, got %s", rw)
+		}
+		maxWindow, _ := time.ParseDuration(attunev1alpha1.DefaultHistoryWindow)
+		if spec.MetricsSource.HistoryWindow != nil {
+			maxWindow = spec.MetricsSource.HistoryWindow.Duration
+		}
+		if rw > maxWindow {
+			return warnings, fmt.Errorf("metricsSource.rateWindow (%s) must not exceed historyWindow (%s)", rw, maxWindow)
 		}
 	}
 

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -256,7 +256,7 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 		if rw < 30*time.Second {
 			return warnings, fmt.Errorf("metricsSource.rateWindow must be at least 30s, got %s", rw)
 		}
-		maxWindow := 168 * time.Hour // default history window
+		maxWindow, _ := time.ParseDuration(attunev1alpha1.DefaultHistoryWindow)
 		if policy.Spec.MetricsSource.HistoryWindow != nil {
 			maxWindow = policy.Spec.MetricsSource.HistoryWindow.Duration
 		}


### PR DESCRIPTION
## Summary

Fixes 4 tech-debt issues:

| Issue | Fix | Files |
|---|---|---|
| #278 | `RateLimitedCollector` silently returns 0 for non-Prometheus throttle checks. Added `SupportsThrottle()` method; `newSafetyMonitor` now checks before registering. | `ratelimit.go`, `helpers.go` |
| #279 | `AttuneDefaults` webhook missing 5 validations (SLO guardrails, canary floor, budget caps, safety period, rateWindow). Invalid defaults could propagate to all policies. | `defaults_validation.go` |
| #280 | SLO query templates re-parsed on every safety observation (150+ parses/cycle). Cached in `Monitor.sloTemplates` at `WithSLOChecker` time. | `monitor.go`, `monitor_test.go` |
| #281 | Hardcoded `168h` in rateWindow validation replaced with `DefaultHistoryWindow` constant. | `validation.go` |

`#282` (token-auth annotations) was reverted; the annotations mean 'compatible with' not 'integrates with'.

## Verification

- `go build ./...` clean
- `go test ./internal/webhook/... ./internal/safety/... ./internal/metrics/... ./internal/controller/... -race -count=1` all pass
- `make verify-quick` green (lint, unit, helm, doc-defaults, RBAC sync, metrics sync)

Closes #278, Closes #279, Closes #280, Closes #281