### PR TITLE
docs: add SLO guardrails guide and v0.1.21 upgrade notes

### DIFF
--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -110,6 +110,9 @@ message rather than triggering a false revert.
 `updateStrategy.sloGuardrails`. Adjust the threshold, widen the
 `evaluationWindow`, or remove the guardrail if the metric is unreliable.
 
+For configuration examples, template variables, and operational tips, see the
+[SLO guardrails guide](../guides/slo-guardrails.md).
+
 ## Observation period
 
 After a resize, the operator observes the pod for a configurable period

--- a/docs/getting-started/first-30-days.md
+++ b/docs/getting-started/first-30-days.md
@@ -140,8 +140,9 @@ notready, throttle, or slo:&lt;name&gt; for SLO guardrail breaches).
 ### Optional production hardening before Auto
 
 - **SLO guardrails**: add PromQL checks so a bad resize reverts on latency or
-  error-rate breach, not only infra signals. Documented under
-  `updateStrategy.sloGuardrails` in the [API reference](../reference/api.md).
+  error-rate breach, not only infra signals. See the
+  [SLO guardrails guide](../guides/slo-guardrails.md) and
+  `updateStrategy.sloGuardrails` in the [configuration reference](../reference/configuration.md#slo-guardrails).
 - **Startup boost**: for JVM or other cold-start heavy apps, enable
   `cpu.startupBoost` so pods get temporary CPU headroom at start, then
   scale back. See the [startup boost guide](../guides/startup-boost.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -28,6 +28,7 @@ This quick start gets you to recommendations. When you are ready to go further:
 |------|------------|
 | Multi-cluster fleet reports and dashboards | [Multi-cluster](../guides/multi-cluster.md#fleet-observability-with-federated-prometheus) |
 | GitOps ConfigMap export and optional PR automation | [GitOps integration](../guides/gitops-integration.md) |
+| Application SLO checks after resize (latency, errors) | [SLO guardrails](../guides/slo-guardrails.md) |
 | Memory limit decrease safety (usage floor on 1.35+) | [Resize API](../architecture/resize-api.md) and [troubleshooting OOM](../guides/troubleshooting.md#oom-after-memory-limit-decrease) |
 | Language runtime defaults (Java, Python, Go, Node) | [Runtime profiles](../guides/runtime-profiles.md) |
 | Node pressure skips and reclaimed capacity | [Bin packing](../guides/bin-packing.md) and [node capacity](../architecture/node-capacity.md) |

--- a/docs/guides/slo-guardrails.md
+++ b/docs/guides/slo-guardrails.md
@@ -1,0 +1,136 @@
+# SLO guardrails
+
+Infrastructure signals (OOMKill, restarts, throttle, NotReady) catch many bad
+resizes. Application-level SLOs catch the rest: latency spikes, error-rate
+jumps, or availability drops that do not show up as container crashes.
+
+`updateStrategy.sloGuardrails` lets you attach PromQL checks that run after
+each resize. If a query breaches its threshold, Attune reverts the resize with
+reason `slo:<guardrail-name>`.
+
+Architecture detail lives under
+[Safety: SLO guardrails](../architecture/safety.md#slo-guardrails). This guide
+covers configuration and day-2 use.
+
+## When to use them
+
+Add guardrails before promoting a policy from Canary to Auto on user-facing
+workloads. Pair them with `autoRevert: true` (the default) so breaches undo
+the change automatically.
+
+Guardrails are optional. Policies without them still revert on OOMKill, restart
+spikes, NotReady, and CPU throttle.
+
+## How they work
+
+1. Attune resizes a pod (Auto, OneShot, Canary, or other applying modes).
+2. The safety monitor waits for each guardrail's `evaluationWindow` (default
+   `5m`, minimum `1m`) so the app can stabilize.
+3. It runs the PromQL query against the policy metrics source.
+4. If the scalar result breaches the threshold in the configured direction
+   (`above` or `below`), the resize is reverted with reason
+   `slo:<name>`.
+5. Query errors, empty series, NaN, or Inf **fail open**: that guardrail is
+   skipped and logged rather than forcing a false revert.
+
+## Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | (required) | Label for logs, events, and revert reason |
+| `query` | string | (required) | PromQL returning a scalar |
+| `threshold` | string | (required) | Value that triggers a revert |
+| `comparison` | string | `above` | `above` (value > threshold) or `below` |
+| `evaluationWindow` | duration | `5m` | Wait after resize before evaluating (min `1m`) |
+
+Template variables in `query`:
+
+| Variable | Expands to |
+|----------|------------|
+| `{{ .Namespace }}` | Policy / pod namespace |
+| `{{ .WorkloadName }}` | Workload name |
+| `{{ .PodName }}` | Resized pod name |
+
+### Example
+
+```yaml
+apiVersion: attune.io/v1alpha1
+kind: AttunePolicy
+metadata:
+  name: checkout-api
+  namespace: production
+spec:
+  targetRef:
+    kind: Deployment
+    name: checkout-api
+  metricsSource:
+    prometheus:
+      address: http://prometheus-server.monitoring:80
+  updateStrategy:
+    type: Canary
+    autoRevert: true
+    safetyObservationPeriod: 5m
+    sloGuardrails:
+      - name: p99-latency
+        query: >-
+          histogram_quantile(0.99,
+            rate(http_request_duration_seconds_bucket{
+              namespace="{{ .Namespace }}",
+              pod="{{ .PodName }}"
+            }[5m]))
+        threshold: "0.5"
+        comparison: above
+        evaluationWindow: 5m
+      - name: error-rate
+        query: >-
+          sum(rate(http_requests_total{
+            namespace="{{ .Namespace }}",
+            pod="{{ .PodName }}",
+            code=~"5.."
+          }[5m]))
+          /
+          sum(rate(http_requests_total{
+            namespace="{{ .Namespace }}",
+            pod="{{ .PodName }}"
+          }[5m]))
+        threshold: "0.01"
+        comparison: above
+```
+
+You can also set `sloGuardrails` on `AttuneDefaults` or
+`AttuneNamespaceDefaults` so policies inherit them when unset. See
+[inheritable UpdateStrategy fields](../reference/configuration.md#inheritable-updatestrategy-fields).
+
+## Operational tips
+
+- Prefer **pod-scoped** labels (`pod="{{ .PodName }}"`) when the metric exists
+  at pod level so canary pods are judged on their own traffic.
+- Keep `evaluationWindow` at least as long as your SLO query range when the
+  range needs warm data (for example `[5m]` rates).
+- Start with Canary so only a fraction of pods are exposed while you tune
+  thresholds.
+- Use `kubectl attune history` to confirm revert reasons; SLO breaches show as
+  `slo:<name>`.
+- Guardrails require a working Prometheus (or compatible) metrics source on the
+  policy. They do not run against Datadog/CloudWatch query languages.
+
+## Troubleshooting
+
+| Symptom | What to check |
+|---------|----------------|
+| Revert reason `slo:p99-latency` | Threshold too tight, or traffic mix after resize changed latency |
+| No SLO reverts while latency is bad | Query returns empty/error (fails open); metric labels wrong; window not elapsed |
+| False reverts right after resize | Widen `evaluationWindow`; exclude cold-start noise from the query |
+| Guardrail never evaluated | Mode is Observe/Recommend (no applying resize), or `autoRevert: false` |
+
+Operator logs at V(1) include skipped guardrails (query errors, NaN/Inf). See
+[Troubleshooting: high revert rate](troubleshooting.md#high-revert-rate) and
+[architecture safety](../architecture/safety.md).
+
+## Related
+
+- [Safety architecture](../architecture/safety.md) (auto-revert triggers, observation period)
+- [Configuration reference: SLO Guardrails](../reference/configuration.md#slo-guardrails)
+- [Canary rollout](canary-rollout.md)
+- [Auto mode](auto-mode.md)
+- [Metrics reference](../reference/metrics.md) (`attune_reverts_total` reason labels)

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -1,7 +1,70 @@
 # Upgrading
 
-This page covers breaking changes between versions. If you are upgrading from an
-earlier pre-release, apply every section below your current version.
+This page covers breaking changes and notable behavior shifts between versions.
+If you are upgrading from an earlier pre-release, apply every section below your
+current version (newest sections first).
+
+## v0.1.20 to v0.1.21
+
+v0.1.21 is a feature release. Existing policies keep working without YAML
+edits. Most new capabilities are **opt-in**. Read this section if you run
+Kubernetes 1.35+, GitOps export, multi-cluster rollups, or memory limit
+control.
+
+### Safe by default (no action required)
+
+| Area | Behavior |
+|------|----------|
+| GitOps pull request automation | Off unless `export.pullRequest.enabled: true` |
+| Fleet report ConfigMap export | Off unless `fleetReport` (or Helm equivalent) is enabled |
+| Runtime profiles | Only apply when `runtimeProfile` is set |
+| Export schema versioning | Additive fields on recommendation ConfigMaps; consumers can ignore new keys |
+
+### Behavior that can change without new fields
+
+**Memory limit decreases on Kubernetes 1.35+.** On 1.35+, Attune no longer
+clamps memory limits the way it did on 1.33/1.34 when the platform allows
+live decreases and the policy uses `controlledValues: RequestsAndLimits` with
+decrease allowed. A **usage floor** still keeps the target limit above recent
+usage (default `memory.decreaseUsageMarginPercent: 10`). On 1.33–1.34, limit
+decreases remain clamped as before.
+
+If you rely on “limits never go down in place,” pin an older cluster version,
+set `memory.allowDecrease: false`, use a restrictive
+[runtime profile](runtime-profiles.md), or keep `controlledValues: RequestsOnly`
+(the default).
+
+**Capacity and node pressure.** Resizes may be skipped more often when nodes
+are under pressure; metrics and status explain the skip. This is protective,
+not a CRD break.
+
+### Opt-in features worth enabling deliberately
+
+| Feature | Where to start |
+|---------|----------------|
+| GitOps PR automation | [GitOps integration](gitops-integration.md#pull-request-automation-opt-in-phase-b) |
+| Multi-cluster fleet report | [Multi-cluster](multi-cluster.md) |
+| Language runtime profiles | [Runtime profiles](runtime-profiles.md) |
+| Deferred / Infeasible UX | Status conditions + [troubleshooting](troubleshooting.md#deferred-or-infeasible-resize-stuck-pods) |
+| SLO PromQL guardrails (unchanged API; guide improved) | [SLO guardrails](slo-guardrails.md) |
+
+### Operator / install notes
+
+- Refresh CRDs with the release install path (`helm upgrade` or
+  `dist/crds.yaml` / `dist/install.yaml` from the tag).
+- Grafana dashboard and PrometheusRule assets gain panels/alerts for GitOps
+  PR outcomes, memory limit decrease safety, capacity skips, and related
+  signals. Re-apply chart or dashboard ConfigMaps if you manage them out of
+  band.
+- `kubectl attune explain` surfaces GitOps PR and runtime profile effective
+  values; upgrade the plugin with the release for matching CLI help.
+
+After upgrade, confirm policies with:
+
+```bash
+kubectl attune status -A
+kubectl attune explain -n <namespace> <policy>
+```
 
 ## v1alpha1 Field Renames (v0.1.0)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Canary Rollout: guides/canary-rollout.md
       - Auto Mode: guides/auto-mode.md
       - Startup Boost: guides/startup-boost.md
+      - SLO Guardrails: guides/slo-guardrails.md
       - Runtime Profiles: guides/runtime-profiles.md
       - HPA Coexistence: guides/hpa-coexistence.md
       - Prometheus Setup: guides/prometheus-setup.md


### PR DESCRIPTION
## Summary

- Add standalone [SLO guardrails guide](docs/guides/slo-guardrails.md) under Guides (MkDocs nav), with configuration, examples, and ops tips drawn from existing safety/config content.
- Link it from quickstart, first-30-days, and architecture safety.
- Add a short **v0.1.20 → v0.1.21** section to [upgrading.md](docs/guides/upgrading.md) covering safe defaults, memory limit decrease behavior on 1.35+, and opt-in features.

## Verification

- Relative link check on touched pages
- `mkdocs build` succeeds; `/guides/slo-guardrails/` and `/guides/upgrading/` render

## Test plan

- [x] MkDocs build locally
- [ ] Docs Check CI green
- [ ] Spot-check rendered nav: Guides → SLO Guardrails; Upgrading newest section first