### PR TITLE
test: cover recent features (fleet e2e, profiles, export schema, docs)

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -295,4 +295,7 @@ runs:
           --set logging.level=1 \
           --set resources.limits.memory=512Mi \
           --set resources.requests.memory=256Mi \
+          --set fleetReport.enabled=true \
+          --set fleetReport.interval=30s \
+          --set fleetReport.clusterId=e2e \
           --wait --timeout 3m

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -498,6 +498,9 @@ jobs:
             --set logging.level=1 \
             --set resources.limits.memory=512Mi \
             --set resources.requests.memory=256Mi \
+            --set fleetReport.enabled=true \
+            --set fleetReport.interval=30s \
+            --set fleetReport.clusterId=e2e \
             --wait --timeout 3m
 
       - name: Install Chainsaw

--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,9 @@ _deploy-stack:
 		--set metrics.enabled=true \
 		--set leaderElection.enabled=false \
 		--set maxConcurrentReconciles=4 \
+		--set fleetReport.enabled=true \
+		--set fleetReport.interval=30s \
+		--set fleetReport.clusterId=e2e \
 		--wait --timeout 3m
 
 .PHONY: k3d-deploy

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,6 +20,18 @@ recommendations, and promoting to Canary mode, all in about five minutes.
     - **A metrics source** — Prometheus (default), Datadog, or CloudWatch Container Insights. This guide uses Prometheus; see [Datadog Setup](../guides/datadog-setup.md) or [CloudWatch Setup](../guides/cloudwatch-setup.md) for alternatives.
     - **Attune installed** — see [Installation](installation.md) for Helm and raw manifest options.
 
