### PR TITLE
chore: polish changelog layout and defaults merge tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.1.19](https://github.com/attune-io/attune/compare/v0.1.18...v0.1.19) (2026-07-13)
 
 
@@ -274,9 +276,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * scope workflow token permissions to job level for Scorecard ([#42](https://github.com/attune-io/attune/issues/42)) ([5251468](https://github.com/attune-io/attune/commit/52514682e36a307e1a0c4a235d0a76255888f79a))
 * stabilize Chainsaw tests and add govulncheck to CI gate ([#95](https://github.com/attune-io/attune/issues/95)) ([011c8ad](https://github.com/attune-io/attune/commit/011c8adc56ee9c6a0e43cf2c13dfec27f18862f4))
 
-## [Unreleased]
-
-## [0.1.0] - 2025-05-26
+## [0.1.0](https://github.com/attune-io/attune/releases/tag/v0.1.0) (2025-05-26)
 
 ### Added
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -51,8 +51,9 @@ func ApplyBuiltInDefaults(policy *attunev1alpha1.AttunePolicy) {
 		policy.Spec.Memory.MaxChangePercent = &v
 	}
 	if policy.Spec.UpdateStrategy.Cooldown == nil {
-		d, _ := time.ParseDuration(attunev1alpha1.DefaultCooldown)
-		policy.Spec.UpdateStrategy.Cooldown = &metav1.Duration{Duration: d}
+		policy.Spec.UpdateStrategy.Cooldown = &metav1.Duration{
+			Duration: mustParseBuiltInDuration(attunev1alpha1.DefaultCooldown),
+		}
 	}
 	if policy.Spec.UpdateStrategy.AutoRevert == nil {
 		v := attunev1alpha1.DefaultAutoRevert
@@ -66,8 +67,9 @@ func ApplyBuiltInDefaults(policy *attunev1alpha1.AttunePolicy) {
 		policy.Spec.MetricsSource.MinimumDataPoints = &v
 	}
 	if policy.Spec.MetricsSource.HistoryWindow == nil {
-		d, _ := time.ParseDuration(attunev1alpha1.DefaultHistoryWindow)
-		policy.Spec.MetricsSource.HistoryWindow = &metav1.Duration{Duration: d}
+		policy.Spec.MetricsSource.HistoryWindow = &metav1.Duration{
+			Duration: mustParseBuiltInDuration(attunev1alpha1.DefaultHistoryWindow),
+		}
 	}
 	if policy.Spec.MetricsSource.QueryStep == nil {
 		policy.Spec.MetricsSource.QueryStep = &metav1.Duration{Duration: attunev1alpha1.DefaultQueryStep}
@@ -84,6 +86,18 @@ func ApplyBuiltInDefaults(policy *attunev1alpha1.AttunePolicy) {
 		v := attunev1alpha1.DefaultExcludeKnownSidecars
 		policy.Spec.ExcludeKnownSidecars = &v
 	}
+}
+
+// mustParseBuiltInDuration parses a package-level default duration constant.
+// It panics on error because the constants are fixed strings in this module;
+// a parse failure means a broken default was introduced at build time, not a
+// runtime user input problem.
+func mustParseBuiltInDuration(s string) time.Duration {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		panic("invalid built-in default duration " + s + ": " + err.Error())
+	}
+	return d
 }
 
 // MergeDefaults merges values from an AttuneDefaults resource into the

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -222,19 +222,21 @@ func TestMergeUpdateStrategy_AllFields(t *testing.T) {
 	assert.Equal(t, 10*time.Minute, policy.SafetyObservationPeriod.Duration)
 	require.Len(t, policy.SLOGuardrails, 1)
 	assert.Equal(t, "p99-latency", policy.SLOGuardrails[0].Name)
-	assert.Len(t, inherited, 12)
-	assert.Contains(t, inherited, "type")
-	assert.Contains(t, inherited, "autoRevert")
-	assert.Contains(t, inherited, "resizeMethod")
-	assert.Contains(t, inherited, "maxConcurrentResizes")
-	assert.Contains(t, inherited, "cooldown")
-	assert.Contains(t, inherited, "maxTotalCpuIncrease")
-	assert.Contains(t, inherited, "maxTotalMemoryIncrease")
-	assert.Contains(t, inherited, "schedule")
-	assert.Contains(t, inherited, "export")
-	assert.Contains(t, inherited, "canary")
-	assert.Contains(t, inherited, "safetyObservationPeriod")
-	assert.Contains(t, inherited, "sloGuardrails")
+	expectedInherited := []string{
+		"type",
+		"autoRevert",
+		"resizeMethod",
+		"maxConcurrentResizes",
+		"cooldown",
+		"maxTotalCpuIncrease",
+		"maxTotalMemoryIncrease",
+		"schedule",
+		"export",
+		"canary",
+		"safetyObservationPeriod",
+		"sloGuardrails",
+	}
+	assert.ElementsMatch(t, expectedInherited, inherited)
 }
 
 // ---------- Direct MergeResourceConfig tests ----------
@@ -280,19 +282,21 @@ func TestMergeResourceConfig_AllFields(t *testing.T) {
 	assert.Equal(t, int32(60), *policy.MaxIncreasePercent)
 	require.NotNil(t, policy.MaxDecreasePercent)
 	assert.Equal(t, int32(30), *policy.MaxDecreasePercent)
-	assert.Len(t, inherited, 12)
-	assert.Contains(t, inherited, "cpu.percentile")
-	assert.Contains(t, inherited, "cpu.overhead")
-	assert.Contains(t, inherited, "cpu.minAllowed")
-	assert.Contains(t, inherited, "cpu.maxAllowed")
-	assert.Contains(t, inherited, "cpu.controlledValues")
-	assert.Contains(t, inherited, "cpu.burstSensitivity")
-	assert.Contains(t, inherited, "cpu.allowDecrease")
-	assert.Contains(t, inherited, "cpu.memoryFromCpuRatio")
-	assert.Contains(t, inherited, "cpu.startupBoost")
-	assert.Contains(t, inherited, "cpu.maxChangePercent")
-	assert.Contains(t, inherited, "cpu.maxIncreasePercent")
-	assert.Contains(t, inherited, "cpu.maxDecreasePercent")
+	expectedInherited := []string{
+		"cpu.percentile",
+		"cpu.overhead",
+		"cpu.minAllowed",
+		"cpu.maxAllowed",
+		"cpu.controlledValues",
+		"cpu.burstSensitivity",
+		"cpu.allowDecrease",
+		"cpu.memoryFromCpuRatio",
+		"cpu.startupBoost",
+		"cpu.maxChangePercent",
+		"cpu.maxIncreasePercent",
+		"cpu.maxDecreasePercent",
+	}
+	assert.ElementsMatch(t, expectedInherited, inherited)
 }
 
 func TestMergeResourceConfig_NilDefaultsIsNoOp(t *testing.T) {
@@ -528,4 +532,18 @@ func TestMergeUpdateStrategy_BothEmptyTypeNoInheritance(t *testing.T) {
 	assert.Contains(t, inherited, "cooldown")
 	assert.Equal(t, attunev1alpha1.UpdateType(""), policy.Type,
 		"Type should remain empty when default is also empty")
+}
+
+func TestMustParseBuiltInDuration_ValidConstants(t *testing.T) {
+	// Guard against typoed default strings silently becoming zero durations.
+	cooldown := mustParseBuiltInDuration(attunev1alpha1.DefaultCooldown)
+	assert.Equal(t, time.Hour, cooldown)
+	history := mustParseBuiltInDuration(attunev1alpha1.DefaultHistoryWindow)
+	assert.Equal(t, 168*time.Hour, history)
+}
+
+func TestMustParseBuiltInDuration_InvalidPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		mustParseBuiltInDuration("not-a-duration")
+	})
 }


### PR DESCRIPTION
## Summary

Closes [#397](https://github.com/attune-io/attune/issues/397): deferred AI code-quality cosmetics (no functional bugs).

### Changes

1. **CHANGELOG.md**
   - `[Unreleased]` moved to the top (Keep a Changelog layout)
   - `0.1.0` heading uses a release tag link like later versions
   - release-please still owns versioned sections; empty Unreleased at top is standard

2. **`pkg/defaults` merge tests**
   - Replaced `assert.Len(t, inherited, 12)` with `assert.ElementsMatch` on explicit expected field slices for `MergeUpdateStrategy` and `MergeResourceConfig`
   - Failures now show which fields are missing or unexpected

3. **Built-in duration constants**
   - `mustParseBuiltInDuration` panics if `DefaultCooldown` / `DefaultHistoryWindow` are invalid (constants only; not user input)
   - Tests: valid constants parse to expected values; invalid string panics

## Validation

- `go test ./pkg/defaults/ -race`
- No product behavior change for operators

Closes #397