### PR TITLE
fix: hold MemoryPressure gate against stale node cache

### DIFF
--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10845,6 +10845,72 @@ func TestShouldSkipResize_NodeCacheMiss(t *testing.T) {
 	assert.NotNil(t, cached, "cached node should not be nil")
 }
 
+// TestShouldSkipResize_ClientsetPrefersLivePressure ensures MemoryPressure is
+// read from the typed Clientset (live API) even when the controller-runtime
+// client still holds a stale node without pressure. Stale informer data must
+// not allow memory request increases under real pressure.
+func TestShouldSkipResize_ClientsetPrefersLivePressure(t *testing.T) {
+	scheme := testScheme()
+	staleNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Conditions: []corev1.NodeCondition{{
+				Type:   corev1.NodeMemoryPressure,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}
+	liveNode := staleNode.DeepCopy()
+	liveNode.Status.Conditions = []corev1.NodeCondition{{
+		Type:   corev1.NodeMemoryPressure,
+		Status: corev1.ConditionTrue,
+	}}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(staleNode).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = kubefake.NewSimpleClientset(liveNode)
+
+	policy := &attunev1alpha1.AttunePolicy{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+			Containers: []corev1.Container{{
+				Name: "app",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+				},
+			}},
+		},
+	}
+	containerRec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("100m"),
+			MemoryRequest: resource.MustParse("32Mi"),
+		},
+	}
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+	}
+
+	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	assert.True(t, skip, "live Clientset MemoryPressure must block memory increase")
+	assert.Contains(t, reason, "MemoryPressure")
+}
+
 func TestShouldSkipResize_QoSClassChange(t *testing.T) {
 	scheme := testScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -882,24 +882,24 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 		}
 	}
 
-	// Node allocatable / pressure (use cached node data when available).
+	// Node allocatable / pressure (use per-cycle cached node data when available).
+	// Prefer the typed Clientset so we read live API status rather than a
+	// potentially stale informer snapshot. Node conditions (MemoryPressure)
+	// and allocatable can change between reconciles; acting on stale False
+	// allows request increases under real pressure.
 	if pod.Spec.NodeName != "" {
 		var node *corev1.Node
 		if checks != nil {
 			if cached, ok := checks.nodeCache.Load(pod.Spec.NodeName); ok {
 				node, _ = cached.(*corev1.Node)
 			} else {
-				var n corev1.Node
-				if err := r.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, &n); err == nil {
-					node = &n
+				node = r.getNodeForResize(ctx, pod.Spec.NodeName)
+				if node != nil {
+					checks.nodeCache.Store(pod.Spec.NodeName, node)
 				}
-				checks.nodeCache.Store(pod.Spec.NodeName, node)
 			}
 		} else {
-			var n corev1.Node
-			if err := r.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, &n); err == nil {
-				node = &n
-			}
+			node = r.getNodeForResize(ctx, pod.Spec.NodeName)
 		}
 		if node != nil {
 			// Skip request *increases* when the node is under pressure so we
@@ -1053,6 +1053,25 @@ func recentMemoryUsage(containerRec attunev1alpha1.ContainerRecommendation) (res
 		return resource.Quantity{}, false
 	}
 	return u, true
+}
+
+// getNodeForResize returns the named node for capacity/pressure checks.
+// Prefer Clientset (live apiserver) when configured; fall back to the
+// controller-runtime client (informer cache). Returns nil on error.
+func (r *AttunePolicyReconciler) getNodeForResize(ctx context.Context, nodeName string) *corev1.Node {
+	if r.Clientset != nil {
+		n, err := r.Clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err == nil {
+			return n
+		}
+	}
+	if r.Client != nil {
+		var n corev1.Node
+		if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, &n); err == nil {
+			return &n
+		}
+	}
+	return nil
 }
 
 // nodePressureBlocksIncrease returns a skip reason when the node is under

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -2239,11 +2239,30 @@ func setNodeMemoryPressure(t *testing.T, nodeName string, pressure bool) {
 	require.NoError(t, applyNodeMemoryPressure(nodeName, pressure))
 }
 
