### PR TITLE
feat: versioned recommendation export schema for GitOps durability

### DIFF
--- a/docs/guides/auto-mode.md
+++ b/docs/guides/auto-mode.md
@@ -199,8 +199,21 @@ When enabled, the operator creates one ConfigMap per workload, named
 `<policy>-<workload>-recommendations`, with an owner reference to the policy
 for automatic cleanup when the policy itself is deleted.
 
-The ConfigMap contains per-container recommended CPU and memory values plus
-a `last-updated` timestamp (RFC3339).
+The ConfigMap is a versioned export artifact (`schema-version: v1`). Breaking
+key renames require a schema bump and docs update.
+
+| Key | Description |
+|-----|-------------|
+| `schema-version` | Export schema version (`v1`) |
+| `policy` | AttunePolicy name |
+| `namespace` | Policy namespace |
+| `workload` / `kind` | Target workload identity |
+| `<container>.cpu-request` / `memory-request` | Recommended requests |
+| `<container>.cpu-limit` / `memory-limit` | Recommended limits (when non-zero) |
+| `<container>.confidence` | Confidence score string |
+| `last-updated` / `generated-at` | RFC3339 generation time |
+
+Labels: `attune.io/policy`, `attune.io/workload`, `attune.io/export-schema=v1`.
 
 Example ConfigMap content:
 
@@ -213,7 +226,11 @@ metadata:
   labels:
     attune.io/policy: my-app
     attune.io/workload: my-deployment
+    attune.io/export-schema: v1
 data:
+  schema-version: v1
+  policy: my-app
+  namespace: default
   workload: my-deployment
   kind: Deployment
   main.cpu-request: "250m"
@@ -222,6 +239,7 @@ data:
   main.memory-limit: "1Gi"
   main.confidence: "0.92"
   last-updated: "2026-05-29T14:30:00Z"
+  generated-at: "2026-05-29T14:30:00Z"
 ```
 
 Inspect exports with the plugin (recommended over raw `kubectl get cm`):
@@ -230,6 +248,8 @@ Inspect exports with the plugin (recommended over raw `kubectl get cm`):
 kubectl attune export list -n <ns>
 # or with last-updated and container counts across all ns
 kubectl attune export -A
+# Ready-to-apply template patch for Git (Deployment / StatefulSet / CronJob)
+kubectl attune diff -n <ns> -o yaml
 ```
 
 **Orphan cleanup**: When a workload leaves the policy's selector (for example

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -17,36 +17,56 @@ Your Git-stored Deployment spec remains unchanged. This means:
 - **No feedback loop**: The operator doesn't write back to Git. The
   recommended values live only in the `AttunePolicy` status.
 
-## Recommended workflow
+## Recommended workflow (GitOps-durable recommendations)
 
-### 1. Start in Recommend mode
+Default in-place resize does **not** update Git or workload templates. After a
+deploy, new pods start with Git resources until Attune re-collects metrics and
+resizes again. Use this flow so recommended sizes **survive the next deploy**.
 
-Deploy `AttunePolicy` resources in your GitOps repo with `type: Recommend`.
-The operator computes recommendations without modifying anything.
+### 1. Start in Recommend mode with export
+
+Deploy `AttunePolicy` resources in your GitOps repo with `type: Recommend`
+and ConfigMap export enabled.
 
 ```yaml
 spec:
   updateStrategy:
     type: Recommend
+    export:
+      configMap: true
 ```
 
 ### 2. Review recommendations
 
 ```bash
 kubectl attune recommendations -n production
+kubectl attune explain -n production api-services
+kubectl attune export list -n production
 ```
 
-### 3. Apply recommendations to Git (manual)
+### 3. Emit a workload template patch and open a PR
 
-Update the Deployment resource requests in your Git repository based on the
-recommendations. This makes the optimization permanent and survives rollouts.
+```bash
+# Strategic-merge-style YAML for Deployment/StatefulSet/CronJob templates
+kubectl attune diff -n production -o yaml > /tmp/attune-resource-patches.yaml
+```
 
-### 4. Use Auto mode for continuous optimization
+Review the patch, apply it to your Git repo (or feed it to kustomize/helm
+values), and let Argo CD / Flux sync. New pods then start near recommended
+sizes without waiting for a full re-observation cycle.
 
-Once you trust the operator's recommendations for a workload, switch to
-`Auto` mode. The operator will continuously right-size pods between
-deployments. After each deployment, it re-learns the usage pattern and
-adjusts.
+Alternatively, read ConfigMaps named
+`<policy>-<workload>-recommendations` (schema key `schema-version: v1`).
+
+### 4. Optional continuous in-place between deploys
+
+Once you trust recommendations, switch to `Auto` (or Canary first). In-place
+resizes keep running pods healthy between deploys; keep committing template
+updates periodically so rollouts stay near target.
+
+**Do not** enable `templatePersistence` under unmanaged GitOps sync unless you
+intentionally want the cluster template to diverge from Git (see configuration
+reference).
 
 ## ArgoCD-specific notes
 

