### PR TITLE
fix: verify operator image inside k3d node after import

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -460,6 +460,29 @@ jobs:
             --tarball=/tmp/attune-e2e.tar --push=false
           k3d image import /tmp/attune-e2e.tar -c "$CLUSTER_NAME"
 
+      - name: Verify operator image inside cluster
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          # k3d image import can report success while the underlying ctr
+          # import fails silently (known issue). Verify the image is
+          # actually available inside the node and retry if not.
+          for attempt in 1 2 3; do
+            if docker exec "k3d-${CLUSTER_NAME}-server-0" \
+              crictl images --output json 2>/dev/null \
+              | jq -e '.images[].repoTags[] | select(test("attune.*e2e"))' >/dev/null 2>&1; then
+              echo "Image attune:e2e verified inside cluster"
+              break
+            fi
+            echo "::warning::attune:e2e not found inside cluster (attempt $attempt), re-importing..."
+            sleep 5
+            k3d image import /tmp/attune-e2e.tar -c "$CLUSTER_NAME"
+            if (( attempt == 3 )); then
+              echo "::error::attune:e2e image not available after 3 import attempts"
+              docker exec "k3d-${CLUSTER_NAME}-server-0" crictl images || true
+              exit 1
+            fi
+          done
+
       - name: Install operator via Helm
         shell: bash -Eeuo pipefail -x {0}
         run: |


### PR DESCRIPTION
## Summary

`k3d image import` can report `Successfully imported 1 image(s)` while the underlying `ctr` import inside the node fails silently. This caused the nightly E2E run to waste 3 minutes on a Helm install timeout before failing with `ErrImageNeverPull`.

## Changes

Adds a new step **"Verify operator image inside cluster"** between the ko build/import step and the Helm install step in the nightly workflow. The step:

1. Checks whether `attune:e2e` is available inside the k3d node via `crictl images`
2. If missing, re-imports the tarball and retries (up to 3 attempts)
3. Dumps `crictl images` on final failure for diagnostics

## Impact

- Successful runs: ~2s overhead (one `crictl images` call)
- Failed imports: catches the problem immediately instead of waiting 3 min for Helm timeout
- Nightly-only; no changes to the main CI workflow

## Evidence

Run [29141630624](https://github.com/attune-io/attune/actions/runs/29141630624): K8s v1.33 and v1.34 failed with `ErrImageNeverPull` despite `k3d image import` reporting success. K8s v1.32 and v1.35 passed. The failure is not version-specific (Jul 7 nightly failed on v1.32 with a different k3d race).

Closes #377