### PR TITLE
test: e2e for deferred, node pressure, and java profile

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -144,6 +144,8 @@ make test-e2e-smoke
 | `test/e2e/fleet-report/` | (infra) | Fleet report ConfigMap is written when `fleetReport` is enabled in E2E Helm |
 | `test/e2e/gitops-pr-dry-run/` | (cross-cutting) | GitOps PR dry-run sets `PullRequestDryRun`/`PullRequestCooldown` without forge credentials |
 | `test/e2e/runtime-profile-defaults/` | (webhook + API) | `runtimeProfile: java` stored and accepted; java+allowDecrease warns at admission |
+| `test/e2e/runtime-profile-java-no-mem-decrease/` | Auto | java profile keeps oversized memory (in-memory `allowDecrease=false`); CR fields stay unset |
+| `test/e2e/resize-blocked-status/` | Recommend | Injected Deferred+Infeasible pod conditions surface `workloads.deferred`/`infeasible` and `ResizeBlocked` |
 | `test/e2e/prometheus-unreachable/` | (cross-cutting) | Handles unreachable Prometheus gracefully without crashing |
 | `test/e2e/grafana-dashboard/` | (helm) | Dashboard ConfigMap renders with `grafanaDashboard.enabled` |
 | `test/e2e/health-probes/` | (infra) | Liveness and readiness probes pass |
@@ -163,14 +165,25 @@ flake-prone or environment-specific:
 |------|-------------------------------------|------------------|
 | **Memory limit usage floor** | Needs controllable “recent usage” (recommendation raw percentile) while decreasing limits; real cgroup usage on pause pods is near zero and does not exercise the floor. | `internal/resize/usage_floor_test.go`, `internal/controller/memory_usage_floor_test.go` |
 | **Version-aware memory limit decrease (clamp vs apply)** | Covered in **Go E2E** `TestE2E_MemoryLimitDecrease_VersionAware` (nightly 1.32–1.35 matrix): Guaranteed pod with oversized limit, `RequestsAndLimits` + `allowDecrease`; asserts limit drops on 1.35+ and stays clamped on 1.33–1.34. Unit tests still own clamp math and version parsing. | `test/e2e-go/e2e_test.go`, `internal/resize/engine_test.go` |
-| **Node pressure / capacity skip** | Needs `MemoryPressure`/`DiskPressure` or allocatable exhaustion. Injecting real pressure on shared CI k3d nodes is flaky and slow. | `internal/controller/resize_pressure_test.go`, `internal/controller/capacity_skip_test.go` |
+| **Node pressure / capacity skip** | Unit tests own reason strings and metric labels. **Go E2E** `TestE2E_NodeMemoryPressure_SkipsMemoryIncrease` patches `MemoryPressure` on the pod’s node (not `t.Parallel`; restores on cleanup). Real allocatable exhaustion remains unit/integration only. | `internal/controller/resize_pressure_test.go`, `capacity_skip_test.go`, `test/e2e-go/` |
+| **Deferred / Infeasible UX** | Real kubelet Deferred/Infeasible needs capacity races (flake-prone). Cluster tests **inject** `PodResizePending` status (Chainsaw + Go E2E) and assert `workloads.deferred`/`infeasible` + `ResizeBlocked`. Helpers stay unit-tested. | `test/e2e/resize-blocked-status/`, `TestE2E_ResizeBlocked_*`, `internal/resize/engine_test.go`, `conditions_test.go` |
 | **GitOps PR live HTTP** | Must not call GitHub/GitLab from CI. Client create/update paths use fake HTTP. Cluster e2e covers **dry-run** and missing-secret only (`test/e2e/gitops-pr-dry-run/`). | `internal/gitops/*_test.go`, `internal/controller/gitops_pr_test.go` |
-| **Runtime profile in-memory defaults** | Controller applies java overhead/allowDecrease only in-memory (not written back to the CR). Unit tests assert `ApplyRuntimeProfileDefaults`; Chainsaw asserts admission warnings + stored profile field. | `pkg/defaults/defaults_test.go`, `test/e2e/runtime-profile-defaults/` |
+| **Runtime profile in-memory defaults** | Unit: `ApplyRuntimeProfileDefaults`. Chainsaw admission + stored field: `runtime-profile-defaults`. Live no memory decrease: `runtime-profile-java-no-mem-decrease` + Go `TestE2E_RuntimeProfileJava_BlocksMemoryDecrease`. | `pkg/defaults/defaults_test.go`, `test/e2e/runtime-profile-*`, `test/e2e-go/` |
 
-When adding behavior in these areas, extend the unit tables first. Only
-add cluster e2e if you can inject the condition deterministically (for
-example fake node conditions via the API) without depending on real
+When adding behavior in these areas, extend the unit tables first. Prefer
+deterministic injection (pod/node status patches) over waiting for real
 resource pressure or external SaaS tokens.
+
+### Chainsaw vs Go E2E (when to use which)
+
+Both run against a real cluster in CI/nightly. Prefer:
+
+| Prefer | Strengths | Weak spots |
+|--------|-----------|------------|
+| **Chainsaw** (`test/e2e/`) | Declarative multi-resource apply, webhook dry-run, pure kubectl/script flows, easy to read in PRs, no compile step | `/bin/sh` (dash) only; weak typed waits; yamllint max 200 cols; awkward for concurrent client-go loops |
+| **Go E2E** (`test/e2e-go/`) | Typed clients, `retry.RetryOnConflict`, status subresource loops, `t.Parallel`, shared helpers, version gates | Heavier to write; must use `t.Parallel()` only when tests do not mutate cluster-scoped state (nodes) |
+
+**Neither** can make the real kubelet emit Deferred/Infeasible without capacity races; inject status and assert operator UX instead. **Node** conditions (MemoryPressure) are injectable but **cluster-scoped**: keep those Go tests non-parallel and always restore.
 
 ### Writing new E2E tests
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -144,7 +144,7 @@ make test-e2e-smoke
 | `test/e2e/fleet-report/` | (infra) | Fleet report ConfigMap is written when `fleetReport` is enabled in E2E Helm |
 | `test/e2e/gitops-pr-dry-run/` | (cross-cutting) | GitOps PR dry-run sets `PullRequestDryRun`/`PullRequestCooldown` without forge credentials |
 | `test/e2e/runtime-profile-defaults/` | (webhook + API) | `runtimeProfile: java` stored and accepted; java+allowDecrease warns at admission |
-| `test/e2e/runtime-profile-java-no-mem-decrease/` | Auto | java profile keeps oversized memory (in-memory `allowDecrease=false`); CR fields stay unset |
+| `test/e2e/runtime-profile-java-no-mem-decrease/` | Recommend | java profile applies memory overhead=40 in explanation; CR overhead/allowDecrease stay unset |
 | `test/e2e/resize-blocked-status/` | Recommend | Injected Deferred+Infeasible pod conditions surface `workloads.deferred`/`infeasible` and `ResizeBlocked` |
 | `test/e2e/prometheus-unreachable/` | (cross-cutting) | Handles unreachable Prometheus gracefully without crashing |
 | `test/e2e/grafana-dashboard/` | (helm) | Dashboard ConfigMap renders with `grafanaDashboard.enabled` |
