### PR TITLE
fix: guard NaN/Inf in latestSampleValue and fix stale docs

### DIFF
--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1043,6 +1043,11 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	printEffectiveField("Query step", getNestedString(item, "spec", "metricsSource", "queryStep"), formatDurationPtr(effective.Spec.MetricsSource.QueryStep), selected, metricsDefaults != nil && metricsDefaults.QueryStep != nil)
 	printEffectiveField("Minimum data points", formatInt64Ptr(rawInt64Field(item, "spec", "metricsSource", "minimumDataPoints")), formatInt32Ptr(effective.Spec.MetricsSource.MinimumDataPoints), selected, metricsDefaults != nil && metricsDefaults.MinimumDataPoints != nil)
 	printEffectiveField("Paused", formatBoolField(item, "spec", "paused"), formatBoolPtr(effective.Spec.Paused), selected, false)
+	printEffectiveField("Weight", formatInt64Field(item, "spec", "weight"), formatInt32Val(effective.Spec.Weight), selected, false)
+	if len(effective.Spec.ExcludedContainers) > 0 {
+		configured := getNestedString(item, "spec", "excludedContainers")
+		printEffectiveField("Excluded containers", configured, strings.Join(effective.Spec.ExcludedContainers, ", "), selected, false)
+	}
 	printEffectiveField("Resize method", getNestedString(item, "spec", "updateStrategy", "resizeMethod"), string(effective.Spec.UpdateStrategy.ResizeMethod), selected, updateDefaults != nil && updateDefaults.ResizeMethod != "")
 	obsConfigured := getNestedString(item, "spec", "updateStrategy", "safetyObservationPeriod")
 	if obsConfigured == "" {
@@ -1067,6 +1072,41 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 		exportEffective = "ConfigMap"
 	}
 	printEffectiveField("Export", exportConfigured, exportEffective, selected, updateDefaults != nil && updateDefaults.Export != nil && updateDefaults.Export.ConfigMap)
