### PR TITLE
test: harden GitOps coverage and surface PR settings

### DIFF
--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1108,6 +1108,33 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	}
 	printEffectiveField("Export", exportConfigured, exportEffective, selected, updateDefaults != nil && updateDefaults.Export != nil && updateDefaults.Export.ConfigMap)
 
+	// GitOps pull request automation (opt-in Phase B)
+	prConfigured := ""
+	if getNestedBool(item, "spec", "updateStrategy", "export", "pullRequest", "enabled") {
+		prConfigured = "true"
+	}
+	prEffective := ""
+	if effective.Spec.UpdateStrategy.Export != nil &&
+		effective.Spec.UpdateStrategy.Export.PullRequest != nil &&
+		effective.Spec.UpdateStrategy.Export.PullRequest.Enabled != nil &&
+		*effective.Spec.UpdateStrategy.Export.PullRequest.Enabled {
+		pr := effective.Spec.UpdateStrategy.Export.PullRequest
+		provider := pr.Provider
+		if provider == "" {
+			provider = "github"
+		}
+		repo := pr.Repository
+		if repo == "" {
+			repo = "(repository required)"
+		}
+		mode := "live"
+		if pr.DryRun != nil && *pr.DryRun {
+			mode = "dry-run"
+		}
+		prEffective = fmt.Sprintf("%s %s (%s)", provider, repo, mode)
+	}
+	printEffectiveField("GitOps PR", prConfigured, prEffective, selected, false)
+
 	// Schedule window display
 	if sched := effective.Spec.UpdateStrategy.Schedule; sched != nil {
 		tz := sched.Timezone

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -2269,6 +2270,51 @@ func TestPrintEffectivePolicySummary_DoesNotPanic(t *testing.T) {
 		},
 	}
 	printEffectivePolicySummary(item, policy, selectedDefaults{defaults: defaults, source: "cluster"})
+}
+
+func TestPrintEffectivePolicySummary_GitOpsPR(t *testing.T) {
+	en := true
+	dry := true
+	policy := &attunev1alpha1.AttunePolicy{
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type: attunev1alpha1.UpdateTypeRecommend,
+				Export: &attunev1alpha1.ExportConfig{
+					ConfigMap: true,
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &dry,
+						Provider:   "github",
+						Repository: "org/app",
+					},
+				},
+			},
+		},
+	}
+	item := unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"updateStrategy": map[string]interface{}{
+				"export": map[string]interface{}{
+					"configMap": true,
+					"pullRequest": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+			},
+		},
+	}}
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	old := os.Stdout
+	os.Stdout = w
+	printEffectivePolicySummary(item, policy, selectedDefaults{})
+	_ = w.Close()
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "GitOps PR")
+	assert.Contains(t, s, "github org/app (dry-run)")
 }
 
 // ---------- mergeDefaultsIntoPolicy parity with controller ----------

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -419,6 +419,31 @@ Built-in known names include `istio-proxy`, `linkerd-proxy`, `consul-dataplane`,
 
 Template changes trigger a rolling update. The operator no-ops when the template already matches and skips patches mid-rollout. **Observe mode never patches.** **Canary** defers template writes until `FullRollout` so a partial canary resize does not roll the whole fleet via the template. Requests are clamped to limits the same way as live resize.
 