@@ -168,7 +168,7 @@ flake-prone or environment-specific:
 | **Node pressure / capacity skip** | Unit tests own reason strings and metric labels. **Go E2E** `TestE2E_NodeMemoryPressure_SkipsMemoryIncrease` patches `MemoryPressure` on the pod’s node (not `t.Parallel`; restores on cleanup). Real allocatable exhaustion remains unit/integration only. | `internal/controller/resize_pressure_test.go`, `capacity_skip_test.go`, `test/e2e-go/` |
 | **Deferred / Infeasible UX** | Real kubelet Deferred/Infeasible needs capacity races (flake-prone). Cluster tests **inject** `PodResizePending` status (Chainsaw + Go E2E) and assert `workloads.deferred`/`infeasible` + `ResizeBlocked`. Helpers stay unit-tested. | `test/e2e/resize-blocked-status/`, `TestE2E_ResizeBlocked_*`, `internal/resize/engine_test.go`, `conditions_test.go` |
 | **GitOps PR live HTTP** | Must not call GitHub/GitLab from CI. Client create/update paths use fake HTTP. Cluster e2e covers **dry-run** and missing-secret only (`test/e2e/gitops-pr-dry-run/`). | `internal/gitops/*_test.go`, `internal/controller/gitops_pr_test.go` |
-| **Runtime profile in-memory defaults** | Unit: `ApplyRuntimeProfileDefaults`. Chainsaw admission + stored field: `runtime-profile-defaults`. Live no memory decrease: `runtime-profile-java-no-mem-decrease` + Go `TestE2E_RuntimeProfileJava_BlocksMemoryDecrease`. | `pkg/defaults/defaults_test.go`, `test/e2e/runtime-profile-*`, `test/e2e-go/` |
+| **Runtime profile in-memory defaults** | Unit: `ApplyRuntimeProfileDefaults`. Chainsaw admission + stored field: `runtime-profile-defaults`. Java-unique overhead=40 in explanation: Chainsaw + Go `TestE2E_RuntimeProfileJava_BlocksMemoryDecrease`. | `pkg/defaults/defaults_test.go`, `test/e2e/runtime-profile-*`, `test/e2e-go/` |
 
 When adding behavior in these areas, extend the unit tables first. Prefer
 deterministic injection (pod/node status patches) over waiting for real

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -411,31 +411,21 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	withinWindow := isWithinResizeWindow(policy.Spec.UpdateStrategy.Schedule, r.now())
 	var newResizedCount int
 
-	// Build podsByWorkload once so both executeResizes and applyStartupBoosts
-	// can reuse it, avoiding duplicate getPodsForWorkload calls per cycle.
-	// Only pre-fetch pods for workloads that have recommendations, not all
-	// discovered workloads (the fallback in executeResizes handles misses).
-	var podsByWorkload map[string][]corev1.Pod
+	// Always list pods for discovered workloads so Deferred/Infeasible
+	// status UX (counts, ResizeBlocked condition, metrics) stays accurate
+	// even when this cycle does not resize (Recommend mode, cooldown, or
+	// outside schedule). executeResizes / startup boost reuse the same map.
+	podsByWorkload := make(map[string][]corev1.Pod, len(workloads))
+	for _, w := range workloads {
+		pods, err := r.getPodsForWorkload(ctx, w)
+		if err != nil {
+			logger.Error(err, "Failed to get pods for workload", "workload", w.GetName())
+			continue
+		}
+		podsByWorkload[w.GetName()] = pods
+	}
 	needPods := isResizeMode(mode) && ((!cooldownActive && withinWindow) ||
 		(policy.Spec.CPU.StartupBoost != nil && r.Clientset != nil && len(recommendations) > 0))
-	if needPods {
-		recWorkloads := make(map[string]bool, len(recommendations))
-		for _, rec := range recommendations {
-			recWorkloads[rec.Workload] = true
-		}
-		podsByWorkload = make(map[string][]corev1.Pod, len(recWorkloads))
-		for _, w := range workloads {
-			if !recWorkloads[w.GetName()] {
-				continue
-			}
-			pods, err := r.getPodsForWorkload(ctx, w)
-			if err != nil {
-				logger.Error(err, "Failed to get pods for workload", "workload", w.GetName())
-				continue
-			}
-			podsByWorkload[w.GetName()] = pods
-		}
-	}
 
 	// Pre-fetch namespace-scoped LimitRanges and ResourceQuotas once so both
 	// executeResizes and applyStartupBoosts can reuse them without duplicate

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -2219,10 +2220,10 @@ func TestE2E_ResizeBlocked_DeferredAndInfeasibleStatus(t *testing.T) {
 			return false, nil
 		}
 		// Prefer both reasons when both counts are set.
-		if blocked.Reason != attunev1alpha1.ReasonPodsDeferredAndInfeasible &&
-			blocked.Reason != attunev1alpha1.ReasonPodsDeferred &&
-			blocked.Reason != attunev1alpha1.ReasonPodsInfeasible {
-			t.Logf("unexpected ResizeBlocked reason=%s", blocked.Reason)
+		// Both counts are set: controller must use the combined reason.
+		if blocked.Reason != attunev1alpha1.ReasonPodsDeferredAndInfeasible {
+			t.Logf("waiting for reason=%s (got %s)",
+				attunev1alpha1.ReasonPodsDeferredAndInfeasible, blocked.Reason)
 			return false, nil
 		}
 		t.Logf("OK: ResizeBlocked reason=%s message=%s", blocked.Reason, blocked.Message)
@@ -2386,12 +2387,13 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 		return false, nil
 	}), "expected memory recommendation above %s", initMem)
 
-	// Hold MemoryPressure long enough that a free resize would have applied
-	// without pressure, re-asserting the condition (node agents may clear it).
+	// Hold MemoryPressure and require a positive skip signal (ResizeSkipped
+	// event mentioning MemoryPressure), not only "memory did not change".
 	initQ := resource.MustParse(initMem)
-	holdUntil := time.Now().Add(90 * time.Second)
-	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 		setNodeMemoryPressure(t, nodeName, true)
+		forcePolicyReconcile(t, policyName, ns, 45*time.Second)
+
 		var live corev1.PodList
 		if err := k8sClient.List(ctx, &live, client.InNamespace(ns), client.MatchingLabels{"app": appName}); err != nil {
 			return false, nil
@@ -2410,11 +2412,24 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 				}
 			}
 		}
-		if time.Now().Before(holdUntil) {
+
+		evs, err := clientset.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+			FieldSelector: "involvedObject.kind=AttunePolicy,involvedObject.name=" + policyName,
+		})
+		if err != nil {
 			return false, nil
 		}
