### PR TITLE
fix: allow template history enums in CRD status schema

### DIFF
--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -898,8 +898,9 @@ type ResizeHistoryEntry struct {
 	// Container is the name of the resized container.
 	Container string `json:"container"`
 
-	// Resource is the resource type that was resized.
-	// +kubebuilder:validation:Enum=cpu;memory;cpu+memory
+	// Resource is the resource type that was resized, or "template" when the
+	// history entry records a workload template persistence patch.
+	// +kubebuilder:validation:Enum=cpu;memory;cpu+memory;template
 	Resource string `json:"resource"`
 
 	// From is the previous resource value.
@@ -909,11 +910,11 @@ type ResizeHistoryEntry struct {
 	To string `json:"to"`
 
 	// Method is the resize method used.
-	// +kubebuilder:validation:Enum=InPlace;Eviction
+	// +kubebuilder:validation:Enum=InPlace;Eviction;TemplatePersistence
 	Method string `json:"method"`
 
 	// Result is the outcome of the resize operation.
-	// +kubebuilder:validation:Enum=Success;Failed;Reverted;Evicted
+	// +kubebuilder:validation:Enum=Success;Failed;Reverted;Evicted;TemplatePatched
 	Result ResizeResult `json:"result"`
 
 	// Reason explains why the resize was reverted or failed.

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -1382,6 +1382,7 @@ spec:
                       enum:
                       - InPlace
                       - Eviction
+                      - TemplatePersistence
                       type: string
                     reason:
                       description: |-
@@ -1391,11 +1392,14 @@ spec:
                         annotation-conflict, immediate-safety-check, slo:<name>.
                       type: string
                     resource:
-                      description: Resource is the resource type that was resized.
+                      description: |-
+                        Resource is the resource type that was resized, or "template" when the
+                        history entry records a workload template persistence patch.
                       enum:
                       - cpu
                       - memory
                       - cpu+memory
+                      - template
                       type: string
                     result:
                       description: Result is the outcome of the resize operation.
@@ -1404,6 +1408,7 @@ spec:
                       - Failed
                       - Reverted
                       - Evicted
+                      - TemplatePatched
                       type: string
                     timestamp:
                       description: Timestamp is when the resize operation occurred.

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -1382,6 +1382,7 @@ spec:
                       enum:
                       - InPlace
                       - Eviction
+                      - TemplatePersistence
                       type: string
                     reason:
                       description: |-
@@ -1391,11 +1392,14 @@ spec:
                         annotation-conflict, immediate-safety-check, slo:<name>.
                       type: string
                     resource:
-                      description: Resource is the resource type that was resized.
+                      description: |-
+                        Resource is the resource type that was resized, or "template" when the
+                        history entry records a workload template persistence patch.
                       enum:
                       - cpu
                       - memory
                       - cpu+memory
+                      - template
                       type: string
                     result:
                       description: Result is the outcome of the resize operation.
@@ -1404,6 +1408,7 @@ spec:
                       - Failed
                       - Reverted
                       - Evicted
+                      - TemplatePatched
                       type: string
                     timestamp:
                       description: Timestamp is when the resize operation occurred.

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -2875,6 +2875,7 @@ spec:
                       enum:
                       - InPlace
                       - Eviction
+                      - TemplatePersistence
                       type: string
                     reason:
                       description: |-
@@ -2884,11 +2885,14 @@ spec:
                         annotation-conflict, immediate-safety-check, slo:<name>.
                       type: string
                     resource:
-                      description: Resource is the resource type that was resized.
+                      description: |-
+                        Resource is the resource type that was resized, or "template" when the
+                        history entry records a workload template persistence patch.
                       enum:
                       - cpu
                       - memory
                       - cpu+memory
+                      - template
                       type: string
                     result:
                       description: Result is the outcome of the resize operation.
@@ -2897,6 +2901,7 @@ spec:
                       - Failed
                       - Reverted
                       - Evicted
+                      - TemplatePatched
                       type: string
                     timestamp:
                       description: Timestamp is when the resize operation occurred.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2874,6 +2874,7 @@ spec:
                       enum:
                       - InPlace
                       - Eviction
+                      - TemplatePersistence
                       type: string
                     reason:
                       description: |-
@@ -2883,11 +2884,14 @@ spec:
                         annotation-conflict, immediate-safety-check, slo:<name>.
                       type: string
                     resource:
-                      description: Resource is the resource type that was resized.
+                      description: |-
+                        Resource is the resource type that was resized, or "template" when the
+                        history entry records a workload template persistence patch.
                       enum:
                       - cpu
                       - memory
                       - cpu+memory
+                      - template
                       type: string
                     result:
                       description: Result is the outcome of the resize operation.
@@ -2896,6 +2900,7 @@ spec:
                       - Failed
                       - Reverted
                       - Evicted
+                      - TemplatePatched
                       type: string
                     timestamp:
                       description: Timestamp is when the resize operation occurred.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -179,7 +179,7 @@ spec:
 | `resizeHistory[].timestamp` | `Time` | When the resize occurred |
 | `resizeHistory[].workload` | `string` | Resized workload name |
 | `resizeHistory[].container` | `string` | Resized container name |
-| `resizeHistory[].resource` | `string` | `cpu`, `memory`, or `cpu+memory` |
+| `resizeHistory[].resource` | `string` | `cpu`, `memory`, `cpu+memory`, or `template` |
 | `resizeHistory[].from` | `string` | Previous value |
 | `resizeHistory[].to` | `string` | New value |
 | `resizeHistory[].method` | `string` | `InPlace`, `Eviction`, or `TemplatePersistence` |

--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -251,11 +251,37 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 					// so the next reconciliation retries. Without this guard, a
 					// transient failure would leave the pod permanently at
 					// boosted CPU with no future expiry attempt.
-					if !boostReduceFailed {
-						delete(pod.Annotations, annotationStartupBoostAt)
+					// Skip the Update entirely when nothing changed (all
+					// containers skipped / already at target) to avoid API churn.
+					if boostReduceFailed {
+						continue
 					}
-					if updateErr := r.Update(ctx, pod); updateErr != nil {
-						logger.Error(updateErr, "Failed to update pod after startup boost expiry", "pod", pod.Name)
+					// Re-fetch + conflict retry (same pattern as boost apply).
+					const maxExpiryAnnotationRetries = 3
+					for attempt := range maxExpiryAnnotationRetries {
+						freshPod, getErr := r.Clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+						if getErr != nil {
+							logger.Error(getErr, "Failed to re-fetch pod for startup boost expiry annotation", "pod", pod.Name)
+							break
+						}
+						if freshPod.Annotations == nil {
+							break
+						}
+						if _, ok := freshPod.Annotations[annotationStartupBoostAt]; !ok {
+							// Already cleared (race with another reconciler).
+							*pod = *freshPod
+							break
+						}
+						delete(freshPod.Annotations, annotationStartupBoostAt)
+						if updateErr := r.Update(ctx, freshPod); updateErr == nil {
+							*pod = *freshPod
+							break
+						} else if !apierrors.IsConflict(updateErr) {
+							logger.Error(updateErr, "Failed to update pod after startup boost expiry", "pod", pod.Name)
+							break
+						}
+						logger.V(1).Info("Boost expiry annotation conflict, retrying",
+							"pod", pod.Name, "attempt", attempt+1)
 					}
 				}
 			}

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -143,7 +143,7 @@ func TestValidate_NilUpdateStrategy(t *testing.T) {
 	assert.NoError(t, err, "nil UpdateStrategy should pass validation")
 	assert.Empty(t, warnings)
 
-	// Also verify UpdateUpdate path.
+	// Also verify Update path.
 	warnings, err = validator.ValidateUpdate(context.Background(), policy, policy)
 	assert.NoError(t, err, "nil UpdateStrategy should pass update validation")
 	assert.Empty(t, warnings)

--- a/pkg/defaults/sidecars_test.go
+++ b/pkg/defaults/sidecars_test.go
@@ -25,8 +25,6 @@ import (
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
 
-func boolPtr(v bool) *bool { return &v }
-
 func TestEffectiveExcludedContainers_DefaultKnownOn(t *testing.T) {
 	policy := &attunev1alpha1.AttunePolicy{}
 	set := EffectiveExcludedContainers(policy)
@@ -41,7 +39,7 @@ func TestEffectiveExcludedContainers_UnionWithUserList(t *testing.T) {
 	policy := &attunev1alpha1.AttunePolicy{
 		Spec: attunev1alpha1.AttunePolicySpec{
 			ExcludedContainers:   []string{"my-agent"},
-			ExcludeKnownSidecars: boolPtr(true),
+			ExcludeKnownSidecars: ptrBool(true),
 		},
 	}
 	set := EffectiveExcludedContainers(policy)
@@ -53,7 +51,7 @@ func TestEffectiveExcludedContainers_OptOutRestoresListOnly(t *testing.T) {
 	policy := &attunev1alpha1.AttunePolicy{
 		Spec: attunev1alpha1.AttunePolicySpec{
 			ExcludedContainers:   []string{"my-agent"},
-			ExcludeKnownSidecars: boolPtr(false),
+			ExcludeKnownSidecars: ptrBool(false),
 		},
 	}
 	set := EffectiveExcludedContainers(policy)
@@ -70,7 +68,7 @@ func TestEffectiveExcludedContainers_NilPolicy(t *testing.T) {
 func TestExclusionReason(t *testing.T) {
 	on := &attunev1alpha1.AttunePolicy{
 		Spec: attunev1alpha1.AttunePolicySpec{
-			ExcludeKnownSidecars: boolPtr(true),
+			ExcludeKnownSidecars: ptrBool(true),
 			ExcludedContainers:   []string{"custom"},
 		},
 	}
@@ -79,7 +77,7 @@ func TestExclusionReason(t *testing.T) {
 
 	off := &attunev1alpha1.AttunePolicy{
 		Spec: attunev1alpha1.AttunePolicySpec{
-			ExcludeKnownSidecars: boolPtr(false),
+			ExcludeKnownSidecars: ptrBool(false),
 			ExcludedContainers:   []string{"istio-proxy"},
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes a real post-#403 bug: CRD OpenAPI enums on `status.resizeHistory` rejected template persistence history entries, so status updates failed when template patches succeeded.

Also clears low/cosmetic AI findings that do not make the code worse (keeps Datadog `/1000` as-is; that finding is a false positive).

## Changes

1. **CRD / API (real bug)**
   - `Method` enum: add `TemplatePersistence`
   - `Result` enum: add `TemplatePatched`
   - `Resource` enum: add `template` (history already wrote this; would still fail admission)
   - Regenerated CRDs, chart CRDs, `dist/crds.yaml`, `dist/install.yaml`
   - Docs: `api.md` resource values

2. **Startup boost expiry (low)**
   - Conflict retry + re-fetch when clearing the boost annotation (mirrors apply path)
   - Skip `Update` when reduce failed (no annotation change; avoid API churn)

3. **Cosmetics**
   - Webhook test comment: `UpdateUpdate` → `Update`
   - `sidecars_test.go`: use shared `ptrBool` instead of duplicate `boolPtr`

## Not changed

- **Datadog pointlist `/1000`**: response timestamps are milliseconds; removing `/1000` would break history windows.

## Test plan

- [x] `go test ./internal/controller/ ./pkg/defaults/ ./internal/webhook/`
- [x] `make verify-quick`
- [ ] CI green