### PR TITLE
fix: use post-resize CPU limit for HPA QoS-aware cap

### DIFF
--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -445,7 +445,7 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				for _, c := range rec.Containers {
 					totalOldCPU += c.Current.CPURequest.MilliValue()
 					totalNewCPU += c.Recommended.CPURequest.MilliValue()
-					totalCPULimit += c.Current.CPULimit.MilliValue()
+					totalCPULimit += c.Recommended.CPULimit.MilliValue()
 				}
 				if totalOldCPU != totalNewCPU {
 					r.adjustHPATargets(ctx, hpaList.Items, rec.Workload, rec.Kind,


### PR DESCRIPTION
Use `Recommended.CPULimit` (post-resize) instead of `Current.CPULimit` (pre-resize) when computing the Burstable HPA target cap.

When Attune resizes limits alongside requests, the pre-resize limit overestimates the cap, allowing a slightly higher HPA target than the container can actually burst to after the resize. Using the post-resize limit ensures the cap reflects the actual cgroup constraint.

One-line change in the call site at `attunepolicy_controller.go:448`.