### PR TITLE
test: metrics coverage, GitOps drift kinds, and PR list head filter

### DIFF
--- a/charts/attune/tests/prometheusrule_test.yaml
+++ b/charts/attune/tests/prometheusrule_test.yaml
@@ -77,6 +77,12 @@ tests:
       - equal:
           path: spec.groups[0].rules[13].labels.severity
           value: info
+      - matchRegex:
+          path: spec.groups[0].rules[13].expr
+          pattern: "attune_memory_limit_decrease_total"
+      - matchRegex:
+          path: spec.groups[0].rules[13].expr
+          pattern: "clamped_usage\\|skipped_unsafe"
 
   - it: should omit gitops PR alert when disabled
     set:

--- a/deploy/grafana/dashboard.json
+++ b/deploy/grafana/dashboard.json
@@ -1240,6 +1240,78 @@
         "type": "prometheus",
         "uid": "${datasource}"
       }
+    },
+    {
+      "id": 125,
+      "type": "timeseries",
+      "title": "GitOps PR outcomes",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 112
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(attune_gitops_pr_total[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 126,
+      "type": "timeseries",
+      "title": "GitOps PR failures",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 112
+      },
+      "targets": [
+        {
+          "expr": "sum by (namespace, policy) (rate(attune_gitops_pr_total{result=\"failed\"}[5m]))",
+          "legendFormat": "{{namespace}}/{{policy}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 127,
+      "type": "timeseries",
+      "title": "Memory limit decrease outcomes",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 120
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(attune_memory_limit_decrease_total[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 128,
+      "type": "timeseries",
+      "title": "Memory limit unsafe/clamped usage",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 120
+      },
+      "targets": [
+        {
+          "expr": "sum by (namespace, policy, result) (rate(attune_memory_limit_decrease_total{result=~\"clamped_usage|skipped_unsafe\"}[5m]))",
+          "legendFormat": "{{namespace}}/{{policy}} {{result}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "schemaVersion": 39,

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -510,8 +510,9 @@ sum by (namespace, policy, reason) (rate(attune_capacity_skip_total[1h]))
 
 **Symptom**: After enabling memory decreases (`memory.allowDecrease: true`
 and `controlledValues: RequestsAndLimits`) on Kubernetes 1.35+, pods OOMKill
-when limits shrink, or Events show `MemoryLimitUsageFloor` / metrics show
-`attune_memory_limit_decrease_total{result="clamped_usage"}`.
+when limits shrink, Events show `MemoryLimitUsageFloor`, metrics show
+`attune_memory_limit_decrease_total{result="clamped_usage"}` or
+`skipped_unsafe`, or the opt-in `AttuneMemoryLimitUnsafe` alert fires.
 
 **Cause**: Live memory limit decreases race with usage spikes. Attune floors
 the target limit above recent usage (recommendation raw percentile) plus

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -37,10 +37,13 @@ func TestRecordCapacitySkip(t *testing.T) {
 
 	recordCapacitySkip(policy, "total pod requests would exceed node allocatable")
 	recordCapacitySkip(policy, "node has MemoryPressure; skipping memory request increase")
+	// Producer strings from nodePressureBlocksIncrease must map to the same pressure label.
+	recordCapacitySkip(policy, "node has DiskPressure; skipping memory request increase")
+	recordCapacitySkip(policy, "node has PIDPressure; skipping CPU request increase")
 	recordCapacitySkip(policy, "quota/limitrange violation: too large") // no metric
 
 	assert.Equal(t, beforeAlloc+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "allocatable")))
-	assert.Equal(t, beforePress+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "pressure")))
+	assert.Equal(t, beforePress+3, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "pressure")))
 }
 
 func TestComputeSavings_ReclaimedAliases(t *testing.T) {

--- a/internal/controller/memory_usage_floor_test.go
+++ b/internal/controller/memory_usage_floor_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/operatormetrics"
 )
 
 func TestApplyMemoryUsageFloor_RaisesUnsafeLimit(t *testing.T) {
@@ -66,10 +68,59 @@ func TestApplyMemoryUsageFloor_RaisesUnsafeLimit(t *testing.T) {
 		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
 	}
 
+	before := promtestutil.ToFloat64(operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
+		"default", "p", "clamped_usage"))
 	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
 	// 500Mi * 1.1 = 550Mi
 	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("550Mi")),
 		"got %s", got.Limits.Memory().String())
