### PR TITLE
fix: exclude dependabot from auto-approve and allow all semver types in auto-merge

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -27,8 +27,8 @@ jobs:
       pull-requests: write
     if: >
       github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       (github.actor == 'SebTardif' ||
-       github.actor == 'dependabot[bot]' ||
        github.actor == 'attune-release-bot[bot]')
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -35,19 +35,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-commit-verification: true
 
-      - name: Approve and enable auto-merge (patch/minor only)
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+      - name: Approve and enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"
-          echo "Auto-merge enabled — will merge when CI passes"
-
-      - name: Skip major updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-        run: echo "Skipping major version update — requires manual review"
+          echo "Auto-merge enabled for ${{ steps.metadata.outputs.update-type }} update"
 
   # NOTE: A rebase-dependabot job was removed here. It updated open
   # Dependabot PR branches on every push to main, but caused more harm


### PR DESCRIPTION
## Problem

`auto-approve.yaml` triggers on `pull_request` which does not have access to repository secrets for Dependabot PRs. The `create-github-app-token` step fails with:

> The 'private-key' input must be set to a non-empty string.

This produces a red "Auto Approve" check on every Dependabot PR (e.g. #354).

Additionally, `dependabot-auto-merge.yaml` skips the approve+merge step for grouped updates classified as `version-update:semver-major` (e.g. `actions/cache` v5 to v6), even though other packages in the group are patch/minor. This means neither workflow enables auto-merge, and Dependabot PRs sit open until merged manually.

## Changes

**`auto-approve.yaml`**: Exclude `dependabot[bot]` from the job condition. This workflow uses `pull_request` events where Dependabot secrets are unavailable. The dedicated `dependabot-auto-merge.yaml` (`pull_request_target`) handles Dependabot exclusively.

**`dependabot-auto-merge.yaml`**: Remove the semver-major skip. CI (unit tests, integration tests, lint, build, CodeQL, Trivy) is the real gate for update safety. If all required checks pass, the update is safe to merge regardless of semver classification.