### PR TITLE
feat: language runtime profiles for memory resize safety

### DIFF
--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -135,6 +135,15 @@ type AttunePolicySpec struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=1000
 	Weight int32 `json:"weight,omitempty"`
+
+	// RuntimeProfile applies language/runtime-oriented defaults for memory
+	// resize safety. Unset or "generic" leaves policy fields unchanged.
+	// Profiles document recommended resizePolicy and decrease settings;
+	// they do not auto-patch pod specs. Supported values: generic, java,
+	// python, golang, nodejs.
+	// +optional
+	// +kubebuilder:validation:Enum=generic;java;python;golang;nodejs
+	RuntimeProfile string `json:"runtimeProfile,omitempty"`
 }
 
 // TargetRef identifies the target workload(s).

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -508,6 +508,20 @@ spec:
                   when debugging unexpected behavior. The operator sets Ready=False
                   with reason=Paused while this field is true.
                 type: boolean
+              runtimeProfile:
+                description: |-
+                  RuntimeProfile applies language/runtime-oriented defaults for memory
+                  resize safety. Unset or "generic" leaves policy fields unchanged.
+                  Profiles document recommended resizePolicy and decrease settings;
+                  they do not auto-patch pod specs. Supported values: generic, java,
+                  python, golang, nodejs.
+                enum:
+                - generic
+                - java
+                - python
+                - golang
+                - nodejs
+                type: string
               targetRef:
                 description: TargetRef identifies the workload(s) to be attuned.
                 properties:

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1053,6 +1053,12 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	printEffectiveField("Minimum data points", formatInt64Ptr(rawInt64Field(item, "spec", "metricsSource", "minimumDataPoints")), formatInt32Ptr(effective.Spec.MetricsSource.MinimumDataPoints), selected, metricsDefaults != nil && metricsDefaults.MinimumDataPoints != nil)
 	printEffectiveField("Paused", formatBoolField(item, "spec", "paused"), formatBoolPtr(effective.Spec.Paused), selected, false)
 	printEffectiveField("Weight", formatInt64Field(item, "spec", "weight"), formatInt32Val(effective.Spec.Weight), selected, false)
+	rpConfigured := getNestedString(item, "spec", "runtimeProfile")
+	rpEffective := effective.Spec.RuntimeProfile
+	if rpEffective == "" {
+		rpEffective = "generic"
+	}
+	printEffectiveField("Runtime profile", rpConfigured, rpEffective, selected, false)
 	knownInherited := selected.defaults != nil && selected.defaults.Spec.ExcludeKnownSidecars != nil
 	printEffectiveField("Exclude known sidecars", formatBoolField(item, "spec", "excludeKnownSidecars"), formatBoolPtr(effective.Spec.ExcludeKnownSidecars), selected, knownInherited)
 	effectiveExclude := pkgdefaults.EffectiveExcludedContainers(effective)

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -508,6 +508,20 @@ spec:
                   when debugging unexpected behavior. The operator sets Ready=False
                   with reason=Paused while this field is true.
                 type: boolean
+              runtimeProfile:
+                description: |-
+                  RuntimeProfile applies language/runtime-oriented defaults for memory
+                  resize safety. Unset or "generic" leaves policy fields unchanged.
+                  Profiles document recommended resizePolicy and decrease settings;
+                  they do not auto-patch pod specs. Supported values: generic, java,
+                  python, golang, nodejs.
+                enum:
+                - generic
+                - java
+                - python
+                - golang
+                - nodejs
+                type: string
               targetRef:
                 description: TargetRef identifies the workload(s) to be attuned.
                 properties:

