### PR TITLE
refactor: extract enforceAllowDecrease helper to reduce duplication

### DIFF
--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/attune-io/attune/internal/conflict"
 	rsmetrics "github.com/attune-io/attune/internal/metrics"
 	"github.com/attune-io/attune/internal/operatormetrics"
+	"github.com/attune-io/attune/internal/recommendation"
 	"github.com/attune-io/attune/internal/resize"
 )
 
@@ -1950,6 +1951,69 @@ func TestComputeRecommendations_CPUAllowDecreaseNilAllowsDecrease(t *testing.T) 
 	cpuRec := rec.Containers[0].Recommended.CPURequest
 	assert.True(t, cpuRec.Cmp(resource.MustParse("4000m")) < 0,
 		"CPU should decrease below current when AllowDecrease is nil, got %s", cpuRec.String())
+}
+
+func TestEnforceAllowDecrease(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+
+	tests := []struct {
+		name           string
+		allowDecrease  bool
+		rec            string
+		current        string
+		wantClamped    bool
+		wantAdjustment string
+	}{
+		{
+			name:          "decrease allowed, rec < current",
+			allowDecrease: true,
+			rec:           "100m",
+			current:       "500m",
+			wantClamped:   false,
+		},
+		{
+			name:           "decrease blocked, rec < current",
+			allowDecrease:  false,
+			rec:            "100m",
+			current:        "500m",
+			wantClamped:    true,
+			wantAdjustment: "CPU decrease from 500m to 100m blocked by allowDecrease=false",
+		},
+		{
+			name:          "decrease blocked, rec > current (increase always allowed)",
+			allowDecrease: false,
+			rec:           "1000m",
+			current:       "500m",
+			wantClamped:   false,
+		},
+		{
+			name:          "decrease blocked, rec == current (no change)",
+			allowDecrease: false,
+			rec:           "500m",
+			current:       "500m",
+			wantClamped:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler := newReconcilerWithClient()
+			rec := resource.MustParse(tt.rec)
+			current := resource.MustParse(tt.current)
+			explain := recommendation.RecommendationExplanation{}
+
+			result := reconciler.enforceAllowDecrease(tt.allowDecrease, rec, current, &explain, policy, "test-container", "CPU")
+
+			if tt.wantClamped {
+				assert.Equal(t, current.String(), result.String(), "should be clamped to current")
+				assert.Equal(t, tt.wantAdjustment, explain.FinalAdjustment)
+				assert.Equal(t, current.String(), explain.Final.String())
+			} else {
+				assert.Equal(t, rec.String(), result.String(), "should not be clamped")
+				assert.Empty(t, explain.FinalAdjustment)
+			}
+		})
+	}
 }
 
 func TestComputeRecommendations_CPUAllowDecreaseBlocked(t *testing.T) {

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -37,6 +37,7 @@ import (
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	rsmetrics "github.com/attune-io/attune/internal/metrics"
+	"github.com/attune-io/attune/internal/recommendation"
 	"github.com/attune-io/attune/internal/resize"
 	"github.com/attune-io/attune/internal/safety"
 )
@@ -758,4 +759,32 @@ func getObservationPeriod(policy *attunev1alpha1.AttunePolicy) time.Duration {
 		return policy.Spec.UpdateStrategy.Canary.ObservationPeriod.Duration
 	}
 	return defaultObservationPeriod
+}
+
+// enforceAllowDecrease clamps a recommendation to the current value when
+// decreases are not allowed. It emits a DecreaseSuppressed event and
+// updates the explanation. Returns the (possibly clamped) recommendation.
+func (r *AttunePolicyReconciler) enforceAllowDecrease(
+	allowDecrease bool,
+	rec resource.Quantity,
+	current resource.Quantity,
+	explain *recommendation.RecommendationExplanation,
+	policy *attunev1alpha1.AttunePolicy,
+	containerName string,
+	resourceType string,
+) resource.Quantity {
+	if allowDecrease || rec.Cmp(current) >= 0 {
+		return rec
+	}
+	unclamped := rec.String()
+	if r.Recorder != nil {
+		r.Recorder.Eventf(policy, nil, corev1.EventTypeNormal, "DecreaseSuppressed", "recommend",
+			"%s decrease blocked by allowDecrease=false for container %s (current: %s)",
+			resourceType, containerName, current.String())
+	}
+	clamped := current.DeepCopy()
+	explain.Final = clamped.DeepCopy()
+	explain.FinalAdjustment = fmt.Sprintf("%s decrease from %s to %s blocked by allowDecrease=false",
+		resourceType, current.String(), unclamped)
+	return clamped
 }

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -385,20 +385,10 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 		// Compute CPU recommendation.
 		if cpuProfile.DataPoints >= int(minimumDataPoints) {
 			cpuRec, cpuExplain, _ := cpuEngine.RecommendWithExplanation(cpuProfile, currentCPUReq)
-			// Enforce AllowDecrease: for CPU, nil defaults to true (decreases
-			// allowed) because CPU throttle is detected by the safety monitor.
+			// CPU AllowDecrease defaults to true (nil || *ptr) because CPU
+			// throttle is detected by the safety monitor.
 			cpuAllowDecrease := policy.Spec.CPU.AllowDecrease == nil || *policy.Spec.CPU.AllowDecrease
-			if !cpuAllowDecrease && cpuRec.Cmp(currentCPUReq) < 0 {
-				unclampedCPU := cpuRec.String()
-				if r.Recorder != nil {
-					r.Recorder.Eventf(policy, nil, corev1.EventTypeNormal, "DecreaseSuppressed", "recommend",
-						"CPU decrease blocked by allowDecrease=false for container %s (current: %s)",
-						containerName, currentCPUReq.String())
-				}
-				cpuRec = currentCPUReq.DeepCopy()
-				cpuExplain.Final = cpuRec.DeepCopy()
-				cpuExplain.FinalAdjustment = fmt.Sprintf("CPU decrease from %s to %s blocked by allowDecrease=false", currentCPUReq.String(), unclampedCPU)
-			}
+			cpuRec = r.enforceAllowDecrease(cpuAllowDecrease, cpuRec, currentCPUReq, &cpuExplain, policy, containerName, "CPU")
 			rec.Recommended.CPURequest = cpuRec
 			explanation.CPU = toAPIRecommendationExplanation(cpuExplain)
 		}
