### PR TITLE
docs: add testify %% escaping convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,6 +384,24 @@ directory. When referencing files elsewhere in the repo (e.g., `charts/`,
   check the failure pattern across multiple runs before blaming a specific
   version. If the failure rotates randomly across versions, the root cause
   is NOT version-specific; look for test setup differences instead.
+- **Testify `%%` escaping:** Testify `assert.*` functions only apply
+  `fmt.Sprintf` to the message when `len(msgAndArgs) > 1` (i.e., format
+  args are passed alongside the message string). With a single message
+  string, `%%` prints literally as `%%`. Use plain `%` when there are no
+  format args; use `%%` only when format args are present.
+
+  ```go
+  // WRONG: single message arg, no Sprintf, %% prints literally
+  assert.Equal(t, 250, v, "50%% cap from 500m")
+
+  // CORRECT: no format args, use plain %
+  assert.Equal(t, 250, v, "50% cap from 500m")
+
+  // CORRECT: format args present, Sprintf runs, %% needed
+  assert.InDelta(t, 0, diff, 5,
+      "within 5%% of 2Gi (got %.1f%% diff)", v, d)
+  ```
+
 - **Deterministic Prometheus data in E2E tests:** Use `vector(1)` (or
   `vector(N)`) as a PromQL query that always returns a fixed value without
   waiting for real metric scrapes. Useful for testing features that evaluate


### PR DESCRIPTION
Add a testing convention for testify `%%` escaping to prevent the bug
fixed in PR #314 from recurring.

Testify `assert.*` functions only apply `fmt.Sprintf` to the message when
`len(msgAndArgs) > 1`. With a single message string (no format args), `%%`
prints literally as `%%` instead of `%`. This caused 6 incorrect test
messages across `chain_test.go` and `change_filter_test.go`.

The convention documents when to use `%` vs `%%` with examples.