### PR TITLE
fix: scorecard token-permissions and AI code quality findings

### DIFF
--- a/.github/workflows/mirror-e2e-images.yaml
+++ b/.github/workflows/mirror-e2e-images.yaml
@@ -20,7 +20,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: mirror-e2e-images
@@ -31,6 +30,9 @@ jobs:
     name: Mirror cert-manager to GHCR
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -313,9 +313,9 @@ x-kubernetes-validations:
   - rule: "!has(self.minAllowed) || !has(self.maxAllowed) || self.minAllowed <= self.maxAllowed"
     message: "memory.minAllowed must be less than or equal to memory.maxAllowed"
 
-# updateStrategy: canary config required when mode is Canary
+# updateStrategy: canary config required when type is Canary
   - rule: "self.updateStrategy.type != 'Canary' || has(self.updateStrategy.canary)"
-    message: "canary configuration is required when mode is Canary"
+    message: "canary configuration is required when updateStrategy.type is Canary"
 
 # weight: immutable after creation (prevents runtime priority races)
   - rule: "self.weight == oldSelf.weight"

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -99,7 +99,7 @@ spec:
   updateStrategy:
     type: Recommend            # Observe | Recommend | OneShot | Canary | Auto
     initialSizing: false       # optional: set pod resources at creation time via webhook
-    canary:                    # required when mode is Canary
+    canary:                    # required when type is Canary
       percentage: 10           # % of pods to resize first
       observationPeriod: 30m   # watch canary pods before proceeding (minimum: 1m)
       autoPromote: true        # promote to full fleet after safe observation (default: false)

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -97,9 +97,9 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 		}
 	}
 
-	// Canary config required when mode is Canary
+	// Canary config required when type is Canary
 	if us.Type == attunev1alpha1.UpdateTypeCanary && us.Canary == nil {
-		return warnings, fmt.Errorf("updateStrategy.canary is required when mode is Canary")
+		return warnings, fmt.Errorf("updateStrategy.canary is required when updateStrategy.type is Canary")
 	}
 
 	// Validate canary observation period has a minimum floor.

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -222,7 +222,7 @@ func TestValidate_CanaryModeWithoutConfig(t *testing.T) {
 	warnings, err := validator.ValidateCreate(context.Background(), policy)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "updateStrategy.canary is required when mode is Canary")
+	assert.Contains(t, err.Error(), "updateStrategy.canary is required when updateStrategy.type is Canary")
 	assert.Empty(t, warnings)
 }
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -13,6 +13,7 @@ exclude = [
   "instagram\\.com",
   "cast\\.ai",
   "helm\\.sh",
+  "cert-manager\\.io",
 ]
 exclude_loopback = true
 max_concurrency = 8

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -422,7 +423,7 @@ func TestReconcile_DeletedPolicy_NoError(t *testing.T) {
 			Name:      "policy-delete",
 			Namespace: namespace,
 		}, &fetched)
-		return err != nil // should be NotFound
+		return apierrors.IsNotFound(err)
 	}, 30*time.Second, 500*time.Millisecond, "policy should be deleted")
 }
 


### PR DESCRIPTION
## What

Fix the OpenSSF Scorecard Token-Permissions score (currently 0) and address
actionable findings from GitHub AI Code Quality scanner.

## Token-Permissions fix

Move `packages: write` from **top-level** to **job-level** in the
`mirror-e2e-images` workflow. Scorecard requires top-level permissions to be
read-only; write permissions must be scoped to individual jobs.

**Before:** top-level `packages: write` causes Scorecard to give 0/10.
**After:** job-level `packages: write` follows least-privilege principle.

## AI Code Quality fixes (2 of 11 actionable)

| Finding | Fix |
|---------|-----|
| Validation error says "mode is Canary" but field is `type` | Changed to "updateStrategy.type is Canary" |
| Integration test uses `err != nil` to check deletion | Changed to `apierrors.IsNotFound(err)` |

### Triaged as false positive / skip (9 of 11)

- **DaysOfWeek `items:Enum` marker**: CRD output confirms the enum IS generated correctly
- **Weight / MaxConcurrentResizes pointer types**: CRD API change not needed; API server defaults work correctly with `int32` + `omitempty`
- **SupportedTargetKindsCSV duplication**: Intentional pattern; kubebuilder enum marker must stay separate
- **CHANGELOG format (2 findings)**: File is managed by release-please
- **ParseDuration error discarded (2 findings)**: Parsing a compile-time constant (`"168h"`); error is impossible
- **Test Discovered assertion**: Could introduce flakiness without meaningful gain