@@ -419,19 +409,10 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 			}
 		} else if memProfile.DataPoints >= int(minimumDataPoints) {
 			memRec, memExplain, _ := memEngine.RecommendWithExplanation(memProfile, currentMemReq)
-			// Enforce AllowDecrease: skip memory decreases unless explicitly allowed.
-			allowDecrease := policy.Spec.Memory.AllowDecrease != nil && *policy.Spec.Memory.AllowDecrease
-			if !allowDecrease && memRec.Cmp(currentMemReq) < 0 {
-				unclampedMem := memRec.String()
-				if r.Recorder != nil {
-					r.Recorder.Eventf(policy, nil, corev1.EventTypeNormal, "DecreaseSuppressed", "recommend",
-						"Memory decrease blocked by allowDecrease=false for container %s (current: %s)",
-						containerName, currentMemReq.String())
-				}
-				memRec = currentMemReq.DeepCopy()
-				memExplain.Final = memRec.DeepCopy()
-				memExplain.FinalAdjustment = fmt.Sprintf("memory decrease from %s to %s blocked by allowDecrease=false", currentMemReq.String(), unclampedMem)
-			}
+			// Memory AllowDecrease defaults to false (!= nil && *ptr) to
+			// prevent OOMKills from memory reduction.
+			memAllowDecrease := policy.Spec.Memory.AllowDecrease != nil && *policy.Spec.Memory.AllowDecrease
+			memRec = r.enforceAllowDecrease(memAllowDecrease, memRec, currentMemReq, &memExplain, policy, containerName, "memory")
 			rec.Recommended.MemoryRequest = memRec
 			explanation.Memory = toAPIRecommendationExplanation(memExplain)
 		}

