### PR TITLE
refactor: extract scaleControlledLimits and setRecommendationGauges helpers

### DIFF
--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -2016,6 +2016,83 @@ func TestEnforceAllowDecrease(t *testing.T) {
 	}
 }
 
+func TestScaleControlledLimits(t *testing.T) {
+	tests := []struct {
+		name          string
+		cpuControlled *string
+		memControlled *string
+		wantCPULim    string
+		wantMemLim    string
+	}{
+		{
+			name:       "nil (default RequestsOnly) keeps original limits",
+			wantCPULim: "1",
+			wantMemLim: "1Gi",
+		},
+		{
+			name:          "RequestsOnly keeps original limits",
+			cpuControlled: stringPtr("RequestsOnly"),
+			memControlled: stringPtr("RequestsOnly"),
+			wantCPULim:    "1",
+			wantMemLim:    "1Gi",
+		},
+		{
+			name:          "RequestsAndLimits scales limits proportionally",
+			cpuControlled: stringPtr("RequestsAndLimits"),
+			memControlled: stringPtr("RequestsAndLimits"),
+			wantCPULim:    "2",      // 500m->1000m req means 1000m->2000m lim (2:1 ratio)
+			wantMemLim:    "1536Mi", // 512Mi->768Mi req means 1Gi->1536Mi lim (2:1 ratio)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := newTestPolicy("test-policy", "default")
+			policy.Spec.CPU.ControlledValues = tt.cpuControlled
+			policy.Spec.Memory.ControlledValues = tt.memControlled
+
+			rec := attunev1alpha1.ContainerRecommendation{
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest:    resource.MustParse("1000m"),
+					CPULimit:      resource.MustParse("1000m"),
+					MemoryRequest: resource.MustParse("768Mi"),
+					MemoryLimit:   resource.MustParse("1Gi"),
+				},
+			}
+
+			scaleControlledLimits(policy, &rec,
+				resource.MustParse("500m"),  // currentCPUReq
+				resource.MustParse("1000m"), // currentCPULim
+				resource.MustParse("512Mi"), // currentMemReq
+				resource.MustParse("1Gi"),   // currentMemLim
+			)
+
+			assert.Equal(t, tt.wantCPULim, rec.Recommended.CPULimit.String())
+			assert.Equal(t, tt.wantMemLim, rec.Recommended.MemoryLimit.String())
+		})
+	}
+}
+
+func TestSetRecommendationGauges(t *testing.T) {
+	rec := &attunev1alpha1.ContainerRecommendation{
+		Recommended: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("500m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+		},
+		Confidence: 0.85,
+	}
+
+	setRecommendationGauges("test-ns", "my-deploy", "main", rec)
+
+	cpuGauge := promtestutil.ToFloat64(operatormetrics.RecommendationCPU.WithLabelValues("test-ns", "my-deploy", "main"))
+	memGauge := promtestutil.ToFloat64(operatormetrics.RecommendationMemory.WithLabelValues("test-ns", "my-deploy", "main"))
+	confGauge := promtestutil.ToFloat64(operatormetrics.Confidence.WithLabelValues("test-ns", "my-deploy", "main"))
+
+	assert.InDelta(t, 0.5, cpuGauge, 1e-9)
+	assert.Equal(t, float64(256*1024*1024), memGauge)
+	assert.InDelta(t, 0.85, confGauge, 1e-9)
+}
+
 func TestComputeRecommendations_CPUAllowDecreaseBlocked(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	// Explicitly disable CPU decreases. nil defaults to true for CPU.

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -37,6 +37,7 @@ import (
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	rsmetrics "github.com/attune-io/attune/internal/metrics"
+	"github.com/attune-io/attune/internal/operatormetrics"
 	"github.com/attune-io/attune/internal/recommendation"
 	"github.com/attune-io/attune/internal/resize"
 	"github.com/attune-io/attune/internal/safety"
@@ -759,6 +760,33 @@ func getObservationPeriod(policy *attunev1alpha1.AttunePolicy) time.Duration {
 		return policy.Spec.UpdateStrategy.Canary.ObservationPeriod.Duration
 	}
 	return defaultObservationPeriod
+}
+
+// scaleControlledLimits scales CPU and memory limits proportionally when the
+// policy's ControlledValues is RequestsAndLimits. This avoids duplicating the
+// ControlledValues resolution logic across prometheus.go and vpa.go.
+func scaleControlledLimits(policy *attunev1alpha1.AttunePolicy, rec *attunev1alpha1.ContainerRecommendation, currentCPUReq, currentCPULim, currentMemReq, currentMemLim resource.Quantity) {
+	cpuControlled := attunev1alpha1.ControlledRequestsOnly
+	if policy.Spec.CPU.ControlledValues != nil {
+		cpuControlled = *policy.Spec.CPU.ControlledValues
+	}
+	memControlled := attunev1alpha1.ControlledRequestsOnly
+	if policy.Spec.Memory.ControlledValues != nil {
+		memControlled = *policy.Spec.Memory.ControlledValues
+	}
+	if cpuControlled == attunev1alpha1.ControlledRequestsAndLimits {
+		rec.Recommended.CPULimit = scaleLimits(currentCPUReq, currentCPULim, rec.Recommended.CPURequest)
+	}
+	if memControlled == attunev1alpha1.ControlledRequestsAndLimits {
+		rec.Recommended.MemoryLimit = scaleLimits(currentMemReq, currentMemLim, rec.Recommended.MemoryRequest)
+	}
+}
+
+// setRecommendationGauges updates Prometheus gauges for the recommendation.
+func setRecommendationGauges(namespace, workloadName, containerName string, rec *attunev1alpha1.ContainerRecommendation) {
+	operatormetrics.RecommendationCPU.WithLabelValues(namespace, workloadName, containerName).Set(float64(rec.Recommended.CPURequest.MilliValue()) / 1000.0)
+	operatormetrics.RecommendationMemory.WithLabelValues(namespace, workloadName, containerName).Set(float64(rec.Recommended.MemoryRequest.Value()))
+	operatormetrics.Confidence.WithLabelValues(namespace, workloadName, containerName).Set(rec.Confidence)
 }
 
 // enforceAllowDecrease clamps a recommendation to the current value when

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -467,25 +467,10 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 		}
 
 		// Scale limits proportionally if ControlledValues is RequestsAndLimits.
-		cpuControlled := attunev1alpha1.ControlledRequestsOnly
-		if policy.Spec.CPU.ControlledValues != nil {
-			cpuControlled = *policy.Spec.CPU.ControlledValues
-		}
-		memControlled := attunev1alpha1.ControlledRequestsOnly
-		if policy.Spec.Memory.ControlledValues != nil {
-			memControlled = *policy.Spec.Memory.ControlledValues
-		}
-		if cpuControlled == attunev1alpha1.ControlledRequestsAndLimits {
-			rec.Recommended.CPULimit = scaleLimits(currentCPUReq, currentCPULim, rec.Recommended.CPURequest)
-		}
-		if memControlled == attunev1alpha1.ControlledRequestsAndLimits {
-			rec.Recommended.MemoryLimit = scaleLimits(currentMemReq, currentMemLim, rec.Recommended.MemoryRequest)
-		}
+		scaleControlledLimits(policy, &rec, currentCPUReq, currentCPULim, currentMemReq, currentMemLim)
 
 		// Set recommendation gauges for this container.
-		operatormetrics.RecommendationCPU.WithLabelValues(policy.Namespace, workload.GetName(), containerName).Set(float64(rec.Recommended.CPURequest.MilliValue()) / 1000.0)
-		operatormetrics.RecommendationMemory.WithLabelValues(policy.Namespace, workload.GetName(), containerName).Set(float64(rec.Recommended.MemoryRequest.Value()))
-		operatormetrics.Confidence.WithLabelValues(policy.Namespace, workload.GetName(), containerName).Set(rec.Confidence)
+		setRecommendationGauges(policy.Namespace, workload.GetName(), containerName, &rec)
 		if rec.Explanation != nil {
 			if rec.Explanation.CPU != nil {
 				operatormetrics.BurstFactor.WithLabelValues(policy.Namespace, workload.GetName(), containerName, "cpu").Set(rec.Explanation.CPU.BurstFactor)

--- a/internal/controller/vpa.go
+++ b/internal/controller/vpa.go
@@ -25,7 +25,6 @@ import (
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	rsmetrics "github.com/attune-io/attune/internal/metrics"
-	"github.com/attune-io/attune/internal/operatormetrics"
 	"github.com/attune-io/attune/internal/recommendation"
 )
 
@@ -157,25 +156,10 @@ func (r *AttunePolicyReconciler) computeVPARecommendationsForWorkload(
 		cRec.Explanation = explanation
 
 		// Scale limits proportionally if ControlledValues is RequestsAndLimits.
-		cpuControlled := attunev1alpha1.ControlledRequestsOnly
-		if policy.Spec.CPU.ControlledValues != nil {
-			cpuControlled = *policy.Spec.CPU.ControlledValues
-		}
-		memControlled := attunev1alpha1.ControlledRequestsOnly
-		if policy.Spec.Memory.ControlledValues != nil {
-			memControlled = *policy.Spec.Memory.ControlledValues
-		}
-		if cpuControlled == attunev1alpha1.ControlledRequestsAndLimits {
-			cRec.Recommended.CPULimit = scaleLimits(currentCPUReq, currentCPULim, cRec.Recommended.CPURequest)
-		}
-		if memControlled == attunev1alpha1.ControlledRequestsAndLimits {
-			cRec.Recommended.MemoryLimit = scaleLimits(currentMemReq, currentMemLim, cRec.Recommended.MemoryRequest)
-		}
+		scaleControlledLimits(policy, &cRec, currentCPUReq, currentCPULim, currentMemReq, currentMemLim)
 
 		// Set recommendation gauges for this container.
-		operatormetrics.RecommendationCPU.WithLabelValues(policy.Namespace, workload.GetName(), containerName).Set(float64(cRec.Recommended.CPURequest.MilliValue()) / 1000.0)
-		operatormetrics.RecommendationMemory.WithLabelValues(policy.Namespace, workload.GetName(), containerName).Set(float64(cRec.Recommended.MemoryRequest.Value()))
-		operatormetrics.Confidence.WithLabelValues(policy.Namespace, workload.GetName(), containerName).Set(cRec.Confidence)
+		setRecommendationGauges(policy.Namespace, workload.GetName(), containerName, &cRec)
 
 		logger.V(1).Info("Computed VPA-based recommendation",
 			"container", containerName,


### PR DESCRIPTION
Removes duplicated ControlledValues limit-scaling and gauge-setting logic between `prometheus.go` and `vpa.go`. Both files had identical blocks for resolving ControlledValues and calling `scaleLimits`, plus identical blocks for setting the three recommendation gauges (CPU, Memory, Confidence).

Follows the same extraction pattern as the `enforceAllowDecrease` refactoring in #293.

## Changes

- **`internal/controller/helpers.go`**: Add `scaleControlledLimits()` and `setRecommendationGauges()` helpers
- **`internal/controller/prometheus.go`**: Replace 16 lines with 2 helper calls
- **`internal/controller/vpa.go`**: Replace 16 lines with 2 helper calls, remove unused `operatormetrics` import
- **`internal/controller/attunepolicy_controller_test.go`**: Add direct unit tests for both new helpers

Net reduction: 109 additions, 35 deletions (74 net, but 77 are new test lines).