### PR TITLE
fix: helm defaults template nil guard and schema validation gaps

### DIFF
--- a/charts/attune/templates/defaults.yaml
+++ b/charts/attune/templates/defaults.yaml
@@ -22,19 +22,20 @@ spec:
   costPricing:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.defaults.updateStrategy }}
   updateStrategy:
-    type: {{ .Values.defaults.updateStrategy.type | default "Recommend" }}
-    {{- if .Values.defaults.updateStrategy.cooldown }}
-    cooldown: {{ .Values.defaults.updateStrategy.cooldown }}
+    type: {{ .type | default "Recommend" }}
+    {{- if .cooldown }}
+    cooldown: {{ .cooldown }}
     {{- end }}
-    {{- if kindIs "bool" .Values.defaults.updateStrategy.autoRevert }}
-    autoRevert: {{ .Values.defaults.updateStrategy.autoRevert }}
+    {{- if kindIs "bool" .autoRevert }}
+    autoRevert: {{ .autoRevert }}
     {{- else }}
     autoRevert: true
     {{- end }}
-    resizeMethod: {{ .Values.defaults.updateStrategy.resizeMethod | default "InPlaceOnly" }}
-    maxConcurrentResizes: {{ .Values.defaults.updateStrategy.maxConcurrentResizes | default 1 }}
-    {{- with .Values.defaults.updateStrategy.schedule }}
+    resizeMethod: {{ .resizeMethod | default "InPlaceOnly" }}
+    maxConcurrentResizes: {{ .maxConcurrentResizes | default 1 }}
+    {{- with .schedule }}
     schedule:
       {{- with .windows }}
       windows:
@@ -48,28 +49,29 @@ spec:
       timezone: {{ . }}
       {{- end }}
     {{- end }}
-    {{- with .Values.defaults.updateStrategy.maxTotalCpuIncrease }}
+    {{- with .maxTotalCpuIncrease }}
     maxTotalCpuIncrease: {{ . }}
     {{- end }}
-    {{- with .Values.defaults.updateStrategy.maxTotalMemoryIncrease }}
+    {{- with .maxTotalMemoryIncrease }}
     maxTotalMemoryIncrease: {{ . }}
     {{- end }}
-    {{- with .Values.defaults.updateStrategy.safetyObservationPeriod }}
+    {{- with .safetyObservationPeriod }}
     safetyObservationPeriod: {{ . }}
     {{- end }}
-    {{- with .Values.defaults.updateStrategy.canary }}
+    {{- with .canary }}
     canary:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.defaults.updateStrategy.export }}
+    {{- with .export }}
     export:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if kindIs "bool" .Values.defaults.updateStrategy.initialSizing }}
-    initialSizing: {{ .Values.defaults.updateStrategy.initialSizing }}
+    {{- if kindIs "bool" .initialSizing }}
+    initialSizing: {{ .initialSizing }}
     {{- end }}
-    {{- with .Values.defaults.updateStrategy.sloGuardrails }}
+    {{- with .sloGuardrails }}
     sloGuardrails:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/attune/values.schema.json
+++ b/charts/attune/values.schema.json
@@ -186,7 +186,7 @@
                     "enabled": { "type": "boolean", "default": true },
                     "threshold": { "type": "string", "default": "0" },
                     "for": { "type": "string", "default": "10m" },
