### PR TITLE
ci: replace hmarr/auto-approve-action with gh CLI

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -27,5 +27,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Auto Approve
-        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
The `hmarr/auto-approve-action` is unmaintained (last commit Feb 2024) and stuck on Node.js 20, which GitHub Actions is deprecating on June 16, 2026.

Replace it with a direct `gh pr review --approve` call, which is pre-installed on all runners and has zero supply chain risk.

## Changes

- Remove `hmarr/auto-approve-action@v4.0.0` dependency
- Use `gh pr review --approve` with `GITHUB_TOKEN`
- No behavior change: still approves the same PRs under the same conditions