### PR TITLE
docs: refresh GA messaging, differentiators, and ADOPTERS

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,8 +1,50 @@
 # Adopters
 
-If you are using Attune in your organization, please add your
-company to this list. It helps the project understand its user base
-and prioritize features.
+Organizations using Attune in production, staging, or evaluation.
+Public adopters build trust for the project and help prioritize features.
+
+## Seeking early adopters
+
+Attune is production-ready for Kubernetes 1.32+ clusters with Prometheus
+(or compatible metrics). If you run Attune and can be named publicly,
+please open a PR adding your organization below.
+
+- Open a PR against this file, or
+- Open a [Discussion](https://github.com/attune-io/attune/discussions)
+  (or an issue labeled `community`) if you prefer maintainer help drafting
+  the entry.
+
+We only list entries with explicit permission. Do not add an organization
+without approval from that organization.
+
+## How to add your organization
+
+1. Fork the repository and edit this file.
+2. Add a row to the table (or a short bullet under **Named adopters**).
+3. Optional fields: industry, approximate scale (nodes or namespaces),
+   contact or blog link, production vs staging.
+4. Open a pull request. Maintainers will merge after a quick check.
+
+### Template row
+
+```markdown
+| Example Corp | platform@example.com | 2026-08 | Production, ~200 nodes, API workloads |
+```
+
+## Named adopters
 
 | Organization | Contact | Date | Description |
 |---|---|---|---|
+| *(none listed yet)* | | | Be the first: open a PR or Discussion |
+
+## Anonymous / NDA usage
+
+If your organization uses Attune but cannot be named, a maintainer may
+record aggregate counts privately. Public entries are preferred when
+possible.
+
+## Rules
+
+- Production, staging, or serious evaluation only (not "starred the repo").
+- No competitor comparisons or unapproved marketing claims.
+- Maintainers may remove entries on request or if they become inaccurate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Project
 
 Attune: Kubernetes operator for in-place pod resource right-sizing (VPA replacement).
-Requires Kubernetes 1.32+ (In-Place Pod Resize; 1.32 alpha with feature gate, 1.33+ beta enabled by default). Built with Go 1.26,
+Requires Kubernetes 1.32+ (In-Place Pod Resize; 1.32 alpha with feature gate, 1.33–1.34 beta enabled by default, 1.35+ GA). Built with Go 1.26,
 controller-runtime v0.24.1, Kubebuilder v4, K8s API v0.36.1.
 
 **Naming convention:** "Attune" (capitalized) in prose and documentation.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 Attune is a Kubernetes operator that automatically right-sizes pod
 resource requests and limits using [In-Place Pod Resize](https://kubernetes.io/blog/2025/12/19/kubernetes-v1-35-in-place-pod-resize-ga/)
-(beta in Kubernetes 1.33+, alpha with feature gate in 1.32). In-place by default, optional eviction fallback for infeasible resizes, and no HPA conflicts.
+(**GA** in Kubernetes 1.35, beta and enabled by default in 1.33–1.34, alpha with feature gate in 1.32). In-place by default, optional eviction fallback for infeasible resizes, and no HPA conflicts.
 
 ---
 
@@ -33,26 +33,31 @@ resource requests and limits using [In-Place Pod Resize](https://kubernetes.io/b
 |---------|--------|
 | Average CPU utilization is **8%** | Billions wasted industry-wide ([CAST AI 2026](https://cast.ai/reports/state-of-kubernetes-optimization/)) |
 | **70%** cite overprovisioning as #1 cost driver | Resources allocated "just in case" never reclaimed ([CNCF 2023](https://www.cncf.io/blog/2023/12/20/cncf-cloud-native-finops-cloud-financial-management-microsurvey/)) |
-| **<1%** run VPA fully automated | VPA evicts pods, conflicts with HPA, causes outages ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)) |
-| In-Place Pod Resize is **beta** (K8s 1.33+, alpha in 1.32) | The foundation for non-disruptive right-sizing now exists |
+| **<1%** run VPA fully automated | VPA often evicts pods, conflicts with HPA, and is hard to run unattended ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)) |
+| In-Place Pod Resize is **GA** (K8s 1.35; beta 1.33–1.34; alpha 1.32) | Non-disruptive right-sizing is a stable Kubernetes primitive |
 
 ## How It's Different
 
+In-place apply is the shared primitive (Kubernetes `/resize`). Attune is the
+**safe unattended loop** on top: measure, decide, canary, verify, and revert.
+
 | | VPA | Goldilocks | Attune |
 |---|---|---|---|
-| Resize method | Evicts pods | No resize (recommend only) | **In-place** (no restarts) |
-| HPA compatible | No (death spirals) | N/A | **Yes** (adjusts base, not %) |
-| Safety | Minimal guardrails | N/A | **Graduated rollout + auto-revert** |
-| Algorithm | Backward-looking histograms | VPA recommender | **Time-of-day-aware + burst detection** |
-| Production confidence | <1% use automated | N/A | **Observe -> Recommend -> Canary (auto-promote) -> Auto** |
+| Resize method | Eviction-based Auto historically; newer modes can use in-place where supported | No resize (recommend only) | **In-place by default** (optional eviction fallback) |
+| HPA compatible | Risky on the same metric (death spirals) | N/A | **Yes** (adjusts base requests, not HPA %) |
+| Safety | Minimal guardrails | N/A | **Auto-revert** (OOM, throttle, restarts, NotReady) + **SLO PromQL guardrails** |
+| Blast radius | All targeted pods | N/A | **Canary** fraction with observation and optional auto-promote |
+| Cold start | None | N/A | **Startup boost** (temporary CPU headroom, then scale back) |
+| Algorithm | Backward-looking histograms | VPA recommender | **Time-of-day-aware + burst detection + confidence scaling** |
+| Production path | <1% run fully automated | Manual apply | **Observe → Recommend → Canary → Auto** |
 
-> **Migrating from VPA?** See the step-by-step [migration guide](docs/guides/migrating-from-vpa.md) for field-by-field mapping, side-by-side YAML, and zero-downtime cutover.
+> **Migrating from VPA?** See the step-by-step [migration guide](docs/guides/migrating-from-vpa.md) for field-by-field mapping, mode matrix, side-by-side YAML, and zero-downtime cutover.
 
 ## Quick Start
 
 ### Prerequisites
 
-- Kubernetes 1.32+ (1.32 requires enabling the `InPlacePodVerticalScaling` feature gate; 1.33+ has it enabled by default)
+- Kubernetes 1.32+ (1.32 requires enabling the `InPlacePodVerticalScaling` feature gate; 1.33–1.34 beta enabled by default; **1.35+ GA**)
 - Prometheus (for usage metrics)
 - Helm 3.16+ or 4.x
 - [cert-manager](https://cert-manager.io/docs/installation/) (for admission webhook TLS; to skip, install with `--set webhooks.enabled=false`)
@@ -262,8 +267,14 @@ The dashboard includes:
 
 - Auto-revert: automatically restores original resources on OOMKill,
   CPU throttle, restart spikes, or pod NotReady.
+- SLO guardrails: PromQL application-health checks (latency, error rate)
+  that trigger revert on threshold breach after a resize.
 - Graduated rollout: five modes from zero-risk to full automation --
-  Observe, Recommend, OneShot, Canary, Auto.
+  Observe, Recommend, OneShot, Canary (optional auto-promote), Auto.
+- Canary rollout: resize a percentage of pods first, observe, then promote
+  so blast radius stays controlled before full Auto.
+- Startup boost: temporary CPU headroom at container start (JIT / cold
+  path), then scale back to the steady-state recommendation.
 - Node capacity guard: validates post-resize requests fit within node
   allocatable before applying changes.
 - LimitRange/ResourceQuota guard: skips resizes that would violate
@@ -285,8 +296,8 @@ The dashboard includes:
 ### Operations
 
 - In-place resize: adjusts CPU and memory on running pods via the
-  K8s 1.32+ `/resize` subresource. The default path is in-place with no
-  restarts. `InPlaceOrRecreate` can optionally fall back to eviction when
+  K8s `/resize` subresource (GA in 1.35). The default path is in-place with
+  no restarts. `InPlaceOrRecreate` can optionally fall back to eviction when
   kubelet rejects an in-place resize.
 - Cost savings estimation: per-workload `EstimatedMonthlySavings` in
   status, CLI (`kubectl attune savings`), and Grafana dashboard.
@@ -310,8 +321,6 @@ The dashboard includes:
   rollouts targeting the same workload.
 - VPA recommendation consumption: use existing VerticalPodAutoscaler
   recommendations as an alternative to Prometheus queries via `metricsSource.vpa`.
-- SLO-based guardrails: PromQL-based application health checks
-  (latency, error rate) that auto-revert resizes on threshold breach.
 - GitOps diff command: `kubectl attune diff` outputs recommendations
   in diff format for ArgoCD/Flux review workflows.
 - Initial sizing webhook: set pod resources at creation time based on
@@ -338,6 +347,7 @@ The dashboard includes:
 | [Multi-Cluster](docs/guides/multi-cluster.md) | Deployment patterns, cross-cluster operations, and graduated rollouts |
 | [Scaling Guide](docs/guides/scaling.md) | Cluster size presets, tuning, and HA deployment |
 | [Canary Rollout](docs/guides/canary-rollout.md) | Graduated rollout strategy |
+| [Startup Boost](docs/guides/startup-boost.md) | Temporary CPU headroom for cold starts |
 | [CLI Reference](docs/reference/cli.md) | kubectl plugin commands |
 | [API Reference](docs/reference/api.md) | CRD specification |
 | [Troubleshooting](docs/guides/troubleshooting.md) | Common issues and solutions |

--- a/charts/attune/README.md
+++ b/charts/attune/README.md
@@ -4,7 +4,7 @@ Safe, in-place Kubernetes pod resource right-sizing operator
 
 ## Prerequisites
 
-- Kubernetes 1.32+ (1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33+ has it enabled by default)
+- Kubernetes 1.32+ (1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33–1.34 beta enabled by default; 1.35+ GA)
 - Prometheus (for usage metrics)
 - Helm 3.16+ or 4.x
 - [cert-manager](https://cert-manager.io/docs/installation/) (for webhook TLS; to skip, use `--set webhooks.enabled=false`)

--- a/charts/attune/README.md.gotmpl
+++ b/charts/attune/README.md.gotmpl
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-- Kubernetes 1.32+ (1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33+ has it enabled by default)
+- Kubernetes 1.32+ (1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33–1.34 beta enabled by default; 1.35+ GA)
 - Prometheus (for usage metrics)
 - Helm 3.16+ or 4.x
 - [cert-manager](https://cert-manager.io/docs/installation/) (for webhook TLS; to skip, use `--set webhooks.enabled=false`)

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,8 +16,9 @@ Safe, in-place Kubernetes pod resource right-sizing. VPA done right.
 ## What is Attune?
 
 Attune is a Kubernetes operator that automatically right-sizes pod resource
-requests and limits using In-Place Pod Resize (beta in Kubernetes 1.33+, alpha
-with feature gate in 1.32). No pod restarts, no HPA conflicts, no outages.
+requests and limits using In-Place Pod Resize (**GA** in Kubernetes 1.35, beta
+enabled by default in 1.33–1.34, alpha with feature gate in 1.32). No pod
+restarts by default, no HPA conflicts, graduated safety controls.
 
 ## Supported tags
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -35,9 +35,10 @@
 organizations run it fully automated ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)). VPA evicts pods, conflicts with HPA, and
 has caused cluster-wide outages.
 
-In 2025, In-Place Pod Resize graduated to beta in Kubernetes 1.33 (KEP-1287,
-with the `/resize` subresource available since 1.32 alpha). For the
-first time, CPU and memory can be changed on running pods without restarts. This unlocks a
+In December 2025, In-Place Pod Resize graduated to **GA** in Kubernetes 1.35
+([KEP-1287](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources);
+beta and enabled by default in 1.33–1.34; alpha with feature gate in 1.32).
+CPU and memory can be changed on running pods without restarts. That unlocks a
 ground-up redesign of resource right-sizing.
 
 ### Mission

--- a/docs/architecture/resize-api.md
+++ b/docs/architecture/resize-api.md
@@ -6,8 +6,9 @@ resize API works and how the operator uses it.
 
 Kubernetes 1.32 added the `/resize` subresource on pods as part of the
 `InPlacePodVerticalScaling` alpha feature gate. Kubernetes 1.33 graduated
-the feature to beta (enabled by default). The subresource accepts a
-modified `PodSpec` with new container resource requests/limits.
+the feature to beta (enabled by default). Kubernetes 1.35 graduated it to
+**GA**. The subresource accepts a modified `PodSpec` with new container
+resource requests/limits.
 
 ```
 PATCH /api/v1/namespaces/{ns}/pods/{name}/resize

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -76,8 +76,9 @@ See [Algorithm](../architecture/algorithm.md) for formulas and details.
 ## In-Place Pod Resize
 
 Kubernetes 1.32 added the `/resize` subresource for in-place pod resize
-(alpha, requires feature gate). Kubernetes 1.33 graduated the feature to
-beta (enabled by default). The kubelet adjusts cgroup limits without
+(alpha, requires the `InPlacePodVerticalScaling` feature gate). Kubernetes
+1.33 graduated the feature to beta (enabled by default). Kubernetes 1.35
+graduated it to **GA** (stable). The kubelet adjusts cgroup limits without
 restarting the container. Attune calls `UpdateResize` on each pod,
 then polls the container status until the new resources are reported or an
 `Infeasible` condition appears.

--- a/docs/getting-started/first-30-days.md
+++ b/docs/getting-started/first-30-days.md
@@ -114,14 +114,19 @@ If recommendations look unreasonable, adjust the policy:
 ## Week 2: Promote to Canary mode
 
 Once you trust the recommendations, switch to Canary mode to test on a
-small subset of pods:
+small subset of pods. This is the blast-radius control step before Auto:
 
 ```bash
 kubectl patch ap my-first-policy -n my-app --type=merge \
-  -p '{"spec":{"updateStrategy":{"type":"Canary","canary":{"percentage":10}}}}'
+  -p '{"spec":{"updateStrategy":{"type":"Canary","canary":{"percentage":10,"observationPeriod":"30m"}}}}'
 ```
 
-This resizes only 10% of matching pods. Monitor:
+This resizes only 10% of matching pods, then observes them for 30 minutes.
+With `autoPromote: true` on the canary config, the operator promotes the
+rest after a clean observation window; otherwise promote to Auto yourself.
+See the [canary rollout guide](../guides/canary-rollout.md).
+
+Monitor:
 
 ```bash
 kubectl attune status -w -n my-app
@@ -131,6 +136,15 @@ kubectl attune history -n my-app
 The history command shows each resize with its result and reason. If a
 resize is reverted, the **REASON** column tells you why (oomkill, restart,
 notready, throttle, or slo:&lt;name&gt; for SLO guardrail breaches).
+
+### Optional production hardening before Auto
+
+- **SLO guardrails**: add PromQL checks so a bad resize reverts on latency or
+  error-rate breach, not only infra signals. Documented under
+  `updateStrategy.sloGuardrails` in the [API reference](../reference/api.md).
+- **Startup boost**: for JVM or other cold-start heavy apps, enable
+  `cpu.startupBoost` so pods get temporary CPU headroom at start, then
+  scale back. See the [startup boost guide](../guides/startup-boost.md).
 
 !!! warning
     If you see repeated reverts, increase the overhead or adjust
@@ -152,6 +166,10 @@ kubectl attune savings -A
 ```
 
 The TOTAL row at the bottom shows aggregate cluster-wide savings.
+
+The production loop is: **measure → recommend → canary apply → verify
+(safety + optional SLO) → revert if needed → continuous Auto**. That is
+what distinguishes Attune from "apply via `/resize` only."
 
 ## Expanding to more workloads
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,11 +11,12 @@
 
 !!! note "In-Place Pod Resize"
     Kubernetes 1.32+ is required because Attune uses the
-    [In-Place Pod Resize](https://kubernetes.io/blog/2025/05/16/kubernetes-v1-33-in-place-pod-resize-beta/)
-    `/resize` subresource, which was added in 1.32.
+    [In-Place Pod Resize](https://kubernetes.io/blog/2025/12/19/kubernetes-v1-35-in-place-pod-resize-ga/)
+    `/resize` subresource (added in 1.32 alpha).
     On **1.32**, you must enable the `InPlacePodVerticalScaling` feature gate
     on the apiserver, controller-manager, scheduler, and all kubelets.
-    On **1.33+**, the feature is enabled by default (beta).
+    On **1.33–1.34**, the feature is enabled by default (beta).
+    On **1.35+**, the feature is **GA** (stable).
 
 ## Install with Helm (recommended)
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,7 +16,7 @@ recommendations, and promoting to Canary mode, all in about five minutes.
     the cluster for exploration.
 
 !!! info "Prerequisites"
-    - **Kubernetes 1.32+** — 1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33+ has it enabled by default.
+    - **Kubernetes 1.32+** — 1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33–1.34 beta enabled by default; **1.35+ GA**.
     - **A metrics source** — Prometheus (default), Datadog, or CloudWatch Container Insights. This guide uses Prometheus; see [Datadog Setup](../guides/datadog-setup.md) or [CloudWatch Setup](../guides/cloudwatch-setup.md) for alternatives.
     - **Attune installed** — see [Installation](installation.md) for Helm and raw manifest options.
 

--- a/docs/guides/migrating-from-vpa.md
+++ b/docs/guides/migrating-from-vpa.md
@@ -4,6 +4,12 @@ This guide walks you through replacing the Kubernetes Vertical Pod Autoscaler
 (VPA) with attune. The migration can be done workload-by-workload
 with no downtime.
 
+VPA is gaining in-place-capable update modes in the ecosystem. That narrows the
+gap on **apply**, but does not replace a production unattended loop. Attune still
+adds startup boost, canary fraction control, SLO PromQL revert, HPA-aware
+coexistence, and a graduated Observe → Recommend → Canary → Auto path. See
+[Why Attune](../why-attune.md) for the full product narrative.
+
 ## VPA vs Attune modes
 
 | VPA Mode | Attune Equivalent | Notes |
@@ -12,6 +18,19 @@ with no downtime.
 | `Initial` | **OneShot** | Set resources once; Attune uses in-place resize instead of restart |
 | `Auto` (with eviction) | **Canary** or **Auto** | In-place first; add `resizeMethod: InPlaceOrRecreate` if you want eviction fallback instead of skipping infeasible pods |
 | `Recommend` (UpdateMode=Off) | **Recommend** | Write recommendations to status without acting |
+| In-place-capable VPA modes (where available) | **Canary** then **Auto** | Shared `/resize` primitive; Attune still owns canary, SLO revert, and startup boost |
+
+## Feature matrix (beyond apply)
+
+| Capability | Typical VPA | Attune |
+|------------|-------------|--------|
+| In-place resize via `/resize` | Where supported by VPA update mode and cluster version | Default path (`InPlaceOnly`) |
+| Eviction / recreate fallback | Classic Auto path | Optional `InPlaceOrRecreate` |
+| Canary fraction + observation | No first-class canary % | **Canary** mode with optional auto-promote |
+| Application SLO revert | Infra signals mainly | **SLO guardrails** (PromQL thresholds) + OOM/throttle/restart/NotReady |
+| Startup / cold-start headroom | No | **Startup boost** then scale-back |
+| HPA on the same metric | Documented conflict risk | Coexistence design (base requests, not HPA %) |
+| Graduated rollout | Off / Initial / Auto | Observe, Recommend, OneShot, Canary, Auto |
 
 ## Step-by-step migration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,9 @@
 Attune is a Kubernetes operator that automatically right-sizes pod
 resource requests and limits using
 [In-Place Pod Resize](https://kubernetes.io/blog/2025/12/19/kubernetes-v1-35-in-place-pod-resize-ga/)
-(beta in Kubernetes 1.33+, alpha with feature gate in 1.32). In-place by default,
-optional eviction fallback for infeasible resizes, and no HPA conflicts.
+(**GA** in Kubernetes 1.35, beta and enabled by default in 1.33–1.34, alpha with
+feature gate in 1.32). In-place by default, optional eviction fallback for
+infeasible resizes, and no HPA conflicts.
 
 ## The Problem
 
@@ -21,20 +22,26 @@ it fully automated ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizin
 Goldilocks show you the numbers but leave you with hundreds of YAML edits
 that sit in the backlog for months.
 
-Kubernetes 1.33 changed this by graduating In-Place Pod Resize to beta
-(enabled by default). The foundation for non-disruptive right-sizing now
-exists. Attune is
-the operator built to use it.
+Kubernetes 1.35 graduated In-Place Pod Resize to **GA** (stable). The feature
+was beta and enabled by default from 1.33, and available as alpha with a
+feature gate on 1.32. The foundation for non-disruptive right-sizing is stable.
+Attune is the operator built for the safe unattended loop on top of that
+primitive.
 
 ## How It's Different
 
+In-place apply is the shared Kubernetes primitive. Attune adds the production
+path: canary blast-radius control, startup boost, and SLO-backed auto-revert.
+
 | | VPA | Goldilocks | Attune |
 |---|---|---|---|
-| Resize method | Evicts pods | No resize (recommend only) | **In-place** (no restarts) |
-| HPA compatible | No (death spirals) | N/A | **Yes** (adjusts base, not %) |
-| Safety | Minimal guardrails | N/A | **Graduated rollout + auto-revert** |
-| Algorithm | Backward-looking histograms | VPA recommender | **Time-of-day-aware + burst detection** |
-| Production path | <1% use automated | N/A | **Observe, Recommend, Canary, Auto** |
+| Resize method | Eviction-based Auto historically; newer modes can use in-place where supported | No resize (recommend only) | **In-place by default** (optional eviction fallback) |
+| HPA compatible | Risky on the same metric (death spirals) | N/A | **Yes** (adjusts base requests, not HPA %) |
+| Safety | Minimal guardrails | N/A | **Auto-revert** + **SLO PromQL guardrails** |
+| Blast radius | All targeted pods | N/A | **Canary** with observation and optional auto-promote |
+| Cold start | None | N/A | **Startup boost**, then scale back |
+| Algorithm | Backward-looking histograms | VPA recommender | **Time-of-day-aware + burst detection + confidence** |
+| Production path | <1% use automated | Manual apply | **Observe → Recommend → Canary → Auto** |
 
 ## Who Is This For?
 
@@ -48,8 +55,10 @@ the operator built to use it.
 
 ## Key Features
 
-- **In-place resize** via the Kubernetes 1.32+ `/resize` subresource
+- **In-place resize** via the Kubernetes `/resize` subresource (GA in 1.35)
 - **Graduated rollout**: Observe, Recommend, OneShot, Canary, Auto
+- **Canary rollout** with observation period and optional auto-promote
+- **Startup boost** for cold-start / JIT CPU headroom
 - **Auto-revert** on OOMKill, CPU throttle, restart spikes, pod NotReady, or SLO guardrail breach
 - **HPA coexistence** without death spirals
 - **Confidence scaling** for sparse data

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -172,6 +172,25 @@ not retrofitted onto a VPA architecture that was never meant for it.
  └──────────────────────┘
 ```
 
+### In-place apply is not enough
+
+Kubernetes In-Place Pod Resize (GA in 1.35) is the **shared primitive**: change
+cgroup limits without recreating the pod. VPA and other tools can use that
+primitive too. The harder problem is running **unattended** in production:
+
+1. **Startup boost** — temporary CPU headroom for cold starts and JIT, then
+   scale back to the steady-state recommendation
+   ([startup boost guide](guides/startup-boost.md)).
+2. **Canary** — resize a percentage of pods first, observe, then promote
+   ([canary rollout guide](guides/canary-rollout.md)).
+3. **SLO + safety revert** — infrastructure signals (OOM, throttle, restarts,
+   NotReady) plus application PromQL guardrails that auto-revert on breach
+   ([safety architecture](architecture/safety.md)).
+
+Those three pillars are the production path. The rest of this page explains
+the graduated modes, recommender, and HPA coexistence that make the loop
+operable day to day.
+
 ### Five modes for every comfort level
 
 You don't have to go from zero to fully-automated overnight. Attune
@@ -193,6 +212,8 @@ Week 3:    Canary mode     →  Resize 10% of pods, watch for issues
 Week 4+:   Auto mode       →  Let the operator handle it continuously
 ```
 
+See also the day-by-day [First 30 Days](getting-started/first-30-days.md) guide.
+
 ### Safety is not an afterthought
 
 Every resize is guarded by a multi-layer safety system:
@@ -204,6 +225,8 @@ Every resize is guarded by a multi-layer safety system:
 - **Restart spike detection**: 2+ restarts after a resize triggers a revert.
 - **Pod health checks**: If the pod loses its `Ready` condition, the operator
   reverts.
+- **SLO guardrails**: Optional PromQL checks (latency, error rate) that
+  revert when application health breaches a threshold after resize.
 - **Exponential backoff**: Each consecutive revert doubles the cooldown period
   (capped at 16x), so the operator doesn't keep hammering a problematic workload.
 - **Degraded condition**: When 3+ of the last 5 resizes are reverted, the


### PR DESCRIPTION
## Summary

Refresh user-facing messaging for the post-IPPR-GA era and document Attune's production differentiators.

Closes #433
Closes #434
Closes #370

## Changes

- **GA maturity**: README, docs site, installation/quickstart/concepts, architecture resize-api, SPEC, chart README, docker hub blurb, AGENTS.md — IPPR is GA in 1.35 (beta 1.33–1.34, alpha 1.32).
- **Differentiators**: comparison tables and Why Attune emphasize in-place as shared primitive vs safe unattended loop (startup boost, canary, SLO + safety revert).
- **Migration / first 30 days**: feature matrix and production hardening notes.
- **ADOPTERS.md**: contribution path, seeking early adopters CTA, rules.
- **Org profile**: updated separately in `attune-io/.github` profile README (same messaging).

## Test plan

- [ ] Grep for stale "IPPR is beta only" claims is clean (or intentionally versioned)
- [ ] MkDocs / docs CI green
- [ ] Links in README and ADOPTERS resolve