### PR TITLE
fix: cap startup boost at maxAllowed and guard NaN/Inf confidence in export

### DIFF
--- a/internal/controller/export.go
+++ b/internal/controller/export.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -66,7 +67,11 @@ func (r *AttunePolicyReconciler) exportRecommendationConfigMaps(
 			if !c.Recommended.MemoryLimit.IsZero() {
 				data[prefix+"memory-limit"] = c.Recommended.MemoryLimit.String()
 			}
-			data[prefix+"confidence"] = fmt.Sprintf("%.2f", c.Confidence)
+			conf := c.Confidence
+			if math.IsNaN(conf) || math.IsInf(conf, 0) {
+				conf = 0
+			}
+			data[prefix+"confidence"] = fmt.Sprintf("%.2f", conf)
 		}
 		data["last-updated"] = r.now().UTC().Format(time.RFC3339)
 

--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -89,6 +89,11 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 					}
 					boostedMillis := int64(float64(recCPU.MilliValue()) * multiplier)
 					boostedCPU := *resource.NewMilliQuantity(boostedMillis, resource.DecimalSI)
+					// Cap at the policy's maxAllowed to respect admin-configured
+					// ceilings even during temporary boost.
+					if policy.Spec.CPU.MaxAllowed != nil && boostedCPU.Cmp(*policy.Spec.CPU.MaxAllowed) > 0 {
+						boostedCPU = policy.Spec.CPU.MaxAllowed.DeepCopy()
+					}
 					// Cap at the container's CPU limit to avoid requests > limits
 					// rejection from the API server.
 					if cpuLim, hasLim := c.Resources.Limits[corev1.ResourceCPU]; hasLim && boostedCPU.Cmp(cpuLim) > 0 {


### PR DESCRIPTION
## What

Two runtime edge-case fixes found during audit round 5:

1. **Startup boost ignores maxAllowed**: The startup boost multiplier could
   push boosted CPU above `policy.spec.cpu.maxAllowed` when the container's
   CPU limit was higher than the admin-configured ceiling. Now caps at
   `maxAllowed` before capping at the container limit.

2. **NaN/Inf confidence in export ConfigMap**: Non-finite confidence values
   from upstream estimators (e.g., insufficient data, division edge cases)
   would produce literal `NaN` or `+Inf` strings in the export ConfigMap,
   confusing downstream consumers. Now guards with a zero fallback.

## Testing

- All 1689 unit tests pass (92.7% coverage)
- `make lint` clean (0 issues)
- Targeted tests: `TestStartupBoost*` and `TestExport*` pass with `-race`