### PR TITLE
ci: use go-version-file instead of hardcoded Go version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  GO_VERSION: "1.26.4"
   GOLANGCI_LINT_VERSION: "v2.12.2"
   GOTESTSUM_VERSION: "v1.13.0"
   K3D_VERSION: "v5.8.3"
@@ -103,7 +102,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - uses: ./.github/actions/install-go-tool
@@ -162,7 +161,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -261,7 +260,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
       - name: Chainsaw dry-run (parse validation)
         shell: bash -Eeuo pipefail {0}
@@ -286,7 +285,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - uses: ./.github/actions/install-go-tool
@@ -386,7 +385,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - uses: ./.github/actions/install-go-tool
@@ -451,7 +450,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - uses: ./.github/actions/install-go-tool
@@ -517,7 +516,7 @@ jobs:
         with:
           cluster-name: ${{ env.K3D_CLUSTER_NAME }}
           kubeconfig-path: ${{ runner.temp }}/attune-e2e-${{ github.run_id }}.kubeconfig
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           k3d-version: ${{ env.K3D_VERSION }}
           k3s-image: ${{ env.K3S_IMAGE }}
           cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
@@ -585,7 +584,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - uses: ./.github/actions/install-go-tool
@@ -612,7 +611,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Regenerate manifests and deepcopy
@@ -693,7 +692,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - uses: ./.github/actions/install-go-tool
@@ -730,7 +729,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - uses: ./.github/actions/setup-clean-docker-config

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -36,7 +36,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.4"
   K3D_VERSION: "v5.8.3"
   CERT_MANAGER_VERSION: "v1.17.2"
   PROMETHEUS_IMAGE: "quay.io/prometheus/prometheus:v3.4.1"
@@ -123,7 +122,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Cache E2E container images
@@ -408,7 +407,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Run fuzz tests (coverage-guided, 30s per target)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.4"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
@@ -107,7 +106,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Check if Docker build is possible
@@ -537,7 +536,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         if: matrix.language == 'go'
         with:
-          go-version: "1.26.4"
+          go-version-file: go.mod
           cache: true
 
       - uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.4"
+          go-version-file: go.mod
           cache: true
 
       - uses: ./.github/actions/install-go-tool
@@ -121,7 +121,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.4"
+          go-version-file: go.mod
           cache: true
 
       - uses: ./.github/actions/setup-clean-docker-config


### PR DESCRIPTION
## What

Replaces all hardcoded `GO_VERSION` env vars and inline `go-version` strings with `go-version-file: go.mod` across all 4 workflow files (ci, release, e2e-nightly, security).

## Why

When Go 1.26.4 was released to fix 3 stdlib CVEs, updating `go.mod` broke CI because the workflow `GO_VERSION` env vars still pointed to `1.26.3` (then `1.26`, which resolved to 1.26.3 via setup-go's stale manifest). This required manual updates in 4 workflow files on top of go.mod and the Dockerfile.

With `go-version-file: go.mod`, Dependabot handles go.mod bumps and CI workflows automatically read the correct version. The update chain shrinks from 3 locations to 2 (go.mod + Dockerfile), both covered by Dependabot.

## How

- Removed `GO_VERSION` env var from ci.yaml, release.yaml, e2e-nightly.yaml
- Replaced all 18 `go-version` references with `go-version-file: go.mod`
- No functional change; setup-go reads the `go` directive from go.mod