### PR TITLE
feat: three-tier defaults merge for cluster and namespace CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* 3-tier defaults merge: namespace AttuneNamespaceDefaults now fills unset fields from cluster AttuneDefaults instead of replacing the whole cluster object (#394)
+
+
 ## [0.1.19](https://github.com/attune-io/attune/compare/v0.1.18...v0.1.19) (2026-07-13)
 
 

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -977,18 +977,24 @@ func fetchSelectedDefaults(ctx context.Context, dynClient dynamic.Interface, nam
 	if err != nil {
 		return selectedDefaults{}, fmt.Errorf("listing AttuneNamespaceDefaults in %s: %w", namespace, err)
 	}
-	if namespaceDefaults != nil {
-		return selectedDefaults{defaults: namespaceDefaults, source: sourceNamespace}, nil
-	}
 
 	clusterDefaults, err := fetchSingleDefaults(ctx, dynClient, defaultsGVR, "")
 	if err != nil {
 		return selectedDefaults{}, fmt.Errorf("listing AttuneDefaults: %w", err)
 	}
-	if clusterDefaults != nil {
-		return selectedDefaults{defaults: clusterDefaults, source: sourceCluster}, nil
+
+	// Match controller fetchDefaults: 3-tier merge when both layers exist.
+	combined := pkgdefaults.CombineDefaultsLayers(clusterDefaults, namespaceDefaults)
+	if combined == nil {
+		return selectedDefaults{source: sourceBuiltIn}, nil
 	}
-	return selectedDefaults{source: sourceBuiltIn}, nil
+	source := sourceCluster
+	if namespaceDefaults != nil && clusterDefaults != nil {
+		source = sourceNamespace // primary layer is namespace; cluster filled gaps
+	} else if namespaceDefaults != nil {
+		source = sourceNamespace
+	}
+	return selectedDefaults{defaults: combined, source: source}, nil
 }
 
 func fetchSingleDefaults(ctx context.Context, dynClient dynamic.Interface, resource schema.GroupVersionResource, namespace string) (*attunev1alpha1.AttuneDefaults, error) {

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -2068,7 +2068,8 @@ func TestPrintExplain_UsesClusterDefaultsWhenNoNamespaceDefaultsExist(t *testing
 	assert.Contains(t, output, "Resize method: InPlaceOrRecreate (source: cluster default, configured: <unset>)")
 }
 
-func TestPrintExplain_NamespaceDefaultsDoNotInheritMissingFieldsFromClusterDefaults(t *testing.T) {
+func TestPrintExplain_NamespaceDefaultsInheritMissingFieldsFromClusterDefaults(t *testing.T) {
+	// Issue #394: 3-tier merge — namespace min data points; cluster fills queryStep and type.
 	nsMinimumDataPoints := int32(96)
 	nsDefaultsObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&attunev1alpha1.AttuneNamespaceDefaults{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "attune.io/v1alpha1", Kind: "AttuneNamespaceDefaults"},
@@ -2141,10 +2142,11 @@ func TestPrintExplain_NamespaceDefaultsDoNotInheritMissingFieldsFromClusterDefau
 	output := buf.String()
 
 	assert.Contains(t, output, "Minimum data points: 96 (source: namespace default, configured: <unset>)")
-	assert.Contains(t, output, "Query step: 5m0s (source: built-in default, configured: <unset>)")
-	assert.Contains(t, output, "Type: Recommend (source: built-in default, configured: <unset>)")
-	assert.NotContains(t, output, "Query step: 1m0s")
-	assert.NotContains(t, output, "Type: Auto")
+	// Cluster fills gaps left by the sparse namespace object (3-tier merge).
+	assert.Contains(t, output, "Query step: 1m0s (source: namespace default, configured: <unset>)")
+	assert.Contains(t, output, "Type: Auto (source: namespace default, configured: <unset>)")
+	assert.NotContains(t, output, "Query step: 5m0s (source: built-in default")
+	assert.NotContains(t, output, "Type: Recommend (source: built-in default")
 }
 
 // ---------- policyReadyReason ----------

--- a/docs/architecture/design.md
+++ b/docs/architecture/design.md
@@ -28,7 +28,7 @@ flowchart TB
 The reconciler loop in `internal/controller/`. On each reconciliation:
 
 1. Fetches the `AttunePolicy` CR.
-2. Resolves one defaults source: `AttuneNamespaceDefaults` for the policy namespace if present, otherwise cluster-scoped `AttuneDefaults`.
+2. Resolves effective defaults with 3-tier merge: cluster-scoped `AttuneDefaults` as baseline, then `AttuneNamespaceDefaults` (namespace fields win; cluster fills unset fields), then per-policy overrides.
 3. Resolves the Prometheus address.
 4. Discovers target workloads via name or label selector.
 5. Checks for opt-out annotations and active rollouts.

--- a/docs/guides/prometheus-setup.md
+++ b/docs/guides/prometheus-setup.md
@@ -94,7 +94,7 @@ Use namespace defaults when different teams or environments need different
 Prometheus backends.
 
 Because the controller resolves a single defaults source per namespace, a
-`AttuneNamespaceDefaults` object shadows cluster defaults for Prometheus
+`AttuneNamespaceDefaults` object overrides set fields on cluster defaults for Prometheus
 config too. If it exists but omits `metricsSource.prometheus.address`, the
 controller falls through to auto-discovery, not to `AttuneDefaults`.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -282,7 +282,15 @@ spec:
 override cluster-scoped `AttuneDefaults`. Policies in the same namespace
 inherit these values unless they specify their own.
 
-**Precedence order:** policy spec > namespace defaults > cluster defaults > built-in defaults
+**Precedence order (per field):** policy spec > namespace defaults >
+cluster defaults > built-in defaults.
+
+When both cluster and namespace defaults exist, fields set on the
+namespace object win; fields left unset on the namespace object are
+filled from the cluster `AttuneDefaults` (not from built-ins alone).
+Example: cluster sets `cooldown=10m` and `percentile=95`; namespace sets
+only `percentile=90` → effective defaults use `percentile=90` and
+`cooldown=10m`.
 
 The spec is identical to `AttuneDefaults` (all fields in
 `AttuneDefaultsSpec` are available). When multiple

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -30,47 +30,50 @@ import (
 	pkgdefaults "github.com/attune-io/attune/pkg/defaults"
 )
 
-// fetchDefaults returns the effective defaults for the given namespace, checking
-// namespace-scoped AttuneNamespaceDefaults first, then falling back to
-// cluster-scoped AttuneDefaults. Returns nil if neither exists.
+// fetchDefaults returns the effective defaults for the given namespace.
+//
+// Precedence (per field): built-in < cluster AttuneDefaults < namespace
+// AttuneNamespaceDefaults < policy (policy applied later via mergeDefaults).
+// When both cluster and namespace defaults exist, namespace values win for
+// fields they set; cluster values fill fields left unset on the namespace
+// object (3-tier merge).
 //
 // If multiple defaults objects exist at the same scope, selection is
 // deterministic: the lexicographically smallest metadata.name wins.
 func (r *AttunePolicyReconciler) fetchDefaults(ctx context.Context, namespace string) (*attunev1alpha1.AttuneDefaults, error) {
-	// Check namespace-scoped defaults first.
 	var nsList attunev1alpha1.AttuneNamespaceDefaultsList
 	if err := r.List(ctx, &nsList, client.InNamespace(namespace)); err != nil {
 		return nil, fmt.Errorf("listing AttuneNamespaceDefaults in %s: %w", namespace, err)
 	}
+	var nsDefaults *attunev1alpha1.AttuneDefaults
 	if len(nsList.Items) > 0 {
-		nsDefaults := nsList.Items[0]
+		picked := nsList.Items[0]
 		for i := 1; i < len(nsList.Items); i++ {
-			if nsList.Items[i].Name < nsDefaults.Name {
-				nsDefaults = nsList.Items[i]
+			if nsList.Items[i].Name < picked.Name {
+				picked = nsList.Items[i]
 			}
 		}
-		// Convert to AttuneDefaults so callers don't need to know the source.
-		return &attunev1alpha1.AttuneDefaults{
-			ObjectMeta: nsDefaults.ObjectMeta,
-			Spec:       nsDefaults.Spec,
-		}, nil
+		nsDefaults = &attunev1alpha1.AttuneDefaults{
+			ObjectMeta: picked.ObjectMeta,
+			Spec:       picked.Spec,
+		}
 	}
 
-	// Fall back to cluster-scoped defaults.
 	var clusterList attunev1alpha1.AttuneDefaultsList
 	if err := r.List(ctx, &clusterList); err != nil {
 		return nil, fmt.Errorf("listing AttuneDefaults: %w", err)
 	}
-	if len(clusterList.Items) == 0 {
-		return nil, nil
-	}
-	clusterDefaults := &clusterList.Items[0]
-	for i := 1; i < len(clusterList.Items); i++ {
-		if clusterList.Items[i].Name < clusterDefaults.Name {
-			clusterDefaults = &clusterList.Items[i]
+	var clusterDefaults *attunev1alpha1.AttuneDefaults
+	if len(clusterList.Items) > 0 {
+		clusterDefaults = &clusterList.Items[0]
+		for i := 1; i < len(clusterList.Items); i++ {
+			if clusterList.Items[i].Name < clusterDefaults.Name {
+				clusterDefaults = &clusterList.Items[i]
+			}
 		}
 	}
-	return clusterDefaults, nil
+
+	return pkgdefaults.CombineDefaultsLayers(clusterDefaults, nsDefaults), nil
 }
 
 // applyBuiltInDefaults fills strategy and metrics fields still unset after
@@ -87,12 +90,12 @@ func (r *AttunePolicyReconciler) applyBuiltInDefaults(policy *attunev1alpha1.Att
 // mergeDefaults delegates to the shared defaults package and logs inherited fields.
 func (r *AttunePolicyReconciler) mergeDefaults(policy *attunev1alpha1.AttunePolicy, defaults *attunev1alpha1.AttuneDefaults) {
 	if defaults == nil {
-		ctrl.Log.V(1).Info("No cluster defaults configured, using built-in values only")
+		ctrl.Log.V(1).Info("No AttuneDefaults configured, using built-in values only")
 		return
 	}
 	inherited := pkgdefaults.MergeDefaults(policy, defaults)
 	if len(inherited) > 0 {
-		ctrl.Log.V(1).Info("Merged cluster defaults into policy",
+		ctrl.Log.V(1).Info("Merged effective defaults into policy",
 			"defaultsName", defaults.Name,
 			"fieldsInherited", inherited)
 	} else {

--- a/internal/controller/defaults_test.go
+++ b/internal/controller/defaults_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,20 +224,22 @@ func TestFetchDefaults_NamespaceScopedOverridesCluster(t *testing.T) {
 	assert.Equal(t, int32(90), result.Spec.CPU.Percentile)
 }
 
-func TestFetchDefaults_NamespaceDefaultsDoNotMergeWithClusterDefaults(t *testing.T) {
+func TestFetchDefaults_NamespaceMergesWithClusterDefaults(t *testing.T) {
+	// Issue #394: 3-tier merge — namespace wins for set fields; cluster fills gaps.
 	clusterDefaults := &attunev1alpha1.AttuneDefaults{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 		Spec: attunev1alpha1.AttuneDefaultsSpec{
-			CPU:    &attunev1alpha1.ResourceConfig{Percentile: 90, Overhead: "20"},
-			Memory: &attunev1alpha1.ResourceConfig{Percentile: 95, Overhead: "40"},
+			CPU: &attunev1alpha1.ResourceConfig{Percentile: 95, Overhead: "20"},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Cooldown: &metav1.Duration{Duration: 10 * time.Minute},
+			},
 		},
 	}
 	nsDefaults := &attunev1alpha1.AttuneNamespaceDefaults{
 		ObjectMeta: metav1.ObjectMeta{Name: "production-defaults", Namespace: "production"},
 		Spec: attunev1alpha1.AttuneDefaultsSpec{
-			CPU: &attunev1alpha1.ResourceConfig{Percentile: 99, Overhead: "20"},
-			// Memory intentionally omitted: namespace defaults should replace,
-			// not merge with, cluster defaults for this namespace.
+			// Override percentile only; cooldown should come from cluster.
+			CPU: &attunev1alpha1.ResourceConfig{Percentile: 90},
 		},
 	}
 	scheme := testScheme()
@@ -249,17 +252,21 @@ func TestFetchDefaults_NamespaceDefaultsDoNotMergeWithClusterDefaults(t *testing
 	defaults, err := r.fetchDefaults(context.Background(), "production")
 	require.NoError(t, err)
 	require.NotNil(t, defaults)
-	assert.Equal(t, int32(99), defaults.Spec.CPU.Percentile)
-	assert.Equal(t, "20", defaults.Spec.CPU.Overhead)
-	assert.Nil(t, defaults.Spec.Memory)
+	require.NotNil(t, defaults.Spec.CPU)
+	assert.Equal(t, int32(90), defaults.Spec.CPU.Percentile, "namespace percentile wins")
+	assert.Equal(t, "20", defaults.Spec.CPU.Overhead, "cluster overhead fills namespace gap")
+	require.NotNil(t, defaults.Spec.UpdateStrategy)
+	require.NotNil(t, defaults.Spec.UpdateStrategy.Cooldown)
+	assert.Equal(t, 10*time.Minute, defaults.Spec.UpdateStrategy.Cooldown.Duration,
+		"cluster cooldown fills namespace gap")
 
 	policy := &attunev1alpha1.AttunePolicy{}
 	r.mergeDefaults(policy, defaults)
-
-	assert.Equal(t, int32(99), policy.Spec.CPU.Percentile)
+	assert.Equal(t, int32(90), policy.Spec.CPU.Percentile)
 	assert.Equal(t, "20", policy.Spec.CPU.Overhead)
-	assert.Zero(t, policy.Spec.Memory.Percentile)
-	assert.Empty(t, policy.Spec.Memory.Overhead)
+	require.NotNil(t, policy.Spec.UpdateStrategy)
+	require.NotNil(t, policy.Spec.UpdateStrategy.Cooldown)
+	assert.Equal(t, 10*time.Minute, policy.Spec.UpdateStrategy.Cooldown.Duration)
 }
 
 func TestMergeDefaults_NamespaceDefaultsUseBuiltInFallbackForOmittedMemory(t *testing.T) {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -100,6 +100,81 @@ func mustParseBuiltInDuration(s string) time.Duration {
 	return d
 }
 
+// CombineDefaultsLayers builds effective defaults from optional cluster and
+// namespace layers. Namespace fields win; cluster fills fields left unset on
+// the namespace object. Returns nil if both layers are nil.
+//
+// Precedence when both exist: cluster < namespace (policy still overrides later
+// via MergeDefaults). CostPricing and all other Spec fields follow the same rule.
+func CombineDefaultsLayers(cluster, namespace *attunev1alpha1.AttuneDefaults) *attunev1alpha1.AttuneDefaults {
+	if namespace == nil {
+		return cluster
+	}
+	if cluster == nil {
+		return namespace
+	}
+
+	// Seed a synthetic policy with namespace values (higher priority), then
+	// MergeDefaults fills gaps from cluster (lower priority).
+	policy := &attunev1alpha1.AttunePolicy{}
+	applyDefaultsSpecToPolicy(policy, namespace.Spec)
+	_ = MergeDefaults(policy, cluster)
+
+	out := &attunev1alpha1.AttuneDefaults{
+		ObjectMeta: namespace.ObjectMeta,
+		Spec:       policyToDefaultsSpec(policy, pickCostPricing(namespace.Spec.CostPricing, cluster.Spec.CostPricing)),
+	}
+	return out
+}
+
+// applyDefaultsSpecToPolicy copies set fields from a defaults Spec onto a policy.
+func applyDefaultsSpecToPolicy(policy *attunev1alpha1.AttunePolicy, spec attunev1alpha1.AttuneDefaultsSpec) {
+	if spec.CPU != nil {
+		policy.Spec.CPU = *spec.CPU.DeepCopy()
+	}
+	if spec.Memory != nil {
+		policy.Spec.Memory = *spec.Memory.DeepCopy()
+	}
+	if spec.MetricsSource != nil {
+		policy.Spec.MetricsSource = *spec.MetricsSource.DeepCopy()
+	}
+	if spec.UpdateStrategy != nil {
+		policy.Spec.UpdateStrategy = spec.UpdateStrategy.DeepCopy()
+	}
+	if spec.ExcludeKnownSidecars != nil {
+		v := *spec.ExcludeKnownSidecars
+		policy.Spec.ExcludeKnownSidecars = &v
+	}
+}
+
+// policyToDefaultsSpec converts a fully merged policy Spec back into defaults Spec.
+// CostPricing is not stored on AttunePolicy and is passed separately.
+func policyToDefaultsSpec(policy *attunev1alpha1.AttunePolicy, cost *attunev1alpha1.CostPricing) attunev1alpha1.AttuneDefaultsSpec {
+	spec := attunev1alpha1.AttuneDefaultsSpec{CostPricing: cost}
+	// ResourceConfig.DeepCopy and MetricsSource.DeepCopy return pointers.
+	spec.CPU = policy.Spec.CPU.DeepCopy()
+	spec.Memory = policy.Spec.Memory.DeepCopy()
+	spec.MetricsSource = policy.Spec.MetricsSource.DeepCopy()
+	if policy.Spec.UpdateStrategy != nil {
+		spec.UpdateStrategy = policy.Spec.UpdateStrategy.DeepCopy()
+	}
+	if policy.Spec.ExcludeKnownSidecars != nil {
+		v := *policy.Spec.ExcludeKnownSidecars
+		spec.ExcludeKnownSidecars = &v
+	}
+	return spec
+}
+
+func pickCostPricing(namespace, cluster *attunev1alpha1.CostPricing) *attunev1alpha1.CostPricing {
+	if namespace != nil {
+		return namespace.DeepCopy()
+	}
+	if cluster != nil {
+		return cluster.DeepCopy()
+	}
+	return nil
+}
+
 // MergeDefaults merges values from an AttuneDefaults resource into the
 // policy where the policy has not specified its own values. Returns the
 // list of field names that were inherited (for debug logging by callers).

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -556,3 +556,63 @@ func TestMustParseBuiltInDuration_InvalidPanics(t *testing.T) {
 		mustParseBuiltInDuration("not-a-duration")
 	})
 }
+
+func TestCombineDefaultsLayers_NilBoth(t *testing.T) {
+	assert.Nil(t, CombineDefaultsLayers(nil, nil))
+}
+
+func TestCombineDefaultsLayers_NamespaceOnly(t *testing.T) {
+	ns := &attunev1alpha1.AttuneDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns"},
+		Spec: attunev1alpha1.AttuneDefaultsSpec{
+			CPU: &attunev1alpha1.ResourceConfig{Percentile: 99},
+		},
+	}
+	got := CombineDefaultsLayers(nil, ns)
+	require.NotNil(t, got)
+	assert.Equal(t, int32(99), got.Spec.CPU.Percentile)
+}
+
+func TestCombineDefaultsLayers_ClusterOnly(t *testing.T) {
+	cl := &attunev1alpha1.AttuneDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "cl"},
+		Spec: attunev1alpha1.AttuneDefaultsSpec{
+			CPU: &attunev1alpha1.ResourceConfig{Percentile: 80},
+		},
+	}
+	got := CombineDefaultsLayers(cl, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, int32(80), got.Spec.CPU.Percentile)
+}
+
+func TestCombineDefaultsLayers_ThreeTier(t *testing.T) {
+	cluster := &attunev1alpha1.AttuneDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: attunev1alpha1.AttuneDefaultsSpec{
+			CPU: &attunev1alpha1.ResourceConfig{Percentile: 95, Overhead: "20"},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Cooldown: &metav1.Duration{Duration: 10 * time.Minute},
+			},
+		},
+	}
+	ns := &attunev1alpha1.AttuneDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns"},
+		Spec: attunev1alpha1.AttuneDefaultsSpec{
+			CPU: &attunev1alpha1.ResourceConfig{Percentile: 90},
+		},
+	}
+	got := CombineDefaultsLayers(cluster, ns)
+	require.NotNil(t, got)
+	assert.Equal(t, int32(90), got.Spec.CPU.Percentile)
+	assert.Equal(t, "20", got.Spec.CPU.Overhead)
+	require.NotNil(t, got.Spec.UpdateStrategy.Cooldown)
+	assert.Equal(t, 10*time.Minute, got.Spec.UpdateStrategy.Cooldown.Duration)
+
+	// Policy still overrides both via MergeDefaults.
+	policy := &attunev1alpha1.AttunePolicy{}
+	policy.Spec.CPU.Percentile = 85
+	MergeDefaults(policy, got)
+	assert.Equal(t, int32(85), policy.Spec.CPU.Percentile)
+	assert.Equal(t, "20", policy.Spec.CPU.Overhead)
+	assert.Equal(t, 10*time.Minute, policy.Spec.UpdateStrategy.Cooldown.Duration)
+}

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -571,10 +571,12 @@ func TestReconcile_DefaultsMergingFromClusterDefaults(t *testing.T) {
 	}, 30*time.Second, 500*time.Millisecond, "policy with defaults should reconcile")
 }
 
-func TestReconcile_NamespaceDefaultsDoNotMergeClusterResourceFields(t *testing.T) {
+func TestReconcile_DefaultsDoNotPrefillPolicySpec(t *testing.T) {
+	// Defaults (cluster + namespace) are applied at reconcile time only; the
+	// webhook must not write inherited values into policy Spec.
 	namespace := "integration-test"
 
-	deploy := newTestDeployment("defaults-app-non-merge", namespace)
+	deploy := newTestDeployment("defaults-app-non-prefill", namespace)
 	require.NoError(t, k8sClient.Create(ctx, deploy))
 
 	clusterDefaults := &attunev1alpha1.AttuneDefaults{
@@ -593,8 +595,6 @@ func TestReconcile_NamespaceDefaultsDoNotMergeClusterResourceFields(t *testing.T
 	require.NoError(t, k8sClient.Create(ctx, clusterDefaults))
 	defer func() { _ = k8sClient.Delete(ctx, clusterDefaults) }()
 
-	// Namespace defaults intentionally omit memory to prove omitted fields do not
-	// inherit from cluster defaults in webhook-enabled flow.
 	nsDefaults := &attunev1alpha1.AttuneNamespaceDefaults{
 		ObjectMeta: metav1.ObjectMeta{Name: "namespace-defaults", Namespace: namespace},
 		Spec: attunev1alpha1.AttuneDefaultsSpec{
@@ -609,13 +609,13 @@ func TestReconcile_NamespaceDefaultsDoNotMergeClusterResourceFields(t *testing.T
 
 	policy := &attunev1alpha1.AttunePolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "policy-namespace-defaults-non-merge",
+			Name:      "policy-namespace-defaults-non-prefill",
 			Namespace: namespace,
 		},
 		Spec: attunev1alpha1.AttunePolicySpec{
 			TargetRef: attunev1alpha1.TargetRef{
 				Kind: "Deployment",
-				Name: func() *string { s := "defaults-app-non-merge"; return &s }(),
+				Name: func() *string { s := "defaults-app-non-prefill"; return &s }(),
 			},
 			MetricsSource: attunev1alpha1.MetricsSource{
 				Prometheus: &attunev1alpha1.PrometheusConfig{
@@ -636,7 +636,7 @@ func TestReconcile_NamespaceDefaultsDoNotMergeClusterResourceFields(t *testing.T
 	assert.Eventually(t, func() bool {
 		var fetched attunev1alpha1.AttunePolicy
 		if err := k8sClient.Get(ctx, types.NamespacedName{
-			Name: "policy-namespace-defaults-non-merge", Namespace: namespace,
+			Name: "policy-namespace-defaults-non-prefill", Namespace: namespace,
 		}, &fetched); err != nil {
 			return false
 		}
@@ -645,7 +645,7 @@ func TestReconcile_NamespaceDefaultsDoNotMergeClusterResourceFields(t *testing.T
 
 	var created attunev1alpha1.AttunePolicy
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
-		Name: "policy-namespace-defaults-non-merge", Namespace: namespace,
+		Name: "policy-namespace-defaults-non-prefill", Namespace: namespace,
 	}, &created))
 	assert.Zero(t, created.Spec.CPU.Percentile, "webhook should not prefill CPU percentile")
 	assert.Empty(t, created.Spec.CPU.Overhead, "webhook should not prefill CPU overhead")


### PR DESCRIPTION
## Summary

Closes #394.

When both cluster `AttuneDefaults` and namespace `AttuneNamespaceDefaults` exist, merge **per field**: namespace wins where set; cluster fills fields left unset on the namespace object. Policies still override both.

### Before

Namespace CR **replaced** the whole cluster layer. Unset namespace fields fell through to **built-in** defaults, ignoring cluster.

### After

```text
built-in < cluster AttuneDefaults < namespace AttuneNamespaceDefaults < policy
```

Example: cluster sets `percentile=95` and `cooldown=10m`; namespace sets only `percentile=90` → effective `percentile=90`, `cooldown=10m`.

### Behavior impact

- Unchanged when only cluster, only namespace, or neither exists.
- **Changes** only when **both** layers exist and the namespace object is sparse (fields omit → cluster, not built-in).

### Changes

- `pkg/defaults.CombineDefaultsLayers` + unit tests
- Controller `fetchDefaults` and `kubectl attune explain` use the same merge
- Docs (configuration, design, prometheus-setup) + CHANGELOG Unreleased

## Test plan

- [x] `go test ./pkg/defaults/ ./internal/controller/ ./cmd/kubectl-attune/`
- [x] `make verify-quick`
- [ ] CI green