+	assert.Equal(t, before+1, promtestutil.ToFloat64(operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
+		"default", "p", "clamped_usage")))
+}
+
+func TestApplyMemoryUsageFloor_SkippedUnsafeIncrementsMetric(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	// Usage is above the current limit: floor clamps back to current → skipped_unsafe.
+	margin := int32(10)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-skip", Namespace: "ns-skip"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			Memory: attunev1alpha1.ResourceConfig{
+				DecreaseUsageMarginPercent: &margin,
+			},
+		},
+	}
+	r := NewAttunePolicyReconciler()
+	r.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "ns-skip"}}
+	rec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			MemoryLimit: resource.MustParse("200Mi"),
+		},
+		Explanation: &attunev1alpha1.ContainerRecommendationExplanation{
+			Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+				RawPercentile: resource.MustParse("300Mi"),
+			},
+		},
+	}
+	target := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("100Mi")},
+	}
+
+	before := promtestutil.ToFloat64(operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
+		"ns-skip", "p-skip", "skipped_unsafe"))
+	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
+	// Floor = max(target, usage*(1+m/100)) but never above current → stays 200Mi.
+	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("200Mi")),
+		"got %s", got.Limits.Memory().String())
+	assert.Equal(t, before+1, promtestutil.ToFloat64(operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
+		"ns-skip", "p-skip", "skipped_unsafe")))
 }
 
 func TestApplyMemoryUsageFloor_SafeDecreaseUnchanged(t *testing.T) {

--- a/internal/fleetreport/exporter.go
+++ b/internal/fleetreport/exporter.go
@@ -113,6 +113,9 @@ func (e *Exporter) applyConfigMap(ctx context.Context, desired *corev1.ConfigMap
 	if err != nil {
 		return fmt.Errorf("get: %w", err)
 	}
+	// Merge patch avoids 409 when concurrent writers touch labels/annotations
+	// (same pattern as recommendation ConfigMap export).
+	base := existing.DeepCopy()
 	existing.Data = desired.Data
 	if existing.Labels == nil {
 		existing.Labels = map[string]string{}
@@ -120,8 +123,8 @@ func (e *Exporter) applyConfigMap(ctx context.Context, desired *corev1.ConfigMap
 	for k, v := range desired.Labels {
 		existing.Labels[k] = v
 	}
-	if err := e.Client.Update(ctx, &existing); err != nil {
-		return fmt.Errorf("update: %w", err)
+	if err := e.Client.Patch(ctx, &existing, client.MergeFrom(base)); err != nil {
+		return fmt.Errorf("patch: %w", err)
 	}
 	return nil
 }

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -86,8 +86,16 @@ func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
 
-	// Find existing open PR with same head branch (filter client-side).
-	listURL := fmt.Sprintf("%s/repos/%s/pulls?state=open&base=%s", base, c.Repository, url.QueryEscape(req.Base))
+	// Find existing open PR for this head branch. GitHub supports head=owner:ref
+	// server-side filtering so we do not miss the PR when base has many open PRs
+	// (default list page size is 30).
+	owner := c.Repository
+	if i := strings.IndexByte(c.Repository, '/'); i > 0 {
+		owner = c.Repository[:i]
+	}
+	listURL := fmt.Sprintf("%s/repos/%s/pulls?state=open&base=%s&head=%s&per_page=100",
+		base, c.Repository, url.QueryEscape(req.Base),
+		url.QueryEscape(owner+":"+req.Head))
 	body, code, err := c.doJSON(ctx, httpClient, http.MethodGet, listURL, nil)
 	if err != nil {
 		return PRResult{}, err
@@ -105,20 +113,26 @@ func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 	if err := json.Unmarshal(body, &existing); err != nil {
 		return PRResult{}, fmt.Errorf("github list PRs decode: %w", err)
 	}
-	for _, pr := range existing {
-		if pr.Head.Ref == req.Head {
-			// Update body/title
-			patchURL := fmt.Sprintf("%s/repos/%s/pulls/%d", base, c.Repository, pr.Number)
-			payload := map[string]string{"title": req.Title, "body": req.Body}
-			_, code, err := c.doJSON(ctx, httpClient, http.MethodPatch, patchURL, payload)
-			if err != nil {
-				return PRResult{}, err
+	if len(existing) > 0 {
+		pr := existing[0]
+		// Prefer an entry whose head ref matches when the response still includes
+		// unrelated PRs (older GitHub or ignored head filter).
+		for i := range existing {
+			if existing[i].Head.Ref == req.Head {
+				pr = existing[i]
+				break
 			}
-			if code < 200 || code >= 300 {
-				return PRResult{}, fmt.Errorf("github update PR: status %d", code)
-			}
-			return PRResult{URL: pr.HTMLURL, Number: pr.Number, Updated: true}, nil
 		}
+		patchURL := fmt.Sprintf("%s/repos/%s/pulls/%d", base, c.Repository, pr.Number)
+		payload := map[string]string{"title": req.Title, "body": req.Body}
+		_, code, err := c.doJSON(ctx, httpClient, http.MethodPatch, patchURL, payload)
+		if err != nil {
+			return PRResult{}, err
+		}
+		if code < 200 || code >= 300 {
+			return PRResult{}, fmt.Errorf("github update PR: status %d", code)
+		}
+		return PRResult{URL: pr.HTMLURL, Number: pr.Number, Updated: true}, nil
 	}
 
 	// Ensure head branch exists (create from base with a bootstrap commit if needed).

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -251,6 +251,40 @@ func TestPathEscapeRef(t *testing.T) {
 	assert.Equal(t, "heads/foo%20bar", pathEscapeRef("heads/foo bar"))
 }
 
+func TestGitHubClient_ListOpenPRsUsesHeadFilter(t *testing.T) {
+	t.Parallel()
+	var listQuery string
+	client := &GitHubClient{
+		Token:      "tok",
+		Repository: "org/repo",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls") {
+				listQuery = r.URL.RawQuery
+				return jsonResp(200, []map[string]interface{}{
+					{
+						"number": 42, "html_url": "https://github.com/org/repo/pull/42",
+						"head": map[string]string{"ref": "attune/x"},
+					},
+				}), nil
+			}
+			if r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/pulls/42") {
+				return jsonResp(200, map[string]interface{}{}), nil
+			}
+			return jsonResp(500, `{"message":"unexpected"}`), nil
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Updated)
+	assert.Equal(t, 42, res.Number)
+	assert.Contains(t, listQuery, "head=")
+	assert.Contains(t, listQuery, "org%3Aattune%2Fx") // owner:branch QueryEscape
+	assert.Contains(t, listQuery, "per_page=100")
+	assert.Contains(t, listQuery, "base=main")
+}
+
 func TestGitHubClient_EnsureHead_RaceRefExists(t *testing.T) {
 	t.Parallel()
 	var headGets int

--- a/internal/gitops/drift.go
+++ b/internal/gitops/drift.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -193,6 +194,12 @@ func podTemplateSpec(w client.Object) *corev1.PodTemplateSpec {
 		return &o.Spec.Template
 	case *appsv1.DaemonSet:
 		return &o.Spec.Template
+	case *appsv1.ReplicaSet:
+		return &o.Spec.Template
+	case *batchv1.Job:
+		return &o.Spec.Template
+	case *batchv1.CronJob:
+		return &o.Spec.JobTemplate.Spec.Template
 	default:
 		return nil
 	}
@@ -210,6 +217,12 @@ func workloadKind(w client.Object) string {
 		return "StatefulSet"
 	case *appsv1.DaemonSet:
 		return "DaemonSet"
+	case *appsv1.ReplicaSet:
+		return "ReplicaSet"
+	case *batchv1.Job:
+		return "Job"
+	case *batchv1.CronJob:
+		return "CronJob"
 	default:
 		return "Workload"
 	}

--- a/internal/gitops/drift_test.go
+++ b/internal/gitops/drift_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,6 +161,103 @@ func TestComputeDrift_StatefulSetAndDaemonSet(t *testing.T) {
 	}
 	assert.True(t, kinds["StatefulSet"], "expected StatefulSet drift")
 	assert.True(t, kinds["DaemonSet"], "expected DaemonSet drift")
+}
+
+func TestComputeDrift_CronJobJobReplicaSet(t *testing.T) {
+	t.Parallel()
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "batch"},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "worker",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "nightly"},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "job",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "rs"},
+		Spec: appsv1.ReplicaSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("500m"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "batch", Kind: "Job",
+			Containers: []attunev1alpha1.ContainerRecommendation{{
+				Name: "worker",
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("250m"),
+				},
+			}},
+		},
+		{
+			Workload: "nightly", Kind: "CronJob",
+			Containers: []attunev1alpha1.ContainerRecommendation{{
+				Name: "job",
+				Recommended: attunev1alpha1.ResourceValues{
+					MemoryRequest: resource.MustParse("128Mi"),
+				},
+			}},
+		},
+		{
+			Workload: "rs", Kind: "ReplicaSet",
+			Containers: []attunev1alpha1.ContainerRecommendation{{
+				Name: "app",
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("100m"),
+				},
+			}},
+		},
+	}
+	d := ComputeDrift([]client.Object{job, cj, rs}, recs, 10)
+	require.Len(t, d, 3)
+	kinds := map[string]bool{}
+	for _, x := range d {
+		kinds[x.Kind] = true
+	}
+	assert.True(t, kinds["Job"], "expected Job drift")
+	assert.True(t, kinds["CronJob"], "expected CronJob drift")
+	assert.True(t, kinds["ReplicaSet"], "expected ReplicaSet drift")
 }
 
 func TestComputeDrift_ZeroTemplateRequestIsFullDrift(t *testing.T) {


### PR DESCRIPTION
## Summary

Multi-perspective improve cycle (2026-08-03) after #467.

### QA
- Assert `attune_memory_limit_decrease_total` for `clamped_usage` and `skipped_unsafe`
- Expand capacity-skip metric coverage for DiskPressure / PIDPressure reason strings
- Pin `AttuneMemoryLimitUnsafe` PromQL in helm unittest

### Developer
- `ComputeDrift` supports CronJob, Job, ReplicaSet pod templates (fixes false NoDrift for batch targets)
- Fleet report ConfigMap write uses Merge patch (fewer 409s under concurrent writers)
- GitHub GitOps PR list uses `head=owner:branch` + `per_page=100` so existing PRs are updated on busy repos

### Docs / dashboard
- Troubleshooting mentions `AttuneMemoryLimitUnsafe`
- Grafana panels live in `deploy/grafana/dashboard.json` (source of truth for `verify-dashboard-metrics`)

## Test plan

- [x] `go test ./internal/controller/ ./internal/gitops/ ./internal/fleetreport/ -race`
- [x] `make helm-unittest`
- [x] `make verify-quick`
- [ ] PR CI green

Closes #468