### PR TITLE
fix: harden GitOps paths, SSRF apiUrl, and refresh dist manifests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,11 @@ make build-plugin
 
 # Run all CI checks locally (lint, test, helm-docs, CRD freshness)
 make verify
+
+# After CRD/API or RBAC changes, refresh release manifests if local
+# verify-release-artifacts fails (tracked under dist/):
+make build-installer IMG=ghcr.io/attune-io/attune:latest
+make build-crds
 ```
 
 ### Running Tests

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -101,6 +101,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -242,6 +253,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -544,6 +566,77 @@ spec:
                         description: ConfigMap enables exporting recommendations to
                           ConfigMaps.
                         type: boolean
+                      pullRequest:
+                        description: |-
+                          PullRequest enables opt-in GitOps PR automation (default off).
+                          Requires a token Secret and repository identity. Never logs the token.
+                        properties:
+                          apiUrl:
+                            description: |-
+                              APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
+                              Defaults: https://api.github.com or https://gitlab.com/api/v4.
+                            type: string
+                          baseBranch:
+                            description: BaseBranch is the PR target branch. Defaults
+                              to "main".
+                            type: string
+                          cooldown:
+                            description: |-
+                              Cooldown is the minimum time between PR create/update attempts for this
+                              policy. Defaults to 24h.
+                            type: string
+                          dryRun:
+                            description: |-
+                              DryRun logs the intended PR and updates status without calling the
+                              remote API. Useful for CI and first enablement.
+                            type: boolean
+                          enabled:
+                            description: Enabled turns on PR automation. Default false.
+                            type: boolean
+                          labels:
+                            description: Labels are applied to the pull request when
+                              supported by the provider.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          minChangePercent:
+                            description: |-
+                              MinChangePercent is the minimum absolute percent change (per container
+                              resource vs template) required to open or update a PR. Defaults to 10.
+                            format: int32
+                            maximum: 100
+                            minimum: 1
+                            type: integer
+                          provider:
+                            description: Provider is "github" or "gitlab". Default
+                              "github".
+                            enum:
+                            - github
+                            - gitlab
+                            type: string
+                          repository:
+                            description: |-
+                              Repository is "owner/name" (GitHub) or "group/project" (GitLab path).
+                              Required when Enabled is true.
+                            type: string
+                          tokenSecretRef:
+                            description: |-
+                              TokenSecretRef references a Secret key holding a PAT / project token.
+                              GitHub: repo contents + pull requests. GitLab: api scope on the project.
+                              Required when Enabled is true.
+                            properties:
+                              key:
+                                description: Key within the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
                     type: object
                   initialSizing:
                     description: |-
@@ -848,6 +941,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -989,6 +1093,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -1291,6 +1406,77 @@ spec:
                         description: ConfigMap enables exporting recommendations to
                           ConfigMaps.
                         type: boolean
+                      pullRequest:
+                        description: |-
+                          PullRequest enables opt-in GitOps PR automation (default off).
+                          Requires a token Secret and repository identity. Never logs the token.
+                        properties:
+                          apiUrl:
+                            description: |-
+                              APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
+                              Defaults: https://api.github.com or https://gitlab.com/api/v4.
+                            type: string
+                          baseBranch:
+                            description: BaseBranch is the PR target branch. Defaults
+                              to "main".
+                            type: string
+                          cooldown:
+                            description: |-
+                              Cooldown is the minimum time between PR create/update attempts for this
+                              policy. Defaults to 24h.
+                            type: string
+                          dryRun:
+                            description: |-
+                              DryRun logs the intended PR and updates status without calling the
+                              remote API. Useful for CI and first enablement.
+                            type: boolean
+                          enabled:
+                            description: Enabled turns on PR automation. Default false.
+                            type: boolean
+                          labels:
+                            description: Labels are applied to the pull request when
+                              supported by the provider.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          minChangePercent:
+                            description: |-
+                              MinChangePercent is the minimum absolute percent change (per container
+                              resource vs template) required to open or update a PR. Defaults to 10.
+                            format: int32
+                            maximum: 100
+                            minimum: 1
+                            type: integer
+                          provider:
+                            description: Provider is "github" or "gitlab". Default
+                              "github".
+                            enum:
+                            - github
+                            - gitlab
+                            type: string
+                          repository:
+                            description: |-
+                              Repository is "owner/name" (GitHub) or "group/project" (GitLab path).
+                              Required when Enabled is true.
+                            type: string
+                          tokenSecretRef:
+                            description: |-
+                              TokenSecretRef references a Secret key holding a PAT / project token.
+                              GitHub: repo contents + pull requests. GitLab: api scope on the project.
+                              Required when Enabled is true.
+                            properties:
+                              key:
+                                description: Key within the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
                     type: object
                   initialSizing:
                     description: |-
@@ -1591,6 +1777,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -1740,6 +1937,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -2001,6 +2209,20 @@ spec:
                   when debugging unexpected behavior. The operator sets Ready=False
                   with reason=Paused while this field is true.
                 type: boolean
+              runtimeProfile:
+                description: |-
+                  RuntimeProfile applies language/runtime-oriented defaults for memory
+                  resize safety. Unset or "generic" leaves policy fields unchanged.
+                  Profiles document recommended resizePolicy and decrease settings;
+                  they do not auto-patch pod specs. Supported values: generic, java,
+                  python, golang, nodejs.
+                enum:
+                - generic
+                - java
+                - python
+                - golang
+                - nodejs
+                type: string
               targetRef:
                 description: TargetRef identifies the workload(s) to be attuned.
                 properties:
@@ -2116,6 +2338,77 @@ spec:
                         description: ConfigMap enables exporting recommendations to
                           ConfigMaps.
                         type: boolean
+                      pullRequest:
+                        description: |-
+                          PullRequest enables opt-in GitOps PR automation (default off).
+                          Requires a token Secret and repository identity. Never logs the token.
+                        properties:
+                          apiUrl:
+                            description: |-
+                              APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
+                              Defaults: https://api.github.com or https://gitlab.com/api/v4.
+                            type: string
+                          baseBranch:
+                            description: BaseBranch is the PR target branch. Defaults
+                              to "main".
+                            type: string
+                          cooldown:
+                            description: |-
+                              Cooldown is the minimum time between PR create/update attempts for this
+                              policy. Defaults to 24h.
+                            type: string
+                          dryRun:
+                            description: |-
+                              DryRun logs the intended PR and updates status without calling the
+                              remote API. Useful for CI and first enablement.
+                            type: boolean
+                          enabled:
+                            description: Enabled turns on PR automation. Default false.
+                            type: boolean
+                          labels:
+                            description: Labels are applied to the pull request when
+                              supported by the provider.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          minChangePercent:
+                            description: |-
+                              MinChangePercent is the minimum absolute percent change (per container
+                              resource vs template) required to open or update a PR. Defaults to 10.
+                            format: int32
+                            maximum: 100
+                            minimum: 1
+                            type: integer
+                          provider:
+                            description: Provider is "github" or "gitlab". Default
+                              "github".
+                            enum:
+                            - github
+                            - gitlab
+                            type: string
+                          repository:
+                            description: |-
+                              Repository is "owner/name" (GitHub) or "group/project" (GitLab path).
+                              Required when Enabled is true.
+                            type: string
+                          tokenSecretRef:
+                            description: |-
+                              TokenSecretRef references a Secret key holding a PAT / project token.
+                              GitHub: repo contents + pull requests. GitLab: api scope on the project.
+                              Required when Enabled is true.
+                            properties:
+                              key:
+                                description: Key within the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
                     type: object
                   initialSizing:
                     description: |-
@@ -2882,7 +3175,8 @@ spec:
                         Reason explains why the resize was reverted or failed.
                         Only populated when Result is Reverted or Failed.
                         Values include: oomkill, restart, notready, throttle,
-                        annotation-conflict, immediate-safety-check, slo:<name>.
+                        annotation-conflict, immediate-safety-check, slo:<name>,
+                        infeasible (kubelet Infeasible / InPlaceOnly skip).
                       type: string
                     resource:
                       description: |-
@@ -2964,6 +3258,17 @@ spec:
                     description: MemoryRequestTotal is the total current memory requests
                       across all workloads (e.g. "2Gi").
                     type: string
+                  reclaimedCpuRequest:
+                    description: |-
+                      ReclaimedCPURequest is estimated freeable CPU request capacity if recommended
+                      decreases were applied (same quantity as cpuRequestReduction). Preferred field
+                      name for bin-packing and cluster-autoscaler capacity planning.
+                    type: string
+                  reclaimedMemoryRequest:
+                    description: |-
+                      ReclaimedMemoryRequest is estimated freeable memory request capacity if
+                      recommended decreases were applied (same quantity as memoryRequestReduction).
+                    type: string
                 type: object
               workloadErrors:
                 description: |-
@@ -3000,9 +3305,23 @@ spec:
                       generating recommendations (from metricsSource.minimumDataPoints).
                     format: int32
                     type: integer
+                  deferred:
+                    description: |-
+                      Deferred is the number of pods whose in-place resize is Deferred by the
+                      kubelet (node cannot accept the change yet). Retried automatically when
+                      the condition clears on a later reconcile.
+                    format: int32
+                    type: integer
                   discovered:
                     description: Discovered is the number of workloads matching the
                       target selector.
+                    format: int32
+                    type: integer
+                  infeasible:
+                    description: |-
+                      Infeasible is the number of pods whose in-place resize is Infeasible on
+                      the current node. With resizeMethod InPlaceOnly these pods are skipped;
+                      with InPlaceOrRecreate the operator may fall back to eviction.
                     format: int32
                     type: integer
                   pending:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -100,6 +100,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -241,6 +252,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -543,6 +565,77 @@ spec:
                         description: ConfigMap enables exporting recommendations to
                           ConfigMaps.
                         type: boolean
+                      pullRequest:
+                        description: |-
+                          PullRequest enables opt-in GitOps PR automation (default off).
+                          Requires a token Secret and repository identity. Never logs the token.
+                        properties:
+                          apiUrl:
+                            description: |-
+                              APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
+                              Defaults: https://api.github.com or https://gitlab.com/api/v4.
+                            type: string
+                          baseBranch:
+                            description: BaseBranch is the PR target branch. Defaults
+                              to "main".
+                            type: string
+                          cooldown:
+                            description: |-
+                              Cooldown is the minimum time between PR create/update attempts for this
+                              policy. Defaults to 24h.
+                            type: string
+                          dryRun:
+                            description: |-
+                              DryRun logs the intended PR and updates status without calling the
+                              remote API. Useful for CI and first enablement.
+                            type: boolean
+                          enabled:
+                            description: Enabled turns on PR automation. Default false.
+                            type: boolean
+                          labels:
+                            description: Labels are applied to the pull request when
+                              supported by the provider.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          minChangePercent:
+                            description: |-
+                              MinChangePercent is the minimum absolute percent change (per container
+                              resource vs template) required to open or update a PR. Defaults to 10.
+                            format: int32
+                            maximum: 100
+                            minimum: 1
+                            type: integer
+                          provider:
+                            description: Provider is "github" or "gitlab". Default
+                              "github".
+                            enum:
+                            - github
+                            - gitlab
+                            type: string
+                          repository:
+                            description: |-
+                              Repository is "owner/name" (GitHub) or "group/project" (GitLab path).
+                              Required when Enabled is true.
+                            type: string
+                          tokenSecretRef:
+                            description: |-
+                              TokenSecretRef references a Secret key holding a PAT / project token.
+                              GitHub: repo contents + pull requests. GitLab: api scope on the project.
+                              Required when Enabled is true.
+                            properties:
+                              key:
+                                description: Key within the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
                     type: object
                   initialSizing:
                     description: |-
@@ -847,6 +940,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -988,6 +1092,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -1290,6 +1405,77 @@ spec:
                         description: ConfigMap enables exporting recommendations to
                           ConfigMaps.
                         type: boolean
+                      pullRequest:
+                        description: |-
+                          PullRequest enables opt-in GitOps PR automation (default off).
+                          Requires a token Secret and repository identity. Never logs the token.
+                        properties:
+                          apiUrl:
+                            description: |-
+                              APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
+                              Defaults: https://api.github.com or https://gitlab.com/api/v4.
+                            type: string
+                          baseBranch:
+                            description: BaseBranch is the PR target branch. Defaults
+                              to "main".
+                            type: string
+                          cooldown:
+                            description: |-
+                              Cooldown is the minimum time between PR create/update attempts for this
+                              policy. Defaults to 24h.
+                            type: string
+                          dryRun:
+                            description: |-
+                              DryRun logs the intended PR and updates status without calling the
+                              remote API. Useful for CI and first enablement.
+                            type: boolean
+                          enabled:
+                            description: Enabled turns on PR automation. Default false.
+                            type: boolean
+                          labels:
+                            description: Labels are applied to the pull request when
+                              supported by the provider.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          minChangePercent:
+                            description: |-
+                              MinChangePercent is the minimum absolute percent change (per container
+                              resource vs template) required to open or update a PR. Defaults to 10.
+                            format: int32
+                            maximum: 100
+                            minimum: 1
+                            type: integer
+                          provider:
+                            description: Provider is "github" or "gitlab". Default
+                              "github".
+                            enum:
+                            - github
+                            - gitlab
+                            type: string
+                          repository:
+                            description: |-
+                              Repository is "owner/name" (GitHub) or "group/project" (GitLab path).
+                              Required when Enabled is true.
+                            type: string
+                          tokenSecretRef:
+                            description: |-
+                              TokenSecretRef references a Secret key holding a PAT / project token.
+                              GitHub: repo contents + pull requests. GitLab: api scope on the project.
+                              Required when Enabled is true.
+                            properties:
+                              key:
+                                description: Key within the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
                     type: object
                   initialSizing:
                     description: |-
@@ -1590,6 +1776,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -1739,6 +1936,17 @@ spec:
                     - RequestsOnly
                     - RequestsAndLimits
                     type: string
+                  decreaseUsageMarginPercent:
+                    description: |-
+                      DecreaseUsageMarginPercent is the minimum headroom above recent memory
+                      usage required when decreasing memory limits (client-side pre-check).
+                      The target limit must be at least usage * (1 + margin/100). Defaults to
+                      10. Only applied on the memory ResourceConfig when a limit decrease is
+                      attempted; ignored for CPU. Set 0 to require limit strictly above usage.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   maxAllowed:
                     anyOf:
                     - type: integer
@@ -2000,6 +2208,20 @@ spec:
                   when debugging unexpected behavior. The operator sets Ready=False
                   with reason=Paused while this field is true.
                 type: boolean
+              runtimeProfile:
+                description: |-
+                  RuntimeProfile applies language/runtime-oriented defaults for memory
+                  resize safety. Unset or "generic" leaves policy fields unchanged.
+                  Profiles document recommended resizePolicy and decrease settings;
+                  they do not auto-patch pod specs. Supported values: generic, java,
+                  python, golang, nodejs.
+                enum:
+                - generic
+                - java
+                - python
+                - golang
+                - nodejs
+                type: string
               targetRef:
                 description: TargetRef identifies the workload(s) to be attuned.
                 properties:
@@ -2115,6 +2337,77 @@ spec:
                         description: ConfigMap enables exporting recommendations to
                           ConfigMaps.
                         type: boolean
+                      pullRequest:
+                        description: |-
+                          PullRequest enables opt-in GitOps PR automation (default off).
+                          Requires a token Secret and repository identity. Never logs the token.
+                        properties:
+                          apiUrl:
+                            description: |-
+                              APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
+                              Defaults: https://api.github.com or https://gitlab.com/api/v4.
+                            type: string
+                          baseBranch:
+                            description: BaseBranch is the PR target branch. Defaults
+                              to "main".
+                            type: string
+                          cooldown:
+                            description: |-
+                              Cooldown is the minimum time between PR create/update attempts for this
+                              policy. Defaults to 24h.
+                            type: string
+                          dryRun:
+                            description: |-
+                              DryRun logs the intended PR and updates status without calling the
+                              remote API. Useful for CI and first enablement.
+                            type: boolean
+                          enabled:
+                            description: Enabled turns on PR automation. Default false.
+                            type: boolean
+                          labels:
+                            description: Labels are applied to the pull request when
+                              supported by the provider.
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          minChangePercent:
+                            description: |-
+                              MinChangePercent is the minimum absolute percent change (per container
+                              resource vs template) required to open or update a PR. Defaults to 10.
+                            format: int32
+                            maximum: 100
+                            minimum: 1
+                            type: integer
+                          provider:
+                            description: Provider is "github" or "gitlab". Default
+                              "github".
+                            enum:
+                            - github
+                            - gitlab
+                            type: string
+                          repository:
+                            description: |-
+                              Repository is "owner/name" (GitHub) or "group/project" (GitLab path).
+                              Required when Enabled is true.
+                            type: string
+                          tokenSecretRef:
+                            description: |-
+                              TokenSecretRef references a Secret key holding a PAT / project token.
+                              GitHub: repo contents + pull requests. GitLab: api scope on the project.
+                              Required when Enabled is true.
+                            properties:
+                              key:
+                                description: Key within the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
                     type: object
                   initialSizing:
                     description: |-
@@ -2881,7 +3174,8 @@ spec:
                         Reason explains why the resize was reverted or failed.
                         Only populated when Result is Reverted or Failed.
                         Values include: oomkill, restart, notready, throttle,
-                        annotation-conflict, immediate-safety-check, slo:<name>.
+                        annotation-conflict, immediate-safety-check, slo:<name>,
+                        infeasible (kubelet Infeasible / InPlaceOnly skip).
                       type: string
                     resource:
                       description: |-
@@ -2963,6 +3257,17 @@ spec:
                     description: MemoryRequestTotal is the total current memory requests
                       across all workloads (e.g. "2Gi").
                     type: string
+                  reclaimedCpuRequest:
+                    description: |-
+                      ReclaimedCPURequest is estimated freeable CPU request capacity if recommended
+                      decreases were applied (same quantity as cpuRequestReduction). Preferred field
+                      name for bin-packing and cluster-autoscaler capacity planning.
+                    type: string
+                  reclaimedMemoryRequest:
+                    description: |-
+                      ReclaimedMemoryRequest is estimated freeable memory request capacity if
+                      recommended decreases were applied (same quantity as memoryRequestReduction).
+                    type: string
                 type: object
               workloadErrors:
                 description: |-
@@ -2999,9 +3304,23 @@ spec:
                       generating recommendations (from metricsSource.minimumDataPoints).
                     format: int32
                     type: integer
+                  deferred:
+                    description: |-
+                      Deferred is the number of pods whose in-place resize is Deferred by the
+                      kubelet (node cannot accept the change yet). Retried automatically when
+                      the condition clears on a later reconcile.
+                    format: int32
+                    type: integer
                   discovered:
                     description: Discovered is the number of workloads matching the
                       target selector.
+                    format: int32
+                    type: integer
+                  infeasible:
+                    description: |-
+                      Infeasible is the number of pods whose in-place resize is Infeasible on
+                      the current node. With resizeMethod InPlaceOnly these pods are skipped;
+                      with InPlaceOrRecreate the operator may fall back to eviction.
                     format: int32
                     type: integer
                   pending:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1494,7 +1494,7 @@ attune/
 - [x] kubectl plugin (via krew)
 - [x] Datadog/CloudWatch metrics support
 - [x] Memory decrease support (with gradual decrease)
-- [ ] Multi-cluster aggregated reporting
+- [x] Multi-cluster aggregated reporting (Phase A/B: federation docs, fleet Grafana dashboard, recording rules, fleet report ConfigMap + collect script; hub control plane deferred)
 - [ ] CNCF Sandbox application
 - [ ] KubeCon talk proposal
 - [ ] ADOPTERS.md with real organizations

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -137,6 +137,11 @@ default 24h).
 - Tokens are **never** written to logs, events, or status.
 - Use a fine-scoped PAT (GitHub: contents + pull requests on one repo;
   GitLab: `api` on one project). Prefer short-lived or fine-grained tokens.
+- Optional `apiUrl` (Enterprise GitHub / self-hosted GitLab) is validated
+  like Prometheus addresses: `http`/`https` only, and cloud metadata plus
+  loopback hosts are rejected so a policy cannot aim the operator token at
+  `169.254.169.254` or similar. Private ClusterIP-style hosts remain allowed
+  for on-prem Git forges.
 
 ### Example
 

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -73,6 +73,8 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 	}
 	drifts := gitops.ComputeDrift(workloads, recs, minPct)
 	if len(drifts) == 0 {
+		logger.V(1).Info("GitOps PR skipped: no drift above threshold",
+			"minChangePercent", minPct, "workloads", len(workloads), "recommendations", len(recs))
 		setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRNoDrift,
 			"No recommendation drift above minChangePercent vs templates")
 		return
@@ -84,8 +86,11 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 	}
 	if last, ok := policy.Annotations[annotationGitOpsPRLastAttempt]; ok {
 		if t, err := time.Parse(time.RFC3339, last); err == nil && r.now().Sub(t) < cooldown {
+			until := t.Add(cooldown).UTC()
+			logger.V(1).Info("GitOps PR skipped: cooldown active",
+				"until", until.Format(time.RFC3339), "lastAttempt", last)
 			setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRCooldown,
-				fmt.Sprintf("Cooldown active until %s", t.Add(cooldown).UTC().Format(time.RFC3339)))
+				fmt.Sprintf("Cooldown active until %s", until.Format(time.RFC3339)))
 			return
 		}
 	}

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -54,7 +54,9 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 	recs []attunev1alpha1.WorkloadRecommendation,
 ) {
 	logger := log.FromContext(ctx)
-	if !gitopsPREnabled(policy.Spec.UpdateStrategy.Export) {
+	// Defensive: defaults normally set UpdateStrategy, but unit tests and
+	// future callers may invoke this without applying defaults first.
+	if policy.Spec.UpdateStrategy == nil || !gitopsPREnabled(policy.Spec.UpdateStrategy.Export) {
 		setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRDisabled, "GitOps pull request automation is disabled")
 		return
 	}

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -108,7 +108,7 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 			"head", head, "base", base, "driftCount", len(drifts))
 		setGitOpsPRCondition(policy, metav1.ConditionTrue, attunev1alpha1.ReasonGitOpsPRDryRun,
 			fmt.Sprintf("Dry-run: would open/update PR on %s (%d drifted resources)", cfg.Repository, len(drifts)))
-		touchGitOpsPRAnnotation(policy, "")
+		r.touchGitOpsPRAnnotation(policy, "")
 		r.persistGitOpsPRAnnotations(ctx, policy)
 		operatormetrics.GitOpsPRTotal.WithLabelValues(policy.Namespace, policy.Name, "dry_run").Inc()
 		return
@@ -150,7 +150,7 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 		setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRFailed,
 			fmt.Sprintf("PR API error: %v", err))
 		operatormetrics.GitOpsPRTotal.WithLabelValues(policy.Namespace, policy.Name, "failed").Inc()
-		touchGitOpsPRAnnotation(policy, "")
+		r.touchGitOpsPRAnnotation(policy, "")
 		r.persistGitOpsPRAnnotations(ctx, policy)
 		return
 	}
@@ -163,7 +163,7 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 		operatormetrics.GitOpsPRTotal.WithLabelValues(policy.Namespace, policy.Name, "created").Inc()
 	}
 	setGitOpsPRCondition(policy, metav1.ConditionTrue, attunev1alpha1.ReasonGitOpsPROpen, msg)
-	touchGitOpsPRAnnotation(policy, res.URL)
+	r.touchGitOpsPRAnnotation(policy, res.URL)
 	r.persistGitOpsPRAnnotations(ctx, policy)
 }
 
@@ -194,11 +194,13 @@ func setGitOpsPRCondition(policy *attunev1alpha1.AttunePolicy, status metav1.Con
 	}
 }
 
-func touchGitOpsPRAnnotation(policy *attunev1alpha1.AttunePolicy, url string) {
+// touchGitOpsPRAnnotation records last attempt using the reconciler clock so
+// cooldown checks (r.now()) stay consistent under tests with a fake clock.
+func (r *AttunePolicyReconciler) touchGitOpsPRAnnotation(policy *attunev1alpha1.AttunePolicy, url string) {
 	if policy.Annotations == nil {
 		policy.Annotations = map[string]string{}
 	}
-	policy.Annotations[annotationGitOpsPRLastAttempt] = time.Now().UTC().Format(time.RFC3339)
+	policy.Annotations[annotationGitOpsPRLastAttempt] = r.now().UTC().Format(time.RFC3339)
 	if url != "" {
 		policy.Annotations[annotationGitOpsPRURL] = url
 	}

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,4 +94,143 @@ func TestReconcileGitOpsPullRequest_DryRun(t *testing.T) {
 		}
 	}
 	assert.True(t, found)
+}
+
+func TestReconcileGitOpsPullRequest_NilUpdateStrategy(t *testing.T) {
+	t.Parallel()
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+	}
+	r := NewAttunePolicyReconciler()
+	// Must not panic when UpdateStrategy is nil (defensive for tests/callers).
+	r.reconcileGitOpsPullRequest(context.Background(), policy, nil, nil)
+	var found bool
+	for _, cond := range policy.Status.Conditions {
+		if cond.Type == attunev1alpha1.ConditionGitOpsPullRequest {
+			found = true
+			assert.Equal(t, attunev1alpha1.ReasonGitOpsPRDisabled, cond.Reason)
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestReconcileGitOpsPullRequest_NoDrift(t *testing.T) {
+	t.Parallel()
+	en := true
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "tok", Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("500m"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("480m"), // 4% < default 10%
+			},
+		}},
+	}}
+	r := NewAttunePolicyReconciler()
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	var reason string
+	for _, cond := range policy.Status.Conditions {
+		if cond.Type == attunev1alpha1.ConditionGitOpsPullRequest {
+			reason = cond.Reason
+		}
+	}
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRNoDrift, reason)
+}
+
+func TestReconcileGitOpsPullRequest_Cooldown(t *testing.T) {
+	t.Parallel()
+	en := true
+	dry := true
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "p",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationGitOpsPRLastAttempt: time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339),
+			},
+		},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &dry,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "tok", Key: "token",
+						},
+						// default cooldown is 24h; last attempt 1h ago → blocked
+					},
+				},
+			},
+		},
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("100m"),
+			},
+		}},
+	}}
+	r := NewAttunePolicyReconciler()
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	var reason string
+	for _, cond := range policy.Status.Conditions {
+		if cond.Type == attunev1alpha1.ConditionGitOpsPullRequest {
+			reason = cond.Reason
+		}
+	}
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRCooldown, reason)
 }

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -174,12 +174,14 @@ func TestReconcileGitOpsPullRequest_Cooldown(t *testing.T) {
 	t.Parallel()
 	en := true
 	dry := true
+	fixed := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
 	policy := &attunev1alpha1.AttunePolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "p",
 			Namespace: "default",
 			Annotations: map[string]string{
-				annotationGitOpsPRLastAttempt: time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339),
+				// 1h before fixed clock; default cooldown 24h → blocked
+				annotationGitOpsPRLastAttempt: fixed.Add(-1 * time.Hour).Format(time.RFC3339),
 			},
 		},
 		Spec: attunev1alpha1.AttunePolicySpec{
@@ -192,7 +194,6 @@ func TestReconcileGitOpsPullRequest_Cooldown(t *testing.T) {
 						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
 							Name: "tok", Key: "token",
 						},
-						// default cooldown is 24h; last attempt 1h ago → blocked
 					},
 				},
 			},
@@ -225,6 +226,7 @@ func TestReconcileGitOpsPullRequest_Cooldown(t *testing.T) {
 		}},
 	}}
 	r := NewAttunePolicyReconciler()
+	r.SetNowFunc(func() time.Time { return fixed })
 	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
 	var reason string
 	for _, cond := range policy.Status.Conditions {
@@ -233,4 +235,15 @@ func TestReconcileGitOpsPullRequest_Cooldown(t *testing.T) {
 		}
 	}
 	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRCooldown, reason)
+}
+
+func TestTouchGitOpsPRAnnotation_UsesReconcilerClock(t *testing.T) {
+	t.Parallel()
+	fixed := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	r := NewAttunePolicyReconciler()
+	r.SetNowFunc(func() time.Time { return fixed })
+	policy := &attunev1alpha1.AttunePolicy{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+	r.touchGitOpsPRAnnotation(policy, "https://example.com/pr/1")
+	assert.Equal(t, fixed.Format(time.RFC3339), policy.Annotations[annotationGitOpsPRLastAttempt])
+	assert.Equal(t, "https://example.com/pr/1", policy.Annotations[annotationGitOpsPRURL])
 }

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -77,3 +77,58 @@ func TestGitLabClient_Update(t *testing.T) {
 	assert.True(t, res.Updated)
 	assert.Equal(t, 3, res.Number)
 }
+
+func TestGitHubClient_UpdateExisting(t *testing.T) {
+	t.Parallel()
+	var methods []string
+	client := &GitHubClient{
+		Token:      "tok",
+		Repository: "org/repo",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			methods = append(methods, r.Method)
+			if r.Method == http.MethodGet {
+				body, _ := json.Marshal([]map[string]interface{}{
+					{
+						"number": 9, "html_url": "https://github.com/org/repo/pull/9",
+						"head": map[string]interface{}{"ref": "attune/x"},
+					},
+				})
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(string(body))), Header: make(http.Header)}, nil
+			}
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Updated)
+	assert.Equal(t, 9, res.Number)
+	assert.Contains(t, methods, http.MethodPatch)
+}
+
+func TestGitHubClient_MissingConfigAndListError(t *testing.T) {
+	t.Parallel()
+	_, err := (&GitHubClient{}).CreateOrUpdate(context.Background(), PRRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token and repository required")
+
+	client := &GitHubClient{
+		Token:      "super-secret-token",
+		Repository: "org/repo",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 401,
+				Body:       io.NopCloser(strings.NewReader(`{"message":"Bad credentials super-secret-token"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	_, err = client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "h", Base: "main",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 401")
+	// API error path must not surface the raw token from the response body.
+	assert.NotContains(t, err.Error(), "super-secret-token")
+}

