### PR TITLE
ci: workflow hygiene gaps (permissions scoping, concurrency, persist-credentials)

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: auto-approve-${{ github.event.pull_request.number || github.run_id }}
@@ -18,6 +17,8 @@ jobs:
     name: Auto Approve
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      pull-requests: write
     if: >
       github.actor == 'SebTardif' ||
       github.actor == 'dependabot[bot]'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -563,6 +563,15 @@ jobs:
           echo "=== Events ==="
           kubectl get events -A --sort-by='.lastTimestamp' | tail -50
 
+      - name: Upload debug logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-debug-logs
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Cleanup k3d cluster
         if: always()
         shell: bash -Eeuo pipefail {0}

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -29,7 +29,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: e2e-nightly-${{ github.ref }}-${{ github.event_name }}-${{ inputs.k8s-version || 'all' }}-${{ inputs.suite || 'all' }}
@@ -457,6 +456,8 @@ jobs:
     name: Nightly Results
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
+    permissions:
+      issues: write
     needs: [test-e2e, fuzz]
     if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: labeler-${{ github.event.pull_request.number }}
@@ -16,6 +15,9 @@ jobs:
     name: Auto-label PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/pr-size.yaml
+++ b/.github/workflows/pr-size.yaml
@@ -5,8 +5,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 concurrency:
   group: pr-size-${{ github.event.pull_request.number }}
@@ -17,6 +15,10 @@ jobs:
     name: Label PR size
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -39,6 +39,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         if: matrix.language == 'go'
@@ -71,6 +73,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -96,6 +100,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-clean-docker-config
 
@@ -118,6 +124,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -177,6 +185,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/install-binary-tool
         with:
@@ -206,6 +215,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high

--- a/.github/workflows/sign-old-releases.yaml
+++ b/.github/workflows/sign-old-releases.yaml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: sign-old-releases
+  cancel-in-progress: false
+
 jobs:
   sign:
     name: Sign Releases

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: stale
@@ -18,6 +17,9 @@ jobs:
     name: Close stale issues and PRs
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:


### PR DESCRIPTION
## Summary

Fixes CI workflow hygiene gaps identified during a full audit against the ci-workflow-hygiene skill.

### Workflow changes (this PR)

- **Permissions scoping**: Move write permissions from workflow level to job level in 5 workflows (auto-approve, pr-size, labeler, stale, e2e-nightly) for Scorecard Token-Permissions compliance
- **Concurrency group**: Add concurrency group to `sign-old-releases.yaml`
- **persist-credentials**: Add `persist-credentials: false` to all 6 checkout steps in `security.yaml`
- **Failure diagnostics**: Upload E2E debug logs as artifact on failure in `ci.yaml`

### Ruleset change (applied via API)

- Add `code_scanning` rule with CodeQL (`alerts_threshold: errors`, `security_alerts_threshold: high_or_higher`) to the `main-branch-protection` ruleset. PRs introducing high-severity CodeQL findings will now be blocked from merging. Scorecard is intentionally excluded (it only runs on push, not PRs).