### PR TITLE
docs: drop broken catalog.redhat.com Operator search link

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -76,10 +76,12 @@ in the web console under **Operators > OperatorHub**, or verify with:
 oc get packagemanifests -n openshift-marketplace attune
 ```
 
-You can also browse the
-[Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/search?target_platforms=Operator&q=attune).
-See the [OpenShift guide](../guides/openshift.md) for catalog details,
-TLS profile integration, and OpenShift-specific configuration.
+For a public web listing of the same package, use
+[OperatorHub.io/operator/attune](https://operatorhub.io/operator/attune)
+(the Red Hat Ecosystem Catalog website search does not reliably list
+community operators). See the [OpenShift guide](../guides/openshift.md)
+for catalog details, TLS profile integration, and OpenShift-specific
+configuration.
 
 **On other clusters with OLM**, install the operator by creating a
 `Subscription`:

--- a/docs/guides/openshift.md
+++ b/docs/guides/openshift.md
@@ -30,10 +30,18 @@ oc get packagemanifests -n openshift-marketplace attune
 oc get packagemanifests -n openshift-marketplace | grep -i attune
 ```
 
-You can also browse the listing online:
+**Where to find it in a browser:** use
+[OperatorHub.io/operator/attune](https://operatorhub.io/operator/attune)
+(same package name **`attune`**). That site is the public web listing for
+the community OLM package.
 
-- [Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/search?target_platforms=Operator&q=attune) (OpenShift community catalog; package **`attune`**)
-- [OperatorHub.io](https://operatorhub.io/operator/attune) (community catalog for any OLM-enabled cluster; same package name)
+!!! note "Red Hat Ecosystem Catalog website"
+    `catalog.redhat.com` search URLs do **not** reliably surface community
+    operators (and some query links drop the search terms on redirect).
+    The OpenShift **in-cluster** Community Operators catalog is the source
+    of truth for installability on OpenShift, not the public website product
+    search. Prefer OperatorHub.io for browsing, or the console / CLI checks
+    above for a live cluster.
 
 !!! note "Catalog filters"
     In OperatorHub filters, select the **Community** source if the list


### PR DESCRIPTION
## Summary

The link we used for the \"Red Hat Ecosystem Catalog\" listing:

`https://catalog.redhat.com/software/search?target_platforms=Operator&q=attune`

does not work in a browser. It **301 redirects to a generic software search** and **drops the query string**, so the page never searches for Attune.

Community operators (package **\`attune\`**) are published into the **in-cluster** OpenShift Community Operators index. They are not reliably listed as products on the public \`catalog.redhat.com\` website (that site mainly surfaces certified products).

### Doc changes

- Remove the broken catalog.redhat.com search link from the OpenShift guide and installation guide.
- Point public browsing at [OperatorHub.io/operator/attune](https://operatorhub.io/operator/attune).
- Keep in-cluster guidance (console search for **Attune** / package **\`attune\`**, \`oc get packagemanifests\`).
- Add a short note explaining why the Red Hat website search is not the right check.

## Test plan

- [x] Confirmed old URL redirects and drops \`q=attune\` (\`curl -D -\`)
- [x] No remaining \`catalog.redhat.com\` links under \`docs/\` or \`README.md\`
- [ ] Spot-check rendered MkDocs pages after merge

Ref #295