### PR TITLE
ci: add Helm schema field name verification against CRD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,6 +147,10 @@ jobs:
         shell: bash -Eeuo pipefail {0}
         run: bash hack/verify-prometheusrule-metrics.sh
 
+      - name: Verify Helm schema field names match CRD
+        shell: bash -Eeuo pipefail {0}
+        run: bash hack/verify-helm-schema-fields.sh
+
   docs-check:
     name: Docs Check
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ verify-doc-tool-versions: ## Verify supported tool version references stay consi
 verify-prometheusrule-metrics: ## Verify PrometheusRule alert expressions use real operator metrics
 	@bash hack/verify-prometheusrule-metrics.sh
 
+.PHONY: verify-helm-schema-fields
+verify-helm-schema-fields: ## Verify Helm values.schema.json field names match CRD field names
+	@bash hack/verify-helm-schema-fields.sh
+
 .PHONY: verify-release-artifacts
 verify-release-artifacts: kustomize ## Verify release artifacts generate cleanly and, if present, match current sources
 	@repo_root=$$(pwd); \
@@ -118,7 +122,7 @@ ci-runner-status: ## Show queued/in-progress CI runs
 	fi
 
 .PHONY: verify-quick
-verify-quick: lint yaml-lint lint-chainsaw test helm-lint helm-docs-check helm-unittest verify-boilerplate tidy-check verify-doc-defaults verify-helm-rbac verify-dashboard-metrics verify-doc-tool-versions verify-prometheusrule-metrics verify-release-artifacts ## Fast pre-commit checks (no integration tests or govulncheck)
+verify-quick: lint yaml-lint lint-chainsaw test helm-lint helm-docs-check helm-unittest verify-boilerplate tidy-check verify-doc-defaults verify-helm-rbac verify-dashboard-metrics verify-doc-tool-versions verify-prometheusrule-metrics verify-helm-schema-fields verify-release-artifacts ## Fast pre-commit checks (no integration tests or govulncheck)
 
 .PHONY: verify
 verify: verify-quick test-integration govulncheck ## Run all CI checks locally (includes integration tests)

--- a/hack/verify-helm-schema-fields.sh
+++ b/hack/verify-helm-schema-fields.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify that Helm values.schema.json field names match the CRD field names.
+# Catches field name mismatches like cpuPerCorePerHour vs cpuPerCoreHour
+# that cause silent data loss when additionalProperties: false is set.
+#
+# The generated CRD YAML is the single source of truth for field names
+# (derived from Go struct json tags by controller-gen).
+
+set -euo pipefail
+
+SCHEMA="charts/attune/values.schema.json"
+CRD="config/crd/bases/attune.io_attunedefaults.yaml"
+
+if [ ! -f "$SCHEMA" ]; then
+  echo "ERROR: $SCHEMA not found"
+  exit 1
+fi
+if [ ! -f "$CRD" ]; then
+  echo "ERROR: $CRD not found (run 'make manifests' first)"
+  exit 1
+fi
+
+ERRORS=0
+
+# compare_fields SECTION JQ_SCHEMA_PATH PYTHON_CRD_PATH
+# Compares property names between the Helm schema and the CRD.
+compare_fields() {
+  local section="$1"
+  local jq_path="$2"
+  local python_path="$3"
+
+  # Extract schema field names
+  local schema_fields
+  schema_fields=$(jq -r "${jq_path} | keys[]" "$SCHEMA" 2>/dev/null | sort)
+  if [ -z "$schema_fields" ]; then
+    echo "WARNING: no properties found in schema at ${jq_path}"
+    return
+  fi
+
+  # Extract CRD field names
+  local crd_fields
+  crd_fields=$(python3 -c "
+import yaml, sys
+with open('${CRD}') as f:
+    crd = yaml.safe_load(f)
+props = crd['spec']['versions'][0]['schema']['openAPIV3Schema']['properties']['spec']['properties']${python_path}
+for k in sorted(props.keys()):
+    print(k)
+" 2>/dev/null)
+  if [ -z "$crd_fields" ]; then
+    echo "WARNING: no properties found in CRD at spec.properties${python_path}"
+    return
+  fi
+
+  # Check: schema fields must exist in CRD
+  while IFS= read -r field; do
+    if ! echo "$crd_fields" | grep -qx "$field"; then
+      echo "ERROR: defaults.${section} schema has '${field}' but CRD does not (typo or renamed field)"
+      ERRORS=$((ERRORS + 1))
+    fi
+  done <<< "$schema_fields"
+
+  # Check: CRD fields missing from schema (warning only, schema may intentionally omit)
+  while IFS= read -r field; do
+    if ! echo "$schema_fields" | grep -qx "$field"; then
+      # Only warn if the section uses additionalProperties: false
+      local strict
+      strict=$(jq -r "${jq_path} | parent | .additionalProperties // true" "$SCHEMA" 2>/dev/null)
+      if [ "$strict" = "false" ]; then
+        echo "WARNING: defaults.${section} CRD has '${field}' but schema omits it (users cannot set this via Helm)"
+      fi
+    fi
+  done <<< "$crd_fields"
+}
+
+echo "Checking Helm schema field names against CRD..."
+
+compare_fields "costPricing" \
+  ".properties.defaults.properties.costPricing.properties" \
+  "['costPricing']['properties']"
+
+compare_fields "cpu" \
+  ".properties.defaults.properties.cpu.properties" \
+  "['cpu']['properties']"
+
+compare_fields "memory" \
+  ".properties.defaults.properties.memory.properties" \
+  "['memory']['properties']"
+
+compare_fields "updateStrategy" \
+  ".properties.defaults.properties.updateStrategy.properties" \
+  "['updateStrategy']['properties']"
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAIL: ${ERRORS} field name mismatch(es) between Helm schema and CRD."
+  echo "The CRD (generated from Go types) is the source of truth."
+  echo "Update values.schema.json to match."
+  exit 1
+fi
+
+echo "OK: all Helm schema field names match CRD field names."


### PR DESCRIPTION
## Problem

PR #301 fixed a field name mismatch where `values.schema.json` used
`cpuPerCorePerHour`/`memoryPerGiBPerHour` (extra "Per") instead of
the CRD's `cpuPerCoreHour`/`memoryPerGiBHour`. With
`additionalProperties: false`, users who configured custom pricing
had their values silently rejected.

No automated check existed to prevent this class of bug.

## Solution

Add `hack/verify-helm-schema-fields.sh` that compares property names
in `values.schema.json` against the generated CRD YAML
(`config/crd/bases/attune.io_attunedefaults.yaml`).

The CRD is the single source of truth (generated from Go struct
`json:""` tags by controller-gen). The script checks four sections:
`defaults.cpu`, `defaults.memory`, `defaults.costPricing`, and
`defaults.updateStrategy`.

**Verified it catches the original bug:**
```
$ sed 's/cpuPerCoreHour/cpuPerCorePerHour/g' ... | bash hack/verify-helm-schema-fields.sh
ERROR: defaults.costPricing schema has 'cpuPerCorePerHour' but CRD does not (typo or renamed field)
FAIL: 1 field name mismatch(es) between Helm schema and CRD.
```

Wired into:
- `make verify-helm-schema-fields` (standalone target)
- `make verify-quick` (pre-commit gate)
- CI `helm-chart` job in `ci.yaml`