+### Export and GitOps pull requests
+
+Write recommendations to ConfigMaps for Argo CD / Flux, and optionally open
+provider PRs when templates drift. Full cookbook:
+[GitOps integration](../guides/gitops-integration.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `updateStrategy.export.configMap` | bool | `false` | When true, write versioned recommendation ConfigMaps named `<policy>-<workload>-recommendations` (schema key `schema-version: v1`). |
+| `updateStrategy.export.pullRequest.enabled` | bool | `false` | Opt-in PR automation (GitHub or GitLab). Requires `repository` and `tokenSecretRef` when enabled. |
+| `updateStrategy.export.pullRequest.provider` | string | `github` | `github` or `gitlab`. |
+| `updateStrategy.export.pullRequest.repository` | string | (required when enabled) | `owner/repo` (GitHub) or project path/id (GitLab). |
+| `updateStrategy.export.pullRequest.tokenSecretRef` | object | (required when enabled) | Secret `name` + `key` for a fine-scoped API token. Never log the token. |
+| `updateStrategy.export.pullRequest.apiUrl` | string | provider default | Enterprise GitHub or self-hosted GitLab API base (SSRF-validated). |
+| `updateStrategy.export.pullRequest.baseBranch` | string | `main` | Target branch for the PR. |
+| `updateStrategy.export.pullRequest.cooldown` | duration | `24h` | Minimum time between PR create/update attempts for this policy. |
+| `updateStrategy.export.pullRequest.minChangePercent` | int32 | `10` | Minimum absolute percent change (per container resource vs template) to open or update a PR (1-100). |
+| `updateStrategy.export.pullRequest.dryRun` | bool | `false` | When true, set status only (`PullRequestDryRun`); no remote API call. |
+| `updateStrategy.export.pullRequest.labels` | []string | `[]` | Labels applied to the PR when the provider supports them (max 20). |
+
+Status condition `GitOpsPullRequest` reports dry-run, open, no-drift, cooldown,
+failed, or disabled. Metric: `attune_gitops_pr_total`. Inspect export ConfigMaps
+with `kubectl attune export list` and effective PR settings with
+`kubectl attune explain <policy>`.
+
 ### Directional Change Caps
 
 Per-resource fields in `cpu` and `memory` that limit how much a recommendation can change per cycle:
@@ -529,6 +554,7 @@ The controller sets these conditions on each `AttunePolicy`:
 | `Degraded` | `HighRevertRate` | Set when 3+ of the last 5 resizes were reverted |
 | `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Set when `updateStrategy.schedule` is configured; indicates whether the current time is within an allowed resize window |
 | `ResizeBlocked` | `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Pods stuck Deferred or Infeasible; see troubleshooting "Deferred or Infeasible resize" |
+| `GitOpsPullRequest` | `PullRequestOpen`, `PullRequestFailed`, `NoDrift`, `PullRequestCooldown`, `PullRequestDryRun`, `PullRequestDisabled` | Opt-in `export.pullRequest` automation status (see [GitOps integration](../guides/gitops-integration.md)) |
 
 ## Exponential Backoff
 

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -212,13 +212,16 @@ func (r *AttunePolicyReconciler) touchGitOpsPRAnnotation(policy *attunev1alpha1.
 }
 
 // persistGitOpsPRAnnotations patches policy annotations so cooldown survives restarts.
-// Best-effort; failures do not fail reconcile.
+// Best-effort; failures do not fail reconcile but are logged at V(1).
 func (r *AttunePolicyReconciler) persistGitOpsPRAnnotations(ctx context.Context, policy *attunev1alpha1.AttunePolicy) {
 	if policy.Annotations == nil {
 		return
 	}
+	logger := log.FromContext(ctx)
 	latest := &attunev1alpha1.AttunePolicy{}
 	if err := r.Get(ctx, client.ObjectKeyFromObject(policy), latest); err != nil {
+		logger.V(1).Info("GitOps PR: failed to re-get policy for annotation persist",
+			"error", err.Error(), "policy", policy.Name, "namespace", policy.Namespace)
 		return
 	}
 	base := latest.DeepCopy()
@@ -231,5 +234,8 @@ func (r *AttunePolicyReconciler) persistGitOpsPRAnnotations(ctx context.Context,
 	if v, ok := policy.Annotations[annotationGitOpsPRURL]; ok {
 		latest.Annotations[annotationGitOpsPRURL] = v
 	}
-	_ = r.Patch(ctx, latest, client.MergeFrom(base))
+	if err := r.Patch(ctx, latest, client.MergeFrom(base)); err != nil {
+		logger.V(1).Info("GitOps PR: failed to patch cooldown annotations",
+			"error", err.Error(), "policy", policy.Name, "namespace", policy.Namespace)
+	}
 }

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -391,3 +391,90 @@ func TestReconcileGitOpsPullRequest_DryRunIncrementsMetric(t *testing.T) {
 	}
 	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRDryRun, reason)
 }
