### PR TITLE
fix: e2e transient download failures with cached Chainsaw and helm retry

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -222,8 +222,22 @@ runs:
       run: |
         helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
         helm repo update
-        helm install prometheus prometheus-community/prometheus \
-          --version ${{ inputs.prometheus-chart-version }} \
+        # Pre-pull the chart tarball with retry to avoid transient CDN failures
+        # (e.g. 504 Gateway Timeout from GitHub-hosted chart assets).
+        for attempt in 1 2 3; do
+          if helm pull prometheus-community/prometheus \
+            --version ${{ inputs.prometheus-chart-version }} \
+            --destination /tmp; then
+            break
+          fi
+          echo "::warning::helm pull attempt $attempt failed, retrying in 10s..."
+          sleep 10
+          if (( attempt == 3 )); then
+            echo "::error::Failed to pull Prometheus chart after 3 attempts"
+            exit 1
+          fi
+        done
+        helm install prometheus /tmp/prometheus-${{ inputs.prometheus-chart-version }}.tgz \
           --namespace monitoring --create-namespace \
           --set server.image.repository=quay.io/prometheus/prometheus \
           --set server.image.tag=v3.4.1 \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -531,7 +531,29 @@ jobs:
       # Lint and unit tests are guaranteed complete via needs: [lint, test-unit].
 
       - name: Install Chainsaw
-        uses: kyverno/action-install-chainsaw@1223ef75bedeb59c4e7b5455463d4316e76dff01 # v0.2.15
+        uses: ./.github/actions/install-binary-tool
+        with:
+          name: chainsaw
+          version: v0.2.15
+          install-command: |
+            ARCH=$(uname -m)
+            case "$ARCH" in
+              x86_64)  ARCH=amd64 ;;
+              aarch64) ARCH=arm64 ;;
+            esac
+            URL="https://github.com/kyverno/chainsaw/releases/download/v0.2.15/chainsaw_linux_${ARCH}.tar.gz"
+            for attempt in 1 2 3; do
+              if curl -fsSL "$URL" -o chainsaw.tar.gz; then
+                tar -xf chainsaw.tar.gz -C "$TOOL_DIR" chainsaw
+                rm chainsaw.tar.gz
+                chmod +x "$TOOL_DIR/chainsaw"
+                exit 0
+              fi
+              echo "::warning::Chainsaw download attempt $attempt failed, retrying in 10s..."
+              sleep 10
+            done
+            echo "::error::Failed to download Chainsaw after 3 attempts"
+            exit 1
 
       - name: Run Chainsaw and Go E2E concurrently
         shell: bash -Eeuo pipefail -x {0}

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -334,8 +334,22 @@ jobs:
         run: |
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo update
-          helm install prometheus prometheus-community/prometheus \
-            --version ${{ env.PROMETHEUS_CHART_VERSION }} \
+          # Pre-pull the chart tarball with retry to avoid transient CDN failures
+          # (e.g. 504 Gateway Timeout from GitHub-hosted chart assets).
+          for attempt in 1 2 3; do
+            if helm pull prometheus-community/prometheus \
+              --version ${{ env.PROMETHEUS_CHART_VERSION }} \
+              --destination /tmp; then
+              break
+            fi
+            echo "::warning::helm pull attempt $attempt failed, retrying in 10s..."
+            sleep 10
+            if (( attempt == 3 )); then
+              echo "::error::Failed to pull Prometheus chart after 3 attempts"
+              exit 1
+            fi
+          done
+          helm install prometheus /tmp/prometheus-${{ env.PROMETHEUS_CHART_VERSION }}.tgz \
             --namespace monitoring --create-namespace \
             --set server.image.repository=quay.io/prometheus/prometheus \
             --set server.image.tag=v3.4.1 \
@@ -399,7 +413,29 @@ jobs:
 
       - name: Install Chainsaw
         if: inputs.suite != 'go-e2e'
-        uses: kyverno/action-install-chainsaw@1223ef75bedeb59c4e7b5455463d4316e76dff01 # v0.2.15
+        uses: ./.github/actions/install-binary-tool
+        with:
+          name: chainsaw
+          version: v0.2.15
+          install-command: |
+            ARCH=$(uname -m)
+            case "$ARCH" in
+              x86_64)  ARCH=amd64 ;;
+              aarch64) ARCH=arm64 ;;
+            esac
+            URL="https://github.com/kyverno/chainsaw/releases/download/v0.2.15/chainsaw_linux_${ARCH}.tar.gz"
+            for attempt in 1 2 3; do
+              if curl -fsSL "$URL" -o chainsaw.tar.gz; then
+                tar -xf chainsaw.tar.gz -C "$TOOL_DIR" chainsaw
+                rm chainsaw.tar.gz
+                chmod +x "$TOOL_DIR/chainsaw"
+                exit 0
+              fi
+              echo "::warning::Chainsaw download attempt $attempt failed, retrying in 10s..."
+              sleep 10
+            done
+            echo "::error::Failed to download Chainsaw after 3 attempts"
+            exit 1
 
       - name: Run Chainsaw suite
         if: inputs.suite != 'go-e2e'


### PR DESCRIPTION
## Problem

The [nightly run on 2026-06-08](https://github.com/attune-io/attune/actions/runs/27124540714) (#317) had 3 of 4 E2E jobs fail due to transient GitHub CDN errors during dependency downloads:

| Job | Failed Step | Error |
|---|---|---|
| E2E (K8s v1.32) | Install Chainsaw | `gzip: stdin: not in gzip format` (HTML error page saved as tar.gz) |
| E2E (K8s v1.33) | Install Chainsaw | same |
| E2E (K8s v1.35) | Install Prometheus | `504 Gateway Timeout` fetching Helm chart |
| E2E (K8s v1.34) | (passed) | same downloads succeeded due to timing |

**Root cause #1:** The `kyverno/action-install-chainsaw` action uses `curl -sL` without `-f`. When GitHub CDN returns a non-200 response, curl silently saves the HTML error body as the `.tar.gz` file.

**Root cause #2:** The Prometheus `helm install` fetches the chart live from GitHub releases with no retry logic.

## Changes

1. **Cached Chainsaw binary**: Replaced third-party `kyverno/action-install-chainsaw` with our existing `install-binary-tool` composite action. This adds caching across runs and uses `curl -fsSL` with a 3-attempt retry loop. Applied to both `ci.yaml` and `e2e-nightly.yaml`.

2. **Prometheus chart retry**: Split `helm install` into `helm pull` (with 3-attempt retry) + `helm install` from local tarball. Applied to both `e2e-nightly.yaml` and the `setup-e2e-cluster` composite action.

3. **Upstream issue**: Filed [kyverno/action-install-chainsaw#97](https://github.com/kyverno/action-install-chainsaw/issues/97) for the missing `curl -f` flag.

Closes #317