-		return true, nil
-	}), "memory request changed under MemoryPressure or wait failed")
+		for _, ev := range evs.Items {
+			if ev.Reason != "ResizeSkipped" {
+				continue
+			}
+			if strings.Contains(ev.Message, "MemoryPressure") {
+				t.Logf("OK: ResizeSkipped event: %s", ev.Message)
+				return true, nil
+			}
+		}
+		return false, nil
+	}), "expected ResizeSkipped event mentioning MemoryPressure while memory stays at %s", initMem)
 
 	require.NoError(t, k8sClient.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{"app": appName}))
 	require.NotEmpty(t, pods.Items)
@@ -2493,9 +2508,32 @@ func TestE2E_RuntimeProfileJava_BlocksMemoryDecrease(t *testing.T) {
 		},
 	}
 	require.NoError(t, k8sClient.Create(ctx, policy))
+	// java-unique default is overhead=40 (platform default memory overhead is 30).
+	// That is the live signal the profile applied, not mere allowDecrease=false
+	// (which is already the platform default when the field is nil).
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var p attunev1alpha1.AttunePolicy
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: ns}, &p); err != nil {
+			return false, nil
+		}
+		for _, rec := range p.Status.Recommendations {
+			for _, cr := range rec.Containers {
+				if cr.Name != "app" || cr.Explanation == nil || cr.Explanation.Memory == nil {
+					continue
+				}
+				if cr.Explanation.Memory.Overhead == 40 {
+					t.Logf("OK: java profile effective memory overhead=40 in explanation")
+					return true, nil
+				}
+				t.Logf("memory explanation overhead=%.0f (want 40)", cr.Explanation.Memory.Overhead)
+			}
+		}
+		return false, nil
+	}), "expected recommendation explanation memory overhead=40 from java runtimeProfile")
+
 	waitForResize(t, policyName, ns, 4*time.Minute)
 
-	// CR must still show unset allowDecrease (defaults are not written back).
+	// CR must still show unset allowDecrease/overhead (defaults are not written back).
 	var stored attunev1alpha1.AttunePolicy
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: ns}, &stored))
 	assert.Nil(t, stored.Spec.Memory.AllowDecrease,
@@ -2509,6 +2547,6 @@ func TestE2E_RuntimeProfileJava_BlocksMemoryDecrease(t *testing.T) {
 	c := podList.Items[0].Spec.Containers[0]
 	origMem := resource.MustParse(initMem)
 	assert.GreaterOrEqual(t, c.Resources.Requests.Memory().Value(), origMem.Value(),
-		"java runtimeProfile should block memory decrease (effective allowDecrease=false), got %s",
+		"memory should not decrease under java defaults, got %s",
 		c.Resources.Requests.Memory().String())
 }

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -2120,3 +2120,395 @@ func TestE2E_MemoryLimitDecrease_VersionAware(t *testing.T) {
 			gitVersion, finalMemLim.String(), initMem)
 	}
 }
