### PR TITLE
ci: add fallback registries for E2E dependency images

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -93,9 +93,12 @@ runs:
       run: |
         # Pull images with docker (parallel layer downloads) and save as
         # tarballs for k3d import. Skip images already restored from cache.
-        # Retries handle transient Docker Hub connectivity issues.
+        # Accepts an optional 3rd argument: a fallback image reference to try
+        # when the primary registry is unreachable (e.g. quay.io outage).
+        # If the fallback succeeds, the image is retagged to the primary name
+        # so downstream manifests (cert-manager.yaml) resolve correctly.
         pull_and_save() {
-          local image="$1" tarball="$2"
+          local image="$1" tarball="$2" fallback="${3:-}"
           [[ -f "$tarball" ]] && { echo "Cached: $tarball"; return 0; }
           for attempt in 1 2 3; do
             if docker pull --platform linux/amd64 "$image"; then
@@ -105,13 +108,29 @@ runs:
             echo "::warning::docker pull attempt $attempt for $image failed, retrying in 10s..."
             sleep 10
           done
-          echo "::error::Failed to pull $image after 3 attempts"
+          if [[ -n "$fallback" ]]; then
+            echo "::warning::Primary registry failed for $image, trying fallback: $fallback"
+            for attempt in 1 2 3; do
+              if docker pull --platform linux/amd64 "$fallback"; then
+                docker tag "$fallback" "$image"
+                docker save "$image" -o "$tarball"
+                return 0
+              fi
+              echo "::warning::fallback pull attempt $attempt for $fallback failed, retrying in 10s..."
+              sleep 10
+            done
+          fi
+          echo "::error::Failed to pull $image after all attempts"
           return 1
         }
-        pull_and_save "quay.io/jetstack/cert-manager-controller:${{ inputs.cert-manager-version }}" /tmp/cert-manager-controller.tar
-        pull_and_save "quay.io/jetstack/cert-manager-webhook:${{ inputs.cert-manager-version }}" /tmp/cert-manager-webhook.tar
-        pull_and_save "quay.io/jetstack/cert-manager-cainjector:${{ inputs.cert-manager-version }}" /tmp/cert-manager-cainjector.tar
-        pull_and_save "${{ inputs.prometheus-image }}" /tmp/prometheus.tar
+        CM_VER="${{ inputs.cert-manager-version }}"
+        OWNER="attune-io"
+        pull_and_save "quay.io/jetstack/cert-manager-controller:${CM_VER}" /tmp/cert-manager-controller.tar "ghcr.io/${OWNER}/mirrors/cert-manager-controller:${CM_VER}"
+        pull_and_save "quay.io/jetstack/cert-manager-webhook:${CM_VER}" /tmp/cert-manager-webhook.tar "ghcr.io/${OWNER}/mirrors/cert-manager-webhook:${CM_VER}"
+        pull_and_save "quay.io/jetstack/cert-manager-cainjector:${CM_VER}" /tmp/cert-manager-cainjector.tar "ghcr.io/${OWNER}/mirrors/cert-manager-cainjector:${CM_VER}"
+        PROM_TAG="${{ inputs.prometheus-image }}"
+        PROM_TAG="${PROM_TAG##*:}"
+        pull_and_save "${{ inputs.prometheus-image }}" /tmp/prometheus.tar "docker.io/prom/prometheus:${PROM_TAG}"
         pull_and_save "${{ inputs.stress-ng-image }}" /tmp/stress-ng.tar
         pull_and_save "${{ inputs.k3s-image }}" /tmp/k3s.tar
 

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -169,9 +169,12 @@ jobs:
         run: |
           # Pull images with docker (parallel layer downloads) and save as
           # tarballs for k3d import. Skip images already restored from cache.
-          # Retries handle transient Docker Hub connectivity issues.
+          # Accepts an optional 3rd argument: a fallback image reference to try
+          # when the primary registry is unreachable (e.g. quay.io outage).
+          # If the fallback succeeds, the image is retagged to the primary name
+          # so downstream manifests (cert-manager.yaml) resolve correctly.
           pull_and_save() {
-            local image="$1" tarball="$2"
+            local image="$1" tarball="$2" fallback="${3:-}"
             [[ -f "$tarball" ]] && { echo "Cached: $tarball"; return 0; }
             for attempt in 1 2 3; do
               if docker pull --platform linux/amd64 "$image"; then
@@ -181,13 +184,29 @@ jobs:
               echo "::warning::docker pull attempt $attempt for $image failed, retrying in 10s..."
               sleep 10
             done
-            echo "::error::Failed to pull $image after 3 attempts"
+            if [[ -n "$fallback" ]]; then
+              echo "::warning::Primary registry failed for $image, trying fallback: $fallback"
+              for attempt in 1 2 3; do
+                if docker pull --platform linux/amd64 "$fallback"; then
+                  docker tag "$fallback" "$image"
+                  docker save "$image" -o "$tarball"
+                  return 0
+                fi
+                echo "::warning::fallback pull attempt $attempt for $fallback failed, retrying in 10s..."
+                sleep 10
+              done
+            fi
+            echo "::error::Failed to pull $image after all attempts"
             return 1
           }