+// applyNodeMemoryPressure patches only the MemoryPressure condition via
+// strategic merge so concurrent kubelet status writes are less likely to
+// wipe the injection entirely. k3s/kubelet still rewrites conditions on
+// its own schedule; callers must re-apply frequently while the test needs
+// pressure held.
 func applyNodeMemoryPressure(nodeName string, pressure bool) error {
+	status := string(corev1.ConditionFalse)
+	if pressure {
+		status = string(corev1.ConditionTrue)
+	}
+	now := metav1.Now().UTC().Format(time.RFC3339)
+	// Strategic merge merges Node conditions by type=type.
+	patch := fmt.Sprintf(`{"status":{"conditions":[{"type":"MemoryPressure","status":%q,"reason":"E2ETest","message":"e2e MemoryPressure injection","lastHeartbeatTime":%q,"lastTransitionTime":%q}]}}`,
+		status, now, now)
+	_, err := clientset.CoreV1().Nodes().Patch(
+		ctx, nodeName, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "status")
+	if err == nil {
+		return nil
+	}
+	// Fallback: full status update (older servers / patch edge cases).
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-		if err != nil {
-			return err
+		node, getErr := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
 		}
 		want := corev1.ConditionFalse
 		if pressure {
@@ -2253,6 +2272,7 @@ func applyNodeMemoryPressure(nodeName string, pressure bool) error {
 		for i := range node.Status.Conditions {
 			if node.Status.Conditions[i].Type == corev1.NodeMemoryPressure {
 				node.Status.Conditions[i].Status = want
+				node.Status.Conditions[i].LastHeartbeatTime = metav1.Now()
 				node.Status.Conditions[i].LastTransitionTime = metav1.Now()
 				node.Status.Conditions[i].Reason = "E2ETest"
 				node.Status.Conditions[i].Message = "e2e MemoryPressure injection"
@@ -2270,9 +2290,23 @@ func applyNodeMemoryPressure(nodeName string, pressure bool) error {
 				Message:            "e2e MemoryPressure injection",
 			})
 		}
-		_, err = clientset.CoreV1().Nodes().UpdateStatus(ctx, node, metav1.UpdateOptions{})
-		return err
+		_, updateErr := clientset.CoreV1().Nodes().UpdateStatus(ctx, node, metav1.UpdateOptions{})
+		return updateErr
 	})
+}
+
+// nodeHasMemoryPressure reports whether the live API shows MemoryPressure=True.
+func nodeHasMemoryPressure(nodeName string) bool {
+	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeMemoryPressure && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // TestE2E_NodeMemoryPressure_SkipsMemoryIncrease patches MemoryPressure on the
@@ -2326,7 +2360,9 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 	t.Logf("injecting MemoryPressure on node %s", nodeName)
 
 	// Hold MemoryPressure for the entire test: k3s/kubelet rewrites node
-	// status and will clear injected conditions within seconds.
+	// status and can clear injected conditions within a second. Re-apply
+	// faster than the kubelet node-status period and re-inject before every
+	// assertion so the operator's live Clientset Get sees pressure=True.
 	setNodeMemoryPressure(t, nodeName, true)
 	t.Cleanup(func() {
 		setNodeMemoryPressure(t, nodeName, false)
@@ -2335,7 +2371,9 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 	donePressure := make(chan struct{})
 	go func() {
 		defer close(donePressure)
-		tck := time.NewTicker(1 * time.Second)
+		// Immediate second inject, then high-frequency hold.
+		_ = applyNodeMemoryPressure(nodeName, true)
+		tck := time.NewTicker(200 * time.Millisecond)
 		defer tck.Stop()
 		for {
 			select {
@@ -2350,6 +2388,13 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 		close(stopPressure)
 		<-donePressure
 	})
+
+	// Do not create the policy until the live API shows pressure. Otherwise
+	// the first reconcile can race a cleared condition and raise memory.
+	require.Eventually(t, func() bool {
+		_ = applyNodeMemoryPressure(nodeName, true)
+		return nodeHasMemoryPressure(nodeName)
+	}, 10*time.Second, 100*time.Millisecond, "MemoryPressure never stuck on node %s", nodeName)
 
 	// minAllowed 256Mi >> 32Mi forces a memory *increase*. CPU starts high so
 	// under pressure the whole container resize is skipped (mem increase gate).
@@ -2389,10 +2434,14 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 	}
 	require.NoError(t, k8sClient.Create(ctx, policy))
 	waitForPolicyDiscovered(t, policyName, ns, 90*time.Second)
+	_ = applyNodeMemoryPressure(nodeName, true)
 
 	initQ := resource.MustParse(initMem)
-	// Single poll: keep pressure (background), wait for rec increase + skip event.
-	require.NoError(t, wait.PollUntilContextTimeout(ctx, 2*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
+	// Single poll: keep pressure (background + per-iteration), wait for rec
+	// increase + skip event.
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 1*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_ = applyNodeMemoryPressure(nodeName, true)
+
 		var live corev1.PodList
 		if err := k8sClient.List(ctx, &live, client.InNamespace(ns), client.MatchingLabels{"app": appName}); err != nil {
 			return false, nil
@@ -2407,7 +2456,8 @@ func TestE2E_NodeMemoryPressure_SkipsMemoryIncrease(t *testing.T) {
 				}
 				mem := c.Resources.Requests.Memory()
 				if mem != nil && mem.Cmp(initQ) > 0 {
-					return false, fmt.Errorf("memory increased to %s under MemoryPressure (want stay at %s)", mem.String(), initMem)
+					return false, fmt.Errorf("memory increased to %s under MemoryPressure (want stay at %s; livePressure=%v)",
+						mem.String(), initMem, nodeHasMemoryPressure(nodeName))
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Main CI failed on [run 30927744201](https://github.com/attune-io/attune/actions/runs/30927744201) after #473 with:

`TestE2E_NodeMemoryPressure_SkipsMemoryIncrease`: memory increased to 64Mi under MemoryPressure.

Root cause: race between kubelet clearing injected node conditions and the operator reading a **stale informer** node snapshot (no MemoryPressure), so the capacity gate did not skip the first resize. Subsequent main commits looked green only because path filters skipped E2E.

## Changes

- Prefer typed `Clientset` for live node status in `shouldSkipResize` (still cache per reconcile cycle; do not cache failed/nil fetches)
- Unit test proving live Clientset `MemoryPressure=True` wins over a stale controller-runtime client node
- Harden E2E injection: strategic merge patch, 200ms re-hold, wait until live API shows pressure before policy create, re-inject every poll iteration

## Test plan

- [x] `go test ./internal/controller/ -run 'TestShouldSkipResize_ClientsetPrefersLivePressure|TestNodePressureBlocksIncrease' -race`
- [x] `go test -tags=e2e ./test/e2e-go/ -c` (compile)
- [ ] PR CI E2E (full matrix)