### PR TITLE
fix: rebase-dependabot.sh missing origin/ prefix and update Dependabot docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,9 +357,18 @@ Dependabot PRs (#348, #349 etc.) are important for **Dependency-Update-Tool (10)
    git push origin HEAD:dependabot/... --force-with-lease
    ```
 3. The DCO workflow now explicitly skips merge commits (in addition to `[bot]` authors) so that occasional update accidents don't block PRs, while the meaningful diff commit still satisfies the spirit of the rule.
-4. After a clean rebase/push, new workflow runs will use the latest workflow definitions (important for auto-approve paths).
-5. Let the existing "Auto-merge Dependabot PRs" + "Auto Approve" jobs do their work once CI is green. They set `--auto --squash`.
+4. After a clean rebase/push, new workflow runs will use the latest workflow definitions.
+5. Let `dependabot-auto-merge.yaml` (`pull_request_target`) handle approval
+   and auto-merge. It approves and enables `--auto --squash` for all semver
+   types (patch, minor, and major). `auto-approve.yaml` (`pull_request`)
+   excludes `dependabot[bot]` because secrets are unavailable in that context.
 6. If the PR is behind and you want it to move faster, the rebase above + `gh pr comment` or just wait is preferred over broad CI skips.
+
+**Grouped updates and semver classification:** `dependabot/fetch-metadata`
+classifies grouped updates by the **highest** semver type in the group. If
+any package has a major bump (e.g. `actions/cache` v5 to v6), the entire
+group is classified as `version-update:semver-major`. Do not gate auto-merge
+on `update-type`; CI is the real safety gate.
 
 **Why this protects the best possible Scorecard:**
 

--- a/scripts/rebase-dependabot.sh
+++ b/scripts/rebase-dependabot.sh
@@ -32,7 +32,8 @@ if [[ "$TARGET" =~ ^[0-9]+$ ]]; then
   BRANCH=$(gh pr view "$TARGET" --json headRefName --jq .headRefName)
   echo "Branch: $BRANCH"
 else
-  BRANCH="$TARGET"
+  # Strip origin/ prefix if present so we always work with bare branch names
+  BRANCH="${TARGET#origin/}"
 fi
 
 echo "Fetching..."

--- a/scripts/rebase-dependabot.sh
+++ b/scripts/rebase-dependabot.sh
@@ -41,7 +41,7 @@ git fetch origin
 LOCAL_BRANCH="rebase-dependabot-$(date +%s)"
 
 echo "Checking out clean worktree for $BRANCH ..."
-git checkout -B "$LOCAL_BRANCH" "$BRANCH"
+git checkout -B "$LOCAL_BRANCH" "origin/$BRANCH"
 
 echo "Rebasing onto origin/main ..."
 git rebase origin/main


### PR DESCRIPTION
## Problem

`scripts/rebase-dependabot.sh` fails when given a PR number because `git checkout -B $LOCAL_BRANCH "$BRANCH"` uses the bare branch name (e.g. `dependabot/github_actions/actions-8854ad8cac`) which does not exist as a local ref after `git fetch origin`. Only `origin/dependabot/...` exists.

Additionally, AGENTS.md Dependabot guidance was stale after PR #355 removed the semver-major skip and excluded dependabot from auto-approve.yaml.

## Changes

**`scripts/rebase-dependabot.sh`**: Prefix branch name with `origin/` on checkout so the script works correctly with PR numbers.

**`AGENTS.md`**: Update Dependabot section to reflect current behavior:
- `auto-approve.yaml` excludes `dependabot[bot]` (secrets unavailable in `pull_request` context)
- `dependabot-auto-merge.yaml` auto-merges all semver types (CI is the real gate)
- Document `dependabot/fetch-metadata` grouped update classification (highest semver type in group)