### PR TITLE
fix: remove upstream workflow files before pushing operatorhub bundle

### DIFF
--- a/hack/operatorhub-pr.sh
+++ b/hack/operatorhub-pr.sh
@@ -110,6 +110,14 @@ reviewers:
   - attune-release-bot[bot]
 CIEOF
 
+    # Remove upstream workflow files from the branch to avoid GitHub App
+    # push rejection ("refusing to allow a GitHub App to create or update
+    # workflow without 'workflows' permission"). We only need the operator
+    # bundle, not the upstream CI workflows.
+    if [ -d ".github/workflows" ]; then
+        git rm -rf --quiet .github/workflows || true
+    fi
+
     # Commit with DCO sign-off
     git add "${OPERATOR_DIR}/"
     git commit -s -m "operator attune (${VERSION})"


### PR DESCRIPTION
## Problem

The OperatorHub PR job in the v0.1.15 release failed with:

```
refusing to allow a GitHub App to create or update workflow
.github/workflows/dco_test.yaml without 'workflows' permission
```

The `attune-io/community-operators` fork includes `.github/workflows/dco_test.yaml` from upstream. When `hack/operatorhub-pr.sh` checks out `upstream/main` and pushes, the GitHub App token lacks `workflows` permission to push workflow files.

## Fix

Delete `.github/workflows` from the branch before committing. Only the operator bundle files (`operators/attune/<version>/`) are needed in the PR to upstream.

## Verification

The `git rm -rf` is guarded by an existence check and uses `|| true` so it is a no-op if no workflow files exist. Previous releases (v0.1.14, v0.1.13) succeeded because the fork was synced without workflow files at the time.

Closes #312