+
+// patchPodResizePending sets PodResizePending with the given reason (Deferred
+// or Infeasible). Kubelet may overwrite status; callers re-apply in a loop.
+func patchPodResizePending(t *testing.T, podName, namespace, reason string) {
+	t.Helper()
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		now := metav1.Now()
+		cond := corev1.PodCondition{
+			Type:               corev1.PodResizePending,
+			Status:             corev1.ConditionTrue,
+			Reason:             reason,
+			Message:            "e2e injected for ResizeBlocked UX",
+			LastTransitionTime: now,
+		}
+		found := false
+		for i := range pod.Status.Conditions {
+			if pod.Status.Conditions[i].Type == corev1.PodResizePending {
+				pod.Status.Conditions[i] = cond
+				found = true
+				break
+			}
+		}
+		if !found {
+			pod.Status.Conditions = append(pod.Status.Conditions, cond)
+		}
+		_, err = clientset.CoreV1().Pods(namespace).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
+		return err
+	}))
+}
+
+// TestE2E_ResizeBlocked_DeferredAndInfeasibleStatus injects kubelet-style
+// PodResizePending conditions and asserts Attune surfaces
+// status.workloads.deferred/infeasible and ResizeBlocked.
+//
+// Real Deferred/Infeasible require node capacity races that are flake-prone on
+// shared k3d. Status injection validates the operator UX path (#436).
+func TestE2E_ResizeBlocked_DeferredAndInfeasibleStatus(t *testing.T) {
+	t.Parallel()
+	ns := uniqueNS("blocked")
+	createNamespace(t, ns)
+
+	const (
+		appName    = "blocked-app"
+		policyName = "blocked-policy"
+	)
+	// Two replicas: one Deferred, one Infeasible.
+	createDeployment(t, appName, ns, "250m", "256Mi", 2)
+	waitForDeploymentReady(t, appName, ns, 90*time.Second)
+
+	createPolicy(t, policyName, ns, appName, attunev1alpha1.UpdateTypeRecommend)
+	waitForPolicyDiscovered(t, policyName, ns, 90*time.Second)
+
+	var pods corev1.PodList
+	require.NoError(t, k8sClient.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{"app": appName}))
+	require.GreaterOrEqual(t, len(pods.Items), 2, "need two pods")
+	// Prefer Running pods.
+	var names []string
+	for i := range pods.Items {
+		if pods.Items[i].DeletionTimestamp != nil || pods.Items[i].Status.Phase != corev1.PodRunning {
+			continue
+		}
+		names = append(names, pods.Items[i].Name)
+		if len(names) == 2 {
+			break
+		}
+	}
+	require.Len(t, names, 2, "need two Running pods")
+	deferredPod, infeasiblePod := names[0], names[1]
+
+	// Re-inject conditions while waiting: kubelet may clear synthetic status.
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		patchPodResizePending(t, deferredPod, ns, "Deferred")
+		patchPodResizePending(t, infeasiblePod, ns, "Infeasible")
+		forcePolicyReconcile(t, policyName, ns, 45*time.Second)
+
+		var p attunev1alpha1.AttunePolicy
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: ns}, &p); err != nil {
+			return false, nil
+		}
+		t.Logf("workloads deferred=%d infeasible=%d", p.Status.Workloads.Deferred, p.Status.Workloads.Infeasible)
+		if p.Status.Workloads.Deferred < 1 || p.Status.Workloads.Infeasible < 1 {
+			return false, nil
+		}
+		var blocked *metav1.Condition
+		for i := range p.Status.Conditions {
+			if p.Status.Conditions[i].Type == attunev1alpha1.ConditionResizeBlocked {
+				blocked = &p.Status.Conditions[i]
+				break
+			}
+		}
+		if blocked == nil || blocked.Status != metav1.ConditionTrue {
+			t.Logf("ResizeBlocked not True yet")
+			return false, nil
+		}
+		// Prefer both reasons when both counts are set.
+		if blocked.Reason != attunev1alpha1.ReasonPodsDeferredAndInfeasible &&
+			blocked.Reason != attunev1alpha1.ReasonPodsDeferred &&
+			blocked.Reason != attunev1alpha1.ReasonPodsInfeasible {
+			t.Logf("unexpected ResizeBlocked reason=%s", blocked.Reason)
+			return false, nil
+		}
+		t.Logf("OK: ResizeBlocked reason=%s message=%s", blocked.Reason, blocked.Message)
+		return true, nil
+	}), "expected Deferred+Infeasible counts and ResizeBlocked condition")
+}
+
+// setNodeMemoryPressure sets or clears NodeMemoryPressure on the named node.
+// Caller must restore in Cleanup. Not parallel-safe across tests that need
+// memory *increases* on the same node.
+func setNodeMemoryPressure(t *testing.T, nodeName string, pressure bool) {
+	t.Helper()
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		want := corev1.ConditionFalse
+		if pressure {
+			want = corev1.ConditionTrue
+		}
+		found := false
+		for i := range node.Status.Conditions {
+			if node.Status.Conditions[i].Type == corev1.NodeMemoryPressure {
+				node.Status.Conditions[i].Status = want
+				node.Status.Conditions[i].LastTransitionTime = metav1.Now()
+				node.Status.Conditions[i].Reason = "E2ETest"
+				node.Status.Conditions[i].Message = "e2e MemoryPressure injection"
+				found = true
+				break
+			}
+		}
+		if !found && pressure {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               corev1.NodeMemoryPressure,
+				Status:             corev1.ConditionTrue,
+				LastHeartbeatTime:  metav1.Now(),
+				LastTransitionTime: metav1.Now(),
+				Reason:             "E2ETest",
+				Message:            "e2e MemoryPressure injection",
+			})
+		}
+		_, err = clientset.CoreV1().Nodes().UpdateStatus(ctx, node, metav1.UpdateOptions{})
+		return err
+	}))
+}
+
+// TestE2E_NodeMemoryPressure_SkipsMemoryIncrease patches MemoryPressure on the
+// pod's node and asserts Attune does not raise an undersized memory request.
+//
+// Not t.Parallel: node status is cluster-scoped and would race other tests.
+func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
+	ns := uniqueNS("pressure")
+	createNamespace(t, ns)
+
+	const (
+		appName    = "pressure-app"
+		policyName = "pressure-policy"
+		initMem    = "32Mi"
+		initCPU    = "500m"
+	)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: appName, Namespace: ns,
+			Labels: map[string]string{"app": appName},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appName}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": appName}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "registry.k8s.io/pause:3.9",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse(initCPU),
+								corev1.ResourceMemory: resource.MustParse(initMem),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, deploy))
+	waitForDeploymentReady(t, appName, ns, 90*time.Second)
+
+	var pods corev1.PodList
+	require.NoError(t, k8sClient.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{"app": appName}))
+	require.NotEmpty(t, pods.Items)
+	nodeName := pods.Items[0].Spec.NodeName
+	require.NotEmpty(t, nodeName, "pod must be scheduled")
+	t.Logf("injecting MemoryPressure on node %s", nodeName)
+
+	setNodeMemoryPressure(t, nodeName, true)
+	t.Cleanup(func() {
+		setNodeMemoryPressure(t, nodeName, false)
+	})
+
+	// minAllowed 128Mi >> 32Mi current forces a memory *increase* recommendation.
+	// Under MemoryPressure, shouldSkipResize blocks that increase.
+	deployName := appName
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: ns},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			TargetRef: attunev1alpha1.TargetRef{Kind: "Deployment", Name: &deployName},
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Prometheus:        &attunev1alpha1.PrometheusConfig{Address: promAddr},
+				MinimumDataPoints: int32Ptr(1),
+				HistoryWindow:     &metav1.Duration{Duration: time.Hour},
+				QueryStep:         &metav1.Duration{Duration: 30 * time.Second},
+			},
+			CPU: attunev1alpha1.ResourceConfig{
+				Percentile:       95,
+				Overhead:         "20",
+				AllowDecrease:    boolPtr(true),
+				MinAllowed:       quantityPtr("50m"),
+				MaxAllowed:       quantityPtr("4000m"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			Memory: attunev1alpha1.ResourceConfig{
+				Percentile:       99,
+				Overhead:         "30",
+				AllowDecrease:    boolPtr(false),
+				MinAllowed:       quantityPtr("128Mi"),
+				MaxAllowed:       quantityPtr("8Gi"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type:       attunev1alpha1.UpdateTypeAuto,
+				Cooldown:   &metav1.Duration{Duration: time.Minute},
+				AutoRevert: boolPtr(true),
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, policy))
+	waitForPolicyDiscovered(t, policyName, ns, 90*time.Second)
+
+	// Wait until recommendations show memory above current (increase intended).
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var p attunev1alpha1.AttunePolicy
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: ns}, &p); err != nil {
+			return false, nil
+		}
+		initQ := resource.MustParse(initMem)
+		for _, rec := range p.Status.Recommendations {
+			for _, cr := range rec.Containers {
+				if cr.Name != "app" {
+					continue
+				}
+				if !cr.Recommended.MemoryRequest.IsZero() && cr.Recommended.MemoryRequest.Cmp(initQ) > 0 {
+					t.Logf("recommendation memory %s > current %s (increase intended)",
+						cr.Recommended.MemoryRequest.String(), initMem)
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}), "expected memory recommendation above %s", initMem)
+
+	// Hold MemoryPressure long enough that a free resize would have applied
+	// without pressure, re-asserting the condition (node agents may clear it).
+	initQ := resource.MustParse(initMem)
+	holdUntil := time.Now().Add(90 * time.Second)
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		setNodeMemoryPressure(t, nodeName, true)
+		var live corev1.PodList
+		if err := k8sClient.List(ctx, &live, client.InNamespace(ns), client.MatchingLabels{"app": appName}); err != nil {
+			return false, nil
+		}
+		for i := range live.Items {
+			if live.Items[i].DeletionTimestamp != nil {
+				continue
+			}
+			for _, c := range live.Items[i].Spec.Containers {
+				if c.Name != "app" {
+					continue
+				}
+				mem := c.Resources.Requests.Memory()
+				if mem != nil && mem.Cmp(initQ) > 0 {
+					return false, fmt.Errorf("memory increased to %s under MemoryPressure (want stay at %s)", mem.String(), initMem)
+				}
+			}
+		}
+		if time.Now().Before(holdUntil) {
+			return false, nil
+		}
+		return true, nil
+	}), "memory request changed under MemoryPressure or wait failed")
+
+	require.NoError(t, k8sClient.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{"app": appName}))
+	require.NotEmpty(t, pods.Items)
+	var c *corev1.Container
+	for i := range pods.Items {
+		if pods.Items[i].DeletionTimestamp != nil {
+			continue
+		}
+		for j := range pods.Items[i].Spec.Containers {
+			if pods.Items[i].Spec.Containers[j].Name == "app" {
+				c = &pods.Items[i].Spec.Containers[j]
+				break
+			}
+		}
+		if c != nil {
+			break
+		}
+	}
+	require.NotNil(t, c)
+	gotMem := c.Resources.Requests.Memory()
+	require.NotNil(t, gotMem)
+	assert.Equal(t, initQ.Value(), gotMem.Value(),
+		"MemoryPressure should block memory request increase: got %s want %s",
+		gotMem.String(), initMem)
+}
+
+// TestE2E_RuntimeProfileJava_BlocksMemoryDecrease verifies java runtimeProfile
+// applies in-memory defaults (allowDecrease=false) so oversized memory is not
+// decreased even when the field is unset on the CR.
+func TestE2E_RuntimeProfileJava_BlocksMemoryDecrease(t *testing.T) {
+	t.Parallel()
+	ns := uniqueNS("javamem")
+	createNamespace(t, ns)
+
+	const (
+		appName    = "java-app"
+		policyName = "java-policy"
+		initMem    = "512Mi"
+	)
+	createDeployment(t, appName, ns, "500m", initMem, 1)
+	waitForDeploymentReady(t, appName, ns, 90*time.Second)
+
+	deployName := appName
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: ns},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			RuntimeProfile: "java",
+			TargetRef:      attunev1alpha1.TargetRef{Kind: "Deployment", Name: &deployName},
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Prometheus:        &attunev1alpha1.PrometheusConfig{Address: promAddr},
+				MinimumDataPoints: int32Ptr(1),
+				HistoryWindow:     &metav1.Duration{Duration: time.Hour},
+				QueryStep:         &metav1.Duration{Duration: 30 * time.Second},
+			},
+			CPU: attunev1alpha1.ResourceConfig{
+				Percentile:       95,
+				Overhead:         "20",
+				AllowDecrease:    boolPtr(true),
+				MinAllowed:       quantityPtr("50m"),
+				MaxAllowed:       quantityPtr("4000m"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			Memory: attunev1alpha1.ResourceConfig{
+				// AllowDecrease and Overhead intentionally unset: java profile
+				// defaults allowDecrease=false and overhead=40 in-memory.
+				Percentile:       99,
+				MinAllowed:       quantityPtr("64Mi"),
+				MaxAllowed:       quantityPtr("8Gi"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type:       attunev1alpha1.UpdateTypeAuto,
+				Cooldown:   &metav1.Duration{Duration: time.Minute},
+				AutoRevert: boolPtr(true),
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, policy))
+	waitForResize(t, policyName, ns, 4*time.Minute)
+
+	// CR must still show unset allowDecrease (defaults are not written back).
+	var stored attunev1alpha1.AttunePolicy
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: ns}, &stored))
+	assert.Nil(t, stored.Spec.Memory.AllowDecrease,
+		"java profile must not persist allowDecrease onto the CR")
+	assert.Equal(t, "", stored.Spec.Memory.Overhead,
+		"java profile must not persist overhead onto the CR")
+
+	var podList corev1.PodList
+	require.NoError(t, k8sClient.List(ctx, &podList, client.InNamespace(ns), client.MatchingLabels{"app": appName}))
+	require.NotEmpty(t, podList.Items)
+	c := podList.Items[0].Spec.Containers[0]
+	origMem := resource.MustParse(initMem)
+	assert.GreaterOrEqual(t, c.Resources.Requests.Memory().Value(), origMem.Value(),
+		"java runtimeProfile should block memory decrease (effective allowDecrease=false), got %s",
+		c.Resources.Requests.Memory().String())
+}

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -2236,7 +2236,11 @@ func TestE2E_ResizeBlocked_DeferredAndInfeasibleStatus(t *testing.T) {
 // memory *increases* on the same node.
 func setNodeMemoryPressure(t *testing.T, nodeName string, pressure bool) {
 	t.Helper()
-	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	require.NoError(t, applyNodeMemoryPressure(nodeName, pressure))
+}
+
+func applyNodeMemoryPressure(nodeName string, pressure bool) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -2268,7 +2272,7 @@ func setNodeMemoryPressure(t *testing.T, nodeName string, pressure bool) {
 		}
 		_, err = clientset.CoreV1().Nodes().UpdateStatus(ctx, node, metav1.UpdateOptions{})
 		return err
-	}))
+	})
 }
 
 // TestE2E_NodeMemoryPressure_SkipsMemoryIncrease patches MemoryPressure on the
