### PR TITLE
fix: use feature-gates+= (append) in k3s config file, not = (replace)

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -239,18 +239,24 @@ jobs:
           # The k3s config file (/etc/rancher/k3s/config.yaml) is loaded
           # during server bootstrap before any component starts, avoiding
           # the CLI arg processing race entirely.
+          #
+          # We use += (append) not = (replace) in the config file to
+          # preserve any feature gates k3s sets internally. The config
+          # file args go through the same GetArgs() function, but the
+          # timing race that broke CLI += does not apply here because
+          # config file processing happens after defaults are populated.
           EXTRA_K3D_ARGS=()
           if [[ "${{ matrix.k8s-version }}" == "v1.32" ]]; then
             K3S_CONFIG="/tmp/k3s-v132-config.yaml"
             cat > "$K3S_CONFIG" <<'K3SEOF'
           kube-apiserver-arg:
-            - "feature-gates=InPlacePodVerticalScaling=true"
+            - "feature-gates+=InPlacePodVerticalScaling=true"
           kube-controller-manager-arg:
-            - "feature-gates=InPlacePodVerticalScaling=true"
+            - "feature-gates+=InPlacePodVerticalScaling=true"
           kube-scheduler-arg:
-            - "feature-gates=InPlacePodVerticalScaling=true"
+            - "feature-gates+=InPlacePodVerticalScaling=true"
           kubelet-arg:
-            - "feature-gates=InPlacePodVerticalScaling=true"
+            - "feature-gates+=InPlacePodVerticalScaling=true"
           K3SEOF
             EXTRA_K3D_ARGS=(--volume "${K3S_CONFIG}:/etc/rancher/k3s/config.yaml@server:*")
           fi


### PR DESCRIPTION
## Problem

PR #297 fixed the nightly E2E v1.32 failure by switching from CLI `--k3s-arg`
flags to a k3s config file mounted at `/etc/rancher/k3s/config.yaml`. This fixed
the **delivery mechanism** (config file loads during bootstrap, avoiding the
`GetArgs()` CLI arg processing race).

However, the config file used `feature-gates=` (replace) instead of
`feature-gates+=` (append). This silently drops any feature gates k3s sets
internally for its own components.

## Fix

Change `=` to `+=` in all four feature gate entries in the k3s config file.
The `+=` syntax works in config file args because they go through the same
`GetArgs()` function. The timing race that broke CLI `+=` does not apply
here because config file processing happens during server initialization,
after k3s populates its default args.

## Summary

| PR | Delivery | Merge behavior |
|----|----------|----------------|
| Original (pre-#296) | CLI `--k3s-arg` (unreliable) | `+=` append (correct) |
| PR #297 | Config file (reliable) | `=` replace (risky) |
| This PR | Config file (reliable) | `+=` append (correct) |

Closes #299