### PR TITLE
feat: version-aware memory limit decrease for kubernetes 1.35+

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/attune-io/attune/internal/controller"
 	"github.com/attune-io/attune/internal/metrics"
 	_ "github.com/attune-io/attune/internal/operatormetrics"
+	"github.com/attune-io/attune/internal/resize"
 	"github.com/attune-io/attune/internal/transform"
 	"github.com/attune-io/attune/internal/webhook"
 )
@@ -195,6 +196,14 @@ func main() {
 	reconciler.Scheme = mgr.GetScheme()
 	reconciler.Clientset = clientset
 	reconciler.Recorder = mgr.GetEventRecorder("attune")
+	if sv, err := clientset.Discovery().ServerVersion(); err != nil {
+		setupLog.Error(err, "unable to detect Kubernetes version; memory limit decreases will remain clamped")
+	} else {
+		allow := resize.AllowsInPlaceMemoryLimitDecrease(sv.GitVersion)
+		reconciler.AllowInPlaceMemoryLimitDecrease = allow
+		setupLog.Info("Kubernetes version for memory limit decrease policy",
+			"gitVersion", sv.GitVersion, "allowInPlaceMemoryLimitDecrease", allow)
+	}
 	reconciler.CollectorTTL = collectorTTL
 	reconciler.MaxConcurrentReconciles = maxConcurrentReconciles
 	reconciler.PrometheusTimeout = prometheusTimeout

--- a/docs/architecture/resize-api.md
+++ b/docs/architecture/resize-api.md
@@ -16,8 +16,14 @@ PATCH /api/v1/namespaces/{ns}/pods/{name}/resize
 
 The kubelet applies the new resources to the running container's cgroup
 limits without restarting it. CPU changes take effect immediately; memory
-limit increases take effect immediately but decreases only apply when the
-container's working set drops below the new limit.
+limit increases take effect immediately.
+
+**Memory limit decreases:**
+
+| Cluster | Behavior |
+|---------|----------|
+| Kubernetes **1.33–1.34** | API rejects in-place memory limit decreases when `resizePolicy` for memory is `NotRequired` (default). Attune **clamps** the limit (keeps the higher current value) unless policy is `RestartContainer`. |
+| Kubernetes **1.35+** (GA) | Live memory limit decreases are allowed. The kubelet does a best-effort check against current usage; a race can still OOM if usage spikes after the check. Attune detects the version at startup and **skips the clamp** so decreases can apply when `allowDecrease` permits. Directional `maxDecreasePercent` still steps large shrinks over multiple cycles. |
 
 ## How Attune uses it
 

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -140,8 +140,11 @@ type AttunePolicyReconciler struct {
 	CollectorTTL            time.Duration // how long unused collectors stay cached (default: 10m)
 	MaxConcurrentReconciles int           // max parallel reconcile goroutines (default: 1)
 	PrometheusTimeout       time.Duration // max time for Prometheus queries per reconcile (default: 5m)
-	nowFunc                 atomic.Pointer[func() time.Time]
-	collectors              sync.Map // map[string]*collectorEntry cache
+	// AllowInPlaceMemoryLimitDecrease is true when the cluster is Kubernetes
+	// 1.35+ (live memory limit decreases permitted). Wired at manager startup.
+	AllowInPlaceMemoryLimitDecrease bool
+	nowFunc                         atomic.Pointer[func() time.Time]
+	collectors                      sync.Map // map[string]*collectorEntry cache
 	// gaugeKeys tracks which Prometheus gauge label combinations each policy
 	// set on its last reconcile. On the next reconcile, only these specific
 	// keys are deleted (not the entire namespace), preventing cross-policy
@@ -493,6 +496,7 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// modes must not modify pod resources.
 	if isResizeMode(mode) && policy.Spec.CPU.StartupBoost != nil && r.Clientset != nil && len(recommendations) > 0 {
 		resizer := resize.NewPodResizer(r.Clientset, logger)
+		resizer.AllowInPlaceMemoryLimitDecrease = r.AllowInPlaceMemoryLimitDecrease
 		r.applyStartupBoosts(ctx, &policy, podsByWorkload, recommendations, resizer, preChecks)
 	}
 

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -118,6 +118,7 @@ func (r *AttunePolicyReconciler) executeResizes(
 	}
 
 	resizer := resize.NewPodResizer(r.Clientset, logger)
+	resizer.AllowInPlaceMemoryLimitDecrease = r.AllowInPlaceMemoryLimitDecrease
 	monitor := r.newSafetyMonitor(logger, collector, policy.Spec.UpdateStrategy.SLOGuardrails)
 
 	var totalResized int
@@ -376,7 +377,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	// the QoS check with the unclamped target but then have its memory
 	// limit preserved by the resize engine, breaking requests == limits.
 	preClamped := target.DeepCopy()
-	target = resize.ClampMemoryLimitForPolicy(pod, containerRec.Name, target)
+	target = resize.ClampMemoryLimitForPolicy(pod, containerRec.Name, target, r.AllowInPlaceMemoryLimitDecrease)
 	if memLim, ok := preClamped.Limits[corev1.ResourceMemory]; ok {
 		if clampedLim, cok := target.Limits[corev1.ResourceMemory]; cok && !memLim.Equal(clampedLim) {
 			logger.Info("Memory limit decrease clamped by resize policy",

--- a/internal/resize/engine.go
+++ b/internal/resize/engine.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -57,6 +59,9 @@ type ResizeResult struct {
 type PodResizer struct {
 	client kubernetes.Interface
 	logger logr.Logger
+	// AllowInPlaceMemoryLimitDecrease skips clamping memory limit decreases
+	// when the cluster permits live decreases (Kubernetes 1.35+).
+	AllowInPlaceMemoryLimitDecrease bool
 }
 
 // NewPodResizer creates a new PodResizer backed by the given Kubernetes client.
@@ -98,8 +103,9 @@ func (r *PodResizer) ResizePod(ctx context.Context, pod *corev1.Pod, container s
 		updated := fresh.DeepCopy()
 		// Clamp the target memory limit when the container's resize policy
 		// for memory is NotRequired (or absent, which defaults to NotRequired).
-		// K8s v1.33 forbids in-place memory limit decreases with NotRequired.
-		adjustedTarget := ClampMemoryLimitForPolicy(fresh, container, target)
+		// K8s v1.33 forbids in-place memory limit decreases with NotRequired;
+		// v1.35+ allows them (best-effort kubelet check).
+		adjustedTarget := ClampMemoryLimitForPolicy(fresh, container, target, r.AllowInPlaceMemoryLimitDecrease)
 		if isInit {
 			current = fresh.Spec.InitContainers[idx].Resources
 			updated.Spec.InitContainers[idx].Resources = mergeResources(current, adjustedTarget)
@@ -277,9 +283,16 @@ func (r *PodResizer) EvictPod(ctx context.Context, pod *corev1.Pod) error {
 
 // ClampMemoryLimitForPolicy prevents memory limit decreases when the
 // container's resize policy for memory is NotRequired (or absent, which
-// defaults to NotRequired). Kubernetes v1.33 rejects in-place memory limit
-// decreases unless the resize policy is RestartContainer.
-func ClampMemoryLimitForPolicy(pod *corev1.Pod, container string, target corev1.ResourceRequirements) corev1.ResourceRequirements {
+// defaults to NotRequired) and the cluster still rejects those decreases.
+//
+// Kubernetes v1.33 rejects in-place memory limit decreases unless the resize
+// policy is RestartContainer. Kubernetes v1.35+ allows live decreases with a
+// best-effort usage check. Pass allowInPlaceMemoryLimitDecrease=true on 1.35+
+// clusters so Attune does not over-clamp.
+func ClampMemoryLimitForPolicy(pod *corev1.Pod, container string, target corev1.ResourceRequirements, allowInPlaceMemoryLimitDecrease bool) corev1.ResourceRequirements {
+	if allowInPlaceMemoryLimitDecrease {
+		return target
+	}
 	if len(target.Limits) == 0 {
 		return target
 	}
@@ -316,6 +329,39 @@ func ClampMemoryLimitForPolicy(pod *corev1.Pod, container string, target corev1.
 		return target
 	}
 	return target
+}
+
+// AllowsInPlaceMemoryLimitDecrease reports whether GitVersion (e.g. "v1.35.0")
+// is at least Kubernetes 1.35, where live memory limit decreases are allowed.
+func AllowsInPlaceMemoryLimitDecrease(gitVersion string) bool {
+	major, minor, ok := parseK8sMajorMinor(gitVersion)
+	if !ok {
+		return false
+	}
+	return major > 1 || (major == 1 && minor >= 35)
+}
+
+// parseK8sMajorMinor extracts major and minor from a GitVersion string.
+func parseK8sMajorMinor(gitVersion string) (major, minor uint, ok bool) {
+	v := strings.TrimSpace(gitVersion)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return 0, 0, false
+	}
+	// Drop build metadata / pre-release after + or -
+	if i := strings.IndexAny(v, "+-"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	maj64, err1 := strconv.ParseUint(parts[0], 10, 32)
+	min64, err2 := strconv.ParseUint(parts[1], 10, 32)
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return uint(maj64), uint(min64), true
 }
 
 // WouldRestartContainer returns true if resizing the named container would

--- a/internal/resize/engine_test.go
+++ b/internal/resize/engine_test.go
@@ -889,8 +889,7 @@ func TestClampMemoryLimitForPolicy(t *testing.T) {
 		expectedMemLim string
 	}{
 		{
-			name: "NotRequired prevents memory limit decrease",
-			resizePolicy: []corev1.ContainerResizePolicy{
+			name: "NotRequired prevents memory limit decrease", resizePolicy: []corev1.ContainerResizePolicy{
 				{ResourceName: corev1.ResourceMemory, RestartPolicy: corev1.NotRequired},
 			},
 			currentMemLim:  "1Gi",
@@ -978,7 +977,7 @@ func TestClampMemoryLimitForPolicy(t *testing.T) {
 				}
 			}
 
-			result := ClampMemoryLimitForPolicy(pod, "app", target)
+			result := ClampMemoryLimitForPolicy(pod, "app", target, false)
 
 			if tt.expectedMemLim == "" {
 				assert.Empty(t, result.Limits)
@@ -990,6 +989,41 @@ func TestClampMemoryLimitForPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClampMemoryLimitForPolicy_AllowInPlaceDecrease(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "app",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+				},
+				ResizePolicy: []corev1.ContainerResizePolicy{
+					{ResourceName: corev1.ResourceMemory, RestartPolicy: corev1.NotRequired},
+				},
+			}},
+		},
+	}
+	target := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+	}
+	// Pre-1.35: clamp preserves current limit.
+	clamped := ClampMemoryLimitForPolicy(pod, "app", target, false)
+	assert.True(t, resource.MustParse("1Gi").Equal(clamped.Limits[corev1.ResourceMemory]))
+	// 1.35+: allow live decrease.
+	unclamped := ClampMemoryLimitForPolicy(pod, "app", target, true)
+	assert.True(t, resource.MustParse("512Mi").Equal(unclamped.Limits[corev1.ResourceMemory]))
+}
+
+func TestAllowsInPlaceMemoryLimitDecrease(t *testing.T) {
+	assert.False(t, AllowsInPlaceMemoryLimitDecrease("v1.33.0"))
+	assert.False(t, AllowsInPlaceMemoryLimitDecrease("v1.34.7"))
+	assert.True(t, AllowsInPlaceMemoryLimitDecrease("v1.35.0"))
+	assert.True(t, AllowsInPlaceMemoryLimitDecrease("v1.35.4-k3s1"))
+	assert.True(t, AllowsInPlaceMemoryLimitDecrease("v1.36.0+abc"))
+	assert.False(t, AllowsInPlaceMemoryLimitDecrease(""))
+	assert.False(t, AllowsInPlaceMemoryLimitDecrease("bogus"))
 }
 
 func TestClampMemoryLimitForPolicy_InitContainer(t *testing.T) {
@@ -1026,7 +1060,7 @@ func TestClampMemoryLimitForPolicy_InitContainer(t *testing.T) {
 		Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
 	}
 
-	result := ClampMemoryLimitForPolicy(pod, "sidecar", target)
+	result := ClampMemoryLimitForPolicy(pod, "sidecar", target, false)
 
 	// NotRequired policy on init container: memory limit decrease from 512Mi
 	// to 256Mi should be clamped back to 512Mi.
@@ -1068,7 +1102,7 @@ func TestClampMemoryLimitForPolicy_ContainerNotFound(t *testing.T) {
 		},
 	}
 
-	result := ClampMemoryLimitForPolicy(pod, "nonexistent", target)
+	result := ClampMemoryLimitForPolicy(pod, "nonexistent", target, false)
 
 	// Target should be returned unmodified when the container is not found.
 	expectedMem := resource.MustParse("128Mi")

--- a/internal/safety/monitor.go
+++ b/internal/safety/monitor.go
@@ -364,7 +364,12 @@ func (m *Monitor) RevertPod(ctx context.Context, record ResizeRecord) error {
 		// decreased in-place when the resize policy is NotRequired. Without
 		// this, reverts that lower the memory limit are rejected by the API
 		// server on v1.33 clusters.
-		revertTarget := resize.ClampMemoryLimitForPolicy(pod, record.Container, record.OriginalResources)
+		// Reverts restore previous (often lower) memory limits. On clusters
+		// that still reject live decreases, clamp so the revert can succeed.
+		// Monitor does not know cluster version; pass false to keep the
+		// safer clamp path (same as pre-1.35). Controllers on 1.35+ that
+		// unclamp apply may still need clamp on revert if original is lower.
+		revertTarget := resize.ClampMemoryLimitForPolicy(pod, record.Container, record.OriginalResources, false)
 		// For Guaranteed QoS pods, the memory limit clamp may cause
 		// requests != limits, which K8s rejects ("Pod QOS Class may not
 		// change as a result of resizing"). Raise the memory request to


### PR DESCRIPTION
## Summary

Allow in-place memory limit decreases on Kubernetes 1.35+ while keeping the v1.33 clamp on older clusters.

Closes #428

## Changes

- `AllowsInPlaceMemoryLimitDecrease(gitVersion)` + startup Discovery probe
- `ClampMemoryLimitForPolicy(..., allow)` used by resizer with cluster flag
- Safety revert still clamps (safe path)
- Architecture docs for 1.33 vs 1.35
- Unit tests for version parse and unclamp path

Client-side usage pre-check vs proposed limit remains follow-up if production data shows need; directional `maxDecreasePercent` already steps large decreases.

## Test plan

- [x] `go test ./internal/resize/ ./internal/safety/ ./internal/controller/ ./cmd/manager/ -race`
- [ ] CI green (matrix includes 1.33 clamp and 1.35 allow paths via unit tests)