### PR TITLE
fix: remove orphan adjustHPATargets comment fragment

### DIFF
--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -263,7 +263,6 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 	}
 }
 
-// adjustHPATargets checks for HPAs with the auto-tune annotation and adjusts
 // boostResizeAndRefetch resizes a single container's CPU to targetCPU
 // (preserving the current memory request) and re-fetches the pod from the API
 // server. On resize failure it returns (original pod, err) so the caller can


### PR DESCRIPTION
## Summary

Removes a leftover `// adjustHPATargets ...` comment fragment above `boostResizeAndRefetch` in `internal/controller/startupboost.go`. Flagged by [GitHub AI findings](https://github.com/attune-io/attune/security/quality/ai-findings); no behavior change.

## Related

- Deferred cosmetics: #397
- FOSSA: no code change (known `golang.org/x/text` FPs already filtered in CI)

## Validation

- Comment-only deletion
- Diff is a single line removal