### PR TITLE
fix: add retry and caching to cert-manager manifest download in e2e-nightly

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -131,6 +131,7 @@ jobs:
             /tmp/cert-manager-controller.tar
             /tmp/cert-manager-webhook.tar
             /tmp/cert-manager-cainjector.tar
+            /tmp/cert-manager.yaml
             /tmp/prometheus.tar
             /tmp/stress-ng.tar
             /tmp/busybox.tar
@@ -317,10 +318,30 @@ jobs:
             /tmp/cert-manager-cainjector.tar \
             -c "$CLUSTER_NAME"
 
+      - name: Download cert-manager manifest
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          if [[ -f /tmp/cert-manager.yaml ]]; then
+            echo "Cached: /tmp/cert-manager.yaml"
+          else
+            for attempt in 1 2 3; do
+              if curl -fsSL -o /tmp/cert-manager.yaml \
+                "https://github.com/cert-manager/cert-manager/releases/download/${{ env.CERT_MANAGER_VERSION }}/cert-manager.yaml"; then
+                break
+              fi
+              echo "::warning::cert-manager.yaml download attempt $attempt failed, retrying in 10s..."
+              sleep 10
+              if (( attempt == 3 )); then
+                echo "::error::Failed to download cert-manager.yaml after 3 attempts"
+                exit 1
+              fi
+            done
+          fi
+
       - name: Install cert-manager
         shell: bash -Eeuo pipefail -x {0}
         run: |
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${{ env.CERT_MANAGER_VERSION }}/cert-manager.yaml
+          kubectl apply -f /tmp/cert-manager.yaml
           kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s


### PR DESCRIPTION
## What This PR Does

Align the nightly workflow's cert-manager install with the composite action's existing pattern: download with `curl -fsSL` (3-attempt retry), cache the manifest across runs via `actions/cache`, and apply from the local file.

## Why

The nightly workflow downloads the cert-manager manifest directly from GitHub with no retry:

```yaml
kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$VERSION/cert-manager.yaml
```

A transient GitHub CDN failure (504, rate limit) kills the E2E job. This is the same failure class that caused #317 for Chainsaw and Prometheus (fixed in PR #321). The cert-manager install was missed in that fix.

The composite action (`setup-e2e-cluster/action.yaml:177-213`) already handles this correctly with caching + retry + local apply. This PR brings the nightly workflow to parity.

## Related Issues

Closes #322

## How to Test

The change is exercised by the next nightly run. The download step will show either `Cached: /tmp/cert-manager.yaml` (cache hit) or the download with retry output.

## Checklist

- [x] Unit tests added/updated (N/A, workflow-only)
- [ ] Integration tests added/updated (N/A)
- [ ] CRD changes regenerated (N/A)
- [ ] Documentation updated (N/A)
- [ ] Helm chart updated (N/A)
- [x] No breaking API changes