### PR TITLE
docs: update SLSA provenance claims after attestation migration

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,8 +25,8 @@ feature: [Report a vulnerability](https://github.com/attune-io/attune/security/a
 - Container images and binaries are signed with
   [cosign](https://github.com/sigstore/cosign) using keyless signing
   (Sigstore OIDC)
-- [SLSA Level 3](https://slsa.dev) provenance is generated for both
-  binary artifacts and container images
+- [SLSA](https://slsa.dev) build provenance is generated for binary
+  artifacts and container images using GitHub's native attestations
 - SBOMs are generated for every release (SPDX format) and attached to
   the GitHub release
 - [FOSSA](https://fossa.com) license compliance scanning runs on every push

--- a/docker/README.md
+++ b/docker/README.md
@@ -68,7 +68,7 @@ cosign verify \
 
 - Runs as non-root (UID 65532)
 - Distroless base image (no shell, no package manager)
-- Signed with cosign + SLSA Level 3 provenance
+- Signed with cosign + SLSA build provenance
 - Trivy-scanned on every release
 
 ## Source


### PR DESCRIPTION
PR #340 replaced `slsa-framework/slsa-github-generator` reusable workflows
with native `actions/attest-build-provenance`. The reusable workflow model
achieved SLSA Build Level 3 (isolated builder); the native attestation
model produces SLSA v1.0 provenance at Build Level 2 (same workflow).

Updates:
- `SECURITY.md`: remove "Level 3" claim, reference native GitHub attestations
- `docker/README.md`: remove "SLSA Level 3" from security bullet