### PR TITLE
ci: disable cancel-in-progress on pr-title check

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -57,6 +57,7 @@ runs:
           /tmp/cert-manager-controller.tar
           /tmp/cert-manager-webhook.tar
           /tmp/cert-manager-cainjector.tar
+          /tmp/cert-manager.yaml
           /tmp/prometheus.tar
           /tmp/stress-ng.tar
           /tmp/k3s.tar
@@ -173,10 +174,40 @@ runs:
           /tmp/cert-manager-cainjector.tar \
           -c "${{ inputs.cluster-name }}"
 
+    - name: Download cert-manager manifest
+      shell: bash -Eeuo pipefail -x {0}
+      run: |
+        if [[ -f /tmp/cert-manager.yaml ]]; then
+          echo "Cached: /tmp/cert-manager.yaml"
+        else
+          for attempt in 1 2 3; do
+            if curl -fsSL -o /tmp/cert-manager.yaml \
+              "https://github.com/cert-manager/cert-manager/releases/download/${{ inputs.cert-manager-version }}/cert-manager.yaml"; then
+              break
+            fi
+            echo "::warning::cert-manager.yaml download attempt $attempt failed, retrying in 10s..."
+            sleep 10
+            if (( attempt == 3 )); then
+              echo "::error::Failed to download cert-manager.yaml after 3 attempts"
+              exit 1
+            fi
+          done
+        fi
+
     - name: Install cert-manager
       shell: bash -Eeuo pipefail -x {0}
       run: |
-        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${{ inputs.cert-manager-version }}/cert-manager.yaml
+        for attempt in 1 2 3; do
+          if kubectl apply -f /tmp/cert-manager.yaml; then
+            break
+          fi
+          echo "::warning::cert-manager install attempt $attempt failed, retrying in 15s..."
+          sleep 15
+          if (( attempt == 3 )); then
+            echo "::error::cert-manager install failed after 3 attempts"
+            exit 1
+          fi
+        done
         kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
         kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
         kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: pr-title-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   semantic-title:

--- a/internal/recommendation/chain_test.go
+++ b/internal/recommendation/chain_test.go
@@ -100,10 +100,20 @@ func TestRecommendationEngine_RealisticMemory(t *testing.T) {
 
 	current := resource.MustParse("512Mi")
 
-	recommended, changed := engine.Recommend(profile, current)
+	recommended, explanation, changed := engine.RecommendWithExplanation(profile, current)
 	assert.True(t, changed)
-	assert.Greater(t, recommended.MilliValue(), int64(0))
-	t.Logf("Memory recommendation: %s (from current %s)", recommended.String(), current.String())
+	// Chain: P99=256Mi → overhead(20%)=~307Mi → confidence(0.95, ~1.0025x)=~308Mi
+	//   → bounds OK → change filter: ~39.8% decrease < 50% max, allowed.
+	assert.Equal(t, int64(268435456), explanation.RawPercentile.Value(),
+		"raw P99 should be 256Mi in bytes")
+	assert.Greater(t, recommended.Value(), int64(280*1024*1024),
+		"recommendation should be at least ~280Mi (above raw percentile + partial overhead)")
+	assert.Less(t, recommended.Value(), int64(350*1024*1024),
+		"recommendation should be below ~350Mi (overhead + confidence, not capped)")
+	assert.Empty(t, explanation.ChangeFilterApplied,
+		"~39.8%% decrease should not trigger the 50%% max change cap")
+	assert.True(t, recommended.Cmp(current) < 0,
+		"recommendation %s should be less than current %s", recommended.String(), current.String())
 }
 
 func TestRecommendationEngine_SmallChangeFiltered(t *testing.T) {


### PR DESCRIPTION
## Problem

The `pr-title` workflow uses `cancel-in-progress: true` in its concurrency group. When two runs trigger simultaneously (e.g., release-please syncing a PR), the first run gets cancelled. GitHub's check API then shows the cancelled run's status on the PR, producing a stuck red X even though the replacement run succeeded.

This happened on PR #298 (`chore(main): release 0.1.15`), where the Semantic PR Title check showed as failed/cancelled despite the title being valid and a successful run existing.

## Fix

Set `cancel-in-progress: false`. The job takes ~1 second, so cancelling it saves nothing. Running both concurrent checks to completion avoids the race condition entirely.

## Verification

- PR #298 was manually unblocked by re-running the cancelled workflow
- This change prevents the issue from recurring on future PR syncs