### PR TITLE
fix: safety revert over-marking, boost annotation conflict, Datadog NaN/Inf, merge logging

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -286,7 +286,7 @@ status:
     memoryRequestReduction: "696Mi"
     estimatedMonthlySavings: "$142.50"  # if costModel is configured
 
-  # Resize history (last 10)
+  # Resize history (last 50)
   resizeHistory:
     - timestamp: "2026-01-15T09:00:00Z"
       workload: api-server
@@ -314,7 +314,7 @@ not via CEL `x-kubernetes-validations` markers. The webhook enforces:
 - `minAllowed <= maxAllowed` for both CPU and memory resource configs
 - Canary config required when `updateStrategy.type` is `Canary`
 - `historyWindow` bounded between 1h and 720h (30 days)
-- `safetyMargin` bounded between 0 and 10.0
+- `burstSensitivity` bounded between 0 and 10.0
 - All float fields (percentile, overhead, etc.) reject NaN and Inf
 - Prometheus address SSRF protection (scheme, host, and IP validation)
 
@@ -536,7 +536,7 @@ Raw Prometheus Data
 ┌──────────────────┐
 │ Confidence       │  Widen recommendation when data is sparse:
 │ Multiplier       │  result *= 1 + multiplier * (1 - confidence) ^ exponent
-│                  │  confidence = min(days_of_data, sqrt(data_points/24))
+│                  │  confidence = clamp(min(days, sqrt(points/24)) / 7, 0, 1)
 │                  │  Factor ranges from 1.0 (7d data) to ~1.8 (4h data)
 └──────┬───────────┘
        │

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -382,9 +382,9 @@ Per-resource fields in `cpu` and `memory` that limit how much a recommendation c
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `maxIncreasePercent` | int32 | `50` | Maximum percentage increase allowed per resize cycle |
-| `maxDecreasePercent` | int32 | `30` | Maximum percentage decrease allowed per resize cycle |
-| `maxChangePercent` | int32 | `50`/`30` | Symmetric change cap (overridden by directional caps if set) |
+| `maxIncreasePercent` | int32 | inherits `maxChangePercent` | Maximum percentage increase allowed per resize cycle. If unset, falls back to `maxChangePercent` (CPU: 50, memory: 30). |
+| `maxDecreasePercent` | int32 | inherits `maxChangePercent` | Maximum percentage decrease allowed per resize cycle. If unset, falls back to `maxChangePercent` (CPU: 50, memory: 30). |
+| `maxChangePercent` | int32 | CPU: `50`, memory: `30` | Symmetric change cap. Used as fallback for `maxIncreasePercent` and `maxDecreasePercent` when they are unset. |
 
 ### Controlled Values
 

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -8403,6 +8403,23 @@ func TestIsWithinResizeWindow_OvernightWindow(t *testing.T) {
 	assert.False(t, isWithinResizeWindow(schedule, time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC)))
 }
 
