### PR TITLE
chore: clear GitHub AI code quality hygiene findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.1.20](https://github.com/attune-io/attune/compare/v0.1.19...v0.1.20) (2026-07-14)
 
 
@@ -20,12 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * allow template history enums in CRD status schema ([#404](https://github.com/attune-io/attune/issues/404)) ([6c48a20](https://github.com/attune-io/attune/commit/6c48a20ba239116c60ce45c48716a22ea95860dc))
 * harden template persistence polish from MPI ([#406](https://github.com/attune-io/attune/issues/406)) ([1ce5ac8](https://github.com/attune-io/attune/commit/1ce5ac8e805e3cdbbc65bf9921e510696ae31e89))
-
-## [Unreleased]
-
-### Changed
-
-* 3-tier defaults merge: namespace AttuneNamespaceDefaults now fills unset fields from cluster AttuneDefaults instead of replacing the whole cluster object (#394)
 
 
 ## [0.1.19](https://github.com/attune-io/attune/compare/v0.1.18...v0.1.19) (2026-07-13)

--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -158,6 +158,7 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 					// kubelet status churn after resize. Without retry, a 409
 					// leaves the annotation unset and the boost never expires.
 					const maxBoostAnnotationRetries = 3
+					annotationPersisted := false
 					for attempt := range maxBoostAnnotationRetries {
 						freshPod, getErr := r.Clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 						if getErr != nil {
@@ -175,6 +176,7 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 						freshPod.Labels[labelTracked] = "true"
 						if updateErr := r.Update(ctx, freshPod); updateErr == nil {
 							*pod = *freshPod
+							annotationPersisted = true
 							break
 						} else if !apierrors.IsConflict(updateErr) {
 							logger.Error(updateErr, "Failed to persist startup boost annotation", "pod", pod.Name)
@@ -182,6 +184,10 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 						}
 						logger.V(1).Info("Boost annotation conflict, retrying",
 							"pod", pod.Name, "attempt", attempt+1)
+					}
+					if !annotationPersisted {
+						logger.V(1).Info("Startup boost annotation was not persisted after retries",
+							"pod", pod.Name, "retries", maxBoostAnnotationRetries)
 					}
 				}
 			} else if boostAtStr != "" {
@@ -258,6 +264,7 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 					}
 					// Re-fetch + conflict retry (same pattern as boost apply).
 					const maxExpiryAnnotationRetries = 3
+					annotationCleared := false
 					for attempt := range maxExpiryAnnotationRetries {
 						freshPod, getErr := r.Clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 						if getErr != nil {
@@ -265,16 +272,21 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 							break
 						}
 						if freshPod.Annotations == nil {
+							// Annotation map gone: boost marker is already absent.
+							*pod = *freshPod
+							annotationCleared = true
 							break
 						}
 						if _, ok := freshPod.Annotations[annotationStartupBoostAt]; !ok {
 							// Already cleared (race with another reconciler).
 							*pod = *freshPod
+							annotationCleared = true
 							break
 						}
 						delete(freshPod.Annotations, annotationStartupBoostAt)
 						if updateErr := r.Update(ctx, freshPod); updateErr == nil {
 							*pod = *freshPod
+							annotationCleared = true
 							break
 						} else if !apierrors.IsConflict(updateErr) {
 							logger.Error(updateErr, "Failed to update pod after startup boost expiry", "pod", pod.Name)
@@ -282,6 +294,10 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 						}
 						logger.V(1).Info("Boost expiry annotation conflict, retrying",
 							"pod", pod.Name, "attempt", attempt+1)
+					}
+					if !annotationCleared {
+						logger.V(1).Info("Startup boost expiry annotation was not cleared after retries",
+							"pod", pod.Name, "retries", maxExpiryAnnotationRetries)
 					}
 				}
 			}

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -34,8 +34,6 @@ import (
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
 
-func boolPtrTP(v bool) *bool { return &v }
-
 func TestTemplatePersistenceEnabled(t *testing.T) {
 	assert.False(t, templatePersistenceEnabled(nil))
 	assert.False(t, templatePersistenceEnabled(&attunev1alpha1.UpdateStrategy{}))
@@ -43,18 +41,18 @@ func TestTemplatePersistenceEnabled(t *testing.T) {
 		TemplatePersistence: &attunev1alpha1.TemplatePersistence{},
 	}))
 	assert.True(t, templatePersistenceEnabled(&attunev1alpha1.UpdateStrategy{
-		TemplatePersistence: &attunev1alpha1.TemplatePersistence{Enabled: boolPtrTP(true)},
+		TemplatePersistence: &attunev1alpha1.TemplatePersistence{Enabled: boolPtr(true)},
 	}))
 }
 
 func TestTemplatePersistenceWhenDefault(t *testing.T) {
 	assert.Equal(t, attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, templatePersistenceWhen(nil))
 	assert.Equal(t, attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, templatePersistenceWhen(&attunev1alpha1.UpdateStrategy{
-		TemplatePersistence: &attunev1alpha1.TemplatePersistence{Enabled: boolPtrTP(true)},
+		TemplatePersistence: &attunev1alpha1.TemplatePersistence{Enabled: boolPtr(true)},
 	}))
 	assert.Equal(t, attunev1alpha1.TemplatePersistenceOnRecommendation, templatePersistenceWhen(&attunev1alpha1.UpdateStrategy{
 		TemplatePersistence: &attunev1alpha1.TemplatePersistence{
-			Enabled: boolPtrTP(true),
+			Enabled: boolPtr(true),
 			When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
 		},
 	}))
@@ -267,7 +265,7 @@ func TestApplyTemplatePersistence_OnRecommendation_Deployment(t *testing.T) {
 	policy := newTestPolicy("p", "default")
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeRecommend
 	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
-		Enabled: boolPtrTP(true),
+		Enabled: boolPtr(true),
 		When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
 	}
 
@@ -338,7 +336,7 @@ func TestApplyTemplatePersistence_AfterSuccessfulResize_OnlyResizedWorkloads(t *
 	policy := newTestPolicy("p", "default")
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
 	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
-		Enabled: boolPtrTP(true),
+		Enabled: boolPtr(true),
 		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
 	}
 
@@ -405,7 +403,7 @@ func TestApplyTemplatePersistence_StatefulSet(t *testing.T) {
 
 	policy := newTestPolicy("p", "default")
 	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
-		Enabled: boolPtrTP(true),
+		Enabled: boolPtr(true),
 		When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
 	}
 	recs := []attunev1alpha1.WorkloadRecommendation{{
@@ -475,7 +473,7 @@ func TestApplyTemplatePersistence_SkipsExcludedContainers(t *testing.T) {
 
 	policy := newTestPolicy("p", "default")
 	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
-		Enabled: boolPtrTP(true),
+		Enabled: boolPtr(true),
 		When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
 	}
 	// only sidecar differs — should no-op entire patch if app has no change
@@ -510,7 +508,10 @@ func TestApplyTemplatePersistence_SkipsExcludedContainers(t *testing.T) {
 
 	var updated appsv1.Deployment
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
-	assert.Equal(t, int64(100), updated.Spec.Template.Spec.Containers[1].Resources.Requests.Cpu().MilliValue())
+	assert.Equal(t, int64(500), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(),
+		"app container should remain untouched")
+	assert.Equal(t, int64(100), updated.Spec.Template.Spec.Containers[1].Resources.Requests.Cpu().MilliValue(),
+		"known sidecar should remain untouched")
 }
 
 func TestSuccessfulResizeWorkloads(t *testing.T) {
@@ -525,9 +526,10 @@ func TestSuccessfulResizeWorkloads(t *testing.T) {
 }
 
 func TestLaggingAfterResizeWorkloads(t *testing.T) {
-	t0 := metav1.NewTime(metav1.Now().Add(-2 * time.Hour))
-	t1 := metav1.NewTime(metav1.Now().Add(-1 * time.Hour))
-	t2 := metav1.Now()
+	now := metav1.Now()
+	t0 := metav1.NewTime(now.Add(-2 * time.Hour))
+	t1 := metav1.NewTime(now.Add(-1 * time.Hour))
+	t2 := now
 
 	got := laggingAfterResizeWorkloads(
 		[]attunev1alpha1.ResizeHistoryEntry{
@@ -660,7 +662,7 @@ func TestApplyTemplatePersistence_SkipsObserveMode(t *testing.T) {
 	policy := newTestPolicy("p", "default")
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeObserve
 	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
-		Enabled: boolPtrTP(true),
+		Enabled: boolPtr(true),
 		When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
 	}
 	recs := []attunev1alpha1.WorkloadRecommendation{{
@@ -726,7 +728,7 @@ func TestApplyTemplatePersistence_SkipsCanaryInProgress(t *testing.T) {
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeCanary
 	policy.Status.Canary = &attunev1alpha1.CanaryStatus{Phase: attunev1alpha1.CanaryPhaseInProgress}
 	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
-		Enabled: boolPtrTP(true),
+		Enabled: boolPtr(true),
 		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
 	}
 	recs := []attunev1alpha1.WorkloadRecommendation{{
@@ -794,7 +796,7 @@ func TestApplyTemplatePersistence_SkipsMidRollout(t *testing.T) {
 
 	policy := newTestPolicy("p", "default")
 	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
-		Enabled: boolPtrTP(true),
+		Enabled: boolPtr(true),
 		When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
 	}
 	recs := []attunev1alpha1.WorkloadRecommendation{{
@@ -857,7 +859,7 @@ func TestApplyTemplatePersistence_NoOpWhenTemplateMatches(t *testing.T) {
 	memDec := true
 	policy.Spec.Memory.AllowDecrease = &memDec
 	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
-		Enabled: boolPtrTP(true),
+		Enabled: boolPtr(true),
 		When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
 	}
 	// Recommendation differs from "current" (live pod) but template already has desired.
@@ -934,7 +936,7 @@ func TestApplyTemplatePersistence_DisabledByDefault(t *testing.T) {
 	assert.Empty(t, history)
 
 	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
-		Enabled: boolPtrTP(false),
+		Enabled: boolPtr(false),
 		When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
 	}
 	history = r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -545,10 +545,15 @@ func TestMergeUpdateStrategy_BothEmptyTypeNoInheritance(t *testing.T) {
 
 func TestMustParseBuiltInDuration_ValidConstants(t *testing.T) {
 	// Guard against typoed default strings silently becoming zero durations.
+	// Only string duration constants need parse guards; Duration-typed
+	// constants are compile-time values (asserted below).
 	cooldown := mustParseBuiltInDuration(attunev1alpha1.DefaultCooldown)
 	assert.Equal(t, time.Hour, cooldown)
 	history := mustParseBuiltInDuration(attunev1alpha1.DefaultHistoryWindow)
 	assert.Equal(t, 168*time.Hour, history)
+
+	// Duration-typed built-ins (not parseable strings).
+	assert.Equal(t, 5*time.Minute, attunev1alpha1.DefaultQueryStep)
 }
 
 func TestMustParseBuiltInDuration_InvalidPanics(t *testing.T) {


### PR DESCRIPTION
## Summary

Clears actionable GitHub AI Code Quality findings without changing product behavior incorrectly.

- Keep a Changelog: put empty `[Unreleased]` first; drop stale #394 note already shipped in v0.1.20 (#409)
- Startup boost: log when annotation write/clear retries are exhausted; keep `*pod` in sync when annotations are nil on expiry
- Tests: shared `boolPtr`, single `now` for lagging-history timestamps, assert app container untouched in sidecar no-op path, guard `DefaultQueryStep`

**Intentionally not changed:** Datadog `/api/v1/query` `pointlist` timestamps stay divided by 1000. Datadog documents those points as milliseconds; unit tests use ms epoch fixtures. Treating them as seconds would regress collection.

## Test plan

- [x] `go test ./internal/controller/ ./pkg/defaults/ ./internal/metrics/ -race -count=1`
- [ ] CI green on this PR