### PR TITLE
ci: add issue linker workflow to catch unlinked issue references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,14 @@ Brief description of the change.
 
 ## Why
 
-Motivation and context. Link to related issue(s).
+Motivation and context.
 
-Fixes #
+## Related Issues
+
+<!-- Use "Closes #N" for issues this PR fixes (auto-closes on merge).
+     Use "Ref #N" for issues that are related but NOT fixed by this PR.
+     Delete this section if no issues are related. -->
+Closes #
 
 ## How to Test
 

--- a/.github/workflows/issue-linker.yaml
+++ b/.github/workflows/issue-linker.yaml
@@ -1,0 +1,124 @@
+name: Issue Linker
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: issue-linker-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-links:
+    name: Check issue links
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const prNumber = context.payload.pull_request.number;
+
+            // Skip Dependabot PRs
+            const author = context.payload.pull_request.user.login;
+            if (author === 'dependabot[bot]' || author === 'renovate[bot]') return;
+
+            // Find all #NNN references (exclude table column refs like |---|)
+            const allRefs = [...body.matchAll(/(?<!\w)#(\d+)/g)]
+              .map(m => parseInt(m[1]))
+              .filter(n => n !== prNumber && n > 0 && n < 100000);
+            const uniqueRefs = [...new Set(allRefs)];
+            if (uniqueRefs.length === 0) return;
+
+            // Find references with closure keywords
+            const closurePattern = /(?:closes?|fixes?|resolves?)\s+#(\d+)/gi;
+            const closedRefs = new Set(
+              [...body.matchAll(closurePattern)].map(m => parseInt(m[1]))
+            );
+
+            // Check which bare refs are open issues in this repo
+            const bareOpenIssues = [];
+            for (const num of uniqueRefs) {
+              if (closedRefs.has(num)) continue;
+              try {
+                const issue = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num
+                });
+                if (issue.data.state === 'open' && !issue.data.pull_request) {
+                  bareOpenIssues.push({ number: num, title: issue.data.title });
+                }
+              } catch {
+                // Not a valid issue number or from another repo
+              }
+            }
+
+            const marker = '<!-- issue-linker-check -->';
+
+            // Delete previous comment if no bare open issues remain
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (bareOpenIssues.length === 0) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id
+                });
+              }
+              return;
+            }
+
+            const issueList = bareOpenIssues
+              .map(i => `| #${i.number} | ${i.title} |`)
+              .join('\n');
+
+            const message = [
+              marker,
+              '### Issue Link Check',
+              '',
+              'This PR references open issues without a closure keyword',
+              '(`Closes`, `Fixes`, or `Resolves`):',
+              '',
+              '| Issue | Title |',
+              '|---|---|',
+              issueList,
+              '',
+              'If this PR fixes any of these, add `Closes #N` to the description',
+              'so they auto-close on merge. If the reference is informational,',
+              'no action needed.',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: message
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: message
+              });
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,20 @@ The repository enforces semantic PR titles via [.github/workflows/pr-title.yaml]
 
 When creating branches, commits, or PRs, make the first line a valid semantic title so the gate passes on the first attempt. This avoids immediate CI failures and repeated title edits.
 
+### Issue closure in PR descriptions
+
+Before running `gh pr create`, check open issues and include `Closes #N`
+for each issue this PR fixes:
+
+```bash
+gh issue list --state open --json number,title --jq '.[] | "#\(.number) \(.title)"'
+```
+
+The `Issue Linker` workflow ([.github/workflows/issue-linker.yaml](.github/workflows/issue-linker.yaml))
+comments on PRs that reference open issues without a closure keyword.
+Use `Closes #N` (auto-closes on merge), `Fixes #N` (same), or
+`Ref #N` (informational, no auto-close).
+
 ### MkDocs documentation links
 
 MkDocs strict mode rejects relative links that resolve outside the `docs/`


### PR DESCRIPTION
## What This PR Does

Add automation to prevent issues from staying open when their fixing PR merges without a `Closes #N` keyword.

## Why

PRs that reference open issues with bare `#N` (without `Closes`, `Fixes`, or `Resolves`) don't trigger GitHub's auto-close on merge. This happens often enough that issues silently remain open after their fix lands.

## Related Issues

Ref #322

## Changes

1. **Issue Linker workflow** (`.github/workflows/issue-linker.yaml`): Runs on `pull_request_target` (opened/edited). Scans the PR description for bare `#N` references, checks if they point to open issues in this repo, and comments with a reminder to add a closure keyword. The comment auto-updates when the PR is edited and self-deletes when all references are resolved. Skips Dependabot/Renovate PRs.

2. **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`): Renamed the `Fixes #` section to `Related Issues` with clear guidance on when to use `Closes #N` vs `Ref #N`.

3. **AGENTS.md**: Added mechanical pre-PR-creation step: check open issues before running `gh pr create` and include `Closes #N` for each issue the PR fixes.

## How to Test

1. Open a PR with body containing `#322` (a currently open issue) without `Closes`
2. The workflow should comment listing #322 as unlinked
3. Edit the PR body to add `Closes #322`
4. The workflow should delete the comment

## Checklist

- [x] Unit tests added/updated (N/A, workflow-only)
- [ ] Integration tests added/updated (if applicable)
- [ ] CRD changes regenerated (N/A)
- [x] Documentation updated (AGENTS.md)
- [ ] Helm chart updated (N/A)
- [x] No breaking API changes