### PR TITLE
test: pressure gate unit coverage and pre-release E2E matrix docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,10 +447,13 @@ directory. When referencing files elsewhere in the repo (e.g., `charts/`,
 - E2E tests that modify CRs mid-test must use a refetch/retry loop to handle
   optimistic concurrency conflicts (the operator reconciles the same object
   concurrently, causing `the object has been modified` errors on update)
-- Go E2E tests (`test/e2e-go/`) must include `t.Parallel()` as the first line.
-  Every test creates a unique namespace via `uniqueNS()`, so they are fully
-  isolated. Without `t.Parallel()`, 13 tests run sequentially (~12 min);
-  with it, they run concurrently (~2 min, bounded by OOMKill at 127s).
+- Go E2E tests (`test/e2e-go/`) must include `t.Parallel()` as the first line,
+  except tests that mutate **cluster-scoped** shared state (for example node
+  conditions such as `MemoryPressure`). Those must run serially and restore
+  state in `t.Cleanup`. Every other test creates a unique namespace via
+  `uniqueNS()`, so they are fully isolated. Without `t.Parallel()`, the suite
+  runs sequentially (~12+ min); with it, tests run concurrently (~2 min,
+  bounded by the longest test such as OOMKill).
 - E2E test policies must use `Cooldown: 1m` (the minimum) to avoid long requeue
   delays during data collection.
 - E2E test pods should use Burstable QoS (requests only, no CPU/memory limits)

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -7,7 +7,8 @@ chart version and `appVersion` are kept in sync in `charts/attune/Chart.yaml`.
 
 ### 1. Prepare the release
 
-Update `CHANGELOG.md` with the new version's changes. Ensure all tests pass:
+Update `CHANGELOG.md` with the new version's changes (or rely on
+release-please). Ensure all tests pass:
 
 ```bash
 make verify
@@ -19,6 +20,30 @@ release, run:
 ```bash
 make test-local
 ```
+
+### 1b. Full E2E matrix (required before tagging a product release)
+
+PR CI runs Chainsaw + Go E2E on **one** Kubernetes version only
+(`rancher/k3s:v1.35.4-k3s1` in `ci.yaml`). Version-sensitive behavior
+(in-place memory limit clamp on 1.33–1.34 vs decrease on 1.35+, k3s 1.32
+feature gate) is only exercised by **E2E Nightly**.
+
+Before merging a release PR or publishing a tag after a feature-heavy
+window:
+
+1. Confirm tip of `main` includes the commits you are releasing.
+2. Dispatch the full matrix (or wait for the next scheduled run on that tip):
+
+```bash
+gh workflow run "E2E Nightly" --repo attune-io/attune
+# Monitor: Actions → E2E Nightly → all E2E (K8s v1.32..v1.35) + Fuzz + Nightly Results
+```
+
+3. Do not ship until all four K8s matrix cells and Fuzz are green on that SHA.
+
+If the release-please PR is **BEHIND** main, update/rebase it (or let
+release-please refresh) so the release notes and version bump include the
+latest commits.
 
 ### 2. Tag the release
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -4,6 +4,10 @@ This page covers breaking changes and notable behavior shifts between versions.
 If you are upgrading from an earlier pre-release, apply every section below your
 current version (newest sections first).
 
+Maintainers: before publishing a release after multi-version product changes,
+run the full E2E Nightly matrix on tip of `main` (see
+[Releasing: full E2E matrix](../contributing/releasing.md#1b-full-e2e-matrix-required-before-tagging-a-product-release)).
+
 ## v0.1.20 to v0.1.21
 
 v0.1.21 is a feature release. Existing policies keep working without YAML

--- a/internal/controller/resize_pressure_test.go
+++ b/internal/controller/resize_pressure_test.go
@@ -51,7 +51,22 @@ func TestNodePressureBlocksIncrease(t *testing.T) {
 			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		},
 	}
-	node := &corev1.Node{
+	// CPU-only increase (memory flat): MemoryPressure must not block.
+	higherCPU := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+	// Both increase.
+	higherBoth := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+
+	memPressure := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{{
@@ -59,7 +74,60 @@ func TestNodePressureBlocksIncrease(t *testing.T) {
 			}},
 		},
 	}
-	assert.Contains(t, nodePressureBlocksIncrease(node, pod, "app", higherMem), "MemoryPressure")
-	assert.Empty(t, nodePressureBlocksIncrease(node, pod, "app", lowerMem))
+	diskPressure := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n2"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type: corev1.NodeDiskPressure, Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	pidPressure := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n3"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type: corev1.NodePIDPressure, Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	// False conditions must not block.
+	pressureFalse := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n4"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse,
+			}},
+		},
+	}
+
+	assert.Contains(t, nodePressureBlocksIncrease(memPressure, pod, "app", higherMem), "MemoryPressure")
+	assert.Empty(t, nodePressureBlocksIncrease(memPressure, pod, "app", lowerMem),
+		"memory decrease under MemoryPressure is allowed")
+	assert.Empty(t, nodePressureBlocksIncrease(memPressure, pod, "app", higherCPU),
+		"CPU-only increase under MemoryPressure is allowed")
+	assert.Contains(t, nodePressureBlocksIncrease(memPressure, pod, "app", higherBoth), "MemoryPressure",
+		"memory increase (with CPU) under MemoryPressure is blocked")
+
+	assert.Contains(t, nodePressureBlocksIncrease(diskPressure, pod, "app", higherMem), "DiskPressure")
+	assert.Contains(t, nodePressureBlocksIncrease(diskPressure, pod, "app", higherCPU), "DiskPressure")
+	assert.Empty(t, nodePressureBlocksIncrease(diskPressure, pod, "app", lowerMem),
+		"decrease under DiskPressure is allowed")
+
+	assert.Contains(t, nodePressureBlocksIncrease(pidPressure, pod, "app", higherCPU), "PIDPressure")
+	assert.Contains(t, nodePressureBlocksIncrease(pidPressure, pod, "app", higherMem), "PIDPressure")
+
+	assert.Empty(t, nodePressureBlocksIncrease(pressureFalse, pod, "app", higherMem))
+	pressureUnknown := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n5"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type: corev1.NodeMemoryPressure, Status: corev1.ConditionUnknown,
+			}},
+		},
+	}
+	assert.Empty(t, nodePressureBlocksIncrease(pressureUnknown, pod, "app", higherMem),
+		"Unknown status must not block")
 	assert.Empty(t, nodePressureBlocksIncrease(nil, pod, "app", higherMem))
+	assert.Empty(t, nodePressureBlocksIncrease(memPressure, pod, "missing", higherMem),
+		"unknown container is a no-op")
 }


### PR DESCRIPTION
## Summary

MPI cycle improvements after the P1–P3 E2E wave:

- **QA / Adversarial:** Expand `TestNodePressureBlocksIncrease` for DiskPressure, PIDPressure, CPU-only vs memory increase under MemoryPressure, ConditionFalse/Unknown, and missing container.
- **Ops / Maintainer / End User:** Document that **E2E Nightly (1.32–1.35)** is required before tagging a product release (PR CI is single-version only). Link from upgrading guide. Note release-please BEHIND main before ship.
- **AGENTS.md:** Exception to mandatory `t.Parallel()` for cluster-scoped node mutation Go E2E tests.

## Gate notes (not in this PR)

- **Release PR #442** remains open; do **not** merge without explicit approval. Rebase/refresh so it is not BEHIND main.
- **E2E Nightly** was dispatched on `de50ff1` (workflow_dispatch) for release readiness.
- Open ready issues: #352 (upstream k3s), #90 (Scorecard re-eval due 2026-08-25), community listings.

## Test plan

- [x] `go test ./internal/controller/ -run TestNodePressure -race`
- [x] `go test ./internal/controller/ -count=1 -race` (full package)
- [ ] PR CI green