--- a/docs/guides/runtime-profiles.md
+++ b/docs/guides/runtime-profiles.md
@@ -1,0 +1,56 @@
+# Runtime profiles
+
+Some language runtimes do not adapt when the container **memory** cgroup
+limit changes in place. Kubernetes and the IPPR GA guidance recommend
+`resizePolicy: RestartContainer` for memory when the app cannot adjust
+dynamically (for example some JVM and Python setups).
+
+Attune `runtimeProfile` applies **safe defaults and admission warnings**
+for those workloads. It does **not** rewrite pod specs or inject JVM flags.
+
+## Profiles
+
+| Profile | When unset fields default | Guidance |
+|---------|---------------------------|----------|
+| `generic` (default / empty) | No profile-specific defaults | Use policy fields as written |
+| `java` | `memory.allowDecrease=false`, `memory.overhead=40` if unset | Prefer RestartContainer for memory on the pod; avoid live heap shrink |
+| `python` | `memory.allowDecrease=false` if unset | Same caution as java for many interpreters |
+| `nodejs` | `memory.allowDecrease=false` if unset | Same caution for V8 heap |
+| `golang` | No extra defaults | Typically adapts to cgroup limits |
+
+Explicit policy values always win over profile defaults.
+
+## Example
+
+```yaml
+apiVersion: attune.io/v1alpha1
+kind: AttunePolicy
+metadata:
+  name: jvm-api
+spec:
+  runtimeProfile: java
+  targetRef:
+    kind: Deployment
+    name: payments-api
+  metricsSource:
+    prometheus:
+      address: http://prometheus-server.monitoring:80
+  updateStrategy:
+    type: Recommend
+```
+
+Admission warns if `runtimeProfile` is `java`/`python`/`nodejs` and
+`memory.allowDecrease: true`.
+
+## Interaction with Kubernetes 1.35+ memory decreases
+
+On 1.35+, Attune can apply live memory limit decreases when the platform
+allows them. Profiles that set `allowDecrease=false` still block Attune
+from recommending or applying decreases until you opt in. See the
+architecture [resize API](../architecture/resize-api.md) notes and
+startup boost for JVM cold-start CPU headroom.
+
+## Related
+
+- [Startup boost](startup-boost.md) for temporary CPU at start (often paired with Java)
+- [Safety architecture](../architecture/safety.md) for auto-revert after resize

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -389,6 +389,7 @@ alternative metrics sources. **At most one** of `prometheus`, `datadog`, or
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `runtimeProfile` | string | (none) | Optional language/runtime profile (`generic`, `java`, `python`, `golang`, `nodejs`). Applies safe memory defaults and admission warnings. See [runtime profiles](../guides/runtime-profiles.md). |
 | `paused` | bool | `false` | Halts all reconciliation for this policy: no metrics collection, no recommendations, no resizes. Existing resizes are not reverted. The operator sets `Ready=False` with `reason=Paused`. |
 
 ### Container exclusion

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -386,6 +386,17 @@ func warnIneffectiveSettings(policy *attunev1alpha1.AttunePolicy) admission.Warn
 		w = append(w, "sloGuardrails require a Prometheus-compatible metrics source; VPA source does not support PromQL queries")
 	}
 
