### PR TITLE
docs: fix stale status-conditions.md reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,8 +268,8 @@ try to use the feature or when improvement cycles audit docs.
 6. Run `make manifests && make generate` - Regenerate CRD + deepcopy
 7. `docs/reference/configuration.md` - Add all new fields to the
    parameter table
-8. `docs/reference/status-conditions.md` - Document new status
-   conditions or reason values
+8. `docs/reference/configuration.md` (Status Conditions section) -
+   Document new status conditions or reason values
 9. `docs/reference/metrics.md` - Document new metric label values
    (e.g., new revert reasons)
 10. `docs/guides/` - Add or update the feature guide (e.g.,


### PR DESCRIPTION
The 'Adding a new operator feature' checklist referenced
`docs/reference/status-conditions.md`, which does not exist. Status
conditions are documented in `docs/reference/configuration.md` under
the 'Status Conditions' section.

Updated the checklist to point to the correct file location.

Found during a multi-perspective improvement rotation (Cycle 1) where
all 14 perspectives returned no actionable code findings. This was the
only documentation inconsistency discovered.