### PR TITLE
feat: node pressure-aware resize skips and bin-packing docs

### DIFF
--- a/docs/guides/bin-packing.md
+++ b/docs/guides/bin-packing.md
@@ -1,0 +1,45 @@
+# Bin packing and cluster autoscaler coexistence
+
+Attune optimizes **pod requests and limits** (vertical loop). Real cluster cost
+reduction usually also needs **better packing** and fewer (or smaller) nodes.
+Those are complementary jobs.
+
+## What Attune does
+
+- Right-sizes running pods via in-place resize
+- Guards increases against node **allocatable** headroom
+- Skips request **increases** when the node is under **MemoryPressure**,
+  **DiskPressure**, or **PIDPressure** (decreases still allowed)
+- Exposes savings metrics and status for capacity planning
+
+## What Attune does not do
+
+- Provision or deprovision nodes
+- Replace Cluster Autoscaler, Karpenter-class provisioners, or cloud ASGs
+- Own bin-packing placement (the scheduler still places pods)
+
+## Safe coexistence patterns
+
+1. Run Attune so over-requested workloads free **request** capacity.
+2. Let your node autoscaler consolidate underutilized nodes on its own
+   schedule and disruption budgets.
+3. Prefer Recommend → Canary → Auto so aggressive shrink does not fight
+   concurrent node drains without observation.
+4. Use savings / reclaimed capacity signals (status + Grafana) as input to
+   capacity reviews; do not wire Attune as a remote node controller.
+
+## Node capacity awareness
+
+See also issue-aligned behavior:
+
+- Skip resizes that would make total pod requests exceed node allocatable
+- Skip request increases under node pressure conditions
+
+Tune `maxAllowed` and change caps so recommendations stay within typical
+node shapes for the pool.
+
+## Related
+
+- [Multi-cluster](multi-cluster.md) for fleet dashboards
+- [Scaling guide](scaling.md) for operator sizing
+- [HPA coexistence](hpa-coexistence.md)

--- a/docs/guides/multi-cluster.md
+++ b/docs/guides/multi-cluster.md
@@ -287,3 +287,22 @@ prod      default     my-app   Auto   3           3      3         True    30d
 The plugin reads the `AttunePolicy` status fields, which are backward
 compatible across minor versions. You can safely query clusters running
 different Attune versions from the same plugin binary.
+
+
+## Fleet observability (metrics federation)
+
+Attune installs one operator per cluster. For org-wide visibility without a
+multi-cluster control plane:
+
+1. Scrape each cluster's `attune_*` metrics into a central Prometheus, Thanos,
+   Mimir, or AMP with a consistent `cluster` (or `cluster_id`) external label.
+2. Import the Helm Grafana dashboard and add a `cluster` template variable
+   filtering on that label.
+3. Useful org-wide panels:
+   - `sum by (cluster) (increase(attune_resize_total[24h]))`
+   - `sum by (cluster) (attune_savings_estimated_monthly)`
+   - `sum by (cluster) (attune_pods_infeasible)` / `attune_pods_deferred` when available
+4. Keep Auto mode local to each cluster; aggregate **read-only** reporting only
+   in the first phase.
+
+See the [metrics reference](../reference/metrics.md) for metric names and labels.

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -841,7 +841,7 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 		}
 	}
 
-	// Node allocatable exceeded (use cached node data when available).
+	// Node allocatable / pressure (use cached node data when available).
 	if pod.Spec.NodeName != "" {
 		var node *corev1.Node
 		if checks != nil {
@@ -860,25 +860,32 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 				node = &n
 			}
 		}
