### PR TITLE
ci: enforce verify-release-artifacts in PR CRD freshness job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
       yaml: ${{ steps.filter.outputs.yaml }}
       docs: ${{ steps.filter.outputs.docs }}
       e2e: ${{ steps.filter.outputs.e2e }}
+      manifests: ${{ steps.filter.outputs.manifests }}
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
@@ -87,6 +88,14 @@ jobs:
               - 'charts/attune/README.md.gotmpl'
             e2e:
               - 'test/e2e/**'
+            # CRDs, kustomize, and tracked release manifests (dist/).
+            # Used by crd-freshness so dist/ cannot lag without a CI failure.
+            manifests:
+              - 'api/**'
+              - 'config/**'
+              - 'charts/attune/crds/**'
+              - 'dist/**'
+              - 'Makefile'
 
   lint:
     name: Lint
@@ -642,7 +651,8 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
     needs: changes
-    if: needs.changes.outputs.go == 'true'
+    # go: API types / controller-gen; manifests: config, chart CRDs, dist/
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.manifests == 'true'
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
@@ -665,6 +675,12 @@ jobs:
             echo "::error::Generated files are stale. Run 'make manifests generate' and commit."
             exit 1
           fi
+
+      # Enforce tracked dist/install.yaml and dist/crds.yaml match current sources
+      # (same check as make verify-quick). Release workflow also regenerates them.
+      - name: Verify release artifacts (dist/)
+        shell: bash -Eeuo pipefail -x {0}
+        run: make verify-release-artifacts IMG=ghcr.io/attune-io/attune:latest
 
   helm-lint:
     name: Helm Lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,6 +510,10 @@ directory. When referencing files elsewhere in the repo (e.g., `charts/`,
 
 - Never commit secrets, API keys, or `.env` files (gitleaks runs in CI)
 - Run `make manifests && make generate` before committing CRD/API changes
+- After CRD/API/RBAC changes, refresh tracked release manifests when
+  `make verify-release-artifacts` fails: `make build-installer` and
+  `make build-crds`, then `git add -f dist/install.yaml dist/crds.yaml`.
+  PR CI's "CRD Freshness Check" enforces this (see #454).
 - Run `make verify` before committing (covers lint, test, helm-docs, CRD freshness)
 - After running `make deploy`, `make k3d-deploy`, or `make kind-deploy`, restore
   `git checkout config/manager/kustomization.yaml` before committing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,13 @@ make build-plugin
 # Run all CI checks locally (lint, test, helm-docs, CRD freshness)
 make verify
 
-# After CRD/API or RBAC changes, refresh release manifests if local
-# verify-release-artifacts fails (tracked under dist/):
+# After CRD/API or RBAC changes, refresh release manifests (dist/install.yaml
+# and dist/crds.yaml). PR CI's "CRD Freshness Check" job runs
+# `make verify-release-artifacts` and fails if these lag:
 make build-installer IMG=ghcr.io/attune-io/attune:latest
 make build-crds
+# dist/ is gitignored for local noise; force-add when committing:
+#   git add -f dist/install.yaml dist/crds.yaml
 ```
 
 ### Running Tests

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -87,10 +87,16 @@ cosign sign --yes docker.io/attuneio/attune-chart:0.2.0
 Generate the combined install manifest for users who do not use Helm:
 
 ```bash
-make build-installer
+make build-installer IMG=ghcr.io/attune-io/attune:latest
+make build-crds
 ```
 
-This writes `dist/install.yaml`, which is uploaded as a release artifact.
+This writes `dist/install.yaml` and `dist/crds.yaml`, uploaded as release
+artifacts. Keep them committed when they change: PR CI runs
+`make verify-release-artifacts` inside the CRD Freshness Check job and fails
+if `dist/` lags CRDs or kustomize config. Force-add if needed
+(`git add -f dist/install.yaml dist/crds.yaml`; `dist/` is gitignored for
+local noise).
 
 ## Pre-release checklist
 


### PR DESCRIPTION
## Summary

Closes #454.

PR CI never ran `make verify-release-artifacts`, so `dist/install.yaml` /
`dist/crds.yaml` could lag CRD and kustomize changes until a local
`make verify` failed. The CRD Freshness Check job now runs that target
after the existing generated-file drift check.

### Changes

- `.github/workflows/ci.yaml`: `manifests` path filter; job runs on
  `go || manifests`; new step `make verify-release-artifacts`
- CONTRIBUTING.md, AGENTS.md, docs/contributing/releasing.md: how to
  refresh and force-add `dist/`

## Test plan

- [x] `make verify-release-artifacts` green locally
- [x] `ci.yaml` parses as YAML
- [ ] CRD Freshness Check green on this PR
- [ ] CI Gate green