### PR TITLE
fix: pre-pull and cache k3s node image to prevent E2E cluster creation failures

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -59,7 +59,8 @@ runs:
           /tmp/cert-manager-cainjector.tar
           /tmp/prometheus.tar
           /tmp/stress-ng.tar
-        key: e2e-images-${{ runner.os }}-cm${{ inputs.cert-manager-version }}-prom${{ inputs.prometheus-chart-version }}-stress0.20.01
+          /tmp/k3s.tar
+        key: e2e-images-${{ runner.os }}-cm${{ inputs.cert-manager-version }}-prom${{ inputs.prometheus-chart-version }}-stress0.20.01-k3s${{ inputs.k3s-image }}
 
     - uses: ./.github/actions/install-binary-tool
       with:
@@ -87,24 +88,39 @@ runs:
         docker builder prune -f || true
         docker system prune -f || true
 
-    - name: Pre-pull cert-manager and Prometheus images
+    - name: Pre-pull container images
       shell: bash -Eeuo pipefail -x {0}
       run: |
+        # Pull images with docker (parallel layer downloads) and save as
+        # tarballs for k3d import. Skip images already restored from cache.
+        # Retries handle transient Docker Hub connectivity issues.
         pull_and_save() {
           local image="$1" tarball="$2"
           [[ -f "$tarball" ]] && { echo "Cached: $tarball"; return 0; }
-          docker pull --platform linux/amd64 "$image"
-          docker save "$image" -o "$tarball"
+          for attempt in 1 2 3; do
+            if docker pull --platform linux/amd64 "$image"; then
+              docker save "$image" -o "$tarball"
+              return 0
+            fi
+            echo "::warning::docker pull attempt $attempt for $image failed, retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Failed to pull $image after 3 attempts"
+          return 1
         }
         pull_and_save "quay.io/jetstack/cert-manager-controller:${{ inputs.cert-manager-version }}" /tmp/cert-manager-controller.tar
         pull_and_save "quay.io/jetstack/cert-manager-webhook:${{ inputs.cert-manager-version }}" /tmp/cert-manager-webhook.tar
         pull_and_save "quay.io/jetstack/cert-manager-cainjector:${{ inputs.cert-manager-version }}" /tmp/cert-manager-cainjector.tar
         pull_and_save "${{ inputs.prometheus-image }}" /tmp/prometheus.tar
         pull_and_save "${{ inputs.stress-ng-image }}" /tmp/stress-ng.tar
+        pull_and_save "${{ inputs.k3s-image }}" /tmp/k3s.tar
 
     - name: Create k3d cluster
       shell: bash -Eeuo pipefail -x {0}
       run: |
+        # Load the pre-pulled k3s image into Docker so k3d uses it
+        # without pulling from Docker Hub (avoids rate-limit/timeout failures).
+        docker load -i /tmp/k3s.tar
         for attempt in 1 2 3; do
           if k3d cluster create "${{ inputs.cluster-name }}" \
             --image ${{ inputs.k3s-image }} \

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -135,7 +135,8 @@ jobs:
             /tmp/prometheus.tar
             /tmp/stress-ng.tar
             /tmp/busybox.tar
-          key: e2e-images-${{ runner.os }}-cm${{ env.CERT_MANAGER_VERSION }}-prom${{ env.PROMETHEUS_CHART_VERSION }}-stress0.20.01-busybox1.37
+            /tmp/k3s.tar
+          key: e2e-images-${{ runner.os }}-cm${{ env.CERT_MANAGER_VERSION }}-prom${{ env.PROMETHEUS_CHART_VERSION }}-stress0.20.01-busybox1.37-k3s${{ matrix.k3s-image }}
 
       - uses: ./.github/actions/install-binary-tool
         with:
@@ -163,16 +164,25 @@ jobs:
           docker builder prune -f || true
           docker system prune -f || true
 