@@ -2321,13 +2325,34 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 	require.NotEmpty(t, nodeName, "pod must be scheduled")
 	t.Logf("injecting MemoryPressure on node %s", nodeName)
 
+	// Hold MemoryPressure for the entire test: k3s/kubelet rewrites node
+	// status and will clear injected conditions within seconds.
 	setNodeMemoryPressure(t, nodeName, true)
 	t.Cleanup(func() {
 		setNodeMemoryPressure(t, nodeName, false)
 	})
+	stopPressure := make(chan struct{})
+	donePressure := make(chan struct{})
+	go func() {
+		defer close(donePressure)
+		tck := time.NewTicker(1 * time.Second)
+		defer tck.Stop()
+		for {
+			select {
+			case <-stopPressure:
+				return
+			case <-tck.C:
+				_ = applyNodeMemoryPressure(nodeName, true)
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		close(stopPressure)
+		<-donePressure
+	})
 
-	// minAllowed 128Mi >> 32Mi current forces a memory *increase* recommendation.
-	// Under MemoryPressure, shouldSkipResize blocks that increase.
+	// minAllowed 256Mi >> 32Mi forces a memory *increase*. CPU starts high so
+	// under pressure the whole container resize is skipped (mem increase gate).
 	deployName := appName
 	policy := &attunev1alpha1.AttunePolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: ns},
@@ -2342,8 +2367,8 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 			CPU: attunev1alpha1.ResourceConfig{
 				Percentile:       95,
 				Overhead:         "20",
-				AllowDecrease:    boolPtr(true),
-				MinAllowed:       quantityPtr("50m"),
+				AllowDecrease:    boolPtr(false),
+				MinAllowed:       quantityPtr("500m"),
 				MaxAllowed:       quantityPtr("4000m"),
 				MaxChangePercent: int32Ptr(100),
 			},
@@ -2351,7 +2376,7 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 				Percentile:       99,
 				Overhead:         "30",
 				AllowDecrease:    boolPtr(false),
-				MinAllowed:       quantityPtr("128Mi"),
+				MinAllowed:       quantityPtr("256Mi"),
 				MaxAllowed:       quantityPtr("8Gi"),
 				MaxChangePercent: int32Ptr(100),
 			},
@@ -2365,35 +2390,9 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 	require.NoError(t, k8sClient.Create(ctx, policy))
 	waitForPolicyDiscovered(t, policyName, ns, 90*time.Second)
 
-	// Wait until recommendations show memory above current (increase intended).
-	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
-		var p attunev1alpha1.AttunePolicy
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: ns}, &p); err != nil {
-			return false, nil
-		}
-		initQ := resource.MustParse(initMem)
-		for _, rec := range p.Status.Recommendations {
-			for _, cr := range rec.Containers {
-				if cr.Name != "app" {
-					continue
-				}
-				if !cr.Recommended.MemoryRequest.IsZero() && cr.Recommended.MemoryRequest.Cmp(initQ) > 0 {
-					t.Logf("recommendation memory %s > current %s (increase intended)",
-						cr.Recommended.MemoryRequest.String(), initMem)
-					return true, nil
-				}
-			}
-		}
-		return false, nil
-	}), "expected memory recommendation above %s", initMem)
-
-	// Hold MemoryPressure and require a positive skip signal (ResizeSkipped
-	// event mentioning MemoryPressure), not only "memory did not change".
 	initQ := resource.MustParse(initMem)
