### PR TITLE
docs: add OperatorHub registry links to installation and OpenShift guides

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -67,9 +67,12 @@ If your cluster has the [Operator Lifecycle Manager](https://olm.operatorframewo
 installed, you can install Attune directly from
 [OperatorHub.io](https://operatorhub.io/operator/attune).
 
-**On OpenShift**, search for "Attune" in the built-in OperatorHub catalog and
-click Install. See the [OpenShift guide](../guides/openshift.md) for
-TLS profile integration and OpenShift-specific configuration.
+**On OpenShift**, the operator is available in the built-in OperatorHub catalog.
+Search for "Attune" in the web console under **Operators > OperatorHub** and
+click Install. You can also browse the listing on the
+[Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/search?target_platforms=Operator&q=attune).
+See the [OpenShift guide](../guides/openshift.md) for TLS profile integration
+and OpenShift-specific configuration.
 
 **On other clusters with OLM**, install the operator by creating a
 `Subscription`:

--- a/docs/guides/openshift.md
+++ b/docs/guides/openshift.md
@@ -12,6 +12,11 @@ OpenShift includes a built-in OperatorHub catalog. Search for "Attune"
 in the web console under **Operators > OperatorHub** and click Install.
 The OLM bundle includes all CRDs, RBAC, and the operator deployment.
 
+You can also browse the listing online:
+
+- [Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/search?target_platforms=Operator&q=attune) (OpenShift embedded catalog)
+- [OperatorHub.io](https://operatorhub.io/operator/attune) (community catalog for any OLM-enabled cluster)
+
 ### Via Helm
 
 ```bash


### PR DESCRIPTION
Add direct web links to both OperatorHub registries where users can browse the Attune operator listing:

- **Red Hat Ecosystem Catalog** (catalog.redhat.com): the prod catalog embedded in every OpenShift cluster
- **OperatorHub.io**: the community catalog for any OLM-enabled cluster

Updated in two places:
- `docs/guides/openshift.md`: both links under the OperatorHub install section
- `docs/getting-started/installation.md`: Red Hat Ecosystem Catalog link in the OLM section