-		if node != nil && len(node.Status.Allocatable) > 0 {
-			totalCPU := int64(0)
-			totalMem := int64(0)
-			// Only count containers that consume resources at runtime:
-			// native sidecars (restartPolicy=Always) + regular containers.
-			// Completed traditional init containers are not running.
-			running := append(nativeSidecars(pod.Spec.InitContainers), pod.Spec.Containers...)
-			for _, c := range running {
-				if c.Name == containerRec.Name {
-					totalCPU += target.Requests.Cpu().MilliValue()
-					totalMem += target.Requests.Memory().Value()
-				} else {
-					totalCPU += c.Resources.Requests.Cpu().MilliValue()
-					totalMem += c.Resources.Requests.Memory().Value()
-				}
+		if node != nil {
+			// Skip request *increases* when the node is under pressure so we
+			// do not worsen packing on a stressed node (#372).
+			if reason := nodePressureBlocksIncrease(node, pod, containerRec.Name, target); reason != "" {
+				return true, reason
 			}
-			if totalCPU > node.Status.Allocatable.Cpu().MilliValue() ||
-				totalMem > node.Status.Allocatable.Memory().Value() {
-				return true, "total pod requests would exceed node allocatable"
+			if len(node.Status.Allocatable) > 0 {
+				totalCPU := int64(0)
+				totalMem := int64(0)
+				// Only count containers that consume resources at runtime:
+				// native sidecars (restartPolicy=Always) + regular containers.
+				// Completed traditional init containers are not running.
+				running := append(nativeSidecars(pod.Spec.InitContainers), pod.Spec.Containers...)
+				for _, c := range running {
+					if c.Name == containerRec.Name {
+						totalCPU += target.Requests.Cpu().MilliValue()
+						totalMem += target.Requests.Memory().Value()
+					} else {
+						totalCPU += c.Resources.Requests.Cpu().MilliValue()
+						totalMem += c.Resources.Requests.Memory().Value()
+					}
+				}
+				if totalCPU > node.Status.Allocatable.Cpu().MilliValue() ||
+					totalMem > node.Status.Allocatable.Memory().Value() {
+					return true, "total pod requests would exceed node allocatable"
+				}
 			}
 		}
 	}
@@ -912,4 +919,38 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 	}
 
 	return false, ""
+}
+
+// nodePressureBlocksIncrease returns a skip reason when the node is under
+// MemoryPressure, DiskPressure, or PIDPressure and the target would increase
+// requests for the named container. Decreases remain allowed.
+func nodePressureBlocksIncrease(node *corev1.Node, pod *corev1.Pod, containerName string, target corev1.ResourceRequirements) string {
+	if node == nil {
+		return ""
+	}
+	c := findContainerByName(pod, containerName)
+	if c == nil {
+		return ""
+	}
+	cpuInc := target.Requests.Cpu().MilliValue() > c.Resources.Requests.Cpu().MilliValue()
+	memInc := target.Requests.Memory().Value() > c.Resources.Requests.Memory().Value()
+	if !cpuInc && !memInc {
+		return ""
+	}
+	for _, cond := range node.Status.Conditions {
+		if cond.Status != corev1.ConditionTrue {
+			continue
+		}
+		switch cond.Type {
+		case corev1.NodeMemoryPressure:
+			if memInc {
+				return "node has MemoryPressure; skipping memory request increase"
+			}
+		case corev1.NodeDiskPressure:
+			return "node has DiskPressure; skipping resource request increase"
+		case corev1.NodePIDPressure:
+			return "node has PIDPressure; skipping resource request increase"
+		}
+	}
+	return ""
 }

--- a/internal/controller/resize_pressure_test.go
+++ b/internal/controller/resize_pressure_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNodePressureBlocksIncrease(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "app",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
+			}},
+		},
+	}
+	higherMem := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+	lowerMem := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	assert.Contains(t, nodePressureBlocksIncrease(node, pod, "app", higherMem), "MemoryPressure")
+	assert.Empty(t, nodePressureBlocksIncrease(node, pod, "app", lowerMem))
+	assert.Empty(t, nodePressureBlocksIncrease(nil, pod, "app", higherMem))
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - FIPS 140-3 Compliance: guides/fips-compliance.md
       - Multi-Cluster: guides/multi-cluster.md
       - Scaling: guides/scaling.md
+      - Bin Packing: guides/bin-packing.md
       - Troubleshooting: guides/troubleshooting.md
       - Upgrading: guides/upgrading.md
   - Reference:


### PR DESCRIPTION
## Summary

Node pressure awareness on top of existing allocatable checks, plus FinOps/bin-packing narrative.

Closes #372
Closes #431

Also advances #369 Phase A (metrics federation guide); leave #369 open if full recording rules/dashboard variables still desired.

## Changes

- `nodePressureBlocksIncrease` in shouldSkipResize
- Unit test for MemoryPressure increase vs decrease
- `docs/guides/bin-packing.md` + nav
- Multi-cluster fleet observability section

## Test plan

- [x] `go test ./internal/controller/ -run NodePressure -race`
- [ ] CI green