### PR TITLE
docs: complete feature surface docs and GitOps reconcile unit tests

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -140,7 +140,8 @@ make test-e2e-smoke
 | `test/e2e/requests-only/` | (cross-cutting) | `controlledValues: RequestsOnly` is accepted and discovers workloads |
 | `test/e2e/query-parameters/` | (cross-cutting) | Prometheus query parameters are accepted without breaking queries |
 | `test/e2e/startup-boost/` | (cross-cutting) | CPU startup boost is applied to new pods |
-| `test/e2e/configmap-export/` | (cross-cutting) | Recommendations are exported to a ConfigMap |
+| `test/e2e/configmap-export/` | (cross-cutting) | Recommendations are exported to a ConfigMap (`schema-version` + export-schema label) |
+| `test/e2e/fleet-report/` | (infra) | Fleet report ConfigMap is written when `fleetReport` is enabled in E2E Helm |
 | `test/e2e/prometheus-unreachable/` | (cross-cutting) | Handles unreachable Prometheus gracefully without crashing |
 | `test/e2e/grafana-dashboard/` | (helm) | Dashboard ConfigMap renders with `grafanaDashboard.enabled` |
 | `test/e2e/health-probes/` | (infra) | Liveness and readiness probes pass |
@@ -149,6 +150,23 @@ make test-e2e-smoke
 | `test/e2e/webhook-validation/` | (webhook) | Rejects invalid overhead and negative cooldown |
 | `test/e2e/webhook-schedule-validation/` | (webhook) | Rejects invalid timezone, day, and window time |
 | `test/e2e/defaults-validation/` | (webhook) | Rejects invalid AttuneDefaults |
+
+### Paths covered primarily by unit tests (not full-cluster e2e)
+
+Some safety and capacity paths are **intentionally unit-tested** rather
+than full Chainsaw/Go e2e, because a faithful cluster simulation is
+flake-prone or environment-specific:
+
+| Path | Why unit tests are the primary gate | Where tests live |
+|------|-------------------------------------|------------------|
+| **Memory limit usage floor** | Needs controllable “recent usage” (recommendation raw percentile) while decreasing limits; real cgroup usage on pause pods is near zero and does not exercise the floor. Kubernetes 1.35+ limit-decrease behavior also varies by version. | `internal/resize/usage_floor_test.go`, `internal/controller/memory_usage_floor_test.go` |
+| **Node pressure / capacity skip** | Needs `MemoryPressure`/`DiskPressure` or allocatable exhaustion. Injecting real pressure on shared CI k3d nodes is flaky and slow. | `internal/controller/resize_pressure_test.go`, `internal/controller/capacity_skip_test.go` |
+| **GitOps PR live HTTP** | Must not call GitHub/GitLab from CI. Client and reconcile paths use fake HTTP / fake clients. | `internal/gitops/*_test.go`, `internal/controller/gitops_pr_test.go` |
+
+When adding behavior in these areas, extend the unit tables first. Only
+add cluster e2e if you can inject the condition deterministically (for
+example fake node conditions via the API) without depending on real
+resource pressure or external SaaS tokens.
 
 ### Writing new E2E tests
 

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -192,6 +192,53 @@ Metric: `attune_gitops_pr_total{result=created|updated|dry_run|failed}`.
 Set `dryRun: true` for first enablement or CI. The operator records
 `PullRequestDryRun` and increments `dry_run` without calling GitHub/GitLab.
 