-	require.NoError(t, wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
-		setNodeMemoryPressure(t, nodeName, true)
-		forcePolicyReconcile(t, policyName, ns, 45*time.Second)
-
+	// Single poll: keep pressure (background), wait for rec increase + skip event.
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 2*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var live corev1.PodList
 		if err := k8sClient.List(ctx, &live, client.InNamespace(ns), client.MatchingLabels{"app": appName}); err != nil {
 			return false, nil
@@ -2413,6 +2412,23 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 			}
 		}
 
+		var p attunev1alpha1.AttunePolicy
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: ns}, &p); err != nil {
+			return false, nil
+		}
+		recIncrease := false
+		for _, rec := range p.Status.Recommendations {
+			for _, cr := range rec.Containers {
+				if cr.Name == "app" && !cr.Recommended.MemoryRequest.IsZero() &&
+					cr.Recommended.MemoryRequest.Cmp(initQ) > 0 {
+					recIncrease = true
+				}
+			}
+		}
+		if !recIncrease {
+			return false, nil
+		}
+
 		evs, err := clientset.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
 			FieldSelector: "involvedObject.kind=AttunePolicy,involvedObject.name=" + policyName,
 		})
@@ -2420,16 +2436,15 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 			return false, nil
 		}
 		for _, ev := range evs.Items {
-			if ev.Reason != "ResizeSkipped" {
-				continue
-			}
-			if strings.Contains(ev.Message, "MemoryPressure") {
+			if ev.Reason == "ResizeSkipped" && strings.Contains(ev.Message, "MemoryPressure") {
 				t.Logf("OK: ResizeSkipped event: %s", ev.Message)
 				return true, nil
 			}
 		}
+		// Nudge reconcile without long nested waits.
+		forcePolicyReconcile(t, policyName, ns, 30*time.Second)
 		return false, nil
-	}), "expected ResizeSkipped event mentioning MemoryPressure while memory stays at %s", initMem)
+	}), "expected memory rec increase + ResizeSkipped(MemoryPressure) with memory held at %s", initMem)
 
 	require.NoError(t, k8sClient.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{"app": appName}))
 	require.NotEmpty(t, pods.Items)

--- a/test/e2e/resize-blocked-status/chainsaw-test.yaml
+++ b/test/e2e/resize-blocked-status/chainsaw-test.yaml
@@ -1,0 +1,177 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: resize-blocked-status
+spec:
+  description: >
+    Inject PodResizePending Deferred/Infeasible on two pods and assert
+    Attune surfaces workloads.deferred/infeasible and ResizeBlocked.
+    Real kubelet Deferred needs node capacity races; status injection
+    validates operator UX (#436). Go E2E covers the same path with retries.
+  timeouts:
+    apply: 30s
+    assert: 5m
+    delete: 30s
+  steps:
+    - name: create-resources
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: e2e-resize-blocked
+        - apply:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: blocked-app
+                namespace: e2e-resize-blocked
+              spec:
+                replicas: 2
+                selector:
+                  matchLabels:
+                    app: blocked-app
+                template:
+                  metadata:
+                    labels:
+                      app: blocked-app
+                  spec:
+                    containers:
+                      - name: app
+                        image: registry.k8s.io/pause:3.9
+                        resources:
+                          requests:
+                            cpu: 250m
+                            memory: 256Mi
+        - apply:
+            resource:
+              apiVersion: attune.io/v1alpha1
+              kind: AttunePolicy
+              metadata:
+                name: blocked-policy
+                namespace: e2e-resize-blocked
+              spec:
+                targetRef:
+                  kind: Deployment
+                  name: blocked-app
+                metricsSource:
+                  prometheus:
+                    address: http://prometheus-server.monitoring:80
+                  minimumDataPoints: 1
+                  historyWindow: 1h
+                cpu:
+                  percentile: 95
+                  overhead: "20"
+                  minAllowed: 50m
+                  maxAllowed: "4000m"
+                memory:
+                  percentile: 99
+                  overhead: "30"
+                  minAllowed: 64Mi
+                  maxAllowed: 8Gi
+                updateStrategy:
+                  type: Recommend
+                  cooldown: 1m
+    - name: inject-and-assert-resize-blocked
+      try:
+        - script:
+            timeout: 5m
+            content: |
+              NS=e2e-resize-blocked
+              POL=blocked-policy
+              for i in $(seq 1 36); do
+                N=$(kubectl -n "$NS" get pods -l app=blocked-app \
+                  --field-selector=status.phase=Running -o name 2>/dev/null | wc -l | tr -d ' ')
+                D=$(kubectl -n "$NS" get attunepolicy "$POL" \
+                  -o jsonpath='{.status.workloads.discovered}' 2>/dev/null || true)
+                if [ "$N" -ge 2 ] && [ "$D" = "1" ]; then
+                  break
+                fi
+                sleep 5
+              done
+              PODS=$(kubectl -n "$NS" get pods -l app=blocked-app \
+                --field-selector=status.phase=Running -o jsonpath='{.items[*].metadata.name}')
+              set -- $PODS
+              P1=$1
+              P2=$2
+              if [ -z "$P1" ] || [ -z "$P2" ]; then
+                echo "FAIL: need two Running pods, got: $PODS"
+                exit 1
+              fi
+              echo "pods: deferred=$P1 infeasible=$P2"
+              cat > /tmp/inject-pending.py <<'PY'
+              import datetime, json, sys
+              pod = json.load(sys.stdin)
+              reason = sys.argv[1]
+              now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+              cond = {
+                  "type": "PodResizePending",
+                  "status": "True",
+                  "reason": reason,
+                  "message": "chainsaw e2e inject",
+                  "lastTransitionTime": now,
+              }
+              conds = pod.setdefault("status", {}).setdefault("conditions", [])
+              out, found = [], False
+              for c in conds:
+                  if c.get("type") == "PodResizePending":
+                      out.append(cond)
+                      found = True
+                  else:
+                      out.append(c)
+              if not found:
+                  out.append(cond)
+              pod["status"]["conditions"] = out
+              json.dump(pod, sys.stdout)
+              PY
+              cat > /tmp/reason-blocked.py <<'PY'
+              import json, sys
+              p = json.load(sys.stdin)
+              for c in p.get("status", {}).get("conditions") or []:
+                  if c.get("type") == "ResizeBlocked":
+                      print(c.get("reason", ""))
+                      break
+              PY
+              inject() {
+                pod=$1
+                reason=$2
+                kubectl -n "$NS" get pod "$pod" -o json \
+                  | python3 /tmp/inject-pending.py "$reason" \
+                  | kubectl -n "$NS" replace --subresource=status -f - >/dev/null
+              }
+              for i in $(seq 1 40); do
+                inject "$P1" Deferred
+                inject "$P2" Infeasible
+                CD=$(kubectl -n "$NS" get attunepolicy "$POL" \
+                  -o jsonpath='{.spec.updateStrategy.cooldown}' 2>/dev/null || echo 1m)
+                if [ "$CD" = "1m" ]; then NEW=61s; else NEW=1m; fi
+                kubectl -n "$NS" patch attunepolicy "$POL" --type=merge \
+                  -p "{\"spec\":{\"updateStrategy\":{\"cooldown\":\"$NEW\"}}}" >/dev/null 2>&1 || true
+                DEF=$(kubectl -n "$NS" get attunepolicy "$POL" \
+                  -o jsonpath='{.status.workloads.deferred}' 2>/dev/null || echo 0)
+                INF=$(kubectl -n "$NS" get attunepolicy "$POL" \
+                  -o jsonpath='{.status.workloads.infeasible}' 2>/dev/null || echo 0)
+                REASON=$(kubectl -n "$NS" get attunepolicy "$POL" -o json \
+                  | python3 /tmp/reason-blocked.py 2>/dev/null || true)
+                echo "try $i deferred=$DEF infeasible=$INF ResizeBlocked=$REASON"
+                if [ "${DEF:-0}" -ge 1 ] 2>/dev/null && [ "${INF:-0}" -ge 1 ] 2>/dev/null \
+                  && [ -n "$REASON" ]; then
+                  echo "OK: ResizeBlocked reason=$REASON deferred=$DEF infeasible=$INF"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "FAIL: ResizeBlocked UX not observed"
+              kubectl -n "$NS" get attunepolicy "$POL" -o yaml || true
+              kubectl -n "$NS" get pods -o wide || true
+              exit 1
+  catch:
+    - describe:
+        apiVersion: attune.io/v1alpha1
+        kind: AttunePolicy
+        namespace: e2e-resize-blocked
+    - podLogs:
+        namespace: attune-system
+        selector: app.kubernetes.io/name=attune

--- a/test/e2e/resize-blocked-status/chainsaw-test.yaml
+++ b/test/e2e/resize-blocked-status/chainsaw-test.yaml
@@ -137,13 +137,23 @@ spec:
               inject() {
                 pod=$1
                 reason=$2
-                kubectl -n "$NS" get pod "$pod" -o json \
-                  | python3 /tmp/inject-pending.py "$reason" \
-                  | kubectl -n "$NS" replace --subresource=status -f - >/dev/null
+                n=0
+                while [ "$n" -lt 5 ]; do
+                  n=$((n + 1))
+                  if kubectl -n "$NS" get pod "$pod" -o json \
+                    | python3 /tmp/inject-pending.py "$reason" \
+                    | kubectl -n "$NS" replace --subresource=status -f - >/tmp/inj.out 2>/tmp/inj.err; then
+                    return 0
+                  fi
+                  echo "inject retry $n for $pod: $(cat /tmp/inj.err 2>/dev/null)"
+                  sleep 1
+                done
+                echo "WARN: inject failed for $pod reason=$reason after retries"
+                return 1
               }
               for i in $(seq 1 40); do
-                inject "$P1" Deferred
-                inject "$P2" Infeasible
+                inject "$P1" Deferred || true
+                inject "$P2" Infeasible || true
                 CD=$(kubectl -n "$NS" get attunepolicy "$POL" \
                   -o jsonpath='{.spec.updateStrategy.cooldown}' 2>/dev/null || echo 1m)
                 if [ "$CD" = "1m" ]; then NEW=61s; else NEW=1m; fi
@@ -157,7 +167,7 @@ spec:
                   | python3 /tmp/reason-blocked.py 2>/dev/null || true)
                 echo "try $i deferred=$DEF infeasible=$INF ResizeBlocked=$REASON"
                 if [ "${DEF:-0}" -ge 1 ] 2>/dev/null && [ "${INF:-0}" -ge 1 ] 2>/dev/null \