--- a/internal/gitops/drift_test.go
+++ b/internal/gitops/drift_test.go
@@ -93,4 +93,125 @@ func TestComputeDrift_BelowThreshold(t *testing.T) {
 func TestBranchName(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "attune/recommendations-default-my-policy", BranchName("default", "my-policy"))
+	assert.Equal(t, "attune/recommendations-ns-with-dots-pol", BranchName("ns.with.dots", "pol"))
+}
+
+func TestComputeDrift_StatefulSetAndDaemonSet(t *testing.T) {
+	t.Parallel()
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "db"},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "pg",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent"},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "agent",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "db", Kind: "StatefulSet",
+			Containers: []attunev1alpha1.ContainerRecommendation{{
+				Name: "pg",
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("500m"),
+				},
+			}},
+		},
+		{
+			Workload: "agent", Kind: "DaemonSet",
+			Containers: []attunev1alpha1.ContainerRecommendation{{
+				Name: "agent",
+				Recommended: attunev1alpha1.ResourceValues{
+					MemoryRequest: resource.MustParse("256Mi"),
+				},
+			}},
+		},
+	}
+	d := ComputeDrift([]client.Object{sts, ds}, recs, 10)
+	require.Len(t, d, 2)
+	kinds := map[string]bool{}
+	for _, x := range d {
+		kinds[x.Kind] = true
+	}
+	assert.True(t, kinds["StatefulSet"], "expected StatefulSet drift")
+	assert.True(t, kinds["DaemonSet"], "expected DaemonSet drift")
+}
+
+func TestComputeDrift_ZeroTemplateRequestIsFullDrift(t *testing.T) {
+	t.Parallel()
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						// No requests on template.
+					}},
+				},
+			},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("100m"),
+			},
+		}},
+	}}
+	d := ComputeDrift([]client.Object{dep}, recs, 10)
+	require.Len(t, d, 1)
+	assert.Equal(t, float64(100), d[0].ChangePercent)
+	assert.Equal(t, "0", d[0].Template)
+}
+
+func TestComputeDrift_UnknownContainerSkipped(t *testing.T) {
+	t.Parallel()
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app"}},
+				},
+			},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "sidecar-missing",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("100m"),
+			},
+		}},
+	}}
+	assert.Empty(t, ComputeDrift([]client.Object{dep}, recs, 10))
 }

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -117,6 +117,15 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 		if pr.Provider != "" && pr.Provider != "github" && pr.Provider != "gitlab" {
 			return warnings, fmt.Errorf("updateStrategy.export.pullRequest.provider must be github or gitlab")
 		}