+func TestIsWithinResizeWindow_OvernightWindowWithDayOfWeek(t *testing.T) {
+	schedule := &attunev1alpha1.ResizeSchedule{
+		Windows:    []attunev1alpha1.TimeWindow{{Start: "22:00", End: "06:00"}},
+		DaysOfWeek: []string{"Wednesday"},
+	}
+	// Wed 23:00: pre-midnight portion, today is Wednesday -> allowed
+	assert.True(t, isWithinResizeWindow(schedule, time.Date(2026, 1, 7, 23, 0, 0, 0, time.UTC)))
+	// Thu 03:00: post-midnight portion, window opened on Wednesday -> allowed
+	assert.True(t, isWithinResizeWindow(schedule, time.Date(2026, 1, 8, 3, 0, 0, 0, time.UTC)))
+	// Thu 23:00: pre-midnight portion, today is Thursday (not in list) -> blocked
+	assert.False(t, isWithinResizeWindow(schedule, time.Date(2026, 1, 8, 23, 0, 0, 0, time.UTC)))
+	// Fri 03:00: post-midnight portion, window would have opened Thu (not in list) -> blocked
+	assert.False(t, isWithinResizeWindow(schedule, time.Date(2026, 1, 9, 3, 0, 0, 0, time.UTC)))
+	// Wed 10:00: outside the window entirely -> blocked
+	assert.False(t, isWithinResizeWindow(schedule, time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC)))
+}
+
 func TestIsWithinResizeWindow_InvalidTimezoneFailsOpen(t *testing.T) {
 	schedule := &attunev1alpha1.ResizeSchedule{
 		Timezone: "Invalid/Zone",

--- a/internal/controller/conditions_test.go
+++ b/internal/controller/conditions_test.go
@@ -209,6 +209,67 @@ func TestConsecutiveReverts(t *testing.T) {
 	}
 }
 
+func TestMarkLatestCycleReverted(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(-1 * time.Hour)
+
+	tests := []struct {
+		name       string
+		history    []attunev1alpha1.ResizeHistoryEntry
+		workload   string
+		container  string
+		wantResult []attunev1alpha1.ResizeResult
+	}{
+		{
+			name: "marks both entries from same cycle",
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "w", Container: "c", Resource: "cpu", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: metav1.NewTime(now)},
+				{Workload: "w", Container: "c", Resource: "memory", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: metav1.NewTime(now)},
+			},
+			workload:   "w",
+			container:  "c",
+			wantResult: []attunev1alpha1.ResizeResult{attunev1alpha1.ResizeResultReverted, attunev1alpha1.ResizeResultReverted},
+		},
+		{
+			name: "only marks latest cycle, not older",
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "w", Container: "c", Resource: "cpu", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: metav1.NewTime(earlier)},
+				{Workload: "w", Container: "c", Resource: "memory", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: metav1.NewTime(earlier)},
+				{Workload: "w", Container: "c", Resource: "cpu", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: metav1.NewTime(now)},
+				{Workload: "w", Container: "c", Resource: "memory", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: metav1.NewTime(now)},
+			},
+			workload:   "w",
+			container:  "c",
+			wantResult: []attunev1alpha1.ResizeResult{attunev1alpha1.ResizeResultSuccess, attunev1alpha1.ResizeResultSuccess, attunev1alpha1.ResizeResultReverted, attunev1alpha1.ResizeResultReverted},
+		},
+		{
+			name: "does not affect other workloads",
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "other", Container: "c", Resource: "cpu", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: metav1.NewTime(now)},
+				{Workload: "w", Container: "c", Resource: "cpu", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: metav1.NewTime(now)},
+			},
+			workload:   "w",
+			container:  "c",
+			wantResult: []attunev1alpha1.ResizeResult{attunev1alpha1.ResizeResultSuccess, attunev1alpha1.ResizeResultReverted},
+		},
+		{
+			name:       "empty history is a no-op",
+			history:    nil,
+			workload:   "w",
+			container:  "c",
+			wantResult: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			markLatestCycleReverted(tt.history, tt.workload, tt.container, "test-reason")
+			for i, want := range tt.wantResult {
+				assert.Equal(t, want, tt.history[i].Result, "entry %d", i)
+			}
+		})
+	}
+}
+
 // ---------- Exponential backoff ----------
 
 func TestGetEffectiveCooldown_NoReverts(t *testing.T) {

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -121,25 +121,16 @@ func isWithinResizeWindow(schedule *attunev1alpha1.ResizeSchedule, now time.Time
 	}
 	localNow := now.In(loc)
 
-	// Check day-of-week constraint.
-	if len(schedule.DaysOfWeek) > 0 {
-		dayName := localNow.Weekday().String()
-		dayAllowed := false
-		for _, d := range schedule.DaysOfWeek {
-			if strings.EqualFold(d, dayName) {
-				dayAllowed = true
-				break
-			}
-		}
-		if !dayAllowed {
-			return false
-		}
-	}
-
-	// Check time windows. If no windows are specified, all times are allowed.
+	// Check time windows first, then validate day-of-week (which may need
+	// to check the previous day for overnight windows).
 	if len(schedule.Windows) == 0 {
+		// No windows: all times are allowed, just check day-of-week.
+		if len(schedule.DaysOfWeek) > 0 {
+			return isDayAllowed(localNow.Weekday(), schedule.DaysOfWeek)
+		}
 		return true
 	}
+
 	nowMinutes := localNow.Hour()*60 + localNow.Minute()
 	for _, w := range schedule.Windows {
 		start := parseHHMM(w.Start)
@@ -150,13 +141,40 @@ func isWithinResizeWindow(schedule *attunev1alpha1.ResizeSchedule, now time.Time
 		if start <= end {
 			// Normal window: e.g. 02:00-06:00
 			if nowMinutes >= start && nowMinutes < end {
+				if len(schedule.DaysOfWeek) > 0 && !isDayAllowed(localNow.Weekday(), schedule.DaysOfWeek) {
+					continue
+				}
 				return true
 			}
 		} else {
 			// Overnight window: e.g. 22:00-06:00
-			if nowMinutes >= start || nowMinutes < end {
+			if nowMinutes >= start {
+				// Pre-midnight portion: check today's day-of-week.
+				if len(schedule.DaysOfWeek) > 0 && !isDayAllowed(localNow.Weekday(), schedule.DaysOfWeek) {
+					continue
+				}
 				return true
 			}
+			if nowMinutes < end {
+				// Post-midnight portion: the window opened yesterday,
+				// so check yesterday's day-of-week.
+				if len(schedule.DaysOfWeek) > 0 && !isDayAllowed(localNow.Add(-24*time.Hour).Weekday(), schedule.DaysOfWeek) {
+					continue
+				}
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isDayAllowed checks whether the given weekday is in the allowed list
+// (case-insensitive comparison).
+func isDayAllowed(day time.Weekday, allowed []string) bool {
+	dayName := day.String()
+	for _, d := range allowed {
+		if strings.EqualFold(d, dayName) {
+			return true
 		}
 	}
 	return false

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -669,6 +669,33 @@ func checkQuotaHeadroom(quota corev1.ResourceQuota, current, target corev1.Resou
 	return nil
 }
 
+// markLatestCycleReverted marks history entries from the most recent resize
+// cycle as reverted. It walks the history in reverse and marks all matching
+// entries whose timestamp equals the first (newest) match. Entries from
+// earlier resize cycles (different timestamps) are left untouched, preventing
+// consecutiveReverts from being inflated by a single revert event.
+func markLatestCycleReverted(history []attunev1alpha1.ResizeHistoryEntry, workload, container, reason string) {
+	var matched bool
+	var matchTS time.Time
+	for i := len(history) - 1; i >= 0; i-- {
+		h := &history[i]
+		if h.Workload == workload && h.Container == container && h.Result == attunev1alpha1.ResizeResultSuccess {
+			if !matched {
+				matchTS = h.Timestamp.Time
+				matched = true
+			}
+			if h.Timestamp.Time.Equal(matchTS) {
+				h.Result = attunev1alpha1.ResizeResultReverted
+				h.Reason = reason
+			} else {
+				break // older cycle
+			}
+		} else if matched {
+			break
+		}
+	}
+}
+
 // consecutiveReverts returns the number of consecutive reverted entries at the
 // end of the resize history.
 func consecutiveReverts(history []attunev1alpha1.ResizeHistoryEntry) int {

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -195,13 +195,12 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 								r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",
 									"Early safety detection reverted resize on pod %s/%s: %s", pod.Name, record.Container, v.Message)
 							}
-							for j := range policy.Status.ResizeHistory {
-								h := &policy.Status.ResizeHistory[j]
-								if h.Workload == trackedWorkload && h.Container == record.Container && h.Result == attunev1alpha1.ResizeResultSuccess {
-									h.Result = attunev1alpha1.ResizeResultReverted
-									h.Reason = v.Reason
-								}
-							}
+							// Mark history entries from the most recent resize cycle
+							// as reverted. Only entries whose timestamp matches the
+							// first (newest) match are marked, so entries from prior
+							// successful cycles are not poisoned and consecutiveReverts
+							// is not inflated.
+							markLatestCycleReverted(policy.Status.ResizeHistory, trackedWorkload, record.Container, v.Reason)
 						}
 					}
 				}
@@ -245,14 +244,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 					r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",
 						"Safety observation reverted resize on pod %s/%s: %s", pod.Name, record.Container, verdict.Message)
 				}
-				// Mark matching history entries as reverted so status reflects the revert.
-				for i := range policy.Status.ResizeHistory {
-					h := &policy.Status.ResizeHistory[i]
-					if h.Workload == trackedWorkload && h.Container == record.Container && h.Result == attunev1alpha1.ResizeResultSuccess {
-						h.Result = attunev1alpha1.ResizeResultReverted
-						h.Reason = verdict.Reason
-					}
-				}
+				markLatestCycleReverted(policy.Status.ResizeHistory, trackedWorkload, record.Container, verdict.Reason)
 			}
 		}
 

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -153,6 +153,10 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 	if err := r.List(ctx, &podList, client.InNamespace(policy.Namespace), client.MatchingLabels{labelTracked: "true"}); err != nil {
 		logger.Error(err, "Failed to list pods for safety observation")
 		operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
+		// Fail safe: assume observations are pending so the reconciler
+		// requeues at the short observation interval instead of the full
+		// cooldown, avoiding a delayed safety detection window.
+		observationsPending = true
 		return
 	}
 