--- a/internal/controller/vpa.go
+++ b/internal/controller/vpa.go
@@ -18,9 +18,7 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -143,34 +141,14 @@ func (r *AttunePolicyReconciler) computeVPARecommendationsForWorkload(
 		// Compute CPU recommendation through the standard engine pipeline.
 		cpuRec, cpuExplain, _ := cpuEngine.RecommendWithExplanation(cpuProfile, currentCPUReq)
 		cpuAllowDecrease := policy.Spec.CPU.AllowDecrease == nil || *policy.Spec.CPU.AllowDecrease
-		if !cpuAllowDecrease && cpuRec.Cmp(currentCPUReq) < 0 {
-			unclampedCPU := cpuRec.String()
-			if r.Recorder != nil {
-				r.Recorder.Eventf(policy, nil, corev1.EventTypeNormal, "DecreaseSuppressed", "recommend",
-					"CPU decrease blocked by allowDecrease=false for container %s (current: %s)",
-					containerName, currentCPUReq.String())
-			}
-			cpuRec = currentCPUReq.DeepCopy()
-			cpuExplain.Final = cpuRec.DeepCopy()
-			cpuExplain.FinalAdjustment = fmt.Sprintf("CPU decrease from %s to %s blocked by allowDecrease=false", currentCPUReq.String(), unclampedCPU)
-		}
+		cpuRec = r.enforceAllowDecrease(cpuAllowDecrease, cpuRec, currentCPUReq, &cpuExplain, policy, containerName, "CPU")
 		cRec.Recommended.CPURequest = cpuRec
 		explanation.CPU = toAPIRecommendationExplanation(cpuExplain)
 
 		// Compute memory recommendation through the standard engine pipeline.
 		memRec, memExplain, _ := memEngine.RecommendWithExplanation(memProfile, currentMemReq)
-		allowDecrease := policy.Spec.Memory.AllowDecrease != nil && *policy.Spec.Memory.AllowDecrease
-		if !allowDecrease && memRec.Cmp(currentMemReq) < 0 {
-			unclampedMem := memRec.String()
-			if r.Recorder != nil {
-				r.Recorder.Eventf(policy, nil, corev1.EventTypeNormal, "DecreaseSuppressed", "recommend",
-					"Memory decrease blocked by allowDecrease=false for container %s (current: %s)",
-					containerName, currentMemReq.String())
-			}
-			memRec = currentMemReq.DeepCopy()
-			memExplain.Final = memRec.DeepCopy()
-			memExplain.FinalAdjustment = fmt.Sprintf("memory decrease from %s to %s blocked by allowDecrease=false", currentMemReq.String(), unclampedMem)
-		}
+		memAllowDecrease := policy.Spec.Memory.AllowDecrease != nil && *policy.Spec.Memory.AllowDecrease
+		memRec = r.enforceAllowDecrease(memAllowDecrease, memRec, currentMemReq, &memExplain, policy, containerName, "memory")
 		cRec.Recommended.MemoryRequest = memRec
 		explanation.Memory = toAPIRecommendationExplanation(memExplain)
 		explanation.CPU.FinalAdjustment = appendNote(explanation.CPU.FinalAdjustment, "source: VPA")


### PR DESCRIPTION
## Summary

Extract the AllowDecrease enforcement logic into a shared `enforceAllowDecrease` method on `AttunePolicyReconciler`, replacing 4 near-identical 12-line blocks across `prometheus.go` and `vpa.go` with single-line calls.

## Changes

| File | Change |
|------|--------|
| `internal/controller/helpers.go` | New `enforceAllowDecrease` helper (+29 lines) |
| `internal/controller/prometheus.go` | Replace 2 inline blocks with helper calls (-22 lines) |
| `internal/controller/vpa.go` | Replace 2 inline blocks with helper calls (-24 lines) |
| `internal/controller/attunepolicy_controller_test.go` | Add `TestEnforceAllowDecrease` with 4 table-driven cases (+64 lines) |

Net: -51 duplicated lines replaced by +29 shared helper lines + 64 test lines.

## Test cases

- Decrease allowed, rec < current: recommendation passes through unchanged
- Decrease blocked, rec < current: clamped to current, event emitted, explanation updated
- Decrease blocked, rec > current: increase always allowed (no clamping)
- Decrease blocked, rec == current: no-change boundary (no clamping)

All existing AllowDecrease integration tests (`TestComputeRecommendations_AllowDecreaseBlocked`, `TestComputeRecommendations_CPUAllowDecreaseNilAllowsDecrease`, `TestComputeRecommendations_CPUAllowDecreaseBlocked`) and VPA path tests continue to pass.

## Verification

- `go build ./...`: clean
- `make lint`: 0 issues
- `make verify-quick`: all checks pass
- `go test ./internal/controller/... -race -count=1`: all pass

Closes #292