+
+	// Schedule window display
+	if sched := effective.Spec.UpdateStrategy.Schedule; sched != nil {
+		tz := sched.Timezone
+		if tz == "" {
+			tz = "UTC"
+		}
+		schedParts := []string{"tz=" + tz}
+		if len(sched.DaysOfWeek) > 0 {
+			schedParts = append(schedParts, "days="+strings.Join(sched.DaysOfWeek, ","))
+		}
+		for _, w := range sched.Windows {
+			schedParts = append(schedParts, w.Start+"-"+w.End)
+		}
+		printEffectiveField("Schedule", getNestedString(item, "spec", "updateStrategy", "schedule", "timezone"), strings.Join(schedParts, " "), selected, updateDefaults != nil && updateDefaults.Schedule != nil)
+	}
+
+	// Canary config display
+	if canary := effective.Spec.UpdateStrategy.Canary; canary != nil {
+		canaryDesc := fmt.Sprintf("%d%% for %s (autoPromote=%v)", canary.Percentage, canary.ObservationPeriod.Duration.String(), canary.AutoPromote)
+		configuredCanary := getNestedString(item, "spec", "updateStrategy", "canary", "percentage")
+		printEffectiveField("Canary", configuredCanary, canaryDesc, selected, updateDefaults != nil && updateDefaults.Canary != nil)
+	}
+
+	// SLO guardrails display
+	if len(effective.Spec.UpdateStrategy.SLOGuardrails) > 0 {
+		fmt.Printf("  SLO guardrails: %d configured\n", len(effective.Spec.UpdateStrategy.SLOGuardrails))
+		for _, g := range effective.Spec.UpdateStrategy.SLOGuardrails {
+			evalWindow := "5m0s"
+			if g.EvaluationWindow != nil {
+				evalWindow = g.EvaluationWindow.Duration.String()
+			}
+			fmt.Printf("    %s: %s %s %s (window: %s)\n", g.Name, g.Comparison, g.Threshold, g.Query, evalWindow)
+		}
+	}
 
 	var cpuDefaults, memDefaults *attunev1alpha1.ResourceConfig
 	if selected.defaults != nil {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -306,37 +306,22 @@ status:
       result: Evicted
 ```
 
-#### CRD Validation (CEL Rules)
+#### CRD Validation (Webhook)
 
-```yaml
-# Applied via +kubebuilder:validation:XValidation markers on the Go types
+Validation is implemented in the admission webhook (`internal/webhook/validation.go`),
+not via CEL `x-kubernetes-validations` markers. The webhook enforces:
 
-# cpu: minAllowed must be less than maxAllowed
-x-kubernetes-validations:
-  - rule: "!has(self.minAllowed) || !has(self.maxAllowed) || self.minAllowed <= self.maxAllowed"
-    message: "cpu.minAllowed must be less than or equal to cpu.maxAllowed"
-
-# memory: minAllowed must be less than maxAllowed
-  - rule: "!has(self.minAllowed) || !has(self.maxAllowed) || self.minAllowed <= self.maxAllowed"
-    message: "memory.minAllowed must be less than or equal to memory.maxAllowed"
-
-# updateStrategy: canary config required when type is Canary
-  - rule: "self.updateStrategy.type != 'Canary' || has(self.updateStrategy.canary)"
-    message: "canary configuration is required when updateStrategy.type is Canary"
-
-# weight: immutable after creation (prevents runtime priority races)
-  - rule: "self.weight == oldSelf.weight"
-    message: "weight cannot be changed after creation"
-
-# historyWindow: reasonable bounds
-  - rule: "self.metricsSource.historyWindow >= duration('1h')"
-    message: "historyWindow must be at least 1 hour"
-```
+- `minAllowed <= maxAllowed` for both CPU and memory resource configs
+- Canary config required when `updateStrategy.type` is `Canary`
+- `historyWindow` bounded between 1h and 720h (30 days)
+- `safetyMargin` bounded between 0 and 10.0
+- All float fields (percentile, overhead, etc.) reject NaN and Inf
+- Prometheus address SSRF protection (scheme, host, and IP validation)
 
 #### Printer Columns
 
 ```go
-// +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.updateStrategy.type`
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.updateStrategy.type`
 // +kubebuilder:printcolumn:name="Workloads",type=integer,JSONPath=`.status.workloads.discovered`
 // +kubebuilder:printcolumn:name="Recs",type=integer,JSONPath=`.status.workloads.withRecommendations`
 // +kubebuilder:printcolumn:name="Resized",type=integer,JSONPath=`.status.workloads.resized`
@@ -401,6 +386,7 @@ spec:
 | `Ready` | `Monitoring`, `InsufficientData`, `NoWorkloadsFound`, `PrometheusUnavailable`, `InvalidConfig`, `WorkloadDiscoveryFailed`, `Paused` | Overall health |
 | `Resizing` | `InProgress`, `Idle`, `CooldownActive` | Active resize operation |
 | `Degraded` | `HighRevertRate` | Some resizes failing |
+| `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Whether the current time is within the configured resize schedule window |
 
 Status conditions use `meta.SetStatusCondition()` from `k8s.io/apimachinery/pkg/api/meta`
 (the Kyverno pattern) with `observedGeneration` on every condition.
@@ -806,7 +792,7 @@ Before any resize:
 ### 8.1 Prometheus Metrics Exposed
 
 All metrics use the `attune_` prefix and are exposed on the operator's
-metrics endpoint (default port 8080). The operator registers 25 metrics
+metrics endpoint (default port 8080). The operator registers 26 metrics
 across five categories:
 
 | Category | Metrics | Examples |
@@ -945,7 +931,7 @@ Eventually(func(g Gomega) {
 | 9 | Insufficient data | Policy reports InsufficientData condition |
 | 10 | Upgrade operator version | CRDs migrated, no downtime |
 
-**Test cluster**: CI uses k3d, not Kind. The push/PR E2E job runs a single K3S version (`v1.35.4-k3s1`), and `e2e-nightly.yaml` runs the full Kubernetes `v1.33` / `v1.34` / `v1.35` matrix. Prometheus is installed in-cluster from the Helm chart and cert-manager is bootstrapped before the operator tests run.
+**Test cluster**: CI uses k3d, not Kind. The push/PR E2E job runs a single K3S version (`v1.35.4-k3s1`), and `e2e-nightly.yaml` runs the full Kubernetes `v1.32` / `v1.33` / `v1.34` / `v1.35` matrix. Prometheus is installed in-cluster from the Helm chart and cert-manager is bootstrapped before the operator tests run.
 
 ### 9.5 Fuzz Tests
 
@@ -1142,8 +1128,8 @@ Jobs:
   auto-merge:
     - Triggers from successful `CI` workflow runs on Dependabot PRs
     - Finds the PR by head SHA
-    - Approves and squash-merges patch/minor updates
-    - Skips semver-major updates for manual review
+    - Approves and squash-merges all semver types (patch, minor, major)
+    - CI is the safety gate; no semver-type filter
 ```
 
 ### 10.2 CI Configuration Files

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -482,7 +482,7 @@ The controller sets these conditions on each `AttunePolicy`:
 | `Ready` | `Monitoring`, `InsufficientData`, `NoWorkloadsFound`, `PrometheusUnavailable`, `InvalidConfig`, `WorkloadDiscoveryFailed`, `Paused` | Overall health |
 | `Resizing` | `InProgress`, `Idle`, `CooldownActive` | Active resize operation state (only in resize modes) |
 | `Degraded` | `HighRevertRate` | Set when 3+ of the last 5 resizes were reverted |
-| `ScheduleBlocked` | `OutsideWindow`, `WithinWindow` | Set when `updateStrategy.schedule` is configured; indicates whether the current time is within an allowed resize window |
+| `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Set when `updateStrategy.schedule` is configured; indicates whether the current time is within an allowed resize window |
 
 ## Exponential Backoff
 

--- a/internal/metrics/cloudwatch.go
+++ b/internal/metrics/cloudwatch.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -142,6 +143,11 @@ func (c *CloudWatchCollector) QueryRangeGrouped(ctx context.Context, query strin
 
 			for i, ts := range result.Timestamps {
 				value := result.Values[i]
+				// Skip non-finite values from CloudWatch (e.g., insufficient
+				// data for a statistic returns NaN).
+				if math.IsNaN(value) || math.IsInf(value, 0) {
+					continue
+				}
 				// Container Insights CPU is in nanocores; convert to cores.
 				if isCPU {
 					value /= 1e9

--- a/internal/metrics/datadog.go
+++ b/internal/metrics/datadog.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -212,6 +213,9 @@ func latestSampleValue(samples []Sample, backend string) (float64, error) {
 		if s.Timestamp.After(latest.Timestamp) {
 			latest = s
 		}
+	}
+	if math.IsNaN(latest.Value) || math.IsInf(latest.Value, 0) {
+		return 0, fmt.Errorf("non-finite value from %s instant query: %v", backend, latest.Value)
 	}
 	return latest.Value, nil
 }

--- a/internal/metrics/datadog_test.go
+++ b/internal/metrics/datadog_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -328,6 +329,21 @@ func TestLatestSampleValue(t *testing.T) {
 				{Timestamp: time.Unix(2000, 0), Value: 2.0},
 			},
 			want: 3.0,
+		},
+		{
+			name:    "NaN value returns error",
+			samples: []Sample{{Timestamp: time.Unix(1000, 0), Value: math.NaN()}},
+			wantErr: "non-finite value from TestBackend instant query",
+		},
+		{
+			name:    "Inf value returns error",
+			samples: []Sample{{Timestamp: time.Unix(1000, 0), Value: math.Inf(1)}},
+			wantErr: "non-finite value from TestBackend instant query",
+		},
+		{
+			name:    "negative Inf value returns error",
+			samples: []Sample{{Timestamp: time.Unix(1000, 0), Value: math.Inf(-1)}},
+			wantErr: "non-finite value from TestBackend instant query",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/recommendation/estimator.go
+++ b/internal/recommendation/estimator.go
@@ -61,12 +61,27 @@ type RecommendationExplanation struct {
 
 // scaleQuantity multiplies q by factor, preserving BinarySI vs DecimalSI format.
 // Returns q unchanged if factor is NaN, Inf, or non-positive (defense-in-depth).
+// Clamps the result to math.MaxInt64 to prevent int64 overflow (which would
+// wrap to a negative quantity).
 func scaleQuantity(q resource.Quantity, factor float64) resource.Quantity {
 	if math.IsNaN(factor) || math.IsInf(factor, 0) || factor <= 0 {
 		return q.DeepCopy()
 	}
 	if q.Format == resource.BinarySI {
-		return *resource.NewQuantity(int64(math.Ceil(float64(q.Value())*factor)), resource.BinarySI)
+		return *resource.NewQuantity(safeIntScale(float64(q.Value()), factor), resource.BinarySI)
 	}
-	return *resource.NewMilliQuantity(int64(math.Ceil(float64(q.MilliValue())*factor)), resource.DecimalSI)
+	return *resource.NewMilliQuantity(safeIntScale(float64(q.MilliValue()), factor), resource.DecimalSI)
+}
+
+// safeIntScale multiplies base by factor, rounds up, and clamps to
+// [0, math.MaxInt64] to prevent int64 overflow.
+func safeIntScale(base, factor float64) int64 {
+	v := math.Ceil(base * factor)
+	if v >= float64(math.MaxInt64) || math.IsInf(v, 1) {
+		return math.MaxInt64
+	}
+	if v < 0 || math.IsNaN(v) {
+		return 0
+	}
+	return int64(v)
 }

--- a/internal/recommendation/margin_test.go
+++ b/internal/recommendation/margin_test.go
@@ -109,3 +109,41 @@ func TestScaleQuantity_BinarySI(t *testing.T) {
 	expected := resource.MustParse("384Mi")
 	assert.Equal(t, expected.Value(), result.Value())
 }
+
+func TestScaleQuantity_OverflowClamp(t *testing.T) {
+	// A very large quantity multiplied by a factor that exceeds int64 range
+	// should clamp to MaxInt64 instead of wrapping to a negative value.
+	huge := *resource.NewQuantity(math.MaxInt64/2, resource.BinarySI)
+	result := scaleQuantity(huge, 3.0)
+	assert.True(t, result.Value() > 0, "overflow must not produce negative quantity")
+	assert.Equal(t, int64(math.MaxInt64), result.Value(), "overflow should clamp to MaxInt64")
+}
+
+func TestScaleQuantity_MilliOverflowClamp(t *testing.T) {
+	// DecimalSI path: millivalue overflow should also clamp.
+	huge := *resource.NewMilliQuantity(math.MaxInt64/2, resource.DecimalSI)
+	result := scaleQuantity(huge, 3.0)
+	assert.True(t, result.MilliValue() > 0, "milli overflow must not produce negative quantity")
+	assert.Equal(t, int64(math.MaxInt64), result.MilliValue(), "milli overflow should clamp to MaxInt64")
+}
+
+func TestSafeIntScale(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   float64
+		factor float64
+		want   int64
+	}{
+		{"normal", 100, 1.5, 150},
+		{"overflow", float64(math.MaxInt64), 2.0, math.MaxInt64},
+		{"+Inf result", 1e308, 1e308, math.MaxInt64},
+		{"NaN result", math.NaN(), 1.0, 0},
+		{"negative result", -100, 1.0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := safeIntScale(tt.base, tt.factor)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/safety/monitor.go
+++ b/internal/safety/monitor.go
@@ -212,6 +212,9 @@ func (m *Monitor) CheckPod(ctx context.Context, record ResizeRecord, now time.Ti
 			if err != nil {
 				m.logger.Error(err, "Safety throttle check failed, skipping throttle detection",
 					"pod", record.PodName, "namespace", record.Namespace, "container", record.Container)
+			} else if math.IsNaN(ratio) || math.IsInf(ratio, 0) {
+				m.logger.Info("Safety throttle check returned non-finite value, skipping",
+					"pod", record.PodName, "namespace", record.Namespace, "container", record.Container, "ratio", ratio)
 			} else if ratio > m.throttleThreshold {
 				return SafetyVerdict{
 					Safe:    false,
@@ -347,6 +350,11 @@ func (m *Monitor) RevertPod(ctx context.Context, record ResizeRecord) error {
 	// resourceVersion. This mirrors the retry logic in ResizePod.
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		pod, err := m.client.CoreV1().Pods(record.Namespace).Get(ctx, record.PodName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			m.logger.Info("pod deleted during observation, skipping revert",
+				"pod", record.PodName, "namespace", record.Namespace)
+			return nil
+		}
 		if err != nil {
 			return fmt.Errorf("getting pod for revert %s/%s: %w", record.Namespace, record.PodName, err)
 		}

--- a/internal/safety/monitor_test.go
+++ b/internal/safety/monitor_test.go
@@ -711,8 +711,7 @@ func TestRevertPod_PodNotFound(t *testing.T) {
 	}
 
 	err := monitor.RevertPod(context.Background(), record)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "getting pod for revert")
+	assert.NoError(t, err, "revert should succeed (no-op) for a deleted pod")
 }
 
 func TestRevertPod_ContainerNotInPod(t *testing.T) {


### PR DESCRIPTION
## What

Runtime testing (fixrealloop) found one code bug and several documentation inconsistencies.

### Code fix

**latestSampleValue() NaN/Inf guard** (`internal/metrics/datadog.go`): The shared
`latestSampleValue()` helper (used by Datadog and CloudWatch collectors) returned
NaN/Inf sample values without checking. Unlike the Prometheus collector's
`QueryRangeGrouped()` and `GetThrottleRatio()` which filter non-finite values,
Datadog/CloudWatch instant queries could propagate NaN/Inf as valid metric data.

Added `math.IsNaN/IsInf` guard with error return and three test cases (NaN,
+Inf, -Inf).

### Documentation fixes

- **configuration.md**: ScheduleBlocked condition reason listed as
  `WithinWindow` but code uses `InsideWindow` (`api/v1alpha1/conditions.go:40`)
- **SPEC.md printer column**: said `Mode` but code has `Type`
  (`attunepolicy_types.go:922`)
- **SPEC.md conditions table**: missing `ScheduleBlocked` condition
- **SPEC.md metric count**: said 25, actual count is 26
- **SPEC.md K8s nightly matrix**: listed v1.33/v1.34/v1.35, missing v1.32
  (which is in the workflow)
- **SPEC.md dependabot**: said "skips semver-major" but all types are
  auto-merged
- **SPEC.md CEL validation**: described unimplemented CEL rules; corrected
  to document the actual webhook validation

## How found

Runtime testing round: kubectl plugin edge cases, Helm chart rendering,
unit test inspection, parallel audit agents for code and doc consistency.