### PR TITLE
ci: retry pure go fuzz deadline flakes in nightly

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -601,13 +601,15 @@ jobs:
 
       - name: Run fuzz tests (coverage-guided, 30s per target)
         shell: bash -Eeuo pipefail -x {0}
-        run: |
+        env:
           # Time-based limits let Go's coverage-guided engine focus on
           # inputs that explore new code paths. 30s per target achieves
           # full branch coverage faster than 1M random iterations.
-          go test ./internal/recommendation/... -run='^$' -fuzz=FuzzPercentileEstimator -fuzztime=30s
-          go test ./internal/recommendation/... -run='^$' -fuzz=FuzzRecommendationEngine -fuzztime=30s
-          go test ./internal/webhook/... -run='^$' -fuzz=FuzzValidateFloatFields -fuzztime=30s
+          # scripts/run-fuzz.sh retries once on pure "context deadline
+          # exceeded" flakes (golang/go#75804) without masking real crashes.
+          FUZZTIME: 30s
+          FUZZ_MAX_RETRIES: "1"
+        run: ./scripts/run-fuzz.sh
 
   report:
     name: Nightly Results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,7 +498,9 @@ directory. When referencing files elsewhere in the repo (e.g., `charts/`,
 ## CI
 
 - Runs on **GitHub-hosted runners** (`ubuntu-latest`) by default
-- Fuzz tests: 30s time-based per target (coverage-guided, not iteration count)
+- Fuzz tests: `scripts/run-fuzz.sh` (30s per target via `FUZZTIME`; coverage-guided).
+  Retries once only on pure `context deadline exceeded` flakes (golang/go#75804);
+  never retries real crashes/asserts. Classifier tests: `scripts/test_run_fuzz.sh`
 - E2E Nightly runs the full K8s version matrix (1.32, 1.33, 1.34, 1.35)
   in parallel (max-parallel: 4); each version creates a fresh k3d cluster
 - Concurrency groups use `cancel-in-progress: false` on main; PRs targeting

--- a/Makefile
+++ b/Makefile
@@ -222,14 +222,13 @@ test-e2e-smoke: chainsaw ## Run a minimal E2E smoke suite (requires a pre-provis
 	go test -tags=e2e ./test/e2e-go/... -run '^TestE2E_OneShotMode_ResizesOnePod$$' -race -count=1 -timeout=10m -v
 
 .PHONY: test-fuzz
-test-fuzz: ## Run fuzz tests (coverage-guided, 30s per target)
-	go test ./internal/recommendation/... -run='^$$' -fuzz=FuzzPercentileEstimator -fuzztime=30s
-	go test ./internal/recommendation/... -run='^$$' -fuzz=FuzzRecommendationEngine -fuzztime=30s
-	go test ./internal/webhook/... -run='^$$' -fuzz=FuzzValidateFloatFields -fuzztime=30s
+test-fuzz: ## Run fuzz tests (coverage-guided; FUZZTIME=30s default, deadline-flake retry)
+	./scripts/run-fuzz.sh
 
 .PHONY: python-test
-python-test: ## Run Python script tests (fossa-filter)
+python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier)
 	python3 scripts/test_fossa_filter.py -v
+	bash scripts/test_run_fuzz.sh
 
 .PHONY: test-bench
 test-bench: ## Run benchmark tests

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -169,19 +169,28 @@ random inputs to catch panics and edge cases:
 
 ```bash
 make test-fuzz
+# faster local loop:
+FUZZTIME=5s make test-fuzz
 ```
 
-This runs each fuzz target for 30 seconds (coverage-guided):
+`make test-fuzz` runs [`scripts/run-fuzz.sh`](https://github.com/attune-io/attune/blob/main/scripts/run-fuzz.sh),
+which executes each coverage-guided target for 30 seconds by default
+(`FUZZTIME`, overridable). Targets:
 
-```bash
-go test ./internal/recommendation/... -run='^$' -fuzz=FuzzPercentileEstimator -fuzztime=30s
-go test ./internal/recommendation/... -run='^$' -fuzz=FuzzRecommendationEngine -fuzztime=30s
-go test ./internal/webhook/...        -run='^$' -fuzz=FuzzValidateFloatFields  -fuzztime=30s
-```
+- `FuzzPercentileEstimator` (`./internal/recommendation/...`)
+- `FuzzRecommendationEngine` (`./internal/recommendation/...`)
+- `FuzzValidateFloatFields` (`./internal/webhook/...`)
+
+The runner continues across targets so one failure does not hide others,
+and retries once only when the log is a pure Go fuzz deadline flake
+(`context deadline exceeded` with no crash corpus or assert; see
+[golang/go#75804](https://github.com/golang/go/issues/75804)). Real
+failures (panic, `failing input written`, `t.Error`) are never retried.
 
 Fuzz targets are defined in `internal/recommendation/fuzz_test.go`
 (estimator and engine) and `internal/webhook/validation_test.go`
-(float-field parsing via `strconv.ParseFloat`).
+(float-field parsing via `strconv.ParseFloat`). Classifier unit tests:
+`bash scripts/test_run_fuzz.sh` (also via `make python-test`).
 
 ## Running all tests
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -173,9 +173,9 @@ make test-fuzz
 FUZZTIME=5s make test-fuzz
 ```
 
-`make test-fuzz` runs [`scripts/run-fuzz.sh`](https://github.com/attune-io/attune/blob/main/scripts/run-fuzz.sh),
-which executes each coverage-guided target for 30 seconds by default
-(`FUZZTIME`, overridable). Targets:
+`make test-fuzz` runs `scripts/run-fuzz.sh`, which executes each
+coverage-guided target for 30 seconds by default (`FUZZTIME`,
+overridable). Targets:
 
 - `FuzzPercentileEstimator` (`./internal/recommendation/...`)
 - `FuzzRecommendationEngine` (`./internal/recommendation/...`)

--- a/scripts/run-fuzz.sh
+++ b/scripts/run-fuzz.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# run-fuzz.sh
+#
+# Run Attune's Go native fuzz targets with hardening against a known
+# toolchain flake: when -fuzztime expires, go test occasionally fails
+# with only "context deadline exceeded" and no failing input
+# (golang/go#75804 / attune-io/attune#420).
+#
+# Strategy (strict, does not mask real bugs):
+# 1. Run each fuzz target independently so one flake cannot hide others.
+# 2. On failure, classify the log:
+#    - deadline flake: "context deadline exceeded" AND no crash corpus /
+#      panic / t.Error lines → retry once.
+#    - anything else → fail that target immediately (no retry).
+# 3. Aggregate: exit non-zero if any target still failed after retry.
+#
+# Usage:
+#   scripts/run-fuzz.sh
+#   FUZZTIME=5s scripts/run-fuzz.sh
+#   scripts/run-fuzz.sh --classify-log /path/to/log   # for tests
+#
+# Env:
+#   FUZZTIME          per-target duration (default: 30s)
+#   FUZZ_MAX_RETRIES  retries for deadline flakes only (default: 1)
+#
+set -euo pipefail
+
+FUZZTIME="${FUZZTIME:-30s}"
+FUZZ_MAX_RETRIES="${FUZZ_MAX_RETRIES:-1}"
+
+# package|target
+TARGETS=(
+  "./internal/recommendation/...|FuzzPercentileEstimator"
+  "./internal/recommendation/...|FuzzRecommendationEngine"
+  "./internal/webhook/...|FuzzValidateFloatFields"
+)
+
+# Classify a go test -fuzz failure log.
+# Prints: deadline_flake | real_failure
+classify_fuzz_failure() {
+  local log_file="$1"
+
+  if [[ ! -s "$log_file" ]]; then
+    echo "real_failure"
+    return 0
+  fi
+
+  # Real crash corpus or assertion path — never treat as flake.
+  if grep -qE 'failing input written to|panic:|[[:alnum:]_./-]+\.go:[0-9]+:' "$log_file"; then
+    echo "real_failure"
+    return 0
+  fi
+
+  # Known toolchain race at -fuzztime boundary (no corpus, no assert).
+  if grep -q 'context deadline exceeded' "$log_file"; then
+    echo "deadline_flake"
+    return 0
+  fi
+
+  echo "real_failure"
+  return 0
+}
+
+run_one_fuzz() {
+  local pkg="$1"
+  local target="$2"
+  local attempt="$3"
+  local log_file="$4"
+  local rc
+
+  echo "==> fuzz ${target} (pkg=${pkg}, fuzztime=${FUZZTIME}, attempt=${attempt})"
+  # Stream output and capture for classification. PIPESTATUS[0] is go test.
+  set +e
+  set -o pipefail
+  go test "${pkg}" -run='^$' -fuzz="${target}" -fuzztime="${FUZZTIME}" 2>&1 | tee "${log_file}"
+  rc=${PIPESTATUS[0]}
+  set +o pipefail
+  set -e
+  return "${rc}"
+}
+
+run_target_with_retry() {
+  local pkg="$1"
+  local target="$2"
+  local log_dir="$3"
+  local attempt=1
+  local max_attempts=$((FUZZ_MAX_RETRIES + 1))
+  local log_file
+  local kind
+
+  while (( attempt <= max_attempts )); do
+    log_file="${log_dir}/${target}.attempt${attempt}.log"
+    if run_one_fuzz "${pkg}" "${target}" "${attempt}" "${log_file}"; then
+      echo "OK: ${target}"
+      return 0
+    fi
+    kind="$(classify_fuzz_failure "${log_file}")"
+    echo "FAIL: ${target} (class=${kind})"
+
+    if [[ "${kind}" == "deadline_flake" ]] && (( attempt < max_attempts )); then
+      echo "WARN: ${target} hit Go fuzz deadline flake; retrying once (see golang/go#75804)"
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    if [[ "${kind}" == "deadline_flake" ]]; then
+      echo "ERROR: ${target} still deadline-flaking after ${FUZZ_MAX_RETRIES} retry(ies)"
+    else
+      echo "ERROR: ${target} real fuzz failure (no deadline-only retry)"
+    fi
+    return 1
+  done
+
+  return 1
+}
+
+if [[ "${1:-}" == "--classify-log" ]]; then
+  if [[ -z "${2:-}" ]]; then
+    echo "Usage: $0 --classify-log <path>" >&2
+    exit 2
+  fi
+  classify_fuzz_failure "$2"
+  exit 0
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  sed -n '2,30p' "$0"
+  exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+failed=0
+failed_targets=()
+
+for entry in "${TARGETS[@]}"; do
+  pkg="${entry%%|*}"
+  target="${entry##*|}"
+  if ! run_target_with_retry "${pkg}" "${target}" "${tmp_dir}"; then
+    failed=1
+    failed_targets+=("${target}")
+  fi
+done
+
+if (( failed )); then
+  echo "Fuzz suite failed: ${failed_targets[*]}"
+  exit 1
+fi
+
+echo "All fuzz targets passed (fuzztime=${FUZZTIME})"

--- a/scripts/test_run_fuzz.sh
+++ b/scripts/test_run_fuzz.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/run-fuzz.sh failure classification.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLASSIFY=("$ROOT/scripts/run-fuzz.sh" --classify-log)
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+assert_eq() {
+  local want="$1" got="$2" name="$3"
+  if [[ "$want" != "$got" ]]; then
+    echo "FAIL: $name: want=$want got=$got" >&2
+    exit 1
+  fi
+  echo "ok: $name"
+}
+
+# Fixture: pure deadline flake from nightly #420
+cat >"$tmpdir/deadline.log" <<'LOG'
+fuzz: elapsed: 30s, execs: 141714 (4822/sec), new interesting: 0 (total: 13)
+fuzz: elapsed: 30s, execs: 141714 (0/sec), new interesting: 0 (total: 13)
+--- FAIL: FuzzRecommendationEngine (30.10s)
+    context deadline exceeded
+FAIL
+exit status 1
+FAILgithub.com/attune-io/attune/internal/recommendation	30.112s
+LOG
+got="$("${CLASSIFY[@]}" "$tmpdir/deadline.log")"
+assert_eq "deadline_flake" "$got" "pure deadline flake"
+
+# Fixture: real assertion failure with corpus write
+cat >"$tmpdir/real_assert.log" <<'LOG'
+--- FAIL: FuzzRecommendationEngine (0.12s)
+    --- FAIL: FuzzRecommendationEngine (0.00s)
+        fuzz_test.go:131: result 5m below minimum bound 10m
+        failing input written to testdata/fuzz/FuzzRecommendationEngine/abc123
+FAIL
+LOG
+got="$("${CLASSIFY[@]}" "$tmpdir/real_assert.log")"
+assert_eq "real_failure" "$got" "assertion + failing input"
+
+# Fixture: panic
+cat >"$tmpdir/panic.log" <<'LOG'
+--- FAIL: FuzzPercentileEstimator (1.00s)
+panic: runtime error: integer divide by zero [recovered]
+FAIL
+LOG
+got="$("${CLASSIFY[@]}" "$tmpdir/panic.log")"
+assert_eq "real_failure" "$got" "panic is real"
+
+# Fixture: deadline text PLUS real assert must stay real
+cat >"$tmpdir/mixed.log" <<'LOG'
+--- FAIL: FuzzRecommendationEngine (30.10s)
+    fuzz_test.go:131: result 5m below minimum bound 10m
+    context deadline exceeded
+    failing input written to testdata/fuzz/FuzzRecommendationEngine/xyz
+FAIL
+LOG
+got="$("${CLASSIFY[@]}" "$tmpdir/mixed.log")"
+assert_eq "real_failure" "$got" "mixed deadline+assert is real"
+
+# Fixture: empty log
+: >"$tmpdir/empty.log"
+got="$("${CLASSIFY[@]}" "$tmpdir/empty.log")"
+assert_eq "real_failure" "$got" "empty log is real"
+
+# Fixture: generic non-zero without deadline
+cat >"$tmpdir/buildfail.log" <<'LOG'
+# github.com/attune-io/attune/internal/recommendation [github.com/attune-io/attune/internal/recommendation.test]
+internal/recommendation/engine.go:10:2: undefined: foo
+FAIL	github.com/attune-io/attune/internal/recommendation [build failed]
+LOG
+got="$("${CLASSIFY[@]}" "$tmpdir/buildfail.log")"
+assert_eq "real_failure" "$got" "build failure is real"
+
+echo "All run-fuzz classifier tests passed"


### PR DESCRIPTION
## Summary

Hardens nightly fuzz against false-positive failures like [#420](https://github.com/attune-io/attune/issues/420).

**Root cause of #420:** E2E was fully green; `FuzzRecommendationEngine` failed after exactly 30s with only `context deadline exceeded` and no crash corpus. That is a known Go toolchain race when `-fuzztime` expires ([golang/go#75804](https://github.com/golang/go/issues/75804)), not a product bug. Same SHA later passed two nightlies.

**Hardening (strict, does not mask real bugs):**

1. Shared `scripts/run-fuzz.sh` for Makefile + nightly (single source of truth).
2. Each fuzz target runs independently; remaining targets still run after a failure.
3. On failure, classify the log:
   - **deadline flake** (`context deadline exceeded` and no `failing input` / panic / `t.Error` lines) → retry **once**.
   - **real failure** → fail immediately (no retry).
4. Classifier unit tests in `scripts/test_run_fuzz.sh` (wired into `make python-test` / `verify-quick`).

## Test plan

- [x] `bash scripts/test_run_fuzz.sh` (6 classifier fixtures)
- [x] `make python-test`
- [x] `FUZZTIME=2s ./scripts/run-fuzz.sh` (all three targets PASS)
- [ ] CI gate green on this PR

Closes #420