### PR TITLE
feat: bootstrap missing GitOps PR head branch from base

### DIFF
--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -207,6 +207,11 @@ The PR/MR description still carries the full drift table. Template patches
 remain a review step (`kubectl attune diff` or your pipeline). Dry-run never
 creates branches or PRs.
 
+Re-bootstrap after a merge is expected when the head branch was deleted.
+On GitLab, if `.attune/RECOMMENDATION_DRIFT.md` already exists on
+`baseBranch`, Attune retries with an update action so the delta stays
+non-empty.
+
 If bootstrap fails (token scopes, missing `baseBranch`, network), status shows
 `PullRequestFailed` with a redacted API error.
 

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -135,8 +135,13 @@ default 24h).
 
 - Token is read from a Kubernetes Secret via `tokenSecretRef`.
 - Tokens are **never** written to logs, events, or status.
-- Use a fine-scoped PAT (GitHub: contents + pull requests on one repo;
-  GitLab: `api` on one project). Prefer short-lived or fine-grained tokens.
+- Use a fine-scoped PAT with write access to create branches and PRs:
+  - **GitHub** (fine-grained): repository **Contents: Read and write** and
+    **Pull requests: Read and write** on the target repo (classic: `repo` on
+    private repos, or `public_repo` for public-only).
+  - **GitLab**: `api` (or project-scoped token with write_repository +
+    write to merge requests) on one project.
+  Prefer short-lived or fine-grained tokens.
 - Optional `apiUrl` (Enterprise GitHub / self-hosted GitLab) is validated
   like Prometheus addresses: `http`/`https` only, and cloud metadata plus
   loopback hosts are rejected so a policy cannot aim the operator token at
@@ -187,12 +192,21 @@ Metric: `attune_gitops_pr_total{result=created|updated|dry_run|failed}`.
 Set `dryRun: true` for first enablement or CI. The operator records
 `PullRequestDryRun` and increments `dry_run` without calling GitHub/GitLab.
 
-### Branch note
+### Branch bootstrap
 
 The operator updates an existing open PR whose head branch is
-`attune/recommendations-<ns>-<policy>`. Creating a brand-new PR requires that
-branch to exist on the remote (your pipeline can create it from the PR body
-diff, or use ConfigMap export + `kubectl attune diff` without live PR create).
-When create fails because the branch is missing, status shows
+`attune/recommendations-<ns>-<policy>`. When no open PR exists and that head
+branch is **missing** on the remote, Attune creates it automatically:
+
+- **GitHub:** empty bootstrap commit on the new branch (same tree as
+  `baseBranch`, so the PR has a single commit delta).
+- **GitLab:** branch created from `baseBranch` with a small marker file at
+  `.attune/RECOMMENDATION_DRIFT.md` (GitLab rejects MRs with no file delta).
+
+The PR/MR description still carries the full drift table. Template patches
+remain a review step (`kubectl attune diff` or your pipeline). Dry-run never
+creates branches or PRs.
+
+If bootstrap fails (token scopes, missing `baseBranch`, network), status shows
 `PullRequestFailed` with a redacted API error.
 

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -186,8 +186,11 @@ func (c *GitHubClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer
 			SHA string `json:"sha"`
 		} `json:"object"`
 	}
-	if err := json.Unmarshal(baseBody, &baseRef); err != nil || baseRef.Object.SHA == "" {
+	if err := json.Unmarshal(baseBody, &baseRef); err != nil {
 		return fmt.Errorf("github get base branch decode: %w", err)
+	}
+	if baseRef.Object.SHA == "" {
+		return fmt.Errorf("github get base branch: empty sha")
 	}
 
 	// Load commit to get tree SHA for empty commit.
@@ -204,8 +207,11 @@ func (c *GitHubClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer
 			SHA string `json:"sha"`
 		} `json:"tree"`
 	}