-                  && [ -n "$REASON" ]; then
+                  && [ "$REASON" = "PodsDeferredAndInfeasible" ]; then
                   echo "OK: ResizeBlocked reason=$REASON deferred=$DEF infeasible=$INF"
                   exit 0
                 fi

--- a/test/e2e/runtime-profile-java-no-mem-decrease/chainsaw-test.yaml
+++ b/test/e2e/runtime-profile-java-no-mem-decrease/chainsaw-test.yaml
@@ -4,8 +4,9 @@ metadata:
   name: runtime-profile-java-no-mem-decrease
 spec:
   description: >
-    runtimeProfile java applies allowDecrease=false in-memory (not on the CR).
-    Oversized memory must not decrease after Auto resize while CPU may change.
+    runtimeProfile java applies memory overhead=40 in-memory (not written to CR).
+    Asserts recommendation explanation.memory.overhead==40 (java-unique vs
+    platform default 30). allowDecrease/overhead stay unset on the stored CR.
   timeouts:
     apply: 30s
     assert: 5m
@@ -63,66 +64,54 @@ spec:
                 cpu:
                   percentile: 95
                   overhead: "20"
-                  allowDecrease: true
                   minAllowed: 50m
                   maxAllowed: "4000m"
-                  maxChangePercent: 100
                 memory:
                   percentile: 99
                   minAllowed: 64Mi
                   maxAllowed: 8Gi
-                  maxChangePercent: 100
                 updateStrategy:
-                  type: Auto
+                  type: Recommend
                   cooldown: 1m
-                  autoRevert: true
-    - name: wait-resize-memory-held
+    - name: assert-java-overhead-explanation
       try:
         - script:
             timeout: 5m
             content: |
               NS=e2e-java-mem
               POL=java-policy
-              cat > /tmp/check-mem.py <<'PY'
-              import sys
-              m = sys.argv[1].strip()
-              ok = m in ("512Mi", "536870912")
-              if m.endswith("Mi") and m[:-2].isdigit() and int(m[:-2]) >= 512:
-                  ok = True
-              if m.isdigit() and int(m) >= 512 * 1024 * 1024:
-                  ok = True
-              if not ok:
-                  print("FAIL: memory decreased to", m)
-                  sys.exit(1)
-              print("OK: memory held at", m)
+              cat > /tmp/check-java-overhead.py <<'PY'
+              import json, sys
+              p = json.load(sys.stdin)
+              for rec in p.get("status", {}).get("recommendations") or []:
+                  for c in rec.get("containers") or []:
+                      expl = (c.get("explanation") or {}).get("memory") or {}
+                      oh = expl.get("overhead")
+                      if oh is not None and float(oh) == 40.0:
+                          print("OK: explanation memory overhead=40")
+                          sys.exit(0)
+              print("FAIL: no explanation.memory.overhead==40")
+              sys.exit(1)
               PY
-              for i in $(seq 1 60); do
-                RESIZED=$(kubectl -n "$NS" get attunepolicy "$POL" \
-                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null || echo 0)
-                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null; then
+              # java-unique: effective memory overhead 40 (platform default is 30).
+              for i in $(seq 1 48); do
+                if kubectl -n "$NS" get attunepolicy "$POL" -o json \
+                  | python3 /tmp/check-java-overhead.py; then
                   AD=$(kubectl -n "$NS" get attunepolicy "$POL" \
                     -o jsonpath='{.spec.memory.allowDecrease}')
                   OH=$(kubectl -n "$NS" get attunepolicy "$POL" \
                     -o jsonpath='{.spec.memory.overhead}')
