### PR TITLE
fix: strengthen memory test assertion and cache cert-manager manifest in E2E

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -57,6 +57,7 @@ runs:
           /tmp/cert-manager-controller.tar
           /tmp/cert-manager-webhook.tar
           /tmp/cert-manager-cainjector.tar
+          /tmp/cert-manager.yaml
           /tmp/prometheus.tar
           /tmp/stress-ng.tar
           /tmp/k3s.tar
@@ -173,10 +174,40 @@ runs:
           /tmp/cert-manager-cainjector.tar \
           -c "${{ inputs.cluster-name }}"
 
+    - name: Download cert-manager manifest
+      shell: bash -Eeuo pipefail -x {0}
+      run: |
+        if [[ -f /tmp/cert-manager.yaml ]]; then
+          echo "Cached: /tmp/cert-manager.yaml"
+        else
+          for attempt in 1 2 3; do
+            if curl -fsSL -o /tmp/cert-manager.yaml \
+              "https://github.com/cert-manager/cert-manager/releases/download/${{ inputs.cert-manager-version }}/cert-manager.yaml"; then
+              break
+            fi
+            echo "::warning::cert-manager.yaml download attempt $attempt failed, retrying in 10s..."
+            sleep 10
+            if (( attempt == 3 )); then
+              echo "::error::Failed to download cert-manager.yaml after 3 attempts"
+              exit 1
+            fi
+          done
+        fi
+
     - name: Install cert-manager
       shell: bash -Eeuo pipefail -x {0}
       run: |
-        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${{ inputs.cert-manager-version }}/cert-manager.yaml
+        for attempt in 1 2 3; do
+          if kubectl apply -f /tmp/cert-manager.yaml; then
+            break
+          fi
+          echo "::warning::cert-manager install attempt $attempt failed, retrying in 15s..."
+          sleep 15
+          if (( attempt == 3 )); then
+            echo "::error::cert-manager install failed after 3 attempts"
+            exit 1
+          fi
+        done
         kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
         kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
         kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s

--- a/internal/recommendation/chain_test.go
+++ b/internal/recommendation/chain_test.go
@@ -100,10 +100,20 @@ func TestRecommendationEngine_RealisticMemory(t *testing.T) {
 
 	current := resource.MustParse("512Mi")
 
-	recommended, changed := engine.Recommend(profile, current)
+	recommended, explanation, changed := engine.RecommendWithExplanation(profile, current)
 	assert.True(t, changed)
-	assert.Greater(t, recommended.MilliValue(), int64(0))
-	t.Logf("Memory recommendation: %s (from current %s)", recommended.String(), current.String())
+	// Chain: P99=256Mi → overhead(20%)=~307Mi → confidence(0.95, ~1.0025x)=~308Mi
+	//   → bounds OK → change filter: ~39.8% decrease < 50% max, allowed.
+	assert.Equal(t, int64(268435456), explanation.RawPercentile.Value(),
+		"raw P99 should be 256Mi in bytes")
+	assert.Greater(t, recommended.Value(), int64(280*1024*1024),
+		"recommendation should be at least ~280Mi (above raw percentile + partial overhead)")
+	assert.Less(t, recommended.Value(), int64(350*1024*1024),
+		"recommendation should be below ~350Mi (overhead + confidence, not capped)")
+	assert.Empty(t, explanation.ChangeFilterApplied,
+		"~39.8%% decrease should not trigger the 50%% max change cap")
+	assert.True(t, recommended.Cmp(current) < 0,
+		"recommendation %s should be less than current %s", recommended.String(), current.String())
 }
 
 func TestRecommendationEngine_SmallChangeFiltered(t *testing.T) {


### PR DESCRIPTION
## Summary

Two improvements from improvement cycle 2:

### 1. Strengthen weak memory recommendation test assertion

`TestRecommendationEngine_RealisticMemory` previously only asserted
`> 0` for the recommendation value. This would pass for literally
any positive number, failing to catch regressions in the memory
recommendation algorithm.

Now uses `RecommendWithExplanation` to verify:
- Raw P99 is exactly 256Mi (268435456 bytes)
- Final recommendation is in expected range (280-350Mi)
- Change filter was not applied (39.8% decrease < 50% cap)
- Recommendation is a decrease from 512Mi current

### 2. Cache cert-manager manifest and retry kubectl apply

The E2E setup was downloading cert-manager.yaml from GitHub releases
on every run without caching or retry. When the k3d API server was
temporarily unavailable, kubectl apply failed on OpenAPI validation
and the entire E2E job failed with no recovery.

- Add cert-manager.yaml to the actions/cache path list
- Download manifest to a local file with 3 retry attempts
- Wrap kubectl apply in a 3-attempt retry loop (15s delay)

This matches the existing retry pattern for docker pull and k3d
cluster create.