-	if err := json.Unmarshal(commitBody, &baseCommit); err != nil || baseCommit.Tree.SHA == "" {
+	if err := json.Unmarshal(commitBody, &baseCommit); err != nil {
 		return fmt.Errorf("github get base commit decode: %w", err)
+	}
+	if baseCommit.Tree.SHA == "" {
+		return fmt.Errorf("github get base commit: empty tree sha")
 	}
 
 	// Empty commit (same tree, parent = base) so head != base for PR creation.
@@ -225,8 +231,11 @@ func (c *GitHubClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer
 	var newCommit struct {
 		SHA string `json:"sha"`
 	}
-	if err := json.Unmarshal(newCommitBody, &newCommit); err != nil || newCommit.SHA == "" {
+	if err := json.Unmarshal(newCommitBody, &newCommit); err != nil {
 		return fmt.Errorf("github create bootstrap commit decode: %w", err)
+	}
+	if newCommit.SHA == "" {
+		return fmt.Errorf("github create bootstrap commit: empty sha")
 	}
 
 	// Create head ref.
@@ -371,34 +380,47 @@ func (c *GitLabClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer
 	}
 
 	// Create branch + bootstrap file commit in one request (start_branch).
+	// Prefer "create"; if the marker already exists on base (prior merge),
+	// retry with "update" so re-bootstrap still produces a non-empty delta.
 	commitURL := fmt.Sprintf("%s/projects/%s/repository/commits", apiBase, projectEscaped)
-	payload := map[string]interface{}{
-		"branch":         head,
-		"start_branch":   baseBranch,
-		"commit_message": bootstrapCommitMessage,
-		"actions": []map[string]string{
-			{
-				"action":    "create",
-				"file_path": ".attune/RECOMMENDATION_DRIFT.md",
-				"content":   "Attune recommendation drift branch.\n\nSee the merge request description for the drift table. Apply template patches via `kubectl attune diff` or your GitOps pipeline.\n",
+	markerContent := "Attune recommendation drift branch.\n\nSee the merge request description for the drift table. Apply template patches via `kubectl attune diff` or your GitOps pipeline.\n"
+	for _, action := range []string{"create", "update"} {
+		payload := map[string]interface{}{
+			"branch":         head,
+			"start_branch":   baseBranch,
+			"commit_message": bootstrapCommitMessage,
+			"actions": []map[string]string{
+				{
+					"action":    action,
+					"file_path": ".attune/RECOMMENDATION_DRIFT.md",
+					"content":   markerContent,
+				},
 			},
-		},
-	}
-	respBody, code, err := c.doJSON(ctx, httpClient, http.MethodPost, commitURL, payload)
-	if err != nil {
-		return fmt.Errorf("gitlab create head branch: %w", err)
-	}
-	// Race: branch appeared; treat as success if GET now succeeds.
-	if code == http.StatusBadRequest || code == http.StatusConflict {
-		_, checkCode, checkErr := c.doJSON(ctx, httpClient, http.MethodGet, branchURL, nil)
-		if checkErr == nil && checkCode >= 200 && checkCode < 300 {
+		}
+		respBody, code, err := c.doJSON(ctx, httpClient, http.MethodPost, commitURL, payload)
+		if err != nil {
+			return fmt.Errorf("gitlab create head branch: %w", err)
+		}
+		if code >= 200 && code < 300 {
 			return nil
 		}
-	}
-	if code < 200 || code >= 300 {
+		// Race: branch appeared; treat as success if GET now succeeds.
+		if code == http.StatusBadRequest || code == http.StatusConflict {
+			_, checkCode, checkErr := c.doJSON(ctx, httpClient, http.MethodGet, branchURL, nil)
+			if checkErr == nil && checkCode >= 200 && checkCode < 300 {
+				return nil
+			}
+		}
+		// File already on base: try update action once.
+		if action == "create" && (code == http.StatusBadRequest || code == http.StatusUnprocessableEntity) {
+			lower := strings.ToLower(string(respBody))
+			if strings.Contains(lower, "already exists") || strings.Contains(lower, "a file with this name already exists") {
+				continue
+			}
+		}
 		return fmt.Errorf("gitlab create head branch: status %d: %s", code, redactToken(string(respBody), c.Token))
 	}
-	return nil
+	return fmt.Errorf("gitlab create head branch: exhausted create/update attempts")
 }
 
 func (c *GitLabClient) doJSON(ctx context.Context, httpClient HTTPDoer, method, rawURL string, payload interface{}) ([]byte, int, error) {

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -71,6 +71,8 @@ type GitLabClient struct {
 	HTTP    HTTPDoer
 }
 
+const bootstrapCommitMessage = "chore(attune): bootstrap recommendation branch"
+
 func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRResult, error) {
 	if c.Token == "" || c.Repository == "" {
 		return PRResult{}, fmt.Errorf("github: token and repository required")
@@ -119,9 +121,13 @@ func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		}
 	}
 
-	// Create: GitHub requires the head branch to exist. We create a PR that
-	// documents drift only; teams apply patches in CI. If the branch is
-	// missing, return a clear error so status shows Failed with message.
+	// Ensure head branch exists (create from base with a bootstrap commit if needed).
+	// GitHub rejects PRs when head and base point at the same commit, so we always
+	// create an empty commit on a new branch rather than a pure ref to base.
+	if err := c.ensureHeadBranch(ctx, httpClient, base, req.Head, req.Base); err != nil {
+		return PRResult{}, err
+	}
+
 	createURL := fmt.Sprintf("%s/repos/%s/pulls", base, c.Repository)
 	payload := map[string]interface{}{
 		"title": req.Title,
@@ -149,6 +155,101 @@ func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		_, _, _ = c.doJSON(ctx, httpClient, http.MethodPost, labURL, map[string]interface{}{"labels": req.Labels})
 	}
 	return PRResult{URL: created.HTMLURL, Number: created.Number, Updated: false}, nil
+}
+
+// ensureHeadBranch creates req head from base with an empty bootstrap commit when
+// the head ref is missing. If the head already exists, this is a no-op.
+func (c *GitHubClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer, apiBase, head, baseBranch string) error {
+	headRefURL := fmt.Sprintf("%s/repos/%s/git/ref/%s", apiBase, c.Repository, pathEscapeRef("heads/"+head))
+	_, code, err := c.doJSON(ctx, httpClient, http.MethodGet, headRefURL, nil)
+	if err != nil {
+		return fmt.Errorf("github check head branch: %w", err)
+	}
+	if code >= 200 && code < 300 {
+		return nil
+	}
+	if code != http.StatusNotFound {
+		return fmt.Errorf("github check head branch: status %d", code)
+	}
+
+	// Resolve base SHA.
+	baseRefURL := fmt.Sprintf("%s/repos/%s/git/ref/%s", apiBase, c.Repository, pathEscapeRef("heads/"+baseBranch))
+	baseBody, code, err := c.doJSON(ctx, httpClient, http.MethodGet, baseRefURL, nil)
+	if err != nil {
+		return fmt.Errorf("github get base branch: %w", err)
+	}
+	if code < 200 || code >= 300 {
+		return fmt.Errorf("github get base branch %q: status %d", baseBranch, code)
+	}
+	var baseRef struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(baseBody, &baseRef); err != nil || baseRef.Object.SHA == "" {
+		return fmt.Errorf("github get base branch decode: %w", err)
+	}
+
+	// Load commit to get tree SHA for empty commit.
+	commitURL := fmt.Sprintf("%s/repos/%s/git/commits/%s", apiBase, c.Repository, baseRef.Object.SHA)
+	commitBody, code, err := c.doJSON(ctx, httpClient, http.MethodGet, commitURL, nil)
+	if err != nil {
+		return fmt.Errorf("github get base commit: %w", err)
+	}
+	if code < 200 || code >= 300 {
+		return fmt.Errorf("github get base commit: status %d", code)
+	}
+	var baseCommit struct {
+		Tree struct {
+			SHA string `json:"sha"`
+		} `json:"tree"`
+	}
+	if err := json.Unmarshal(commitBody, &baseCommit); err != nil || baseCommit.Tree.SHA == "" {
+		return fmt.Errorf("github get base commit decode: %w", err)
+	}
+
+	// Empty commit (same tree, parent = base) so head != base for PR creation.
+	newCommitURL := fmt.Sprintf("%s/repos/%s/git/commits", apiBase, c.Repository)
+	newCommitPayload := map[string]interface{}{
+		"message": bootstrapCommitMessage,
+		"tree":    baseCommit.Tree.SHA,
+		"parents": []string{baseRef.Object.SHA},
+	}
+	newCommitBody, code, err := c.doJSON(ctx, httpClient, http.MethodPost, newCommitURL, newCommitPayload)
+	if err != nil {
+		return fmt.Errorf("github create bootstrap commit: %w", err)
+	}
+	if code < 200 || code >= 300 {
+		return fmt.Errorf("github create bootstrap commit: status %d: %s", code, redactToken(string(newCommitBody), c.Token))
+	}
+	var newCommit struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.Unmarshal(newCommitBody, &newCommit); err != nil || newCommit.SHA == "" {
+		return fmt.Errorf("github create bootstrap commit decode: %w", err)
+	}
+
+	// Create head ref.
+	createRefURL := fmt.Sprintf("%s/repos/%s/git/refs", apiBase, c.Repository)
+	createRefPayload := map[string]string{
+		"ref": "refs/heads/" + head,
+		"sha": newCommit.SHA,
+	}
+	refBody, code, err := c.doJSON(ctx, httpClient, http.MethodPost, createRefURL, createRefPayload)
+	if err != nil {
+		return fmt.Errorf("github create head branch: %w", err)
+	}
+	// 422 if another reconciler raced and created the ref; treat as success.
+	if code == http.StatusUnprocessableEntity {
+		_, checkCode, checkErr := c.doJSON(ctx, httpClient, http.MethodGet, headRefURL, nil)
+		if checkErr == nil && checkCode >= 200 && checkCode < 300 {
+			return nil
+		}
+	}
+	if code < 200 || code >= 300 {
+		return fmt.Errorf("github create head branch: status %d: %s", code, redactToken(string(refBody), c.Token))
+	}
+	return nil
 }
 
 func (c *GitHubClient) doJSON(ctx context.Context, httpClient HTTPDoer, method, rawURL string, payload interface{}) ([]byte, int, error) {
@@ -224,6 +325,10 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		return PRResult{URL: existing[0].WebURL, Number: existing[0].IID, Updated: true}, nil
 	}
 
+	if err := c.ensureHeadBranch(ctx, httpClient, base, project, req.Head, req.Base); err != nil {
+		return PRResult{}, err
+	}
+
 	createURL := fmt.Sprintf("%s/projects/%s/merge_requests", base, project)
 	payload := map[string]interface{}{
 		"title":         req.Title,
@@ -247,6 +352,53 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		return PRResult{}, fmt.Errorf("gitlab create MR decode: %w", err)
 	}
 	return PRResult{URL: created.WebURL, Number: created.IID, Updated: false}, nil
+}
+
+// ensureHeadBranch creates the source branch from base with a bootstrap commit
+// when missing. GitLab rejects MRs with no commit delta, so we add a small
+// marker file under .attune/ rather than an empty commit.
+func (c *GitLabClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer, apiBase, projectEscaped, head, baseBranch string) error {
+	branchURL := fmt.Sprintf("%s/projects/%s/repository/branches/%s", apiBase, projectEscaped, url.PathEscape(head))
+	_, code, err := c.doJSON(ctx, httpClient, http.MethodGet, branchURL, nil)
+	if err != nil {
+		return fmt.Errorf("gitlab check head branch: %w", err)
+	}
+	if code >= 200 && code < 300 {
+		return nil
+	}
+	if code != http.StatusNotFound {
+		return fmt.Errorf("gitlab check head branch: status %d", code)
+	}
+
+	// Create branch + bootstrap file commit in one request (start_branch).
+	commitURL := fmt.Sprintf("%s/projects/%s/repository/commits", apiBase, projectEscaped)
+	payload := map[string]interface{}{
+		"branch":         head,
+		"start_branch":   baseBranch,
+		"commit_message": bootstrapCommitMessage,
+		"actions": []map[string]string{
+			{
+				"action":    "create",
+				"file_path": ".attune/RECOMMENDATION_DRIFT.md",
+				"content":   "Attune recommendation drift branch.\n\nSee the merge request description for the drift table. Apply template patches via `kubectl attune diff` or your GitOps pipeline.\n",
+			},
+		},
+	}
+	respBody, code, err := c.doJSON(ctx, httpClient, http.MethodPost, commitURL, payload)
+	if err != nil {
+		return fmt.Errorf("gitlab create head branch: %w", err)
+	}
+	// Race: branch appeared; treat as success if GET now succeeds.
+	if code == http.StatusBadRequest || code == http.StatusConflict {
+		_, checkCode, checkErr := c.doJSON(ctx, httpClient, http.MethodGet, branchURL, nil)
+		if checkErr == nil && checkCode >= 200 && checkCode < 300 {
+			return nil
+		}
+	}
+	if code < 200 || code >= 300 {
+		return fmt.Errorf("gitlab create head branch: status %d: %s", code, redactToken(string(respBody), c.Token))
+	}
+	return nil
 }
 
 func (c *GitLabClient) doJSON(ctx context.Context, httpClient HTTPDoer, method, rawURL string, payload interface{}) ([]byte, int, error) {
@@ -283,4 +435,14 @@ func redactToken(s, token string) string {
 		return s
 	}
 	return strings.ReplaceAll(s, token, "[redacted]")
+}
+
+// pathEscapeRef escapes each path segment of a git ref (e.g. heads/attune/foo)
+// so slashes remain path separators for the GitHub git/ref API.
+func pathEscapeRef(ref string) string {
+	parts := strings.Split(ref, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
 }

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -249,3 +249,91 @@ func TestPathEscapeRef(t *testing.T) {
 	// Spaces must be escaped; slashes preserved as separators.
 	assert.Equal(t, "heads/foo%20bar", pathEscapeRef("heads/foo bar"))
 }
+
+func TestGitHubClient_EnsureHead_RaceRefExists(t *testing.T) {
+	t.Parallel()
+	var headGets int
+	client := &GitHubClient{
+		Token:      "tok",
+		Repository: "org/repo",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			path := r.URL.Path
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(path, "/pulls"):
+				return jsonResp(200, "[]"), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/git/ref/heads/attune/x"):
+				headGets++
+				if headGets == 1 {
+					return jsonResp(404, `{"message":"Not Found"}`), nil
+				}
+				// After concurrent create race: ref exists.
+				return jsonResp(200, map[string]interface{}{
+					"object": map[string]string{"sha": "other"},
+				}), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/git/ref/heads/main"):
+				return jsonResp(200, map[string]interface{}{
+					"object": map[string]string{"sha": "base-sha"},
+				}), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/git/commits/base-sha"):
+				return jsonResp(200, map[string]interface{}{
+					"tree": map[string]string{"sha": "tree-sha"},
+				}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/git/commits"):
+				return jsonResp(201, map[string]string{"sha": "new-commit-sha"}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/git/refs"):
+				return jsonResp(422, `{"message":"Reference already exists"}`), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/pulls"):
+				return jsonResp(201, map[string]interface{}{
+					"number": 5, "html_url": "https://github.com/org/repo/pull/5",
+				}), nil
+			default:
+				return jsonResp(500, `{"message":"unexpected `+r.Method+` `+path+`"}`), nil
+			}
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 5, res.Number)
+	assert.GreaterOrEqual(t, headGets, 2)
+}
+
+func TestGitLabClient_EnsureHead_FileExistsOnBase_UsesUpdate(t *testing.T) {
+	t.Parallel()
+	var commitBodies []string
+	client := &GitLabClient{
+		Token:   "gl-token",
+		Project: "g/p",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			path := r.URL.Path
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(path, "/merge_requests"):
+				return jsonResp(200, "[]"), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/repository/branches/"):
+				return jsonResp(404, `{"message":"404 Branch Not Found"}`), nil
+			case r.Method == http.MethodPost && strings.Contains(path, "/repository/commits"):
+				b, _ := io.ReadAll(r.Body)
+				commitBodies = append(commitBodies, string(b))
+				if strings.Contains(string(b), `"action":"create"`) {
+					return jsonResp(400, `{"message":"A file with this name already exists"}`), nil
+				}
+				return jsonResp(201, map[string]string{"id": "c2"}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/merge_requests"):
+				return jsonResp(201, map[string]interface{}{
+					"iid": 12, "web_url": "https://gitlab.com/g/p/-/merge_requests/12",
+				}), nil
+			default:
+				return jsonResp(500, `{"message":"unexpected `+r.Method+` `+path+`"}`), nil
+			}
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 12, res.Number)
+	require.Len(t, commitBodies, 2)
+	assert.Contains(t, commitBodies[0], `"create"`)
+	assert.Contains(t, commitBodies[1], `"update"`)
+}

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -19,29 +19,47 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) Do(r *http.Request) (*http.Response, error) { return f(r) }
 
-func TestGitHubClient_Create(t *testing.T) {
+func jsonResp(code int, v interface{}) *http.Response {
+	var body string
+	switch t := v.(type) {
+	case string:
+		body = t
+	default:
+		b, _ := json.Marshal(v)
+		body = string(b)
+	}
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func TestGitHubClient_Create_HeadExists(t *testing.T) {
 	t.Parallel()
 	var sawAuth string
+	var paths []string
 	client := &GitHubClient{
 		Token:      "secret-token-xyz",
 		Repository: "org/repo",
 		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			sawAuth = r.Header.Get("Authorization")
-			if r.Method == http.MethodGet {
-				return &http.Response{
-					StatusCode: 200,
-					Body:       io.NopCloser(strings.NewReader("[]")),
-					Header:     make(http.Header),
-				}, nil
+			paths = append(paths, r.Method+" "+r.URL.Path)
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls"):
+				return jsonResp(200, "[]"), nil
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/ref/heads/"):
+				// head already exists
+				return jsonResp(200, map[string]interface{}{
+					"object": map[string]string{"sha": "abc"},
+				}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls"):
+				return jsonResp(201, map[string]interface{}{
+					"number": 7, "html_url": "https://github.com/org/repo/pull/7",
+				}), nil
+			default:
+				return jsonResp(500, `{"message":"unexpected `+r.Method+` `+r.URL.Path+`"}`), nil
 			}
-			body, _ := json.Marshal(map[string]interface{}{
-				"number": 7, "html_url": "https://github.com/org/repo/pull/7",
-			})
-			return &http.Response{
-				StatusCode: 201,
-				Body:       io.NopCloser(strings.NewReader(string(body))),
-				Header:     make(http.Header),
-			}, nil
 		}),
 	}
 	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
@@ -51,8 +69,100 @@ func TestGitHubClient_Create(t *testing.T) {
 	assert.Equal(t, 7, res.Number)
 	assert.Contains(t, res.URL, "pull/7")
 	assert.Equal(t, "Bearer secret-token-xyz", sawAuth)
-	// Error paths must not echo token in message when redacted helper used
 	assert.Equal(t, "[redacted]", redactToken("secret-token-xyz", "secret-token-xyz"))
+	// Must not have attempted bootstrap commit when head exists.
+	for _, p := range paths {
+		assert.NotContains(t, p, "/git/commits")
+		assert.NotContains(t, p, "/git/refs")
+	}
+}
+
+func TestGitHubClient_Create_BootstrapsMissingHead(t *testing.T) {
+	t.Parallel()
+	var methods []string
+	client := &GitHubClient{
+		Token:      "tok",
+		Repository: "org/repo",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			methods = append(methods, r.Method+" "+r.URL.Path)
+			path := r.URL.Path
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(path, "/pulls"):
+				return jsonResp(200, "[]"), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/git/ref/heads/attune/x"):
+				return jsonResp(404, `{"message":"Not Found"}`), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/git/ref/heads/main"):
+				return jsonResp(200, map[string]interface{}{
+					"object": map[string]string{"sha": "base-sha"},
+				}), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/git/commits/base-sha"):
+				return jsonResp(200, map[string]interface{}{
+					"tree": map[string]string{"sha": "tree-sha"},
+				}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/git/commits"):
+				return jsonResp(201, map[string]string{"sha": "new-commit-sha"}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/git/refs"):
+				return jsonResp(201, map[string]interface{}{
+					"ref": "refs/heads/attune/x",
+				}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/pulls"):
+				return jsonResp(201, map[string]interface{}{
+					"number": 42, "html_url": "https://github.com/org/repo/pull/42",
+				}), nil
+			default:
+				return jsonResp(500, `{"message":"unexpected `+r.Method+` `+path+`"}`), nil
+			}
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "drift table", Head: "attune/x", Base: "main",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 42, res.Number)
+	assert.False(t, res.Updated)
+	// Bootstrap sequence must appear.
+	joined := strings.Join(methods, "\n")
+	assert.Contains(t, joined, "GET /repos/org/repo/git/ref/heads/attune/x")
+	assert.Contains(t, joined, "GET /repos/org/repo/git/ref/heads/main")
+	assert.Contains(t, joined, "POST /repos/org/repo/git/commits")
+	assert.Contains(t, joined, "POST /repos/org/repo/git/refs")
+	assert.Contains(t, joined, "POST /repos/org/repo/pulls")
+}
+
+func TestGitLabClient_Create_BootstrapsMissingHead(t *testing.T) {
+	t.Parallel()
+	var methods []string
+	client := &GitLabClient{
+		Token:   "gl-token",
+		Project: "g/p",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			methods = append(methods, r.Method+" "+r.URL.Path)
+			path := r.URL.Path
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(path, "/merge_requests"):
+				return jsonResp(200, "[]"), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/repository/branches/"):
+				return jsonResp(404, `{"message":"404 Branch Not Found"}`), nil
+			case r.Method == http.MethodPost && strings.Contains(path, "/repository/commits"):
+				return jsonResp(201, map[string]string{"id": "c1"}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/merge_requests"):
+				return jsonResp(201, map[string]interface{}{
+					"iid": 11, "web_url": "https://gitlab.com/g/p/-/merge_requests/11",
+				}), nil
+			default:
+				return jsonResp(500, `{"message":"unexpected `+r.Method+` `+path+`"}`), nil
+			}
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 11, res.Number)
+	assert.False(t, res.Updated)
+	joined := strings.Join(methods, "\n")
+	assert.Contains(t, joined, "repository/commits")
+	assert.Contains(t, joined, "merge_requests")
 }
 
 func TestGitLabClient_Update(t *testing.T) {
@@ -129,6 +239,13 @@ func TestGitHubClient_MissingConfigAndListError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "status 401")
-	// API error path must not surface the raw token from the response body.
 	assert.NotContains(t, err.Error(), "super-secret-token")
+}
+
+func TestPathEscapeRef(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "heads/attune/x", pathEscapeRef("heads/attune/x"))
+	assert.Equal(t, "heads/attune/recommendations-ns-pol", pathEscapeRef("heads/attune/recommendations-ns-pol"))
+	// Spaces must be escaped; slashes preserved as separators.
+	assert.Equal(t, "heads/foo%20bar", pathEscapeRef("heads/foo bar"))
 }


### PR DESCRIPTION
## Summary

Closes #453.

When opt-in GitOps pull request automation has no open PR and the head
branch (`attune/recommendations-<ns>-<policy>`) is missing:

- **GitHub:** create an empty bootstrap commit (same tree as base) and open the PR
- **GitLab:** create the branch from base with `.attune/RECOMMENDATION_DRIFT.md` (create, then update if the marker already exists on base)

Dry-run is unchanged (no API mutations). Token scopes documented.

## Test plan

- [x] `go test ./internal/gitops/ -count=1`
- [x] Unit coverage: missing head bootstrap, head exists, GitLab file-exists update retry, GitHub ref race
- [ ] CI green

## Reviewer

Addressed Important findings: GitLab update-on-exists, race tests, empty-sha errors, docs re-bootstrap note.