### PR TITLE
docs: document OpenShift catalog package name and OCP 4.19+

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ helm install attune oci://ghcr.io/attune-io/charts/attune \
 ```
 
 Also available via [OperatorHub.io](https://operatorhub.io/operator/attune)
-(OLM) and raw manifests. See the
+(OLM package **`attune`**) and on OpenShift 4.19+ in the built-in OperatorHub
+Community catalog under the same name. Raw manifests are published with each
+release. See the
 [Installation Guide](https://attune-io.github.io/attune/getting-started/installation/)
+and [OpenShift guide](https://attune-io.github.io/attune/guides/openshift/)
 for all options.
 
 ### Create a Policy

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -67,12 +67,19 @@ If your cluster has the [Operator Lifecycle Manager](https://olm.operatorframewo
 installed, you can install Attune directly from
 [OperatorHub.io](https://operatorhub.io/operator/attune).
 
-**On OpenShift**, the operator is available in the built-in OperatorHub catalog.
-Search for "Attune" in the web console under **Operators > OperatorHub** and
-click Install. You can also browse the listing on the
+**On OpenShift 4.19+**, the operator is in the built-in OperatorHub
+**Community** catalog under package name **`attune`** (display name
+**Attune**; CSV names look like `attune.v0.1.16`). Search for "Attune"
+in the web console under **Operators > OperatorHub**, or verify with:
+
+```bash
+oc get packagemanifests -n openshift-marketplace attune
+```
+
+You can also browse the
 [Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/search?target_platforms=Operator&q=attune).
-See the [OpenShift guide](../guides/openshift.md) for TLS profile integration
-and OpenShift-specific configuration.
+See the [OpenShift guide](../guides/openshift.md) for catalog details,
+TLS profile integration, and OpenShift-specific configuration.
 
 **On other clusters with OLM**, install the operator by creating a
 `Subscription`:

--- a/docs/guides/openshift.md
+++ b/docs/guides/openshift.md
@@ -8,14 +8,37 @@ security considerations.
 
 ### Via OperatorHub (recommended for OpenShift)
 
-OpenShift includes a built-in OperatorHub catalog. Search for "Attune"
-in the web console under **Operators > OperatorHub** and click Install.
-The OLM bundle includes all CRDs, RBAC, and the operator deployment.
+OpenShift includes a built-in OperatorHub catalog. Search for **Attune**
+(OLM package name **`attune`**) in the web console under
+**Operators > OperatorHub** and click Install. The OLM bundle includes
+all CRDs, RBAC, and the operator deployment.
+
+| Field | Value |
+|---|---|
+| **Display name** | Attune |
+| **Package name** | `attune` |
+| **CSV name** | `attune.vX.Y.Z` (for example `attune.v0.1.16`) |
+| **Channel** | `stable` |
+| **Catalog** | Community Operators (`community-operator-index`) |
+| **OpenShift versions** | **4.19+** (Attune requires Kubernetes 1.32+) |
+
+CLI check on an OpenShift cluster:
+
+```bash
+oc get packagemanifests -n openshift-marketplace attune
+# or
+oc get packagemanifests -n openshift-marketplace | grep -i attune
+```
 
 You can also browse the listing online:
 
-- [Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/search?target_platforms=Operator&q=attune) (OpenShift embedded catalog)
-- [OperatorHub.io](https://operatorhub.io/operator/attune) (community catalog for any OLM-enabled cluster)
+- [Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/search?target_platforms=Operator&q=attune) (OpenShift community catalog; package **`attune`**)
+- [OperatorHub.io](https://operatorhub.io/operator/attune) (community catalog for any OLM-enabled cluster; same package name)
+
+!!! note "Catalog filters"
+    In OperatorHub filters, select the **Community** source if the list
+    is large. Do not search for `attune-operator`; that is not the
+    package or CSV name used in the catalog.
 
 ### Via Helm
 


### PR DESCRIPTION
## Summary

After investigating #295, Attune is already in the OpenShift community catalog. Docs already claimed that, but they did not spell out **how to find it**.

Updates:

- **Package name:** `attune` (display name Attune; CSV `attune.vX.Y.Z`)
- **OpenShift versions:** 4.19+ (matches K8s 1.32+ requirement)
- **Where to look:** OperatorHub Community source; `oc get packagemanifests … attune`
- **Avoid:** searching for `attune-operator` (wrong CSV/package name that caused the false Pyxis miss)

Files: `docs/guides/openshift.md`, `docs/getting-started/installation.md`, `README.md`.

## Test plan

- [x] Re-read updated sections for accuracy against Pyxis (`csv_name==attune.v0.1.16`)
- [ ] Docs site / MkDocs renders the note admonition

Ref #295