+### First enablement
+
+Use this ordered path when turning on PR automation for the first time.
+
+1. **Export recommendations first** (optional but recommended): set
+   `export.configMap: true` and confirm
+   `kubectl attune export list` shows ConfigMaps. See
+   [Export mode](#export-mode-for-gitops-pipelines) above.
+2. **Create a fine-grained token** with the scopes in
+   [Security](#security) (GitHub: Contents + Pull requests write on one
+   repo; GitLab: project write for repository and merge requests).
+3. **Store the token** in the policy namespace (never in the CR):
+   ```bash
+   kubectl -n production create secret generic attune-gitops \
+     --from-literal=token="ghp_..."
+   ```
+4. **Enable dry-run** on the policy (`pullRequest.enabled: true`,
+   `dryRun: true`, `repository`, `tokenSecretRef`). Wait for condition
+   `GitOpsPullRequest` with reason `PullRequestDryRun` (or `NoDrift` if
+   templates already match). Metric
+   `attune_gitops_pr_total{result="dry_run"}` should increase when
+   drift is present.
+5. **Inspect what a real PR would say**: the condition message includes
+   the repository and drift count; the body template is the same as
+   live PRs (see [Status](#status)).
+6. **Turn off dry-run** (`dryRun: false` or omit). On the first live run
+   with drift, Attune **bootstraps the head branch** if missing, then
+   opens the PR:
+   - **GitHub:** empty bootstrap commit on
+     `attune/recommendations-<ns>-<policy>` (same tree as `baseBranch`).
+   - **GitLab:** branch from `baseBranch` plus
+     `.attune/RECOMMENDATION_DRIFT.md` (create, or update if that file
+     already exists on base after a prior merge).
+7. **Apply template patches via Git**, not by hoping the empty/bootstrap
+   commit is enough:
+   ```bash
+   kubectl attune diff -n production -o yaml > /tmp/attune-patches.yaml
+   # Review, commit to the PR branch (or a new branch), merge via normal GitOps.
+   ```
+8. **Verify**: condition reason `PullRequestOpen` and message containing
+   the PR URL; annotation `attune.io/gitops-pr-url`; metric
+   `result="created"` or `updated`. Failures set `PullRequestFailed`
+   without logging the token.
+
+Cooldown (default 24h) prevents PR thrash. After a merge, if the head branch
+is deleted, the next cycle may bootstrap again when drift returns.
+
 ### Branch bootstrap
 
 The operator updates an existing open PR whose head branch is

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -378,6 +378,11 @@ across the capabilities that matter most.
 | No SaaS dependency | Yes | 7/16 (all OSS + ScaleOps) |
 | kubectl plugin with savings estimates | Yes | 0/16 |
 | Canary rollout for resizes | Yes | 0/16 |
+| GitOps export + optional PR automation | Yes | Rare as open source (most SaaS use proprietary sync) |
+| Multi-cluster fleet report / federation-friendly dashboards | Yes | Common on commercial platforms; rare in OSS |
+| Memory limit usage floor (client-side OOM race guard) | Yes | Varies; often platform-specific |
+| Language runtime profiles for memory defaults | Yes | Rare as first-class CRD field |
+| Reclaimed capacity + node pressure skip metrics | Yes | Often bundled into commercial “bin pack” products |
 
 ### Where commercial tools win
 
@@ -400,10 +405,22 @@ capabilities that Attune intentionally does not cover:
 - **No SaaS dependency**: Your metrics stay in your Prometheus. No data
   leaves the cluster.
 - **Kubernetes-native**: Standard CRDs, conditions, events, and kubectl
-  plugin. Works with existing GitOps workflows.
-- **Safety-first**: The only open-source tool with OOMKill detection,
-  CPU throttle monitoring, restart spike detection, and automatic revert
-  with exponential backoff.
+  plugin. Works with existing GitOps workflows (versioned recommendation
+  ConfigMaps and optional pull request automation; see
+  [GitOps integration](guides/gitops-integration.md)).
+- **Safety-first**: OOMKill detection, CPU throttle monitoring, restart
+  spike detection, automatic revert with exponential backoff, and a
+  **memory usage floor** when decreasing limits on Kubernetes 1.35+
+  ([resize API](architecture/resize-api.md)).
+- **Fleet and multi-cluster**: Federated Prometheus dashboards and an
+  optional per-cluster fleet report ConfigMap for rollups
+  ([multi-cluster](guides/multi-cluster.md#fleet-observability-with-federated-prometheus)).
+- **Runtime profiles**: Language-oriented memory defaults (Java, Python,
+  Node.js, Go) so right-sizing matches runtime behavior
+  ([runtime profiles](guides/runtime-profiles.md)).
+- **Capacity awareness**: Skip increases under node pressure and surface
+  reclaimed request capacity for bin packing
+  ([bin packing](guides/bin-packing.md)).
 - **Cost**: Free forever (Apache 2.0). Commercial tools charge $10,000-50,000+/year
   for large clusters.
 

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/operatormetrics"
 )
 
 func TestGitopsPREnabled(t *testing.T) {
@@ -246,4 +248,146 @@ func TestTouchGitOpsPRAnnotation_UsesReconcilerClock(t *testing.T) {
 	r.touchGitOpsPRAnnotation(policy, "https://example.com/pr/1")
 	assert.Equal(t, fixed.Format(time.RFC3339), policy.Annotations[annotationGitOpsPRLastAttempt])
 	assert.Equal(t, "https://example.com/pr/1", policy.Annotations[annotationGitOpsPRURL])
+}
+
+func TestReconcileGitOpsPullRequest_MissingSecret(t *testing.T) {
+	// Live PR path (dryRun false) with drift but no token secret → Failed,
+	// failed metric, no panic, no network.
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	dry := false
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &dry,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "missing-tok", Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	// Fake client has policy + dep only: no Secret named missing-tok.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+
+	before := promtestutil.ToFloat64(operatormetrics.GitOpsPRTotal.WithLabelValues("default", "p", "failed"))
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("100m"),
+			},
+		}},
+	}}
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+
+	var reason, message string
+	for _, cond := range policy.Status.Conditions {
+		if cond.Type == attunev1alpha1.ConditionGitOpsPullRequest {
+			reason = cond.Reason
+			message = cond.Message
+		}
+	}
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRFailed, reason)
+	assert.Contains(t, message, "token secret")
+	assert.NotContains(t, message, "ghp_")
+	assert.Equal(t, before+1, promtestutil.ToFloat64(operatormetrics.GitOpsPRTotal.WithLabelValues("default", "p", "failed")))
+}
+
+func TestReconcileGitOpsPullRequest_DryRunIncrementsMetric(t *testing.T) {
+	// Complements DryRun reason assertion: dry-run path increments metric
+	// and never requires a Secret in the fake client.
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	dry := true
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "dry-metric", Namespace: "ns-dry"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &dry,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "tok", Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "ns-dry"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	before := promtestutil.ToFloat64(operatormetrics.GitOpsPRTotal.WithLabelValues("ns-dry", "dry-metric", "dry_run"))
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("100m"),
+			},
+		}},
+	}}
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, before+1, promtestutil.ToFloat64(operatormetrics.GitOpsPRTotal.WithLabelValues("ns-dry", "dry-metric", "dry_run")))
+	var reason string
+	for _, cond := range policy.Status.Conditions {
+		if cond.Type == attunev1alpha1.ConditionGitOpsPullRequest {
+			reason = cond.Reason
+		}
+	}
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRDryRun, reason)
 }


### PR DESCRIPTION
## Summary

Closes #458, #459, #460, and #461.

| Issue | Deliverable |
|-------|-------------|
| #458 | why-attune wins + capability table: fleet, GitOps PR, usage floor, runtime profiles, reclaimed/pressure |
| #459 | GitOps “First enablement” cookbook (dry-run → secret → live → verify) |
| #460 | Fake-client tests: missing token secret → `PullRequestFailed` + metric; dry-run metric without Secret |
| #461 | Document unit-first testing for usage floor, node pressure, and live GitOps HTTP in `docs/contributing/testing.md` |

## Test plan

- [x] `go test ./internal/controller/ -run GitOpsPullRequest`
- [ ] Docs CI / link check
- [ ] Unit + CI gate green