+	// Runtime profile guidance vs live memory decrease.
+	switch policy.Spec.RuntimeProfile {
+	case "java", "python", "nodejs":
+		if policy.Spec.Memory.AllowDecrease != nil && *policy.Spec.Memory.AllowDecrease {
+			w = append(w, fmt.Sprintf(
+				"runtimeProfile=%s recommends against live memory decreases (many runtimes do not shrink heaps on cgroup limit change); prefer allowDecrease=false and/or memory resizePolicy RestartContainer",
+				policy.Spec.RuntimeProfile,
+			))
+		}
+	}
+
 	// maxConcurrentResizes > 1 in OneShot mode.
 	if mode == attunev1alpha1.UpdateTypeOneShot && policy.Spec.UpdateStrategy.MaxConcurrentResizes > 1 {
 		w = append(w, "maxConcurrentResizes > 1 has no effect in OneShot mode; only one pod is resized per cycle")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Canary Rollout: guides/canary-rollout.md
       - Auto Mode: guides/auto-mode.md
       - Startup Boost: guides/startup-boost.md
+      - Runtime Profiles: guides/runtime-profiles.md
       - HPA Coexistence: guides/hpa-coexistence.md
       - Prometheus Setup: guides/prometheus-setup.md
       - Datadog Setup: guides/datadog-setup.md

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -86,6 +86,34 @@ func ApplyBuiltInDefaults(policy *attunev1alpha1.AttunePolicy) {
 		v := attunev1alpha1.DefaultExcludeKnownSidecars
 		policy.Spec.ExcludeKnownSidecars = &v
 	}
+	applyRuntimeProfileDefaults(policy)
+}
+
+// applyRuntimeProfileDefaults fills unset resource fields from the optional
+// runtimeProfile. Explicit policy fields always win.
+func applyRuntimeProfileDefaults(policy *attunev1alpha1.AttunePolicy) {
+	switch policy.Spec.RuntimeProfile {
+	case "", "generic":
+		return
+	case "java":
+		// JVM heaps often ignore live cgroup memory decreases; prefer no
+		// memory decrease and slightly higher memory overhead when unset.
+		if policy.Spec.Memory.AllowDecrease == nil {
+			v := false
+			policy.Spec.Memory.AllowDecrease = &v
+		}
+		if policy.Spec.Memory.Overhead == "" {
+			policy.Spec.Memory.Overhead = "40"
+		}
+	case "python", "nodejs":
+		if policy.Spec.Memory.AllowDecrease == nil {
+			v := false
+			policy.Spec.Memory.AllowDecrease = &v
+		}
+	case "golang":
+		// Go runtimes generally adapt; leave allowDecrease unset (platform default).
+		return
+	}
 }
 
 // mustParseBuiltInDuration parses a package-level default duration constant.

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -709,3 +709,31 @@ func TestCombineDefaultsLayers_NamespaceSetsAllSectionsOverCluster(t *testing.T)
 	assert.True(t, *got.Spec.ExcludeKnownSidecars)
 	assert.Equal(t, "0.009", got.Spec.CostPricing.MemoryPerGiBHour)
 }
+
+func TestApplyRuntimeProfileDefaults_Java(t *testing.T) {
+	policy := &attunev1alpha1.AttunePolicy{
+		Spec: attunev1alpha1.AttunePolicySpec{
+			RuntimeProfile: "java",
+		},
+	}
+	ApplyBuiltInDefaults(policy)
+	require.NotNil(t, policy.Spec.Memory.AllowDecrease)
+	assert.False(t, *policy.Spec.Memory.AllowDecrease)
+	assert.Equal(t, "40", policy.Spec.Memory.Overhead)
+}
+
+func TestApplyRuntimeProfileDefaults_ExplicitWins(t *testing.T) {
+	allow := true
+	policy := &attunev1alpha1.AttunePolicy{
+		Spec: attunev1alpha1.AttunePolicySpec{
+			RuntimeProfile: "java",
+			Memory: attunev1alpha1.ResourceConfig{
+				AllowDecrease: &allow,
+				Overhead:      "15",
+			},
+		},
+	}
+	ApplyBuiltInDefaults(policy)
+	assert.True(t, *policy.Spec.Memory.AllowDecrease)
+	assert.Equal(t, "15", policy.Spec.Memory.Overhead)
+}


### PR DESCRIPTION
## Summary

Optional `runtimeProfile` for memory-safe defaults and admission warnings (java/python/nodejs).

Closes #432

## Changes

- CRD field + codegen
- `ApplyBuiltInDefaults` profile fill for unset fields
- Webhook warnings when profile conflicts with live memory decrease
- Docs guide + nav + configuration table
- `kubectl attune explain` shows effective profile

Does not auto-detect language from images or patch pod resizePolicy (explicit profile only).

## Test plan

- [x] `go test ./pkg/defaults/ ./internal/webhook/ ./cmd/kubectl-attune/ -race`
- [x] `make lint`
- [ ] CI green