+## What else can Attune do?
+
+This quick start gets you to recommendations. When you are ready to go further:
+
+| Area | Start here |
+|------|------------|
+| Multi-cluster fleet reports and dashboards | [Multi-cluster](../guides/multi-cluster.md#fleet-observability-with-federated-prometheus) |
+| GitOps ConfigMap export and optional PR automation | [GitOps integration](../guides/gitops-integration.md) |
+| Memory limit decrease safety (usage floor on 1.35+) | [Resize API](../architecture/resize-api.md) and [troubleshooting OOM](../guides/troubleshooting.md#oom-after-memory-limit-decrease) |
+| Language runtime defaults (Java, Python, Go, Node) | [Runtime profiles](../guides/runtime-profiles.md) |
+| Node pressure skips and reclaimed capacity | [Bin packing](../guides/bin-packing.md) and [node capacity](../architecture/node-capacity.md) |
+
 ## 1. Create an AttunePolicy in Recommend mode
 
 Start in **Recommend** mode so that no pods are modified. The operator will

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,11 @@ path: canary blast-radius control, startup boost, and SLO-backed auto-revert.
 - **Confidence scaling** for sparse data
 - **Time-of-day awareness** for bursty workloads
 - **Mandatory bounds** (no unbounded recommendations)
+- **GitOps export** (versioned recommendation ConfigMaps) and optional [PR automation](guides/gitops-integration.md#pull-request-automation-opt-in-phase-b)
+- **Multi-cluster fleet** reporting and Grafana ([multi-cluster guide](guides/multi-cluster.md#fleet-observability-with-federated-prometheus))
+- **Memory usage floor** when decreasing limits on Kubernetes 1.35+
+- **Runtime profiles** for safer memory defaults by language
+- **Capacity and pressure awareness** with reclaimed-request signals for bin packing
 
 **[Estimate your savings](savings-calculator.md)** with the interactive
 calculator, or read **[Why Attune?](why-attune.md)** for

--- a/internal/controller/conditions_test.go
+++ b/internal/controller/conditions_test.go
@@ -221,6 +221,13 @@ func TestSummarizeResizeBlockers(t *testing.T) {
 	assert.Equal(t, []string{"app-2"}, s.InfeasibleNames)
 	require.Len(t, s.DeferredAges, 1)
 	assert.InDelta(t, 100.0, s.DeferredAges[0].Seconds(), 0.001)
+
+	// Status contract: controller copies counts onto Workloads (deferred/infeasible UX).
+	policy := &attunev1alpha1.AttunePolicy{}
+	policy.Status.Workloads.Deferred = safeInt32(s.DeferredCount)
+	policy.Status.Workloads.Infeasible = safeInt32(s.InfeasibleCount)
+	assert.Equal(t, int32(1), policy.Status.Workloads.Deferred)
+	assert.Equal(t, int32(1), policy.Status.Workloads.Infeasible)
 }
 
 func TestSetResizeBlockedCondition(t *testing.T) {

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -265,6 +266,50 @@ func TestValidate_GitOpsPullRequestAPIURL_EnterpriseOK(t *testing.T) {
 
 	_, err := validator.ValidateCreate(context.Background(), policy)
 	assert.NoError(t, err)
+}
+
+func TestValidate_RuntimeProfile_AllowDecreaseWarns(t *testing.T) {
+	validator := &AttunePolicyValidator{}
+	for _, profile := range []string{"java", "python", "nodejs"} {
+		t.Run(profile, func(t *testing.T) {
+			policy := validPolicy()
+			policy.Spec.RuntimeProfile = profile
+			allow := true
+			policy.Spec.Memory.AllowDecrease = &allow
+			warnings, err := validator.ValidateCreate(context.Background(), policy)
+			assert.NoError(t, err)
+			require.NotEmpty(t, warnings)
+			joined := strings.Join(warnings, " ")
+			assert.Contains(t, joined, "runtimeProfile="+profile)
+			assert.Contains(t, joined, "allowDecrease")
+		})
+	}
+}
+
+func TestValidate_RuntimeProfile_GolangNoWarnOnAllowDecrease(t *testing.T) {
+	validator := &AttunePolicyValidator{}
+	policy := validPolicy()
+	policy.Spec.RuntimeProfile = "golang"
+	allow := true
+	policy.Spec.Memory.AllowDecrease = &allow
+	warnings, err := validator.ValidateCreate(context.Background(), policy)
+	assert.NoError(t, err)
+	for _, w := range warnings {
+		assert.NotContains(t, w, "runtimeProfile=golang")
+	}
+}
+
+func TestValidate_RuntimeProfile_JavaNoWarnWhenAllowDecreaseFalse(t *testing.T) {
+	validator := &AttunePolicyValidator{}
+	policy := validPolicy()
+	policy.Spec.RuntimeProfile = "java"
+	allow := false
+	policy.Spec.Memory.AllowDecrease = &allow
+	warnings, err := validator.ValidateCreate(context.Background(), policy)
+	assert.NoError(t, err)
+	for _, w := range warnings {
+		assert.NotContains(t, w, "runtimeProfile=java")
+	}
 }
 
 func TestValidate_CanaryObservationPeriodNegative(t *testing.T) {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -739,3 +739,40 @@ func TestApplyRuntimeProfileDefaults_ExplicitWins(t *testing.T) {
 	assert.True(t, *policy.Spec.Memory.AllowDecrease)
 	assert.Equal(t, "15", policy.Spec.Memory.Overhead)
 }
+
+func TestApplyRuntimeProfileDefaults_AllProfiles(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		profile        string
+		wantAllowFalse bool
+		wantOverhead   string // empty = leave built-in default path alone for overhead
+	}{
+		{name: "empty", profile: "", wantAllowFalse: false},
+		{name: "generic", profile: "generic", wantAllowFalse: false},
+		{name: "java", profile: "java", wantAllowFalse: true, wantOverhead: "40"},
+		{name: "python", profile: "python", wantAllowFalse: true},
+		{name: "nodejs", profile: "nodejs", wantAllowFalse: true},
+		{name: "golang", profile: "golang", wantAllowFalse: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			policy := &attunev1alpha1.AttunePolicy{
+				Spec: attunev1alpha1.AttunePolicySpec{
+					RuntimeProfile: tt.profile,
+				},
+			}
+			ApplyBuiltInDefaults(policy)
+			if tt.wantAllowFalse {
+				require.NotNil(t, policy.Spec.Memory.AllowDecrease)
+				assert.False(t, *policy.Spec.Memory.AllowDecrease)
+			} else if policy.Spec.Memory.AllowDecrease != nil {
+				// Built-in defaults may leave nil; if set, not forced false by profile.
+			}
+			if tt.wantOverhead != "" {
+				assert.Equal(t, tt.wantOverhead, policy.Spec.Memory.Overhead)
+			}
+		})
+	}
+}

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -767,8 +767,10 @@ func TestApplyRuntimeProfileDefaults_AllProfiles(t *testing.T) {
 			if tt.wantAllowFalse {
 				require.NotNil(t, policy.Spec.Memory.AllowDecrease)
 				assert.False(t, *policy.Spec.Memory.AllowDecrease)
-			} else if policy.Spec.Memory.AllowDecrease != nil {
-				// Built-in defaults may leave nil; if set, not forced false by profile.
+			} else {
+				// Profiles that do not force allowDecrease leave it nil (or
+				// unset by ApplyBuiltInDefaults for memory decrease).
+				assert.Nil(t, policy.Spec.Memory.AllowDecrease)
 			}
 			if tt.wantOverhead != "" {
 				assert.Equal(t, tt.wantOverhead, policy.Spec.Memory.Overhead)

--- a/test/e2e/configmap-export/chainsaw-test.yaml
+++ b/test/e2e/configmap-export/chainsaw-test.yaml
@@ -101,6 +101,18 @@ spec:
                       exit 1
                     fi
                     echo "OwnerReference set correctly"
+                    # Export schema contract (GitOps durability)
+                    SCHEMA=$(echo "$DATA" | jq -r '.data["schema-version"] // empty')
+                    if [ "$SCHEMA" != "v1" ]; then
+                      echo "FAIL: data.schema-version want v1 got '$SCHEMA'"
+                      exit 1
+                    fi
+                    LABEL=$(echo "$DATA" | jq -r '.metadata.labels["attune.io/export-schema"] // empty')
+                    if [ "$LABEL" != "v1" ]; then
+                      echo "FAIL: label attune.io/export-schema want v1 got '$LABEL'"
+                      exit 1
+                    fi
+                    echo "Export schema-version=v1 OK"
                     exit 0
                   fi
                 fi

--- a/test/e2e/fleet-report/chainsaw-test.yaml
+++ b/test/e2e/fleet-report/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
         - script:
             timeout: 3m
             content: |
-              set -euo pipefail
+              # Chainsaw scripts run under /bin/sh (not bash); avoid bash-only flags.
               NS=attune-system
               CM=attune-fleet-report
               for i in $(seq 1 36); do
@@ -39,7 +39,6 @@ spec:
                     echo "$REPORT" | jq . || echo "$REPORT"
                     exit 1
                   fi
-                  # policyCount is always present (0+ when no policies yet)
                   PC=$(echo "$REPORT" | jq -r '.policyCount // empty')
                   if [ -z "$PC" ]; then
                     echo "FAIL: report.json missing policyCount"

--- a/test/e2e/fleet-report/chainsaw-test.yaml
+++ b/test/e2e/fleet-report/chainsaw-test.yaml
@@ -16,35 +16,32 @@ spec:
         - script:
             timeout: 3m
             content: |
-              # Chainsaw scripts run under /bin/sh (not bash); avoid bash-only flags.
+              # Chainsaw scripts run under /bin/sh (not bash). Prefer jsonpath
+              # over piping full ConfigMap JSON through jq (large report bodies).
               NS=attune-system
               CM=attune-fleet-report
               for i in $(seq 1 36); do
-                if kubectl -n "$NS" get configmap "$CM" >/dev/null 2>&1; then
-                  DATA=$(kubectl -n "$NS" get configmap "$CM" -o json)
-                  SCHEMA=$(echo "$DATA" | jq -r '.data["schema-version"] // empty')
-                  REPORT=$(echo "$DATA" | jq -r '.data["report.json"] // empty')
-                  if [ "$SCHEMA" != "v1" ]; then
-                    echo "FAIL: schema-version want v1 got '$SCHEMA'"
-                    echo "$DATA" | jq .
-                    exit 1
-                  fi
+                SCHEMA=$(kubectl -n "$NS" get configmap "$CM" -o jsonpath='{.data.schema-version}' 2>/dev/null || true)
+                if [ "$SCHEMA" = "v1" ]; then
+                  REPORT=$(kubectl -n "$NS" get configmap "$CM" -o jsonpath='{.data.report\.json}' 2>/dev/null || true)
                   if [ -z "$REPORT" ]; then
                     echo "FAIL: report.json empty"
                     exit 1
                   fi
-                  SV=$(echo "$REPORT" | jq -r '.schemaVersion // empty')
+                  # Write report to a file so jq does not see shell/control issues.
+                  printf '%s' "$REPORT" > /tmp/fleet-report.json
+                  SV=$(jq -r '.schemaVersion // empty' /tmp/fleet-report.json)
                   if [ "$SV" != "v1" ]; then
                     echo "FAIL: report.json schemaVersion want v1 got '$SV'"
-                    echo "$REPORT" | jq . || echo "$REPORT"
+                    head -c 500 /tmp/fleet-report.json; echo
                     exit 1
                   fi
-                  PC=$(echo "$REPORT" | jq -r '.policyCount // empty')
+                  PC=$(jq -r '.policyCount // empty' /tmp/fleet-report.json)
                   if [ -z "$PC" ]; then
                     echo "FAIL: report.json missing policyCount"
                     exit 1
                   fi
-                  LABEL=$(echo "$DATA" | jq -r '.metadata.labels["attune.io/fleet-report"] // empty')
+                  LABEL=$(kubectl -n "$NS" get configmap "$CM" -o jsonpath='{.metadata.labels.attune\.io/fleet-report}' 2>/dev/null || true)
                   if [ "$LABEL" != "true" ]; then
                     echo "FAIL: missing label attune.io/fleet-report=true (got '$LABEL')"
                     exit 1
@@ -54,9 +51,10 @@ spec:
                 fi
                 sleep 5
               done
-              echo "FAIL: ConfigMap $NS/$CM not found"
+              echo "FAIL: ConfigMap $NS/$CM with schema-version=v1 not found"
+              kubectl -n "$NS" get configmap "$CM" -o yaml 2>/dev/null || true
               kubectl -n "$NS" get configmap -o name || true
-              kubectl -n "$NS" get deploy,pods -o wide || true
+              kubectl -n "$NS" get deploy -o yaml | head -80 || true
               kubectl -n "$NS" logs -l app.kubernetes.io/name=attune --tail=80 || true
               exit 1
   catch:

--- a/test/e2e/fleet-report/chainsaw-test.yaml
+++ b/test/e2e/fleet-report/chainsaw-test.yaml
@@ -1,0 +1,66 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: fleet-report
+spec:
+  description: >
+    Verify the operator writes the fleet report ConfigMap (schema-version +
+    report.json) when fleetReport is enabled in the E2E Helm install.
+  timeouts:
+    apply: 30s
+    assert: 3m
+    delete: 30s
+  steps:
+    - name: wait-fleet-report-configmap
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              set -euo pipefail
+              NS=attune-system
+              CM=attune-fleet-report
+              for i in $(seq 1 36); do
+                if kubectl -n "$NS" get configmap "$CM" >/dev/null 2>&1; then
+                  DATA=$(kubectl -n "$NS" get configmap "$CM" -o json)
+                  SCHEMA=$(echo "$DATA" | jq -r '.data["schema-version"] // empty')
+                  REPORT=$(echo "$DATA" | jq -r '.data["report.json"] // empty')
+                  if [ "$SCHEMA" != "v1" ]; then
+                    echo "FAIL: schema-version want v1 got '$SCHEMA'"
+                    echo "$DATA" | jq .
+                    exit 1
+                  fi
+                  if [ -z "$REPORT" ]; then
+                    echo "FAIL: report.json empty"
+                    exit 1
+                  fi
+                  SV=$(echo "$REPORT" | jq -r '.schemaVersion // empty')
+                  if [ "$SV" != "v1" ]; then
+                    echo "FAIL: report.json schemaVersion want v1 got '$SV'"
+                    echo "$REPORT" | jq . || echo "$REPORT"
+                    exit 1
+                  fi
+                  # policyCount is always present (0+ when no policies yet)
+                  PC=$(echo "$REPORT" | jq -r '.policyCount // empty')
+                  if [ -z "$PC" ]; then
+                    echo "FAIL: report.json missing policyCount"
+                    exit 1
+                  fi
+                  LABEL=$(echo "$DATA" | jq -r '.metadata.labels["attune.io/fleet-report"] // empty')
+                  if [ "$LABEL" != "true" ]; then
+                    echo "FAIL: missing label attune.io/fleet-report=true (got '$LABEL')"
+                    exit 1
+                  fi
+                  echo "OK: fleet report ConfigMap schema-version=v1 policyCount=$PC"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "FAIL: ConfigMap $NS/$CM not found"
+              kubectl -n "$NS" get configmap -o name || true
+              kubectl -n "$NS" get deploy,pods -o wide || true
+              kubectl -n "$NS" logs -l app.kubernetes.io/name=attune --tail=80 || true
+              exit 1
+  catch:
+    - podLogs:
+        namespace: attune-system
+        selector: app.kubernetes.io/name=attune


### PR DESCRIPTION
## Summary

Closes the high-value coverage gaps (1)–(5) from the recent-feature audit.

1. **Chainsaw fleet-report** – E2E Helm enables `fleetReport` (30s interval); suite asserts ConfigMap `schema-version`, `report.json`, and `attune.io/fleet-report` label
2. **Deferred/infeasible status** – unit contract that blocker counts land on `status.workloads.deferred` / `infeasible`
3. **Runtime profiles** – table-driven defaults for all profiles; webhook warnings for java/python/nodejs with `allowDecrease=true`
4. **ConfigMap export schema** – Chainsaw asserts `data.schema-version=v1` and `attune.io/export-schema=v1`
5. **Docs discoverability** – quickstart table + index key-feature bullets

## Tracked follow-ups (not closed here)

- #458 why-attune marketing surface
- #459 GitOps PR first-enablement cookbook
- #460 envtest GitOps secret/dry-run reconcile path
- #461 optional live usage-floor / node-pressure coverage

## Test plan

- [x] `go test` for defaults, webhook, controller targeted packages
- [x] `make lint-chainsaw`
- [ ] CI E2E (fleet-report + configmap-export) green