--- a/docs/guides/openshift.md
+++ b/docs/guides/openshift.md
@@ -175,3 +175,10 @@ OpenShift integration works alongside all other Attune features:
 - **NetworkPolicy**: The default NetworkPolicy allows egress to
   Prometheus and the Kubernetes API. No OpenShift-specific changes are
   needed.
+- **GitOps (OpenShift GitOps / Argo CD)**: Default in-place resize does
+  **not** update Git or Deployment templates. After a rollout, new pods
+  start from Git resources until Attune re-resizes. For durable sizes
+  across deploys, use Recommend + export ConfigMaps and
+  `kubectl attune diff -o yaml` to open PRs, or opt into
+  `templatePersistence` only if you accept live template mutation. See
+  the [GitOps integration guide](gitops-integration.md).

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -8746,12 +8746,18 @@ func TestExportRecommendationConfigMaps_CreatesConfigMap(t *testing.T) {
 		Name:      "test-policy-my-app-recommendations",
 	}, &cm)
 	require.NoError(t, err)
+	assert.Equal(t, RecommendationExportSchemaVersion, cm.Data["schema-version"])
+	assert.Equal(t, "test-policy", cm.Data["policy"])
+	assert.Equal(t, "default", cm.Data["namespace"])
 	assert.Equal(t, "my-app", cm.Data["workload"])
 	assert.Equal(t, "Deployment", cm.Data["kind"])
 	assert.Equal(t, "250m", cm.Data["main.cpu-request"])
 	assert.Equal(t, "256Mi", cm.Data["main.memory-request"])
 	assert.Equal(t, "0.95", cm.Data["main.confidence"])
+	assert.NotEmpty(t, cm.Data["last-updated"])
+	assert.Equal(t, cm.Data["last-updated"], cm.Data["generated-at"])
 	assert.Equal(t, "test-policy", cm.Labels["attune.io/policy"])
+	assert.Equal(t, RecommendationExportSchemaVersion, cm.Labels["attune.io/export-schema"])
 }
 
 func TestExportRecommendationConfigMaps_UpdatesExisting(t *testing.T) {

--- a/internal/controller/export.go
+++ b/internal/controller/export.go
@@ -32,6 +32,10 @@ import (
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
 
+// RecommendationExportSchemaVersion is the stable version of the ConfigMap
+// export data schema. Bump when keys or semantics change in a breaking way.
+const RecommendationExportSchemaVersion = "v1"
+
 // exportRecommendationConfigMaps creates or updates ConfigMaps with
 // recommendation data for GitOps workflows.
 func (r *AttunePolicyReconciler) exportRecommendationConfigMaps(
@@ -54,8 +58,11 @@ func (r *AttunePolicyReconciler) exportRecommendationConfigMaps(
 			continue
 		}
 		data := map[string]string{
-			"workload": rec.Workload,
-			"kind":     rec.Kind,
+			"schema-version": RecommendationExportSchemaVersion,
+			"policy":         policy.Name,
+			"namespace":      policy.Namespace,
+			"workload":       rec.Workload,
+			"kind":           rec.Kind,
 		}
 		for _, c := range rec.Containers {
 			prefix := c.Name + "."
@@ -74,14 +81,16 @@ func (r *AttunePolicyReconciler) exportRecommendationConfigMaps(
 			data[prefix+"confidence"] = fmt.Sprintf("%.2f", conf)
 		}
 		data["last-updated"] = r.now().UTC().Format(time.RFC3339)
+		data["generated-at"] = data["last-updated"]
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      cmName,
 				Namespace: policy.Namespace,
 				Labels: map[string]string{
-					"attune.io/policy":   policy.Name,
-					"attune.io/workload": rec.Workload,
+					"attune.io/policy":        policy.Name,
+					"attune.io/workload":      rec.Workload,
+					"attune.io/export-schema": RecommendationExportSchemaVersion,
 				},
 			},
 			Data: data,


### PR DESCRIPTION
## Summary

GitOps-durable recommendations **Phase A**: versioned export artifact + documented patch flow.

**Does not implement Phase B** (opt-in PR automation). That work is tracked in **#443**.

## Changes

- ConfigMap export: `schema-version: v1`, `policy`, `namespace`, `generated-at`, label `attune.io/export-schema`
- Docs: end-to-end Recommend → export → `kubectl attune diff -o yaml` → Git PR
- OpenShift guide: in-place does not update Git; point to GitOps durability path
- Unit tests assert schema stability keys

## Issue linking

- **Phase A (this PR):** implements the must-have path from #368 (export schema, CLI patch docs, GitOps flow).
- **Phase B (follow-up):** #443 (opt-in GitHub/GitLab PR automation).
- Use `Ref #368` rather than closing #368 until Phase A acceptance on that issue is checked; close #368 only after verifying Phase A checkboxes, with #443 left open for Phase B.

Ref #368
Ref #443

## Test plan

- [x] `go test ./internal/controller/ -run ExportRecommendation -race`
- [x] `go test ./cmd/kubectl-attune/ -run Diff -race`
- [ ] CI green