-          pull_and_save "quay.io/jetstack/cert-manager-controller:${{ env.CERT_MANAGER_VERSION }}" /tmp/cert-manager-controller.tar
-          pull_and_save "quay.io/jetstack/cert-manager-webhook:${{ env.CERT_MANAGER_VERSION }}" /tmp/cert-manager-webhook.tar
-          pull_and_save "quay.io/jetstack/cert-manager-cainjector:${{ env.CERT_MANAGER_VERSION }}" /tmp/cert-manager-cainjector.tar
-          pull_and_save "${{ env.PROMETHEUS_IMAGE }}" /tmp/prometheus.tar
+          CM_VER="${{ env.CERT_MANAGER_VERSION }}"
+          OWNER="attune-io"
+          pull_and_save "quay.io/jetstack/cert-manager-controller:${CM_VER}" /tmp/cert-manager-controller.tar "ghcr.io/${OWNER}/mirrors/cert-manager-controller:${CM_VER}"
+          pull_and_save "quay.io/jetstack/cert-manager-webhook:${CM_VER}" /tmp/cert-manager-webhook.tar "ghcr.io/${OWNER}/mirrors/cert-manager-webhook:${CM_VER}"
+          pull_and_save "quay.io/jetstack/cert-manager-cainjector:${CM_VER}" /tmp/cert-manager-cainjector.tar "ghcr.io/${OWNER}/mirrors/cert-manager-cainjector:${CM_VER}"
+          PROM_TAG="${{ env.PROMETHEUS_IMAGE }}"
+          PROM_TAG="${PROM_TAG##*:}"
+          pull_and_save "${{ env.PROMETHEUS_IMAGE }}" /tmp/prometheus.tar "docker.io/prom/prometheus:${PROM_TAG}"
           pull_and_save "${{ env.STRESS_NG_IMAGE }}" /tmp/stress-ng.tar
           pull_and_save "${{ env.CPU_BURN_IMAGE }}" /tmp/busybox.tar
           pull_and_save "rancher/k3s:${{ matrix.k3s-image }}" /tmp/k3s.tar

--- a/.github/workflows/mirror-e2e-images.yaml
+++ b/.github/workflows/mirror-e2e-images.yaml
@@ -1,0 +1,90 @@
+# Mirror E2E dependency images to GHCR so CI has a fallback when
+# upstream registries (quay.io) are unreachable from GitHub-hosted runners.
+#
+# After the first run, make each ghcr.io/attune-io/mirrors/* package
+# public via Settings > Packages > Package settings > Danger zone.
+name: Mirror E2E Images
+
+on:
+  schedule:
+    # Weekly Sunday 06:00 UTC (keeps GHCR copies warm)
+    - cron: "0 6 * * 0"
+  push:
+    branches: [main]
+    paths:
+      # Re-mirror whenever image versions change
+      - ".github/workflows/ci.yaml"
+      - ".github/workflows/e2e-nightly.yaml"
+      - ".github/workflows/mirror-e2e-images.yaml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: mirror-e2e-images
+  cancel-in-progress: true
+
+jobs:
+  mirror:
+    name: Mirror cert-manager to GHCR
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github/workflows/ci.yaml
+          sparse-checkout-cone-mode: false
+
+      - name: Read pinned versions from ci.yaml
+        id: versions
+        shell: bash
+        run: |
+          CM=$(grep 'CERT_MANAGER_VERSION:' .github/workflows/ci.yaml \
+               | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          PROM=$(grep 'PROMETHEUS_IMAGE:' .github/workflows/ci.yaml \
+                 | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "cert_manager=${CM}" >> "$GITHUB_OUTPUT"
+          echo "prometheus=${PROM}" >> "$GITHUB_OUTPUT"
+          echo "Mirror targets: cert-manager=${CM}  prometheus=${PROM}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror cert-manager images
+        shell: bash
+        env:
+          CM_VERSION: ${{ steps.versions.outputs.cert_manager }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          for component in controller webhook cainjector; do
+            src="quay.io/jetstack/cert-manager-${component}:${CM_VERSION}"
+            dst="ghcr.io/${OWNER}/mirrors/cert-manager-${component}:${CM_VERSION}"
+            echo "::group::${component}"
+            docker pull --platform linux/amd64 "$src"
+            docker tag "$src" "$dst"
+            docker push "$dst"
+            echo "::endgroup::"
+          done
+
+      - name: Mirror Prometheus image
+        shell: bash
+        env:
+          PROM_IMAGE: ${{ steps.versions.outputs.prometheus }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          # Extract tag from full image ref (quay.io/prometheus/prometheus:v3.4.1 -> v3.4.1)
+          PROM_TAG="${PROM_IMAGE##*:}"
+          dst="ghcr.io/${OWNER}/mirrors/prometheus:${PROM_TAG}"
+          docker pull --platform linux/amd64 "$PROM_IMAGE"
+          docker tag "$PROM_IMAGE" "$dst"
+          docker push "$dst"


### PR DESCRIPTION
## Problem

When quay.io is unreachable from GitHub-hosted runners, E2E tests fail because cert-manager and Prometheus images cannot be pulled (commit e58d249, CI run 26862293253). The `actions/cache` layer prevents this when warm, but on cache misses the single-registry pull has no fallback.

## Solution

Two-layer fallback:

1. **Mirror workflow** (`mirror-e2e-images.yaml`): copies cert-manager and Prometheus images to GHCR weekly and on version bumps (reads versions from ci.yaml).

2. **Fallback in `pull_and_save()`**: accepts an optional 3rd argument for a fallback image reference. If the primary registry fails after 3 retries, tries the fallback. On success, retags to the primary name so downstream manifests resolve correctly.

### Fallback mapping

| Image | Primary | Fallback |
|---|---|---|
| cert-manager (3 images) | quay.io/jetstack/ | ghcr.io/attune-io/mirrors/ |
| Prometheus | quay.io/prometheus/ | docker.io/prom/prometheus |
| stress-ng | ghcr.io | (none, usually reliable) |
| k3s | Docker Hub | (none, usually reliable) |

Updated in both the composite action and the nightly workflow.

## Post-merge

After the mirror workflow runs for the first time, make each `ghcr.io/attune-io/mirrors/*` package public via Settings > Packages > Package settings > Danger zone.