+
+func TestReconcileGitOpsPullRequest_IncompleteConfig(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	cases := []struct {
+		name string
+		pr   *attunev1alpha1.GitOpsPullRequestConfig
+	}{
+		{
+			name: "empty repository",
+			pr: &attunev1alpha1.GitOpsPullRequestConfig{
+				Enabled: &en, Repository: "",
+				TokenSecretRef: &attunev1alpha1.SecretKeyRef{Name: "tok", Key: "token"},
+			},
+		},
+		{
+			name: "nil tokenSecretRef",
+			pr: &attunev1alpha1.GitOpsPullRequestConfig{
+				Enabled: &en, Repository: "org/repo",
+			},
+		},
+		{
+			name: "empty secret key",
+			pr: &attunev1alpha1.GitOpsPullRequestConfig{
+				Enabled: &en, Repository: "org/repo",
+				TokenSecretRef: &attunev1alpha1.SecretKeyRef{Name: "tok", Key: ""},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			policy := &attunev1alpha1.AttunePolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+				Spec: attunev1alpha1.AttunePolicySpec{
+					UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+						Export: &attunev1alpha1.ExportConfig{PullRequest: tc.pr},
+					},
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy).Build()
+			r := NewAttunePolicyReconciler()
+			r.Client = c
+			r.reconcileGitOpsPullRequest(context.Background(), policy, nil, nil)
+			var reason, message string
+			for _, cond := range policy.Status.Conditions {
+				if cond.Type == attunev1alpha1.ConditionGitOpsPullRequest {
+					reason = cond.Reason
+					message = cond.Message
+				}
+			}
+			assert.Equal(t, attunev1alpha1.ReasonGitOpsPRFailed, reason)
+			assert.Contains(t, message, "repository")
+			assert.Contains(t, message, "tokenSecretRef")
+		})
+	}
+}
+
+func TestSetGitOpsPRCondition_ReplaceAndPreserveTransition(t *testing.T) {
+	t.Parallel()
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", Generation: 3},
+	}
+	// First set
+	setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRNoDrift, "none")
+	require.Len(t, policy.Status.Conditions, 1)
+	first := policy.Status.Conditions[0].LastTransitionTime
+
+	// Same status+reason: preserve LastTransitionTime, update message/generation
+	setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRNoDrift, "still none")
+	require.Len(t, policy.Status.Conditions, 1)
+	assert.Equal(t, first, policy.Status.Conditions[0].LastTransitionTime)
+	assert.Equal(t, "still none", policy.Status.Conditions[0].Message)
+	assert.Equal(t, int64(3), policy.Status.Conditions[0].ObservedGeneration)
+
+	// Different reason: replace condition (new transition time allowed)
+	setGitOpsPRCondition(policy, metav1.ConditionTrue, attunev1alpha1.ReasonGitOpsPRDryRun, "dry")
+	require.Len(t, policy.Status.Conditions, 1)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRDryRun, policy.Status.Conditions[0].Reason)
+	assert.Equal(t, metav1.ConditionTrue, policy.Status.Conditions[0].Status)
+	assert.Equal(t, "dry", policy.Status.Conditions[0].Message)
+}

--- a/internal/fleetreport/exporter_test.go
+++ b/internal/fleetreport/exporter_test.go
@@ -60,3 +60,41 @@ func TestExporter_exportOnce_WritesConfigMap(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "true", cm.Labels[ConfigMapLabel])
 }
