### PR TITLE
test: cover defaults merge edges and clarify explain source

### DIFF
--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -51,8 +51,11 @@ const (
 	sourcePolicy          = "policy"
 	sourceNamespace       = "namespace default"
 	sourceCluster         = "cluster default"
-	sourceBuiltIn         = "built-in default"
-	unsetValue            = "<unset>"
+	// sourceMergedDefaults is used when both cluster and namespace defaults CRs
+	// exist and were combined (3-tier merge); individual fields may come from either layer.
+	sourceMergedDefaults = "merged defaults (namespace+cluster)"
+	sourceBuiltIn        = "built-in default"
+	unsetValue           = "<unset>"
 )
 
 var gvr = schema.GroupVersionResource{
@@ -990,7 +993,7 @@ func fetchSelectedDefaults(ctx context.Context, dynClient dynamic.Interface, nam
 	}
 	source := sourceCluster
 	if namespaceDefaults != nil && clusterDefaults != nil {
-		source = sourceNamespace // primary layer is namespace; cluster filled gaps
+		source = sourceMergedDefaults
 	} else if namespaceDefaults != nil {
 		source = sourceNamespace
 	}

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -1936,7 +1936,8 @@ func TestPrintExplain_ShowsPolicyNamespaceAndBuiltInEffectiveValues(t *testing.T
 	assert.Contains(t, output, "Cooldown: 30m0s (source: policy, configured: 30m)")
 	assert.Contains(t, output, "Query step: 10m0s (source: policy, configured: 10m)")
 	assert.Contains(t, output, "Minimum data points: 120 (source: policy, configured: 120)")
-	assert.Contains(t, output, "Resize method: InPlaceOrRecreate (source: namespace default, configured: <unset>)")
+	// Both cluster and namespace defaults exist → merged source label (3-tier).
+	assert.Contains(t, output, "Resize method: InPlaceOrRecreate (source: merged defaults (namespace+cluster), configured: <unset>)")
 	assert.Contains(t, output, "Max change: 70% (source: policy, configured: 70%)")
 	assert.Contains(t, output, "Max change: 30% (source: built-in default, configured: <unset>)")
 	assert.Contains(t, output, "Observation period: 5m0s (source: built-in default, configured: <unset>)")
@@ -2141,10 +2142,10 @@ func TestPrintExplain_NamespaceDefaultsInheritMissingFieldsFromClusterDefaults(t
 	require.NoError(t, err)
 	output := buf.String()
 
-	assert.Contains(t, output, "Minimum data points: 96 (source: namespace default, configured: <unset>)")
+	assert.Contains(t, output, "Minimum data points: 96 (source: merged defaults (namespace+cluster), configured: <unset>)")
 	// Cluster fills gaps left by the sparse namespace object (3-tier merge).
-	assert.Contains(t, output, "Query step: 1m0s (source: namespace default, configured: <unset>)")
-	assert.Contains(t, output, "Type: Auto (source: namespace default, configured: <unset>)")
+	assert.Contains(t, output, "Query step: 1m0s (source: merged defaults (namespace+cluster), configured: <unset>)")
+	assert.Contains(t, output, "Type: Auto (source: merged defaults (namespace+cluster), configured: <unset>)")
 	assert.NotContains(t, output, "Query step: 5m0s (source: built-in default")
 	assert.NotContains(t, output, "Type: Recommend (source: built-in default")
 }

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -616,3 +616,50 @@ func TestCombineDefaultsLayers_ThreeTier(t *testing.T) {
 	assert.Equal(t, "20", policy.Spec.CPU.Overhead)
 	assert.Equal(t, 10*time.Minute, policy.Spec.UpdateStrategy.Cooldown.Duration)
 }
+
+func TestCombineDefaultsLayers_AllSpecSectionsAndCostPricing(t *testing.T) {
+	falseVal := false
+	cluster := &attunev1alpha1.AttuneDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: attunev1alpha1.AttuneDefaultsSpec{
+			Memory: &attunev1alpha1.ResourceConfig{Percentile: 99, Overhead: "30"},
+			MetricsSource: &attunev1alpha1.MetricsSource{
+				HistoryWindow: &metav1.Duration{Duration: 48 * time.Hour},
+			},
+			ExcludeKnownSidecars: &falseVal,
+			CostPricing: &attunev1alpha1.CostPricing{
+				CPUPerCoreHour: "0.05",
+			},
+		},
+	}
+	ns := &attunev1alpha1.AttuneDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns"},
+		Spec: attunev1alpha1.AttuneDefaultsSpec{
+			CPU: &attunev1alpha1.ResourceConfig{Percentile: 80},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type: attunev1alpha1.UpdateTypeAuto,
+			},
+			// CostPricing omitted → inherit cluster.
+		},
+	}
+	got := CombineDefaultsLayers(cluster, ns)
+	require.NotNil(t, got)
+	assert.Equal(t, int32(80), got.Spec.CPU.Percentile)
+	require.NotNil(t, got.Spec.Memory)
+	assert.Equal(t, int32(99), got.Spec.Memory.Percentile)
+	require.NotNil(t, got.Spec.MetricsSource)
+	require.NotNil(t, got.Spec.MetricsSource.HistoryWindow)
+	assert.Equal(t, 48*time.Hour, got.Spec.MetricsSource.HistoryWindow.Duration)
+	require.NotNil(t, got.Spec.UpdateStrategy)
+	assert.Equal(t, attunev1alpha1.UpdateTypeAuto, got.Spec.UpdateStrategy.Type)
+	require.NotNil(t, got.Spec.ExcludeKnownSidecars)
+	assert.False(t, *got.Spec.ExcludeKnownSidecars)
+	require.NotNil(t, got.Spec.CostPricing)
+	assert.Equal(t, "0.05", got.Spec.CostPricing.CPUPerCoreHour)
+
+	// Namespace CostPricing wins when set.
+	ns.Spec.CostPricing = &attunev1alpha1.CostPricing{CPUPerCoreHour: "0.01"}
+	got = CombineDefaultsLayers(cluster, ns)
+	require.NotNil(t, got.Spec.CostPricing)
+	assert.Equal(t, "0.01", got.Spec.CostPricing.CPUPerCoreHour)
+}


### PR DESCRIPTION
## Summary

Quality-only MPI pass (no product features).

1. **Tests:** broader coverage of `CombineDefaultsLayers` (memory, metrics, update strategy, excludeKnownSidecars, CostPricing).
2. **UX accuracy:** `kubectl attune explain` reports `merged defaults (namespace+cluster)` when both default CRs are combined, instead of attributing every inherited field to "namespace default".

## Not in this PR

- No new features (#372, #368, etc.)
- Release PR #401 left for explicit approval

## Test plan

- [x] `go test ./pkg/defaults/ ./cmd/kubectl-attune/ ./internal/controller/`
- [x] `make verify-quick`
- [ ] CI green