+		// apiUrl is optional (defaults to github.com / gitlab.com). When set,
+		// apply the same SSRF host checks as Prometheus addresses so a
+		// malicious policy cannot aim the operator's bearer token at cloud
+		// metadata or loopback endpoints.
+		if pr.APIURL != "" {
+			if err := validation.PrometheusAddress(pr.APIURL); err != nil {
+				return warnings, fmt.Errorf("updateStrategy.export.pullRequest.apiUrl: %w", err)
+			}
+		}
 	}
 
 	// Validate canary observation period has a minimum floor.

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -226,6 +226,47 @@ func TestValidate_CanaryModeWithoutConfig(t *testing.T) {
 	assert.Empty(t, warnings)
 }
 
+func TestValidate_GitOpsPullRequestAPIURL_SSRF(t *testing.T) {
+	validator := &AttunePolicyValidator{}
+	en := true
+	policy := validPolicy()
+	policy.Spec.UpdateStrategy.Export = &attunev1alpha1.ExportConfig{
+		PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+			Enabled:    &en,
+			Repository: "org/repo",
+			TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+				Name: "tok", Key: "token",
+			},
+			APIURL: "http://169.254.169.254/",
+		},
+	}
+
+	_, err := validator.ValidateCreate(context.Background(), policy)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apiUrl")
+	assert.Contains(t, err.Error(), "metadata")
+}
+
+func TestValidate_GitOpsPullRequestAPIURL_EnterpriseOK(t *testing.T) {
+	validator := &AttunePolicyValidator{}
+	en := true
+	policy := validPolicy()
+	policy.Spec.UpdateStrategy.Export = &attunev1alpha1.ExportConfig{
+		PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+			Enabled:    &en,
+			Repository: "org/repo",
+			Provider:   "github",
+			TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+				Name: "tok", Key: "token",
+			},
+			APIURL: "https://ghe.example.com/api/v3",
+		},
+	}
+
+	_, err := validator.ValidateCreate(context.Background(), policy)
+	assert.NoError(t, err)
+}
+
 func TestValidate_CanaryObservationPeriodNegative(t *testing.T) {
 	validator := &AttunePolicyValidator{}
 	policy := validPolicy()


### PR DESCRIPTION
## Summary

Multi-perspective improvement batch after fleet/GitOps waves landed on main.

- Guard `reconcileGitOpsPullRequest` when `UpdateStrategy` is nil
- Use reconciler clock for GitOps PR cooldown annotations (consistent with `r.now()`)
- Admission SSRF checks for `export.pullRequest.apiUrl` (metadata/loopback blocked)
- V(1) skip logs for no-drift and cooldown
- Broader unit coverage: StatefulSet/DaemonSet drift, GitHub PR update, cooldown/no-drift, token-safe API errors
- Mark multi-cluster fleet reporting complete in SPEC checklist
- Refresh stale `dist/install.yaml` and `dist/crds.yaml`
- CONTRIBUTING note for dist refresh (`Ref #454`)

## Test plan

- [x] `go test ./internal/gitops/ ./internal/controller/ ./internal/webhook/ -run 'GitOps|ComputeDrift|GitHub|TouchGitOps'`
- [x] `make verify-quick`
- [ ] CI green on this PR

## Related

- Ref #453 (GitOps auto-create head branch; follow-up, not closed here)
- Ref #454 (CI verify-release-artifacts; follow-up, not closed here)

Does not close incomplete AC. Release PR #442 is unchanged (needs explicit merge OK).