### PR TITLE
fix: remove confidence floor and add QoS-aware HPA target cap

### DIFF
--- a/docs/guides/hpa-coexistence.md
+++ b/docs/guides/hpa-coexistence.md
@@ -48,6 +48,38 @@ spec:
     the utilization percentage, which may cause HPA to scale out. Set
     conservative bounds to prevent requests from dropping too far.
 
+### QoS-aware HPA target adjustment
+
+When Attune lowers a pod's CPU request, it recalculates the HPA target to
+preserve the same absolute CPU threshold:
+
+```
+newTarget = baseTarget * (oldRequest / newRequest)
+```
+
+The upper cap on this target depends on the pod's QoS class:
+
+- **Burstable** (limit > request): targets above 100% are allowed, up to
+  `floor(limit / request * 100)`. The container can burst up to its CPU
+  limit, so utilization above 100% of request is achievable. This preserves
+  the absolute threshold without triggering premature scale-outs.
+- **Guaranteed** (limit == request): targets are capped at 100%. Utilization
+  cannot exceed 100% when cgroups enforce `limit == request`.
+- **BestEffort** (no requests/limits): not applicable; HPA resource metrics
+  require requests to be set.
+
+For example, if a Burstable pod has `request: 300m` and `limit: 1000m` with
+HPA target 70%, and requests drop from 500m to 300m:
+
+```
+newTarget = 70 * (500 / 300) = 116%
+burstableCap = floor(1000 / 300 * 100) = 333%
+finalTarget = min(116, 333) = 116%
+```
+
+The 116% target preserves the original 350m absolute threshold
+(`116% * 300m = 348m`).
+
 ### Set appropriate bounds
 
 Choose a `min` bound for CPU that keeps the HPA utilization target in a

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -441,15 +441,17 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				if !resizedWorkloads[rec.Workload] {
 					continue
 				}
