### PR TITLE
fix: unnecessary %% escapes in test messages and invalid jq parent filter

### DIFF
--- a/hack/verify-helm-schema-fields.sh
+++ b/hack/verify-helm-schema-fields.sh
@@ -68,7 +68,8 @@ for k in sorted(props.keys()):
     if ! echo "$schema_fields" | grep -qx "$field"; then
       # Only warn if the section uses additionalProperties: false
       local strict
-      strict=$(jq -r "${jq_path} | parent | .additionalProperties // true" "$SCHEMA" 2>/dev/null)
+      local section_path="${jq_path%.properties}"
+      strict=$(jq -r "${section_path} | .additionalProperties // true" "$SCHEMA" 2>/dev/null)
       if [ "$strict" = "false" ]; then
         echo "WARNING: defaults.${section} CRD has '${field}' but schema omits it (users cannot set this via Helm)"
       fi

--- a/internal/recommendation/chain_test.go
+++ b/internal/recommendation/chain_test.go
@@ -67,7 +67,7 @@ func TestRecommendationEngine_RealisticCPU(t *testing.T) {
 	//   → bounds OK → change filter: 241m vs 500m = 52% decrease > 50%
 	//   → capped at 500m - 250m = 250m.
 	assert.Equal(t, int64(250), recommended.MilliValue(),
-		"50%% max decrease from 500m should cap at 250m")
+		"50% max decrease from 500m should cap at 250m")
 }
 
 func TestRecommendationEngine_RealisticMemory(t *testing.T) {
@@ -111,7 +111,7 @@ func TestRecommendationEngine_RealisticMemory(t *testing.T) {
 	assert.Less(t, recommended.Value(), int64(350*1024*1024),
 		"recommendation should be below ~350Mi (overhead + confidence, not capped)")
 	assert.Empty(t, explanation.ChangeFilterApplied,
-		"~39.8%% decrease should not trigger the 50%% max change cap")
+		"~39.8% decrease should not trigger the 50% max change cap")
 	assert.True(t, recommended.Cmp(current) < 0,
 		"recommendation %s should be less than current %s", recommended.String(), current.String())
 }
@@ -151,7 +151,7 @@ func TestRecommendationEngine_SmallChangeFiltered(t *testing.T) {
 	current := resource.MustParse("500m")
 	recommended, changed := engine.Recommend(profile, current)
 
-	assert.False(t, changed, "change <10%% should be filtered out")
+	assert.False(t, changed, "change <10% should be filtered out")
 	assert.Equal(t, current.MilliValue(), recommended.MilliValue(),
 		"filtered recommendation should equal current")
 }
@@ -176,7 +176,7 @@ func TestRecommendationEngine_LargeChangeCapped(t *testing.T) {
 	recommended, changed := engine.Recommend(profile, current)
 	assert.True(t, changed)
 	assert.Equal(t, int64(300), recommended.MilliValue(),
-		"50%% max increase from 200m should cap at 300m")
+		"50% max increase from 200m should cap at 300m")
 }
 
 func TestRecommendationEngine_HighVsLowConfidence(t *testing.T) {

--- a/internal/recommendation/change_filter_test.go
+++ b/internal/recommendation/change_filter_test.go
@@ -117,7 +117,7 @@ func TestChangeFilter_BinarySIMemoryCapping(t *testing.T) {
 	// The code computes in millis: current=536870912000, delta=268435456000,
 	// capped=805306368000, then divides by 1000 and ceils: 805306368.
 	assert.Equal(t, int64(805306368), result.Value(),
-		"50%% increase from 512Mi should produce 768Mi")
+		"50% increase from 512Mi should produce 768Mi")
 }
 
 func TestChangeFilter_BinarySIMemoryDecreaseCapping(t *testing.T) {
@@ -135,7 +135,7 @@ func TestChangeFilter_BinarySIMemoryDecreaseCapping(t *testing.T) {
 	assert.Equal(t, resource.BinarySI, result.Format)
 	// 1Gi = 1073741824 bytes. 50% decrease = 536870912.
 	assert.Equal(t, int64(536870912), result.Value(),
-		"50%% decrease from 1Gi should produce 512Mi")
+		"50% decrease from 1Gi should produce 512Mi")
 }
 
 func TestChangeFilter_ZeroCurrent(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix 7 real findings from GitHub AI code quality scan (out of 12 total; 5 were false positives).

### Test message escaping (6 fixes)

Testify assert functions (`assert.Equal`, `assert.Empty`, `assert.False`) only apply
`fmt.Sprintf` when `len(msgAndArgs) > 1`. When only a single message string is passed
(no format arguments), the string is used as-is. This means `%%` prints literally as
`%%` instead of the intended `%`.

Fixed in:
- `internal/recommendation/chain_test.go` (4 instances)
- `internal/recommendation/change_filter_test.go` (2 instances)

Note: `internal/controller/prometheus_test.go` correctly uses `%%` because it passes
format arguments (`memRec.String()`, `pctDiff`), so Sprintf runs and `%%` becomes `%`.

### jq parent filter (1 fix)

`jq` has no `parent` builtin filter. The call in `hack/verify-helm-schema-fields.sh`
silently failed (suppressed by `2>/dev/null`), making the `additionalProperties: false`
check a no-op. Fixed by using bash parameter expansion (`${jq_path%.properties}`) to
compute the parent path.

### False positives (not fixed, documented)

| File | Finding | Reason |
|------|---------|--------|
| AGENTS.md | Expand sign-off warning | Doc style for agents, clear as-is |
| verify-helm-schema-fields.sh | Hardcoded `[0]` index | Single CRD version, premature |
| chain_test.go | `assert.True` to `assert.Truef` | Both handle format args identically |
| monitor.go | Extract `ThrottleGraceWindow` | Already triaged and rejected as cosmetic |
| monitor.go | Add SLO evaluation comment | Existing inline comment sufficient |
| monitor.go | Extract `isFinite` helper | Two usages, premature abstraction |
| monitor.go | Cache SLO threshold parsing | `ParseFloat` is nanoseconds; mutex adds risk |