### PR TITLE
ci: run E2E when lint/unit are path-skipped

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -498,16 +498,21 @@ jobs:
           paths: test-results/integration.xml
 
   # E2E tests run in a single job with one shared k3d cluster.
-  # Cluster setup starts immediately (needs: changes only) and overlaps with
-  # lint/unit. A gate step polls the GitHub API until lint+unit complete,
-  # then both Chainsaw and Go E2E run concurrently on the shared cluster.
-  # This saves ~3 min vs two separate jobs blocked on lint/unit.
+  # needs includes lint/unit when they run; when they are path-skipped
+  # (e2e-only PRs), always() + success|skipped checks still allow E2E.
+  # Without that, GitHub skips dependents of skipped jobs and e2e-only
+  # PRs never execute Chainsaw (seen on #407).
   test-e2e:
     name: E2E
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     needs: [changes, lint, test-unit]
-    if: needs.changes.outputs.go-source == 'true' || needs.changes.outputs.e2e == 'true'
+    if: |
+      always()
+      && needs.changes.result == 'success'
+      && (needs.changes.outputs.go-source == 'true' || needs.changes.outputs.e2e == 'true')
+      && (needs.lint.result == 'success' || needs.lint.result == 'skipped')
+      && (needs.test-unit.result == 'success' || needs.test-unit.result == 'skipped')
     env:
       K3D_CLUSTER_NAME: e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
@@ -528,7 +533,7 @@ jobs:
           prometheus-chart-version: ${{ env.PROMETHEUS_CHART_VERSION }}
           stress-ng-image: ${{ env.STRESS_NG_IMAGE }}
 
-      # Lint and unit tests are guaranteed complete via needs: [lint, test-unit].
+      # Lint/unit either succeeded or were path-skipped (see job if: above).
 
       - name: Install Chainsaw
         uses: ./.github/actions/install-binary-tool

--- a/test/e2e/template-persistence-after-resize/chainsaw-test.yaml
+++ b/test/e2e/template-persistence-after-resize/chainsaw-test.yaml
@@ -169,17 +169,17 @@ spec:
                   -o json 2>/dev/null || true)
                 if [ -n "$CPU" ] && [ "$CPU" != "500m" ]; then
                   echo "Template CPU updated from 500m to $CPU (memory=$MEM)"
+                  # Require history so we prove AfterSuccessfulResize path, not a manual template edit.
                   if echo "$HIST" | grep -q '"result":"TemplatePatched"' && \
                      echo "$HIST" | grep -q '"method":"TemplatePersistence"'; then
                     echo "History records TemplatePersistence / TemplatePatched"
                     exit 0
                   fi
-                  echo "WARN: history not yet showing TemplatePatched; template change is sufficient"
-                  exit 0
+                  echo "Template changed but history not yet TemplatePatched; waiting (attempt $i)"
                 fi
                 sleep 5
               done
-              echo "FAIL: template still at original sizes after successful resize"
+              echo "FAIL: expected template CPU change + TemplatePatched history after successful resize"
               kubectl get deploy "$DEPLOY" -n "$NS" -o yaml
               kubectl get attunepolicy "$POLICY" -n "$NS" -o yaml
               exit 1

--- a/test/e2e/template-persistence-after-resize/chainsaw-test.yaml
+++ b/test/e2e/template-persistence-after-resize/chainsaw-test.yaml
@@ -169,13 +169,18 @@ spec:
                   -o json 2>/dev/null || true)
                 if [ -n "$CPU" ] && [ "$CPU" != "500m" ]; then
                   echo "Template CPU updated from 500m to $CPU (memory=$MEM)"
-                  # Require history so we prove AfterSuccessfulResize path, not a manual template edit.
-                  if echo "$HIST" | grep -q '"result":"TemplatePatched"' && \
-                     echo "$HIST" | grep -q '"method":"TemplatePersistence"'; then
-                    echo "History records TemplatePersistence / TemplatePatched"
+                  # Prove AfterSuccessfulResize wrote history (not only a template field change).
+                  # kubectl -o json may space after colons; match result/method values loosely.
+                  RESULTS=$(kubectl get attunepolicy "$POLICY" -n "$NS" \
+                    -o jsonpath='{range .status.resizeHistory[*]}{.result}{" "}{.method}{"\n"}{end}' 2>/dev/null || true)
+                  if echo "$RESULTS" | grep -q 'TemplatePatched' && \
+                     echo "$RESULTS" | grep -q 'TemplatePersistence'; then
+                    echo "History records TemplatePersistence / TemplatePatched:"
+                    echo "$RESULTS"
                     exit 0
                   fi
                   echo "Template changed but history not yet TemplatePatched; waiting (attempt $i)"
+                  echo "history rows: $RESULTS"
                 fi
                 sleep 5
               done


### PR DESCRIPTION
## Summary

Fixes E2E never running on e2e-only PRs (as on #407 for AfterSuccessfulResize).

### Root cause

`test-e2e` has `needs: [changes, lint, test-unit]`. For PRs that only touch `test/e2e/**`:

- `e2e=true` (path filter)
- lint and unit are **skipped** (`go-source=false`)
- GitHub skips dependents of skipped jobs → **E2E never starts**

### Fix

```yaml
if: |
  always()
  && needs.changes.result == 'success'
  && (go-source || e2e)
  && (lint success|skipped)
  && (test-unit success|skipped)
```

### Also

- Stricter AfterSuccessfulResize Chainsaw assert: require `TemplatePatched` + `TemplatePersistence` in history (proves the path, not only a template field change).

## Why this PR

#405 was closed by #407 without Chainsaw ever executing. This PR must stay open until **E2E is green** (not skipped).

## Test plan

- [ ] CI **E2E** job runs (not skipped)
- [ ] Chainsaw includes `template-persistence-after-resize`
- [ ] Full E2E green