+
+func TestExporter_NeedLeaderElection(t *testing.T) {
+	t.Parallel()
+	assert.True(t, (&Exporter{}).NeedLeaderElection())
+}
+
+func TestExporter_Start_StopsOnCancel(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "attune-system"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+	e := &Exporter{
+		Client:    c,
+		Log:       logr.Discard(),
+		Namespace: "attune-system",
+		// Empty name uses default attune-fleet-report
+		ClusterID: "c",
+		Interval:  50 * time.Millisecond,
+		Now:       func() time.Time { return time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC) },
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- e.Start(ctx) }()
+	// Allow initial ExportOnce + at least one tick, then cancel.
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+	var cm corev1.ConfigMap
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: "attune-system", Name: "attune-fleet-report"}, &cm)
+	require.NoError(t, err, "Start should default Name and export ConfigMap")
+	assert.Equal(t, "v1", cm.Data["schema-version"])
+}

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -456,7 +456,15 @@ func redactToken(s, token string) string {
 	if token == "" {
 		return s
 	}
-	return strings.ReplaceAll(s, token, "[redacted]")
+	// Exact match first, then common encodings that APIs may echo in error bodies.
+	s = strings.ReplaceAll(s, token, "[redacted]")
+	if enc := url.QueryEscape(token); enc != token {
+		s = strings.ReplaceAll(s, enc, "[redacted]")
+	}
+	if enc := url.PathEscape(token); enc != token {
+		s = strings.ReplaceAll(s, enc, "[redacted]")
+	}
+	return s
 }
 
 // pathEscapeRef escapes each path segment of a git ref (e.g. heads/attune/foo)

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -336,4 +337,14 @@ func TestGitLabClient_EnsureHead_FileExistsOnBase_UsesUpdate(t *testing.T) {
 	require.Len(t, commitBodies, 2)
 	assert.Contains(t, commitBodies[0], `"create"`)
 	assert.Contains(t, commitBodies[1], `"update"`)
+}
+
+func TestRedactToken_Encodings(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "[redacted]", redactToken("secret-token-xyz", "secret-token-xyz"))
+	assert.Equal(t, "plain", redactToken("plain", ""))
+	tok := "ghp_a+b/c=d"
+	assert.Equal(t, "err [redacted] end", redactToken("err "+tok+" end", tok))
+	assert.Equal(t, "q=[redacted]", redactToken("q="+url.QueryEscape(tok), tok))
+	assert.Equal(t, "p=[redacted]", redactToken("p="+url.PathEscape(tok), tok))
 }

--- a/internal/gitops/drift_test.go
+++ b/internal/gitops/drift_test.go
@@ -215,3 +215,67 @@ func TestComputeDrift_UnknownContainerSkipped(t *testing.T) {
 	}}
 	assert.Empty(t, ComputeDrift([]client.Object{dep}, recs, 10))
 }
+
+func TestComputeDrift_NameOnlyMatchWhenKindDiffers(t *testing.T) {
+	// Recommendations sometimes omit or mismatch Kind; ComputeDrift falls back
+	// to matching on workload name alone.
+	t.Parallel()
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "ReplicaSet", // wrong kind; name still matches
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("100m"),
+			},
+		}},
+	}}
+	d := ComputeDrift([]client.Object{dep}, recs, 10)
+	require.Len(t, d, 1)
+	assert.Equal(t, "cpu", d[0].Resource)
+	assert.Equal(t, "api", d[0].Workload)
+}
+
+func TestComputeDrift_SkipsWorkloadWithoutRecommendation(t *testing.T) {
+	t.Parallel()
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+						},
+					}},
+				},
+			},
+		},
+	}
+	// Recommendation for a different workload only.
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "other", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{CPURequest: resource.MustParse("100m")},
+		}},
+	}}
+	assert.Empty(t, ComputeDrift([]client.Object{dep}, recs, 10))
+}

--- a/internal/gitops/drift_test.go
+++ b/internal/gitops/drift_test.go
@@ -273,7 +273,7 @@ func TestComputeDrift_SkipsWorkloadWithoutRecommendation(t *testing.T) {
 	recs := []attunev1alpha1.WorkloadRecommendation{{
 		Workload: "other", Kind: "Deployment",
 		Containers: []attunev1alpha1.ContainerRecommendation{{
-			Name: "app",
+			Name:        "app",
 			Recommended: attunev1alpha1.ResourceValues{CPURequest: resource.MustParse("100m")},
 		}},
 	}}


### PR DESCRIPTION
## Summary

Multi-perspective improvement pass focused on recent GitOps / fleet / export surface.

- **Tests:** incomplete `export.pullRequest` config, condition replace/preserve transition, ComputeDrift name-only match, fleet `Exporter.Start` cancel + defaults, token redaction encodings
- **CLI:** `kubectl attune explain` shows GitOps PR provider/repository/dry-run
- **Correctness:** log V(1) on GitOps annotation persist Get/Patch failures; redact QueryEscape/PathEscape token forms in provider error bodies
- **Docs:** `docs/reference/configuration.md` export + pullRequest field table and `GitOpsPullRequest` status reasons

## Test plan

- [x] `go test ./internal/controller/ ./internal/gitops/ ./internal/fleetreport/ ./cmd/kubectl-attune/ -race -count=1`
- [ ] CI E2E + unit on this PR

## Notes

- Does not close community/tracking issues (#108–#123, #352, #90, #113)
- Release PR #442 remains open (needs explicit approval to merge)