-      - name: Pre-pull cert-manager and Prometheus images
+      - name: Pre-pull container images
         shell: bash -Eeuo pipefail -x {0}
         run: |
           # Pull images with docker (parallel layer downloads) and save as
           # tarballs for k3d import. Skip images already restored from cache.
+          # Retries handle transient Docker Hub connectivity issues.
           pull_and_save() {
             local image="$1" tarball="$2"
             [[ -f "$tarball" ]] && { echo "Cached: $tarball"; return 0; }
-            docker pull --platform linux/amd64 "$image"
-            docker save "$image" -o "$tarball"
+            for attempt in 1 2 3; do
+              if docker pull --platform linux/amd64 "$image"; then
+                docker save "$image" -o "$tarball"
+                return 0
+              fi
+              echo "::warning::docker pull attempt $attempt for $image failed, retrying in 10s..."
+              sleep 10
+            done
+            echo "::error::Failed to pull $image after 3 attempts"
+            return 1
           }
           pull_and_save "quay.io/jetstack/cert-manager-controller:${{ env.CERT_MANAGER_VERSION }}" /tmp/cert-manager-controller.tar
           pull_and_save "quay.io/jetstack/cert-manager-webhook:${{ env.CERT_MANAGER_VERSION }}" /tmp/cert-manager-webhook.tar
@@ -180,11 +190,15 @@ jobs:
           pull_and_save "${{ env.PROMETHEUS_IMAGE }}" /tmp/prometheus.tar
           pull_and_save "${{ env.STRESS_NG_IMAGE }}" /tmp/stress-ng.tar
           pull_and_save "${{ env.CPU_BURN_IMAGE }}" /tmp/busybox.tar
+          pull_and_save "rancher/k3s:${{ matrix.k3s-image }}" /tmp/k3s.tar
 
       - name: Create k3d cluster
         shell: bash -Eeuo pipefail -x {0}
         run: |
           rm -f "$KUBECONFIG"
+          # Load the pre-pulled k3s image into Docker so k3d uses it
+          # without pulling from Docker Hub (avoids rate-limit/timeout failures).
+          docker load -i /tmp/k3s.tar
           # Retry cluster creation up to 3 times. k3d can fail transiently
           # when Docker containers vanish mid-creation due to daemon
           # contention with concurrent CI runs.


### PR DESCRIPTION
## Problem

E2E tests fail intermittently when k3d cannot pull the k3s node image from Docker Hub during cluster creation. The failure mode is a timeout:

```
docker failed to pull image 'rancher/k3s:v1.34.7-k3s1':
Error response from daemon: Get "https://registry-1.docker.io/v2/":
net/http: request canceled while waiting for connection
(Client.Timeout exceeded while awaiting headers)
```

All 3 retry attempts fail because the retries only retry the `k3d cluster create` command, which repeats the same Docker Hub pull with the same connectivity issue.

**Root cause:** The workflow pre-pulls and caches 6 images (cert-manager, Prometheus, stress-ng, busybox) as tarballs via `actions/cache`, but the k3s node image itself is not pre-pulled or cached. k3d pulls it on the fly during cluster creation, where Docker Hub rate limits or transient connectivity issues cause timeouts.

Observed in [nightly run 26858361803](https://github.com/attune-io/attune/actions/runs/26858361803) where K8s v1.34 failed while v1.32, v1.33, and v1.35 succeeded (different runners, different connectivity).

## Fix

1. **Pre-pull the k3s image** with the same `pull_and_save()` function used for other images, now with 3-attempt retry logic and 10s backoff
2. **Cache the k3s tarball** via `actions/cache` so subsequent runs skip the pull entirely
3. **`docker load` before `k3d cluster create`** so k3d finds the image locally and never attempts a Docker Hub pull

Applied to both:
- `.github/workflows/e2e-nightly.yaml` (nightly matrix, per-K8s-version cache key)
- `.github/actions/setup-e2e-cluster/action.yaml` (CI composite action)