--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -153,17 +154,34 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 				// resize succeeded. Without this guard, a failed boost
 				// would trigger a spurious expiry resize on the next reconcile.
 				if boostedAny {
-					if pod.Annotations == nil {
-						pod.Annotations = make(map[string]string)
-					}
-					pod.Annotations[annotationStartupBoostAt] = now.UTC().Format(time.RFC3339)
-					pod.Annotations[annotationPolicy] = policy.Name
-					if pod.Labels == nil {
-						pod.Labels = make(map[string]string)
-					}
-					pod.Labels[labelTracked] = "true"
-					if updateErr := r.Update(ctx, pod); updateErr != nil {
-						logger.Error(updateErr, "Failed to persist startup boost annotation", "pod", pod.Name)
+					// Re-fetch from API server and retry on conflict to handle
+					// kubelet status churn after resize. Without retry, a 409
+					// leaves the annotation unset and the boost never expires.
+					const maxBoostAnnotationRetries = 3
+					for attempt := range maxBoostAnnotationRetries {
+						freshPod, getErr := r.Clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+						if getErr != nil {
+							logger.Error(getErr, "Failed to re-fetch pod for boost annotation", "pod", pod.Name)
+							break
+						}
+						if freshPod.Annotations == nil {
+							freshPod.Annotations = make(map[string]string)
+						}
+						freshPod.Annotations[annotationStartupBoostAt] = now.UTC().Format(time.RFC3339)
+						freshPod.Annotations[annotationPolicy] = policy.Name
+						if freshPod.Labels == nil {
+							freshPod.Labels = make(map[string]string)
+						}
+						freshPod.Labels[labelTracked] = "true"
+						if updateErr := r.Update(ctx, freshPod); updateErr == nil {
+							*pod = *freshPod
+							break
+						} else if !apierrors.IsConflict(updateErr) {
+							logger.Error(updateErr, "Failed to persist startup boost annotation", "pod", pod.Name)
+							break
+						}
+						logger.V(1).Info("Boost annotation conflict, retrying",
+							"pod", pod.Name, "attempt", attempt+1)
 					}
 				}
 			} else if boostAtStr != "" {

--- a/internal/metrics/datadog.go
+++ b/internal/metrics/datadog.go
@@ -135,6 +135,9 @@ func (c *DatadogCollector) QueryRangeGrouped(ctx context.Context, query string, 
 		for _, point := range series.Pointlist {
 			ts := time.Unix(int64(point[0])/1000, 0) // Datadog timestamps are milliseconds
 			value := point[1]
+			if math.IsNaN(value) || math.IsInf(value, 0) {
+				continue
+			}
 			// Convert nanocores to cores for CPU metrics.
 			if isCPU {
 				value /= 1e9

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -190,7 +190,7 @@ func MergeUpdateStrategy(policy *attunev1alpha1.UpdateStrategy, defaults *attune
 		return nil
 	}
 	var inherited []string
-	if policy.Type == "" {
+	if policy.Type == "" && defaults.Type != "" {
 		policy.Type = defaults.Type
 		inherited = append(inherited, "type")
 	}


### PR DESCRIPTION
## What

Four runtime bugs found during audit round 6:

### 1. Safety observation over-marks historical resize entries (HIGH)

When a safety revert occurred, **all** historical `Success` entries for the
same workload/container were marked as `Reverted`, not just the entries from
the current resize cycle. This inflated `consecutiveReverts()`, causing:
- Premature `Degraded` condition (threshold: 3+ reverts in last 5 entries)
- Escalated exponential backoff (`2^N` cooldown multiplier hitting cap faster)

**Fix:** New `markLatestCycleReverted()` function walks history in reverse and
only marks entries whose timestamp matches the first (newest) match, leaving
entries from prior successful cycles untouched.

### 2. Startup boost annotation conflict causes permanent CPU inflation (HIGH)

The boost timestamp annotation was written with a bare `r.Update()` and no
retry on conflict. A 409 from kubelet status churn left the annotation unset.
Without the annotation, the boost could never expire (neither the apply nor
the expiry branch matched on subsequent reconciles), permanently inflating
the pod's CPU by the boost multiplier.

**Fix:** Added a 3-retry loop with API server re-fetch, matching the conflict
handling pattern already used in safety annotation cleanup.

### 3. Datadog QueryRangeGrouped missing NaN/Inf filter (MEDIUM)

The Prometheus and CloudWatch collectors both filter NaN/Inf values from range
query results, but the Datadog collector did not. Non-finite values from
missing data points could reach downstream estimators.

**Fix:** Added `math.IsNaN(value) || math.IsInf(value, 0)` guard consistent
with the other collectors.

### 4. MergeUpdateStrategy false inherited logging (LOW)

`MergeUpdateStrategy` reported "type" as inherited even when `defaults.Type`
was empty (no actual value inherited), inconsistent with all other merge
fields that check both sides.

**Fix:** Added `&& defaults.Type != ""` to the condition.

## Testing

- 1694 tests pass (5 new for `markLatestCycleReverted`)
- 92.7% coverage
- `make lint` clean (0 issues)