-				var totalOldCPU, totalNewCPU int64
+				var totalOldCPU, totalNewCPU, totalCPULimit int64
 				for _, c := range rec.Containers {
 					totalOldCPU += c.Current.CPURequest.MilliValue()
 					totalNewCPU += c.Recommended.CPURequest.MilliValue()
+					totalCPULimit += c.Current.CPULimit.MilliValue()
 				}
 				if totalOldCPU != totalNewCPU {
 					r.adjustHPATargets(ctx, hpaList.Items, rec.Workload, rec.Kind,
 						*resource.NewMilliQuantity(totalOldCPU, resource.DecimalSI),
-						*resource.NewMilliQuantity(totalNewCPU, resource.DecimalSI))
+						*resource.NewMilliQuantity(totalNewCPU, resource.DecimalSI),
+						*resource.NewMilliQuantity(totalCPULimit, resource.DecimalSI))
 				}
 			}
 		}

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -8958,7 +8958,7 @@ func TestAdjustHPATargets_ScalesTargetUtilization(t *testing.T) {
 
 	// CPU went from 200m to 400m, so target should halve: 80 * (200/400) = 40.
 	r.adjustHPATargets(context.Background(), hpas, "my-app", "Deployment",
-		resource.MustParse("200m"), resource.MustParse("400m"))
+		resource.MustParse("200m"), resource.MustParse("400m"), resource.Quantity{})
 
 	var hpa autoscalingv2.HorizontalPodAutoscaler
 	err := fakeClient.Get(context.Background(), client.ObjectKey{
@@ -9016,7 +9016,7 @@ func TestAdjustHPATargets_PreservesThirdPartyAnnotations(t *testing.T) {
 
 	r.adjustHPATargets(context.Background(), []autoscalingv2.HorizontalPodAutoscaler{staleHPA},
 		"my-app", "Deployment",
-		resource.MustParse("200m"), resource.MustParse("400m"))
+		resource.MustParse("200m"), resource.MustParse("400m"), resource.Quantity{})
 
 	var hpa autoscalingv2.HorizontalPodAutoscaler
 	err := fakeClient.Get(context.Background(), client.ObjectKey{
@@ -9286,7 +9286,7 @@ func TestAdjustHPATargets_IdempotentOnSecondCall(t *testing.T) {
 
 	// First call: 200m -> 400m, target should halve: 80 * (200/400) = 40.
 	r.adjustHPATargets(context.Background(), hpas, "my-app", "Deployment",
-		resource.MustParse("200m"), resource.MustParse("400m"))
+		resource.MustParse("200m"), resource.MustParse("400m"), resource.Quantity{})
 
 	// Re-fetch the HPA to get updated state.
 	var hpa autoscalingv2.HorizontalPodAutoscaler
@@ -9300,7 +9300,7 @@ func TestAdjustHPATargets_IdempotentOnSecondCall(t *testing.T) {
 	// Second call with same args (e.g., canary promote). Target should stay 40.
 	updatedHPAs := []autoscalingv2.HorizontalPodAutoscaler{hpa}
 	r.adjustHPATargets(context.Background(), updatedHPAs, "my-app", "Deployment",
-		resource.MustParse("200m"), resource.MustParse("400m"))
+		resource.MustParse("200m"), resource.MustParse("400m"), resource.Quantity{})
 
 	err = fakeClient.Get(context.Background(), client.ObjectKey{
 		Namespace: "default",
@@ -9761,7 +9761,7 @@ func TestAdjustHPATargets_SkipsWithoutAnnotation(t *testing.T) {
 	r.Scheme = scheme
 
 	r.adjustHPATargets(context.Background(), hpas, "my-app", "Deployment",
-		resource.MustParse("200m"), resource.MustParse("400m"))
+		resource.MustParse("200m"), resource.MustParse("400m"), resource.Quantity{})
 
 	var hpa autoscalingv2.HorizontalPodAutoscaler
 	err := fakeClient.Get(context.Background(), client.ObjectKey{
@@ -9815,7 +9815,7 @@ func TestAdjustHPATargets_GetErrorDoesNotCrash(t *testing.T) {
 
 	// Should not panic; logs the Get error and moves on.
 	r.adjustHPATargets(context.Background(), hpas, "my-app", "Deployment",
-		resource.MustParse("200m"), resource.MustParse("400m"))
+		resource.MustParse("200m"), resource.MustParse("400m"), resource.Quantity{})
 }
 
 func TestAdjustHPATargets_UpdateErrorPreservesOriginal(t *testing.T) {
@@ -9863,7 +9863,7 @@ func TestAdjustHPATargets_UpdateErrorPreservesOriginal(t *testing.T) {
 	// Should not panic; logs the Update error.
 	r.adjustHPATargets(context.Background(), []autoscalingv2.HorizontalPodAutoscaler{hpa},
 		"my-app", "Deployment",
-		resource.MustParse("200m"), resource.MustParse("400m"))
+		resource.MustParse("200m"), resource.MustParse("400m"), resource.Quantity{})
 
 	// The stored HPA should still have the original target since update failed.
 	var storedHPA autoscalingv2.HorizontalPodAutoscaler
@@ -9912,10 +9912,10 @@ func TestAdjustHPATargets_ClampsAbove100(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	// old=1000m, new=100m -> 80 * 1000/100 = 800, clamped to 100
+	// old=1000m, new=100m -> 80 * 1000/100 = 800, clamped to 100 (Guaranteed QoS: no limit)
 	r.adjustHPATargets(context.Background(), []autoscalingv2.HorizontalPodAutoscaler{hpa},
 		"my-app", "Deployment",
-		resource.MustParse("1000m"), resource.MustParse("100m"))
+		resource.MustParse("1000m"), resource.MustParse("100m"), resource.Quantity{})
 
 	var stored autoscalingv2.HorizontalPodAutoscaler
 	require.NoError(t, fakeClient.Get(context.Background(),
@@ -9963,12 +9963,166 @@ func TestAdjustHPATargets_ClampsBelow1(t *testing.T) {
 	// old=10m, new=10000m -> 50 * 10/10000 = 0.05, int32 = 0, clamped to 1
 	r.adjustHPATargets(context.Background(), []autoscalingv2.HorizontalPodAutoscaler{hpa},
 		"my-app", "Deployment",
-		resource.MustParse("10m"), resource.MustParse("10000m"))
+		resource.MustParse("10m"), resource.MustParse("10000m"), resource.Quantity{})
 
 	var stored autoscalingv2.HorizontalPodAutoscaler
 	require.NoError(t, fakeClient.Get(context.Background(),
 		client.ObjectKey{Namespace: "default", Name: "clamp-low-hpa"}, &stored))
 	assert.Equal(t, int32(1), *stored.Spec.Metrics[0].Resource.Target.AverageUtilization)
+}
+
+func TestAdjustHPATargets_BurstableAllowsAbove100(t *testing.T) {
+	// Burstable QoS: limit > request. The computed target can exceed 100%
+	// and should be capped at floor(limit/request*100) instead of 100.
+	scheme := testScheme()
+	target := int32(70)
+	hpa := autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "burstable-hpa",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationHPAAutoTune: "true",
+			},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: "Deployment",
+				Name: "my-app",
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: &target,
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&hpa).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+
+	// old=500m, new=300m, limit=1000m -> 70 * 500/300 = 116
+	// Burstable cap: floor(1000/300 * 100) = 333
+	// 116 < 333, so newTarget = 116 (not clamped to 100)
+	r.adjustHPATargets(context.Background(), []autoscalingv2.HorizontalPodAutoscaler{hpa},
+		"my-app", "Deployment",
+		resource.MustParse("500m"), resource.MustParse("300m"), resource.MustParse("1000m"))
+
+	var stored autoscalingv2.HorizontalPodAutoscaler
+	require.NoError(t, fakeClient.Get(context.Background(),
+		client.ObjectKey{Namespace: "default", Name: "burstable-hpa"}, &stored))
+	assert.Equal(t, int32(116), *stored.Spec.Metrics[0].Resource.Target.AverageUtilization,
+		"Burstable pod should allow target above 100")
+}
+
+func TestAdjustHPATargets_BurstableCapsAtLimitRatio(t *testing.T) {
+	// Burstable QoS: verify the target is capped at floor(limit/request*100)
+	// when the computed target exceeds the limit ratio.
+	scheme := testScheme()
+	target := int32(80)
+	hpa := autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "burstable-cap-hpa",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationHPAAutoTune: "true",
+			},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: "Deployment",
+				Name: "my-app",
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: &target,
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&hpa).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+
+	// old=1000m, new=100m, limit=200m -> 80 * 1000/100 = 800
+	// Burstable cap: floor(200/100 * 100) = 200
+	// 800 > 200, so newTarget = 200
+	r.adjustHPATargets(context.Background(), []autoscalingv2.HorizontalPodAutoscaler{hpa},
+		"my-app", "Deployment",
+		resource.MustParse("1000m"), resource.MustParse("100m"), resource.MustParse("200m"))
+
+	var stored autoscalingv2.HorizontalPodAutoscaler
+	require.NoError(t, fakeClient.Get(context.Background(),
+		client.ObjectKey{Namespace: "default", Name: "burstable-cap-hpa"}, &stored))
+	assert.Equal(t, int32(200), *stored.Spec.Metrics[0].Resource.Target.AverageUtilization,
+		"Burstable target should be capped at floor(limit/request*100)")
+}
+
+func TestAdjustHPATargets_GuaranteedCapsAt100(t *testing.T) {
+	// Guaranteed QoS: limit == request. Target should be capped at 100
+	// even though cpuLimit is set (not zero).
+	scheme := testScheme()
+	target := int32(70)
+	hpa := autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guaranteed-hpa",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationHPAAutoTune: "true",
+			},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: "Deployment",
+				Name: "my-app",
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: &target,
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&hpa).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+
+	// old=500m, new=300m, limit=300m (Guaranteed: limit == request)
+	// 70 * 500/300 = 116
+	// Guaranteed cap: floor(300/300 * 100) = 100
+	// 116 > 100, so newTarget = 100
+	r.adjustHPATargets(context.Background(), []autoscalingv2.HorizontalPodAutoscaler{hpa},
+		"my-app", "Deployment",
+		resource.MustParse("500m"), resource.MustParse("300m"), resource.MustParse("300m"))
+
+	var stored autoscalingv2.HorizontalPodAutoscaler
+	require.NoError(t, fakeClient.Get(context.Background(),
+		client.ObjectKey{Namespace: "default", Name: "guaranteed-hpa"}, &stored))
+	assert.Equal(t, int32(100), *stored.Spec.Metrics[0].Resource.Target.AverageUtilization,
+		"Guaranteed pod (limit==request) should cap at 100")
 }
 
 func TestBuildRecommendationEngines_NilMaxChangePercent(t *testing.T) {

--- a/internal/controller/hpa.go
+++ b/internal/controller/hpa.go
@@ -33,7 +33,7 @@ func (r *AttunePolicyReconciler) adjustHPATargets(
 	ctx context.Context,
 	hpas []autoscalingv2.HorizontalPodAutoscaler,
 	workloadName, workloadKind string,
-	oldCPURequest, newCPURequest resource.Quantity,
+	oldCPURequest, newCPURequest, cpuLimit resource.Quantity,
 ) {
 	logger := log.FromContext(ctx)
 	for i := range hpas {
@@ -66,10 +66,17 @@ func (r *AttunePolicyReconciler) adjustHPATargets(
 					baseTarget = int32(v)
 				}
 			}
-			// newTarget = baseTarget * (oldRequest / newRequest), capped at 100.
+			// newTarget = baseTarget * (oldRequest / newRequest), with a
+			// QoS-aware upper cap: Burstable pods (limit > request) can
+			// use targets above 100% up to floor(limit/request*100);
+			// Guaranteed pods (limit == request) are capped at 100%.
 			newTarget := int32(float64(baseTarget) * float64(oldCPURequest.MilliValue()) / float64(newCPURequest.MilliValue()))
-			if newTarget > 100 {
-				newTarget = 100
+			maxTarget := int32(100)
+			if !cpuLimit.IsZero() && cpuLimit.Cmp(newCPURequest) > 0 {
+				maxTarget = int32(float64(cpuLimit.MilliValue()) / float64(newCPURequest.MilliValue()) * 100)
+			}
+			if newTarget > maxTarget {
+				newTarget = maxTarget
 			}
 			if newTarget < 1 {
 				newTarget = 1

--- a/internal/recommendation/chain.go
+++ b/internal/recommendation/chain.go
@@ -116,15 +116,15 @@ func (e *RecommendationEngine) RecommendWithExplanation(profile metrics.UsagePro
 	afterBurst := scaleQuantity(afterOverhead, burstFactor)
 
 	confidence := profile.Confidence
-	if confidence < 0.1 {
-		confidence = 0.1
-	}
 	if confidence > 1.0 {
 		confidence = 1.0
 	}
+	if confidence < 0 {
+		confidence = 0
+	}
 	// Confidence factor adds a buffer for uncertainty: at confidence=1.0
-	// (7 days of data), factor=1.0 (no extra buffer). At confidence=0.1
-	// (minimum data), factor≈1.8 (80% extra buffer on top of overhead).
+	// (7 days of data), factor=1.0 (no extra buffer). At confidence=0.0
+	// (no data), factor=2.0 (100% extra buffer on top of overhead).
 	// Formula: 1 + multiplier * (1-confidence)^exponent.
 	confidenceFactor := 1.0
 	if e.confidenceMultiplier != 0 && e.confidenceExponent != 0 {

--- a/internal/recommendation/chain_test.go
+++ b/internal/recommendation/chain_test.go
@@ -425,6 +425,26 @@ func TestRecommendationEngine_ExplainChain(t *testing.T) {
 	assert.Equal(t, int64(250), explanation.AfterChangeFilter.MilliValue())
 }
 
+func TestRecommendationEngine_ZeroConfidenceGivesMaxBuffer(t *testing.T) {
+	// With confidence=0.0 (no data), the confidence factor should be 2.0
+	// (100% buffer). The old vestigial floor at 0.1 would cap this at ~1.81.
+	engine := NewEngine(
+		95,
+		20.0,
+		resource.MustParse("50m"),
+		resource.MustParse("4000m"),
+		200, 200, // wide change limits so they don't interfere
+		EngineOpts{IsCPU: true},
+	)
+	profile := buildRealisticCPUProfile(0.200, 0.0)
+	current := resource.MustParse("500m")
+
+	_, explanation, _ := engine.RecommendWithExplanation(profile, current)
+	// factor = 1 + 1.0 * (1 - 0.0)^2 = 2.0
+	assert.InDelta(t, 2.0, explanation.ConfidenceFactor, 0.0001,
+		"zero confidence should produce factor 2.0 (100% buffer)")
+}
+
 func TestRecommendationEngine_ZeroCurrentBypassesChangeFilter(t *testing.T) {
 	// When the current allocation is 0m (container with no explicit resource
 	// requests), the change filter cannot compute a percentage change and is


### PR DESCRIPTION
## Summary

Fixes two related issues in the recommendation and HPA adjustment pipelines.

Closes #333
Closes #332

## Issue #333: Remove vestigial confidence floor

The recommendation chain in `chain.go` floored confidence at 0.1 before applying the formula `1 + multiplier * (1-confidence)^exponent`. This floor was a leftover from an older formula that divided by confidence (still in `confidence.go` for unit tests). The production formula uses subtraction, so the floor is unnecessary and capped the maximum safety buffer at 81% instead of 100%.

| Confidence | Before (floored) | After (actual) |
|---|---|---|
| 0.00 | 1.81 (81% buffer) | 2.00 (100% buffer) |
| 0.05 | 1.81 (81% buffer) | 1.90 (90% buffer) |
| 0.10 | 1.81 (81% buffer) | 1.81 (81% buffer) |
| 0.50+ | unchanged | unchanged |

This is conservative-direction: more buffer for low-confidence workloads.

## Issue #332: QoS-aware HPA target adjustment

`adjustHPATargets` unconditionally capped computed HPA targets at 100%. This broke the absolute CPU threshold preservation for Burstable pods where `limit > request`.

Now the cap is QoS-aware:
- **Burstable** (limit > request): cap at `floor(limit/request*100)`
- **Guaranteed** (limit == request): cap at 100%
- **Zero limit** (unknown): cap at 100%

Example: target=70%, request drops 500m to 300m, limit=1000m:
```
newTarget = 70 * (500/300) = 116%
burstableCap = floor(1000/300 * 100) = 333%
finalTarget = 116%  (preserves 350m absolute threshold)
```

## Tests

- Unit: `TestRecommendationEngine_ZeroConfidenceGivesMaxBuffer` (factor=2.0)
- Unit: `TestAdjustHPATargets_BurstableAllowsAbove100` (116% target)
- Unit: `TestAdjustHPATargets_BurstableCapsAtLimitRatio` (200% cap)
- Unit: `TestAdjustHPATargets_GuaranteedCapsAt100` (100% cap)
- All existing HPA tests updated and passing
- `make verify-quick` passes