-                  if [ -n "$AD" ]; then
-                    echo "FAIL: allowDecrease should stay unset on CR, got $AD"
+                  if [ -n "$AD" ] || [ -n "$OH" ]; then
+                    echo "FAIL: CR should not persist allowDecrease/overhead (ad='$AD' oh='$OH')"
                     exit 1
                   fi
-                  if [ -n "$OH" ]; then
-                    echo "FAIL: overhead should stay unset on CR, got $OH"
-                    exit 1
-                  fi
-                  MEM=$(kubectl -n "$NS" get pods -l app=java-app \
-                    -o jsonpath='{.items[0].spec.containers[0].resources.requests.memory}')
-                  echo "resized=$RESIZED memory.request=$MEM"
-                  python3 /tmp/check-mem.py "$MEM"
-                  exit $?
+                  echo "OK: java profile applied overhead=40 in-memory; CR fields unset"
+                  exit 0
                 fi
                 sleep 5
               done
-              echo "FAIL: no resize recorded"
+              echo "FAIL: java overhead explanation not observed"
               kubectl -n "$NS" get attunepolicy "$POL" -o yaml || true
-              kubectl -n "$NS" get pods -o yaml || true
               exit 1
   catch:
     - describe:

--- a/test/e2e/runtime-profile-java-no-mem-decrease/chainsaw-test.yaml
+++ b/test/e2e/runtime-profile-java-no-mem-decrease/chainsaw-test.yaml
@@ -1,0 +1,134 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: runtime-profile-java-no-mem-decrease
+spec:
+  description: >
+    runtimeProfile java applies allowDecrease=false in-memory (not on the CR).
+    Oversized memory must not decrease after Auto resize while CPU may change.
+  timeouts:
+    apply: 30s
+    assert: 5m
+    delete: 30s
+  steps:
+    - name: create-resources
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: e2e-java-mem
+        - apply:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: java-app
+                namespace: e2e-java-mem
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    app: java-app
+                template:
+                  metadata:
+                    labels:
+                      app: java-app
+                  spec:
+                    containers:
+                      - name: app
+                        image: registry.k8s.io/pause:3.9
+                        resources:
+                          requests:
+                            cpu: 500m
+                            memory: 512Mi
+        - apply:
+            resource:
+              apiVersion: attune.io/v1alpha1
+              kind: AttunePolicy
+              metadata:
+                name: java-policy
+                namespace: e2e-java-mem
+              spec:
+                runtimeProfile: java
+                targetRef:
+                  kind: Deployment
+                  name: java-app
+                metricsSource:
+                  prometheus:
+                    address: http://prometheus-server.monitoring:80
+                  minimumDataPoints: 1
+                  historyWindow: 1h
+                cpu:
+                  percentile: 95
+                  overhead: "20"
+                  allowDecrease: true
+                  minAllowed: 50m
+                  maxAllowed: "4000m"
+                  maxChangePercent: 100
+                memory:
+                  percentile: 99
+                  minAllowed: 64Mi
+                  maxAllowed: 8Gi
+                  maxChangePercent: 100
+                updateStrategy:
+                  type: Auto
+                  cooldown: 1m
+                  autoRevert: true
+    - name: wait-resize-memory-held
+      try:
+        - script:
+            timeout: 5m
+            content: |
+              NS=e2e-java-mem
+              POL=java-policy
+              cat > /tmp/check-mem.py <<'PY'
+              import sys
+              m = sys.argv[1].strip()
+              ok = m in ("512Mi", "536870912")
+              if m.endswith("Mi") and m[:-2].isdigit() and int(m[:-2]) >= 512:
+                  ok = True
+              if m.isdigit() and int(m) >= 512 * 1024 * 1024:
+                  ok = True
+              if not ok:
+                  print("FAIL: memory decreased to", m)
+                  sys.exit(1)
+              print("OK: memory held at", m)
+              PY
+              for i in $(seq 1 60); do
+                RESIZED=$(kubectl -n "$NS" get attunepolicy "$POL" \
+                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null || echo 0)
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null; then
+                  AD=$(kubectl -n "$NS" get attunepolicy "$POL" \
+                    -o jsonpath='{.spec.memory.allowDecrease}')
+                  OH=$(kubectl -n "$NS" get attunepolicy "$POL" \
+                    -o jsonpath='{.spec.memory.overhead}')
+                  if [ -n "$AD" ]; then
+                    echo "FAIL: allowDecrease should stay unset on CR, got $AD"
+                    exit 1
+                  fi
+                  if [ -n "$OH" ]; then
+                    echo "FAIL: overhead should stay unset on CR, got $OH"
+                    exit 1
+                  fi
+                  MEM=$(kubectl -n "$NS" get pods -l app=java-app \
+                    -o jsonpath='{.items[0].spec.containers[0].resources.requests.memory}')
+                  echo "resized=$RESIZED memory.request=$MEM"
+                  python3 /tmp/check-mem.py "$MEM"
+                  exit $?
+                fi
+                sleep 5
+              done
+              echo "FAIL: no resize recorded"
+              kubectl -n "$NS" get attunepolicy "$POL" -o yaml || true
+              kubectl -n "$NS" get pods -o yaml || true
+              exit 1
+  catch:
+    - describe:
+        apiVersion: attune.io/v1alpha1
+        kind: AttunePolicy
+        namespace: e2e-java-mem
+    - podLogs:
+        namespace: attune-system
+        selector: app.kubernetes.io/name=attune


### PR DESCRIPTION
## Summary

Cluster coverage for recent features (P1–P3), plus a controller fix so Deferred/Infeasible UX works outside active resize cycles.

### Product fix
- Always list pods for discovered workloads so `workloads.deferred` / `infeasible` and `ResizeBlocked` update in Recommend mode and during cooldown (not only when about to resize).

### Tests
| Priority | Coverage |
|----------|----------|
| **P1** Deferred/Infeasible UX | Go E2E + Chainsaw inject `PodResizePending`; assert counts + `PodsDeferredAndInfeasible` |
| **P2** MemoryPressure skip | Go E2E (serial): force memory increase + inject node MemoryPressure; assert `ResizeSkipped` event and memory stays put |
| **P3** Java runtime profile | Go E2E + Chainsaw: **java-unique** `explanation.memory.overhead==40` (platform default is 30); CR fields stay unset |

### Docs
- Chainsaw vs Go E2E guidance and updated coverage table in `docs/contributing/testing.md`

### Reviewer notes addressed
- Java test no longer claims allowDecrease causality (that is the platform nil-default).
- Pressure test requires a positive skip event, not only absence of change.
- Chainsaw inject retries on status conflict.

## Test plan
- [x] `go test -tags=e2e -c ./test/e2e-go/`
- [x] `make lint-chainsaw`
- [x] Unit: SummarizeResizeBlockers / SetResizeBlocked / NodePressure
- [ ] PR CI E2E (Chainsaw + Go)