### PR TITLE
fix: bump Go to 1.26.5 for CVE-2026-39822 and GO-2026-5856

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # BuildKit features (--platform, --mount) are supported natively since Docker 20.10.
 # No # syntax directive needed; it triggers a registry pull that fails on macOS
 # self-hosted runners where the keychain is locked in headless sessions.
-FROM --platform=$BUILDPLATFORM golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5@sha256:079e59808d2d252516e27e3f3a9c003740dee7f75e55aa71528766d52bcfc16a AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/attune-io/attune
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1


### PR DESCRIPTION
## Summary

Bumps Go from 1.26.4 to 1.26.5 to fix two stdlib vulnerabilities that break the Security workflow on main.

## Vulnerabilities fixed

| ID | Severity | Component | Description | Detected by |
|---|---|---|---|---|
| CVE-2026-39822 | HIGH | `os.Root` | Symlink following vulnerability | Trivy Image Scan |
| GO-2026-5856 | HIGH | `crypto/tls` | Encrypted Client Hello privacy leak | Govulncheck |

## Changes

- `go.mod`: `go 1.26.4` to `go 1.26.5`

## Verification

- `make build`: passes
- `make test`: 1678 tests pass, 92.8% coverage