### PR TITLE
docs: replace retired Go Report Card badge with coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/attune-io/attune/actions/workflows/ci.yaml/badge.svg)](https://github.com/attune-io/attune/actions/workflows/ci.yaml)
 [![Security](https://github.com/attune-io/attune/actions/workflows/security.yaml/badge.svg)](https://github.com/attune-io/attune/actions/workflows/security.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/attune-io/attune)](https://goreportcard.com/report/github.com/attune-io/attune)
+[![Coverage](https://img.shields.io/badge/coverage-90%25%2B-brightgreen)](https://github.com/attune-io/attune/blob/main/docs/contributing/testing.md)
 [![Release](https://img.shields.io/github/v/release/attune-io/attune?logo=github&color=green)](https://github.com/attune-io/attune/releases/latest)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/attune-io/attune?logo=go)](go.mod)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)


### PR DESCRIPTION
## Summary

- Remove the Go Report Card badge (service sunset; badge shows "retired").
- Add a coverage badge: **90%+** (measured ~92.7% on `./internal/...`; CI fails below 80%).
- Link the badge to [docs/contributing/testing.md](docs/contributing/testing.md).

## Why 90%+ instead of an exact percent

A floor badge avoids README churn when coverage moves within the 90s. CI remains the enforcement gate.

## Test plan

- [x] Confirmed local `go tool cover -func` total for `./internal/...` is 92.7%
- [x] Confirmed CI unit job logs report the same total coverage class
- [ ] README renders correctly on GitHub after merge