-                    "severity": { "type": "string", "default": "warning" }
+                    "severity": { "type": "string", "default": "warning", "enum": ["critical", "warning", "info"] }
                   }
                 },
                 "prometheusUnreachable": {
@@ -195,7 +195,7 @@
                   "properties": {
                     "enabled": { "type": "boolean", "default": true },
                     "for": { "type": "string", "default": "10m" },
-                    "severity": { "type": "string", "default": "warning" }
+                    "severity": { "type": "string", "default": "warning", "enum": ["critical", "warning", "info"] }
                   }
                 },
                 "degraded": {
@@ -204,7 +204,7 @@
                   "properties": {
                     "enabled": { "type": "boolean", "default": true },
                     "for": { "type": "string", "default": "5m" },
-                    "severity": { "type": "string", "default": "critical" }
+                    "severity": { "type": "string", "default": "critical", "enum": ["critical", "warning", "info"] }
                   }
                 },
                 "highRevertRate": {
@@ -214,7 +214,7 @@
                     "enabled": { "type": "boolean", "default": true },
                     "threshold": { "type": "string", "default": "0.5" },
                     "for": { "type": "string", "default": "15m" },
-                    "severity": { "type": "string", "default": "critical" }
+                    "severity": { "type": "string", "default": "critical", "enum": ["critical", "warning", "info"] }
                   }
                 },
                 "reconcileStale": {
@@ -224,7 +224,7 @@
                     "enabled": { "type": "boolean", "default": true },
                     "staleDuration": { "type": "string", "default": "30m" },
                     "for": { "type": "string", "default": "5m" },
-                    "severity": { "type": "string", "default": "warning" }
+                    "severity": { "type": "string", "default": "warning", "enum": ["critical", "warning", "info"] }
                   }
                 },
                 "budgetExhausted": {
@@ -233,7 +233,7 @@
                   "properties": {
                     "enabled": { "type": "boolean", "default": true },
                     "for": { "type": "string", "default": "30m" },
-                    "severity": { "type": "string", "default": "warning" }
+                    "severity": { "type": "string", "default": "warning", "enum": ["critical", "warning", "info"] }
                   }
                 },
                 "dataQuality": {
@@ -242,7 +242,7 @@
                   "properties": {
                     "enabled": { "type": "boolean", "default": true },
                     "for": { "type": "string", "default": "30m" },
-                    "severity": { "type": "string", "default": "warning" }
+                    "severity": { "type": "string", "default": "warning", "enum": ["critical", "warning", "info"] }
                   }
                 },
                 "requestsClamped": {
@@ -251,7 +251,7 @@
                   "properties": {
                     "enabled": { "type": "boolean", "default": true },
                     "for": { "type": "string", "default": "1h" },
-                    "severity": { "type": "string", "default": "info" }
+                    "severity": { "type": "string", "default": "info", "enum": ["critical", "warning", "info"] }
                   }
                 },
                 "staleRecommendations": {
@@ -260,7 +260,7 @@
                   "properties": {
                     "enabled": { "type": "boolean", "default": true },
                     "for": { "type": "string", "default": "1h" },
-                    "severity": { "type": "string", "default": "warning" }
+                    "severity": { "type": "string", "default": "warning", "enum": ["critical", "warning", "info"] }
                   }
                 },
                 "revertFailures": {
@@ -269,7 +269,7 @@
                   "properties": {
                     "enabled": { "type": "boolean", "default": true },
                     "for": { "type": "string", "default": "5m" },
-                    "severity": { "type": "string", "default": "critical" }
+                    "severity": { "type": "string", "default": "critical", "enum": ["critical", "warning", "info"] }
                   }
                 }
               }
@@ -465,9 +465,11 @@
             "canary": {
               "type": "object",
               "description": "Canary rollout configuration",
+              "additionalProperties": false,
               "properties": {
                 "percentage": { "type": "integer", "minimum": 1, "maximum": 100 },
-                "observationPeriod": { "type": "string" }
+                "observationPeriod": { "type": "string" },
+                "autoPromote": { "type": "boolean" }
               }
             },
             "export": {
@@ -491,11 +493,14 @@
               "description": "Application-level SLO metrics to check after resize",
               "items": {
                 "type": "object",
+                "required": ["name", "query", "threshold"],
+                "additionalProperties": false,
                 "properties": {
                   "name": { "type": "string", "description": "Guardrail name for logging and status" },
                   "query": { "type": "string", "description": "PromQL query returning a scalar value" },
                   "threshold": { "type": "string", "description": "Value that triggers a revert" },
-                  "comparison": { "type": "string", "enum": ["above", "below"], "description": "Revert when value is above or below threshold" }
+                  "comparison": { "type": "string", "enum": ["above", "below"], "description": "Revert when value is above or below threshold" },
+                  "evaluationWindow": { "type": "string", "description": "How long after resize to check (default: 5m)" }
                 }
               }
             }


### PR DESCRIPTION
## Summary

Fixes a template rendering bug and tightens Helm chart JSON schema validation, found during runtime audit Round 4.

## Changes

### Bug fix
- **defaults.yaml**: Wrap the `updateStrategy` block in `{{- with }}` to prevent nil pointer dereference when `defaults.enabled=true` with `updateStrategy: null`. Previously, setting `defaults.enabled: true` without an `updateStrategy` block would crash `helm template`.

### Schema validation improvements
- **Severity enum**: All 10 PrometheusRule alert severity fields now enforce `enum: [critical, warning, info]`. Typos like `severity: cirtical` are caught at install time instead of producing invalid PrometheusRule resources.
- **Canary config**: Added `additionalProperties: false` and `autoPromote` property (matching the CRD type).
- **SLO guardrails**: Added `required: [name, query, threshold]`, `additionalProperties: false`, and `evaluationWindow` property. A guardrail with only `name` but no `query` was previously accepted by the schema.

## Testing
- `make helm-lint` passes (all 4 CI value files)
- `make helm-unittest` passes (100/100 tests)
- Schema correctly rejects invalid severity values
- `make test` passes (1689 tests, 92.7% coverage)
- `make lint` passes (0 issues)