### PR TITLE
feat: capacity skip metrics and reclaimed capacity signals

### DIFF
--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -991,6 +991,17 @@ type SavingsStatus struct {
 	// under-provisioned workloads based on configured or default pricing (e.g. "$5.00").
 	// +optional
 	EstimatedMonthlyCostIncrease string `json:"estimatedMonthlyCostIncrease,omitempty"`
+
+	// ReclaimedCPURequest is estimated freeable CPU request capacity if recommended
+	// decreases were applied (same quantity as cpuRequestReduction). Preferred field
+	// name for bin-packing and cluster-autoscaler capacity planning.
+	// +optional
+	ReclaimedCPURequest string `json:"reclaimedCpuRequest,omitempty"`
+
+	// ReclaimedMemoryRequest is estimated freeable memory request capacity if
+	// recommended decreases were applied (same quantity as memoryRequestReduction).
+	// +optional
+	ReclaimedMemoryRequest string `json:"reclaimedMemoryRequest,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -1508,6 +1508,17 @@ spec:
                     description: MemoryRequestTotal is the total current memory requests
                       across all workloads (e.g. "2Gi").
                     type: string
+                  reclaimedCpuRequest:
+                    description: |-
+                      ReclaimedCPURequest is estimated freeable CPU request capacity if recommended
+                      decreases were applied (same quantity as cpuRequestReduction). Preferred field
+                      name for bin-packing and cluster-autoscaler capacity planning.
+                    type: string
+                  reclaimedMemoryRequest:
+                    description: |-
+                      ReclaimedMemoryRequest is estimated freeable memory request capacity if
+                      recommended decreases were applied (same quantity as memoryRequestReduction).
+                    type: string
                 type: object
               workloadErrors:
                 description: |-

--- a/charts/attune/files/grafana-dashboard.json
+++ b/charts/attune/files/grafana-dashboard.json
@@ -1077,11 +1077,7 @@
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
-      ],
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      }
+      ]
     },
     {
       "id": 123,
@@ -1099,11 +1095,7 @@
           "legendFormat": "cpu",
           "refId": "A"
         }
-      ],
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      }
+      ]
     },
     {
       "id": 124,
@@ -1121,11 +1113,7 @@
           "legendFormat": "memory",
           "refId": "A"
         }
-      ],
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      }
+      ]
     }
   ],
   "schemaVersion": 39,

--- a/charts/attune/files/grafana-dashboard.json
+++ b/charts/attune/files/grafana-dashboard.json
@@ -1060,6 +1060,72 @@
           "legendFormat": "patches"
         }
       ]
+    },
+    {
+      "id": 122,
+      "type": "timeseries",
+      "title": "Capacity / pressure resize skips",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 104
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(attune_capacity_skip_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "id": 123,
+      "type": "stat",
+      "title": "Reclaimed request CPU (cores)",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 104
+      },
+      "targets": [
+        {
+          "expr": "sum(attune_reclaimed_request_cpu_cores)",
+          "legendFormat": "cpu",
+          "refId": "A"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "id": 124,
+      "type": "stat",
+      "title": "Reclaimed request memory (bytes)",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 104
+      },
+      "targets": [
+        {
+          "expr": "sum(attune_reclaimed_request_memory_bytes)",
+          "legendFormat": "memory",
+          "refId": "A"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
     }
   ],
   "schemaVersion": 39,

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -1508,6 +1508,17 @@ spec:
                     description: MemoryRequestTotal is the total current memory requests
                       across all workloads (e.g. "2Gi").
                     type: string
+                  reclaimedCpuRequest:
+                    description: |-
+                      ReclaimedCPURequest is estimated freeable CPU request capacity if recommended
+                      decreases were applied (same quantity as cpuRequestReduction). Preferred field
+                      name for bin-packing and cluster-autoscaler capacity planning.
+                    type: string
+                  reclaimedMemoryRequest:
+                    description: |-
+                      ReclaimedMemoryRequest is estimated freeable memory request capacity if
+                      recommended decreases were applied (same quantity as memoryRequestReduction).
+                    type: string
                 type: object
               workloadErrors:
                 description: |-

--- a/deploy/grafana/dashboard.json
+++ b/deploy/grafana/dashboard.json
@@ -1174,6 +1174,72 @@
           "legendFormat": "patches"
         }
       ]
+    },
+    {
+      "id": 122,
+      "type": "timeseries",
+      "title": "Capacity / pressure resize skips",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 104
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(attune_capacity_skip_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "id": 123,
+      "type": "stat",
+      "title": "Reclaimed request CPU (cores)",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 104
+      },
+      "targets": [
+        {
+          "expr": "sum(attune_reclaimed_request_cpu_cores)",
+          "legendFormat": "cpu",
+          "refId": "A"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "id": 124,
+      "type": "stat",
+      "title": "Reclaimed request memory (bytes)",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 104
+      },
+      "targets": [
+        {
+          "expr": "sum(attune_reclaimed_request_memory_bytes)",
+          "legendFormat": "memory",
+          "refId": "A"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
     }
   ],
   "schemaVersion": 39,

--- a/docs/architecture/node-capacity.md
+++ b/docs/architecture/node-capacity.md
@@ -1,0 +1,83 @@
+# Node capacity and pressure formulas
+
+Attune applies **always-on** node capacity and pressure gates in the resize
+path (not opt-in). They are safety defaults: skip or avoid request increases
+that cannot fit on the current node or that worsen a stressed node. They do
+not require a policy feature flag.
+
+Related product work: capacity-aware recommendations (#372 / #445) and
+bin-packing / reclaimed capacity signals (#431 / #446).
+
+## Multi-container pod formula
+
+For a pod on node `N` with target container `C` and proposed target requests
+`T_cpu`, `T_mem`:
+
+1. Build the set of **running** containers:
+   - All `spec.containers`
+   - Init containers with `restartPolicy: Always` (native sidecars)
+   - Traditional init containers that have finished are **not** counted
+2. For each running container `X`:
+   - If `X == C`, use proposed targets `T_*`
+   - Else use current requests of `X`
+3. Sum CPU millicores and memory bytes → `sum_cpu`, `sum_mem`
+4. Read `N.status.allocatable` for CPU and memory
+5. **Skip resize** if `sum_cpu > allocatable_cpu` OR `sum_mem > allocatable_mem`
+
+Reason string: `total pod requests would exceed node allocatable`.
+
+Metric: `attune_capacity_skip_total{reason="allocatable"}`.
+
+### What this is not
+
+- Not a full free-headroom model against all other pods on the node. The
+  check is **intra-pod** vs node allocatable (the kubelet / scheduler already
+  enforced neighbor pods when this pod was placed).
+- Does not sum every pod on the node. That would race with the scheduler and
+  mis-account static/mirror pods without requests.
+
+## DaemonSet special case
+
+DaemonSet pods are **node-bound**: there is one pod per node (subject to
+nodeSelector / affinity). Capacity gates still use the same formula against
+the **current** node:
+
+- Increases that would make *this* DaemonSet pod's total requests exceed
+  that node's allocatable are skipped.
+- Attune does not rebalance across nodes or skip entire DaemonSets cluster-wide.
+- Prefer conservative `maxAllowed` for DaemonSets so recommendations stay
+  within the smallest node pool shape you schedule them on.
+
+## Pressure gates
+
+When the node has any of these conditions `True`:
+
+| Condition | Effect |
+|-----------|--------|
+| `MemoryPressure` | Skip **memory request increases** (CPU increases still allowed) |
+| `DiskPressure` | Skip **any request increase** (CPU or memory) |
+| `PIDPressure` | Skip **any request increase** |
+
+**Decreases remain allowed** under pressure (they free capacity).
+
+Metric: `attune_capacity_skip_total{reason="pressure"}`.
+
+## Always-on default
+
+These gates run for every resize attempt. There is no `capacityAware: false`
+escape hatch in the first release. To effectively disable pressure sensitivity
+you would need nodes without those conditions; allocatable skip only fires
+when the proposed pod total exceeds allocatable.
+
+## Reclaimed capacity (bin packing signal)
+
+When recommendations are **below** current requests, status and metrics
+expose freeable request capacity for node consolidation tools:
+
+- Status: `status.savings.reclaimedCpuRequest` / `reclaimedMemoryRequest`
+  (aliases of the reduction fields)
+- Metrics: `attune_reclaimed_request_cpu_cores`, `attune_reclaimed_request_memory_bytes`
+
+These are **estimated** from recommendations, not measured node free space.
+Use them with Cluster Autoscaler / Karpenter-class tools as capacity review
+inputs, not as a remote node controller. See [bin packing](../guides/bin-packing.md).

--- a/docs/guides/bin-packing.md
+++ b/docs/guides/bin-packing.md
@@ -43,3 +43,38 @@ node shapes for the pool.
 - [Multi-cluster](multi-cluster.md) for fleet dashboards
 - [Scaling guide](scaling.md) for operator sizing
 - [HPA coexistence](hpa-coexistence.md)
+
+## Reclaimed capacity signals
+
+After each reconcile (non-Observe modes), Attune estimates freeable **request**
+capacity if recommended decreases were applied:
+
+| Surface | Field / metric |
+|---------|----------------|
+| Status | `status.savings.reclaimedCpuRequest`, `reclaimedMemoryRequest` |
+| Status (legacy names) | `cpuRequestReduction`, `memoryRequestReduction` |
+| Prometheus | `attune_reclaimed_request_cpu_cores{namespace,policy}` |
+| Prometheus | `attune_reclaimed_request_memory_bytes{namespace,policy}` |
+| Prometheus (namespace totals) | `attune_savings_cpu_cores_total`, `attune_savings_memory_bytes_total` |
+
+### Using with cluster autoscalers
+
+1. Prefer Attune in Recommend or Canary until reclaimed capacity is stable.
+2. Feed reclaimed metrics into capacity dashboards (Grafana panel
+   "Reclaimed request capacity").
+3. Let Cluster Autoscaler / Karpenter consolidate on **their** disruption
+   budgets; do not trigger node delete from Attune.
+4. Cross-check node pressure skips (`attune_capacity_skip_total`) so you do
+   not interpret "no resize" as "no savings opportunity."
+
+### Phase B design (optional export for consolidation controllers)
+
+Future opt-in work (not required for Phase A):
+
+- Annotate or export a small ConfigMap per namespace with aggregate
+  `reclaimedCpu` / `reclaimedMemory` and policy generation for external
+  consolidation controllers to scrape without Prometheus.
+- No hard dependency on a vendor autoscaler API in Attune core.
+
+See also [node capacity formulas](../architecture/node-capacity.md).
+

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -460,6 +460,27 @@ Common causes:
 - **notready**: readiness probe fails post-resize. Verify probe configuration.
 - **slo:&lt;name&gt;**: an SLO guardrail query breached its threshold after resize. Review the guardrail's PromQL query and threshold in `updateStrategy.sloGuardrails`.
 
+### Resize skipped for node capacity or pressure
+
+**Symptom**: Events show `ResizeSkipped` with "exceed node allocatable" or
+"node has MemoryPressure/DiskPressure/PIDPressure", and
+`attune_capacity_skip_total` increments.
+
+**Cause**: Always-on safety gates refuse request **increases** that would
+make this pod's total requests exceed the node's allocatable, or that would
+raise requests while the node is under pressure. Decreases still proceed.
+
+**Fix**:
+
+1. Free capacity on the node (evict low-priority pods) or move the workload.
+2. Lower `maxAllowed` / change caps so recommendations fit typical node shapes.
+3. For DaemonSets, size against the **smallest** node pool that runs them.
+4. Inspect formulas in [Node capacity](../architecture/node-capacity.md).
+
+```promql
+sum by (namespace, policy, reason) (rate(attune_capacity_skip_total[1h]))
+```
+
 ### OOM after memory limit decrease
 
 **Symptom**: After enabling memory decreases (`memory.allowDecrease: true`

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -178,6 +178,8 @@ spec:
 | `savings.cpuRequestIncrease` | `string` | Total CPU increase for under-provisioned workloads (e.g. "500m") |
 | `savings.memoryRequestIncrease` | `string` | Total memory increase for under-provisioned workloads (e.g. "512Mi") |
 | `savings.estimatedMonthlyCostIncrease` | `string` | Estimated monthly cost increase for under-provisioned workloads |
+| `savings.reclaimedCpuRequest` | `string` | Freeable CPU request if recommended decreases apply (alias of cpuRequestReduction) |
+| `savings.reclaimedMemoryRequest` | `string` | Freeable memory request if recommended decreases apply (alias of memoryRequestReduction) |
 | `resizeHistory[].timestamp` | `Time` | When the resize occurred |
 | `resizeHistory[].workload` | `string` | Resized workload name |
 | `resizeHistory[].container` | `string` | Resized container name |

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -250,6 +250,25 @@ Total times all Prometheus samples for a container metric were non-finite
 | `container` | Container name |
 | `metric_type` | `cpu` or `memory` |
 
+### attune_capacity_skip_total
+
+Resize attempts skipped because of node **allocatable** headroom or node
+**pressure** conditions (always-on safety gates). See
+[Node capacity formulas](../architecture/node-capacity.md) and
+[Troubleshooting: Resize skipped for capacity](../guides/troubleshooting.md#resize-skipped-for-node-capacity-or-pressure).
+
+| Label | Description |
+|-------|-------------|
+| `namespace` | Policy namespace |
+| `policy` | Policy name |
+| `reason` | `allocatable` or `pressure` |
+
+```promql
+sum by (namespace, policy, reason) (
+  rate(attune_capacity_skip_total[1h])
+)
+```
+
 ## Gauges
 
 ### attune_recommendation_cpu_cores
@@ -271,6 +290,34 @@ Recommended memory (bytes) for each workload container.
 | `namespace` | Workload namespace |
 | `workload` | Workload name |
 | `container` | Container name |
+
+### attune_reclaimed_request_cpu_cores
+
+Estimated freeable CPU request cores for a policy if recommended decreases
+were applied. Bin-packing / cluster-autoscaler capacity planning signal.
+Same quantity as savings CPU reduction, labeled by policy.
+
+| Label | Description |
+|-------|-------------|
+| `namespace` | Policy namespace |
+| `policy` | Policy name |
+
+### attune_reclaimed_request_memory_bytes
+
+Estimated freeable memory request bytes for a policy if recommended decreases
+were applied.
+
+| Label | Description |
+|-------|-------------|
+| `namespace` | Policy namespace |
+| `policy` | Policy name |
+
+```promql
+sum by (namespace, policy) (attune_reclaimed_request_cpu_cores)
+sum by (namespace, policy) (attune_reclaimed_request_memory_bytes)
+```
+
+See [Bin packing](../guides/bin-packing.md#reclaimed-capacity-signals).
 
 ### attune_savings_cpu_cores_total
 

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -371,11 +371,13 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			"workloadsWithRecs", len(recommendations))
 		// Reset savings gauges in Observe mode so they don't show stale values.
 		updateSavingsGauges(policy.Namespace, savingsAccumulator{}, nil)
+		updateReclaimedCapacityGauges(policy.Namespace, policy.Name, savingsAccumulator{})
 	} else {
 		policy.Status.Recommendations = recommendations
 		var acc savingsAccumulator
 		policy.Status.Savings, acc = r.computeSavings(recommendations, defaults)
 		updateSavingsGauges(policy.Namespace, acc, defaults)
+		updateReclaimedCapacityGauges(policy.Namespace, policy.Name, acc)
 	}
 
 	// Export recommendations to ConfigMaps for GitOps workflows if configured.
@@ -923,6 +925,8 @@ func (r *AttunePolicyReconciler) handleDeletion(ctx context.Context, policy *att
 			operatormetrics.SavingsEstimatedMonthly.DeleteLabelValues(policy.Namespace)
 		}
 	}
+	operatormetrics.ReclaimedRequestCPU.DeleteLabelValues(policy.Namespace, policy.Name)
+	operatormetrics.ReclaimedRequestMemory.DeleteLabelValues(policy.Namespace, policy.Name)
 
 	// Remove the finalizer to allow garbage collection.
 	patch := client.MergeFrom(policy.DeepCopy())

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/operatormetrics"
+)
+
+func TestRecordCapacitySkip(t *testing.T) {
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cap-test", Namespace: "ns-cap"},
+	}
+	beforeAlloc := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "allocatable"))
+	beforePress := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "pressure"))
+
+	recordCapacitySkip(policy, "total pod requests would exceed node allocatable")
+	recordCapacitySkip(policy, "node has MemoryPressure; skipping memory request increase")
+	recordCapacitySkip(policy, "quota/limitrange violation: too large") // no metric
+
+	assert.Equal(t, beforeAlloc+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "allocatable")))
+	assert.Equal(t, beforePress+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "pressure")))
+}
+
+func TestComputeSavings_ReclaimedAliases(t *testing.T) {
+	r := newSavingsReconciler()
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "api",
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name: "app",
+					Current: attunev1alpha1.ResourceValues{
+						CPURequest:    resource.MustParse("500m"),
+						MemoryRequest: resource.MustParse("1Gi"),
+					},
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest:    resource.MustParse("200m"),
+						MemoryRequest: resource.MustParse("512Mi"),
+					},
+				},
+			},
+		},
+	}
+	savings, acc := r.computeSavings(recs, nil)
+	assert.Equal(t, savings.CPURequestReduction, savings.ReclaimedCPURequest)
+	assert.Equal(t, savings.MemoryRequestReduction, savings.ReclaimedMemoryRequest)
+	assert.NotEmpty(t, savings.ReclaimedCPURequest)
+	assert.NotEmpty(t, savings.ReclaimedMemoryRequest)
+	assert.Greater(t, acc.totalCPUSaved, int64(0))
+}

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -420,6 +421,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 				"pod", pod.Name, "container", containerRec.Name)
 			r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
 				"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
+			recordCapacitySkip(policy, reason)
 		} else {
 			// Determine whether the "already at target" came from a change
 			// filter suppression (the raw recommendation differed but the
@@ -958,6 +960,23 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 	}
 
 	return false, ""
+}
+
+// recordCapacitySkip increments capacity/pressure skip metrics when the skip
+// reason matches node headroom or pressure gates (#445).
+func recordCapacitySkip(policy *attunev1alpha1.AttunePolicy, reason string) {
+	if policy == nil || reason == "" {
+		return
+	}
+	switch {
+	case strings.Contains(reason, "exceed node allocatable"):
+		operatormetrics.CapacitySkipTotal.WithLabelValues(policy.Namespace, policy.Name, "allocatable").Inc()
+	case strings.Contains(reason, "MemoryPressure"),
+		strings.Contains(reason, "DiskPressure"),
+		strings.Contains(reason, "PIDPressure"),
+		strings.Contains(reason, "node pressure"):
+		operatormetrics.CapacitySkipTotal.WithLabelValues(policy.Namespace, policy.Name, "pressure").Inc()
+	}
 }
 
 // applyMemoryUsageFloor raises a decreasing memory limit so it stays above

--- a/internal/controller/savings.go
+++ b/internal/controller/savings.go
@@ -85,9 +85,12 @@ func (r *AttunePolicyReconciler) computeSavings(recommendations []attunev1alpha1
 	}
 	if acc.totalCPUSaved > 0 {
 		savings.CPURequestReduction = resource.NewMilliQuantity(acc.totalCPUSaved, resource.DecimalSI).String()
+		// Alias for bin-packing / cluster-autoscaler capacity planning (#446).
+		savings.ReclaimedCPURequest = savings.CPURequestReduction
 	}
 	if acc.totalMemSaved > 0 {
 		savings.MemoryRequestReduction = resource.NewQuantity(acc.totalMemSaved, resource.BinarySI).String()
+		savings.ReclaimedMemoryRequest = savings.MemoryRequestReduction
 	}
 	if acc.totalCPUIncrease > 0 {
 		savings.CPURequestIncrease = resource.NewMilliQuantity(acc.totalCPUIncrease, resource.DecimalSI).String()
@@ -128,6 +131,14 @@ func updateSavingsGauges(namespace string, acc savingsAccumulator, defaults *att
 	cpuPrice, memPrice := getCostPricing(defaults)
 	monthlySavings := (cpuCoresSaved*cpuPrice + memGiBSaved*memPrice) * hoursPerMonth
 	operatormetrics.SavingsEstimatedMonthly.WithLabelValues(namespace).Set(monthlySavings)
+}
+
+// updateReclaimedCapacityGauges publishes freeable request capacity for
+// bin-packing / cluster-autoscaler feedback (#446). Labels include policy.
+func updateReclaimedCapacityGauges(namespace, policy string, acc savingsAccumulator) {
+	cpuCoresSaved := float64(acc.totalCPUSaved) / 1000.0
+	operatormetrics.ReclaimedRequestCPU.WithLabelValues(namespace, policy).Set(cpuCoresSaved)
+	operatormetrics.ReclaimedRequestMemory.WithLabelValues(namespace, policy).Set(float64(acc.totalMemSaved))
 }
 
 // getCostPricing reads pricing from AttuneDefaults, falling back to defaults.

--- a/internal/operatormetrics/metrics.go
+++ b/internal/operatormetrics/metrics.go
@@ -288,6 +288,36 @@ var (
 		},
 		[]string{"namespace", "policy", "result"},
 	)
+
+	// CapacitySkipTotal counts resize skips due to node capacity or pressure.
+	// reason: allocatable (pod requests would exceed node allocatable),
+	// pressure (MemoryPressure/DiskPressure/PIDPressure blocks increases).
+	CapacitySkipTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "attune_capacity_skip_total",
+			Help: "Resize skips due to node allocatable headroom or pressure conditions",
+		},
+		[]string{"namespace", "policy", "reason"},
+	)
+
+	// ReclaimedRequestCPU is freeable CPU request cores if recommended decreases apply.
+	// Same quantity as savings CPU reduction; named for bin-packing / CA capacity planning.
+	ReclaimedRequestCPU = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "attune_reclaimed_request_cpu_cores",
+			Help: "Estimated freeable CPU request cores from recommended decreases (bin-packing signal)",
+		},
+		[]string{"namespace", "policy"},
+	)
+
+	// ReclaimedRequestMemory is freeable memory request bytes if recommended decreases apply.
+	ReclaimedRequestMemory = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "attune_reclaimed_request_memory_bytes",
+			Help: "Estimated freeable memory request bytes from recommended decreases (bin-packing signal)",
+		},
+		[]string{"namespace", "policy"},
+	)
 )
 
 // WebhookTimer tracks webhook operation duration and result.
@@ -348,5 +378,8 @@ func init() {
 		RevertFailuresTotal,
 		TemplatePatchTotal,
 		MemoryLimitDecreaseTotal,
+		CapacitySkipTotal,
+		ReclaimedRequestCPU,
+		ReclaimedRequestMemory,
 	)
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Design: architecture/design.md
       - Algorithm: architecture/algorithm.md
       - Resize API: architecture/resize-api.md
+      - Node capacity: architecture/node-capacity.md
       - Safety: architecture/safety.md
   - Community:
       - CNCF Landscape: community/cncf-landscape.md


### PR DESCRIPTION
## Summary

Complete remaining #372 / #431 acceptance criteria: capacity-skip observability, design formulas, and reclaimed capacity signals for bin-packing / CA feedback.

## Changes

- Metric `attune_capacity_skip_total{reason=allocatable|pressure}` on resize skips
- Status aliases `savings.reclaimedCpuRequest` / `reclaimedMemoryRequest`
- Gauges `attune_reclaimed_request_cpu_cores` / `attune_reclaimed_request_memory_bytes`
- Architecture note: multi-container + DaemonSet formulas; gates are always-on
- Bin-packing guide: reclaimed signals + Phase B export design
- Troubleshooting, metrics docs, Grafana panels

## Test plan

- [x] Unit tests for capacity skip metric and reclaimed aliases
- [x] Existing capacity skip unit tests remain
- [x] `make manifests generate`
- [ ] CI green

Closes #445
Closes #446
Closes #372
Closes #431