### PR TITLE
fix: fail-closed node increases and enrich nightly failure issues

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -644,6 +644,8 @@ jobs:
           fi
           echo "All nightly tests passed (E2E: $e2e_result, Fuzz: $fuzz_result)"
 
+      # Enriched failure body: failed job names, steps, and first Go E2E FAIL
+      # lines when artifacts are available (#484). Falls back to a minimal body.
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'
         env:
@@ -656,7 +658,31 @@ jobs:
             echo "Open nightly failure issue already exists, skipping creation"
             exit 0
           fi
-          body=$(cat <<EOF
+
+          art_dir=$(mktemp -d)
+          # Best-effort: download e2e debug artifacts for test name extraction.
+          # Do not fail the report job if download/parse fails.
+          set +e
+          gh run download "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
+            --dir "$art_dir" \
+            --pattern 'e2e-nightly-*' 2>/dev/null \
+            || gh run download "${{ github.run_id }}" \
+              --repo "${{ github.repository }}" \
+              --dir "$art_dir" 2>/dev/null \
+            || true
+          set -e
+
+          body=$(bash scripts/nightly-failure-issue-body.sh \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --run-id "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
+            --e2e-result "${{ needs.test-e2e.result }}" \
+            --fuzz-result "${{ needs.fuzz.result }}" \
+            --artifact-dir "$art_dir" \
+            || true)
+          if [[ -z "${body// }" ]]; then
+            body=$(cat <<EOF
           The [nightly run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed.
 
           - E2E result: \`${{ needs.test-e2e.result }}\`
@@ -665,6 +691,7 @@ jobs:
           Check the workflow run for details.
           EOF
           )
+          fi
           gh issue create \
             --title "Nightly failed on $(date -u +%Y-%m-%d)" \
             --label e2e-nightly-failure \

--- a/docs/architecture/node-capacity.md
+++ b/docs/architecture/node-capacity.md
@@ -66,6 +66,20 @@ Pressure is read via the typed Kubernetes clientset (live API), not only
 the informer cache, and is re-checked immediately before `UpdateResize`
 so a mid-reconcile condition flip cannot authorize an increase.
 
+## Unavailable node status (fail-closed for increases)
+
+If the pod has a `nodeName` but Attune cannot load the Node object
+(Clientset and controller-runtime client both fail or are unset),
+**request increases are skipped**. Decreases still proceed (same idea as
+pressure: free capacity without needing a pressure read).
+
+Reason string: `node status unavailable; skipping request increase`.
+Metric: `attune_capacity_skip_total{reason="unavailable"}`.
+Event: `ResizeSkipped`.
+
+Empty `nodeName` (not scheduled yet) does not use this path; scheduling
+gates apply elsewhere.
+
 ## Always-on default
 
 These gates run for every resize attempt. There is no `capacityAware: false`

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -487,20 +487,24 @@ sum(rate(attune_fleet_report_export_total{result="failed"}[5m]))
 
 ### Resize skipped for node capacity or pressure
 
-**Symptom**: Events show `ResizeSkipped` with "exceed node allocatable" or
-"node has MemoryPressure/DiskPressure/PIDPressure", and
-`attune_capacity_skip_total` increments.
+**Symptom**: Events show `ResizeSkipped` with "exceed node allocatable",
+"node has MemoryPressure/DiskPressure/PIDPressure", or
+"node status unavailable", and `attune_capacity_skip_total` increments
+(`reason` label: `allocatable`, `pressure`, or `unavailable`).
 
 **Cause**: Always-on safety gates refuse request **increases** that would
-make this pod's total requests exceed the node's allocatable, or that would
-raise requests while the node is under pressure. Decreases still proceed.
+make this pod's total requests exceed the node's allocatable, that would
+raise requests while the node is under pressure, or when the Node object
+cannot be loaded (API/RBAC failure). Decreases still proceed.
 
 **Fix**:
 
 1. Free capacity on the node (evict low-priority pods) or move the workload.
 2. Lower `maxAllowed` / change caps so recommendations fit typical node shapes.
 3. For DaemonSets, size against the **smallest** node pool that runs them.
-4. Inspect formulas in [Node capacity](../architecture/node-capacity.md).
+4. For `unavailable`: check operator RBAC for `nodes` get/list/watch and
+   apiserver health; Attune fails closed on increases until the node is readable.
+5. Inspect formulas in [Node capacity](../architecture/node-capacity.md).
 
 ```promql
 sum by (namespace, policy, reason) (rate(attune_capacity_skip_total[1h]))

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -301,8 +301,9 @@ Total times all Prometheus samples for a container metric were non-finite
 
 ### attune_capacity_skip_total
 
-Resize attempts skipped because of node **allocatable** headroom or node
-**pressure** conditions (always-on safety gates). See
+Resize attempts skipped because of node **allocatable** headroom, node
+**pressure** conditions, or **unavailable** node status when applying a
+request increase (always-on safety gates). See
 [Node capacity formulas](../architecture/node-capacity.md) and
 [Troubleshooting: Resize skipped for capacity](../guides/troubleshooting.md#resize-skipped-for-node-capacity-or-pressure).
 
@@ -310,7 +311,7 @@ Resize attempts skipped because of node **allocatable** headroom or node
 |-------|-------------|
 | `namespace` | Policy namespace |
 | `policy` | Policy name |
-| `reason` | `allocatable` or `pressure` |
+| `reason` | `allocatable`, `pressure`, or `unavailable` |
 
 ```promql
 sum by (namespace, policy, reason) (

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -42,18 +42,21 @@ func TestRecordCapacitySkip(t *testing.T) {
 	}
 	beforeAlloc := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "allocatable"))
 	beforePress := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "pressure"))
+	beforeUnavail := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "unavailable"))
 
 	// Exact producer strings from shouldSkipResize / nodePressureBlocksIncrease.
 	recordCapacitySkip(policy, "total pod requests would exceed node allocatable")
 	recordCapacitySkip(policy, "node has MemoryPressure; skipping memory request increase")
 	recordCapacitySkip(policy, "node has DiskPressure; skipping resource request increase")
 	recordCapacitySkip(policy, "node has PIDPressure; skipping resource request increase")
+	recordCapacitySkip(policy, "node status unavailable; skipping request increase")
 	recordCapacitySkip(policy, "quota/limitrange violation: too large")                  // no metric
 	recordCapacitySkip(policy, "")                                                       // no metric
 	recordCapacitySkip(nil, "node has MemoryPressure; skipping memory request increase") // no metric
 
 	assert.Equal(t, beforeAlloc+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "allocatable")))
 	assert.Equal(t, beforePress+3, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "pressure")))
+	assert.Equal(t, beforeUnavail+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "unavailable")))
 }
 
 // TestGetNodeForResize_PrefersClientsetThenFallsBack covers live vs cache
@@ -321,6 +324,192 @@ func TestExecuteResizes_MemoryPressure_EmitsResizeSkippedAndCapacitySkipMetric(t
 			}
 		default:
 			require.True(t, found, "expected ResizeSkipped event mentioning MemoryPressure")
+			return
+		}
+	}
+}
+
+// TestShouldSkipResize_NilNodeBlocksIncrease allows decreases when the node
+// cannot be loaded (#483 fail-closed for increases only).
+func TestShouldSkipResize_NilNodeBlocksIncrease(t *testing.T) {
+	scheme := testScheme()
+	r := NewAttunePolicyReconciler()
+	r.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+	r.Clientset = kubefake.NewSimpleClientset() // no nodes
+	r.Scheme = scheme
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName: "missing-node",
+			Containers: []corev1.Container{{
+				Name: "app",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
+			}},
+		},
+	}
+	rec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("100m"),
+			MemoryRequest: resource.MustParse("128Mi"),
+		},
+	}
+	higherMem := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+	lowerMem := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+	}
+
+	skip, reason := r.shouldSkipResize(context.Background(), &attunev1alpha1.AttunePolicy{}, pod, rec, higherMem, nil)
+	assert.True(t, skip)
+	assert.Contains(t, reason, "node status unavailable")
+
+	skip, reason = r.shouldSkipResize(context.Background(), &attunev1alpha1.AttunePolicy{}, pod, rec, lowerMem, nil)
+	assert.False(t, skip, "decreases must not be blocked when node is unavailable: %s", reason)
+}
+
+// TestExecuteResizes_NilNode_BlocksIncreaseEmitsEventAndMetric covers the
+// full resize path when node Get fails and the target is a memory increase.
+func TestExecuteResizes_NilNode_BlocksIncreaseEmitsEventAndMetric(t *testing.T) {
+	const (
+		policyNS   = "default"
+		policyName = "nil-node-policy"
+		appName    = "nil-node-app"
+	)
+
+	pod := newResizePod(appName, "500m", "512Mi", "1000m", "1Gi")
+	pod.Spec.NodeName = "does-not-exist"
+	deploy := newTestDeployment(appName, policyNS, map[string]string{"app": appName})
+
+	reconciler, _ := newResizeReconciler(pod, deploy)
+	// Clientset has only the pod; no node object.
+	reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
+	recorder := events.NewFakeRecorder(10)
+	reconciler.Recorder = recorder
+
+	policy := newTestPolicy(policyName, policyNS)
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation(appName,
+			"500m", "512Mi", "1000m", "1Gi",
+			"500m", "1Gi", "1000m", "2Gi"),
+	}
+
+	beforeUnavail := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable"))
+	count, history := reconciler.executeResizes(
+		context.Background(),
+		policy,
+		[]client.Object{deploy},
+		recommendations,
+		podMap(appName, pod),
+		nil,
+		nil,
+	)
+	assert.Equal(t, 0, count)
+	assert.Empty(t, history)
+	assert.Equal(t, beforeUnavail+1,
+		testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable")))
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "ResizeSkipped") && strings.Contains(event, "node status unavailable") {
+				found = true
+			}
+		default:
+			require.True(t, found, "expected ResizeSkipped for unavailable node")
+			return
+		}
+	}
+}
+
+// TestExecuteResizes_NilNode_LiveRecheckBlocksIncrease after shouldSkip
+// saw a cached node, live Get nil still fail-closes increases (#483).
+func TestExecuteResizes_NilNode_LiveRecheckBlocksIncrease(t *testing.T) {
+	const (
+		policyNS   = "default"
+		policyName = "nil-live-recheck-policy"
+		nodeName   = "cached-only-node"
+		appName    = "live-nil-app"
+	)
+
+	pod := newResizePod(appName, "500m", "512Mi", "1000m", "1Gi")
+	pod.Spec.NodeName = nodeName
+	deploy := newTestDeployment(appName, policyNS, map[string]string{"app": appName})
+	cachedNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Conditions: []corev1.NodeCondition{{
+				Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse,
+			}},
+		},
+	}
+
+	// Client has the node for shouldSkip; Clientset has only the pod so live
+	// re-check getNodeForResize fails after Clientset miss and client... wait,
+	// getNodeForResize tries Clientset first then Client. If Client has the
+	// node, live re-check succeeds. To force live nil we need Client without
+	// node OR Clientset empty and Client empty.
+	// Seed checks.nodeCache so shouldSkip does not call Get; live re-check
+	// always calls getNodeForResize which uses Clientset then Client.
+	// Empty Clientset + empty Client → nil live.
+	reconciler, _ := newResizeReconciler(pod, deploy)
+	reconciler.Client = fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(deploy, pod).Build()
+	reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
+	recorder := events.NewFakeRecorder(10)
+	reconciler.Recorder = recorder
+
+	policy := newTestPolicy(policyName, policyNS)
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation(appName,
+			"500m", "512Mi", "1000m", "1Gi",
+			"500m", "1Gi", "1000m", "2Gi"),
+	}
+	checks := &resizePreChecks{}
+	checks.nodeCache.Store(nodeName, cachedNode)
+
+	beforeUnavail := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable"))
+	count, _ := reconciler.executeResizes(
+		context.Background(),
+		policy,
+		[]client.Object{deploy},
+		recommendations,
+		podMap(appName, pod),
+		nil,
+		checks,
+	)
+	assert.Equal(t, 0, count, "live re-check with nil node must block increase")
+	assert.Equal(t, beforeUnavail+1,
+		testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable")))
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "ResizeSkipped") && strings.Contains(event, "node status unavailable") {
+				found = true
+			}
+		default:
+			require.True(t, found)
 			return
 		}
 	}

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -482,8 +482,17 @@ func (r *AttunePolicyReconciler) resizeContainer(
 				"pidPressure", nodeConditionStatus(live, corev1.NodePIDPressure),
 				"memTarget", target.Requests.Memory().String(),
 				"cpuTarget", target.Requests.Cpu().String())
+		} else if targetIncreasesRequests(pod, containerRec.Name, target) {
+			// Fail-closed: cannot verify pressure/allocatable (#483).
+			reason := "node status unavailable; skipping request increase"
+			logger.Info("Skipping resize (live re-check): "+reason,
+				"pod", pod.Name, "container", containerRec.Name, "node", pod.Spec.NodeName)
+			r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
+				"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
+			recordCapacitySkip(policy, reason)
+			return nil, resizeOutcomeNone
 		} else {
-			logger.Info("node unavailable for live pressure re-check; applying resize",
+			logger.V(1).Info("node unavailable for live re-check; allowing non-increase resize",
 				"pod", pod.Name, "container", containerRec.Name, "node", pod.Spec.NodeName)
 		}
 	}
@@ -963,6 +972,10 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 					return true, "total pod requests would exceed node allocatable"
 				}
 			}
+		} else if targetIncreasesRequests(pod, containerRec.Name, target) {
+			// Fail-closed for increases when node status is unavailable (#483).
+			// Decreases still proceed (same philosophy as pressure gates).
+			return true, "node status unavailable; skipping request increase"
 		}
 	}
 
@@ -1011,7 +1024,21 @@ func recordCapacitySkip(policy *attunev1alpha1.AttunePolicy, reason string) {
 		strings.Contains(reason, "PIDPressure"),
 		strings.Contains(reason, "node pressure"):
 		operatormetrics.CapacitySkipTotal.WithLabelValues(policy.Namespace, policy.Name, "pressure").Inc()
+	case strings.Contains(reason, "node status unavailable"):
+		operatormetrics.CapacitySkipTotal.WithLabelValues(policy.Namespace, policy.Name, "unavailable").Inc()
 	}
+}
+
+// targetIncreasesRequests reports whether target raises CPU and/or memory
+// requests for the named container relative to the live pod spec.
+func targetIncreasesRequests(pod *corev1.Pod, containerName string, target corev1.ResourceRequirements) bool {
+	c := findContainerByName(pod, containerName)
+	if c == nil {
+		return false
+	}
+	cpuInc := target.Requests.Cpu().MilliValue() > c.Resources.Requests.Cpu().MilliValue()
+	memInc := target.Requests.Memory().Value() > c.Resources.Requests.Memory().Value()
+	return cpuInc || memInc
 }
 
 // applyMemoryUsageFloor raises a decreasing memory limit so it stays above

--- a/internal/operatormetrics/metrics.go
+++ b/internal/operatormetrics/metrics.go
@@ -309,13 +309,13 @@ var (
 		[]string{"namespace", "policy", "result"},
 	)
 
-	// CapacitySkipTotal counts resize skips due to node capacity or pressure.
-	// reason: allocatable (pod requests would exceed node allocatable),
-	// pressure (MemoryPressure/DiskPressure/PIDPressure blocks increases).
+	// CapacitySkipTotal counts resize skips due to node capacity, pressure,
+	// or unavailable node status (fail-closed increases).
+	// reason: allocatable, pressure, or unavailable.
 	CapacitySkipTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "attune_capacity_skip_total",
-			Help: "Resize skips due to node allocatable headroom or pressure conditions",
+			Help: "Resize skips due to node allocatable, pressure, or unavailable node status",
 		},
 		[]string{"namespace", "policy", "reason"},
 	)

--- a/scripts/nightly-failure-issue-body.sh
+++ b/scripts/nightly-failure-issue-body.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Build an enriched body for e2e-nightly failure issues (#484).
+# Best-effort: never exits non-zero solely because enrichment failed.
+#
+# Usage:
+#   scripts/nightly-failure-issue-body.sh \
+#     --run-url URL --run-id ID --repo OWNER/REPO \
+#     --e2e-result RESULT --fuzz-result RESULT \
+#     [--artifact-dir DIR]
+#
+# Env: GH_TOKEN for gh api (optional for artifact-only mode)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RUN_URL=""
+RUN_ID=""
+REPO=""
+E2E_RESULT=""
+FUZZ_RESULT=""
+ARTIFACT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-url) RUN_URL="${2:-}"; shift 2 ;;
+    --run-id) RUN_ID="${2:-}"; shift 2 ;;
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --e2e-result) E2E_RESULT="${2:-}"; shift 2 ;;
+    --fuzz-result) FUZZ_RESULT="${2:-}"; shift 2 ;;
+    --artifact-dir) ARTIFACT_DIR="${2:-}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,20p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$RUN_URL" || -z "$E2E_RESULT" || -z "$FUZZ_RESULT" ]]; then
+  echo "required: --run-url, --e2e-result, --fuzz-result" >&2
+  exit 2
+fi
+
+failed_jobs_md=""
+if [[ -n "$RUN_ID" && -n "$REPO" ]] && command -v gh >/dev/null 2>&1; then
+  # shellcheck disable=SC2016
+  jobs_json=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate 2>/dev/null || true)
+  if [[ -n "$jobs_json" ]]; then
+    failed_jobs_md=$(printf '%s' "$jobs_json" | python3 "${SCRIPT_DIR}/nightly_failure_jobs.py" 2>/dev/null || true)
+  fi
+fi
+
+fail_tests_md=""
+if [[ -n "$ARTIFACT_DIR" && -d "$ARTIFACT_DIR" ]]; then
+  # Cap at 5 unique Go test names across go-e2e logs
+  mapfile -t fails < <(
+    # shellcheck disable=SC2086
+    find "$ARTIFACT_DIR" -type f \( -name 'go-e2e*.log' -o -name '*go-e2e*.log' -o -name 'go-e2e.log' \) 2>/dev/null \
+      | while read -r f; do
+          # Prefer --- FAIL: lines
+          grep -E '^--- FAIL: ' "$f" 2>/dev/null || true
+        done \
+      | sed -E 's/^--- FAIL: ([^ ]+).*/\1/' \
+      | awk 'NF && !seen[$0]++' \
+      | head -5
+  )
+  if ((${#fails[@]} > 0)); then
+    fail_tests_md=$(printf -- '- `%s`\n' "${fails[@]}")
+  fi
+  # Chainsaw summary if present
+  chainsaw_line=$(find "$ARTIFACT_DIR" -type f -name 'chainsaw*.log' 2>/dev/null | head -1 | while read -r f; do
+    grep -E 'Failed\s+tests|FAIL\s|Tests Summary' "$f" 2>/dev/null | tail -5
+  done || true)
+fi
+
+{
+  echo "The [nightly run](${RUN_URL}) failed."
+  echo
+  echo "- E2E result: \`${E2E_RESULT}\`"
+  echo "- Fuzz result: \`${FUZZ_RESULT}\`"
+  if [[ -n "$failed_jobs_md" ]]; then
+    echo
+    echo "### Failed jobs"
+    echo
+    echo "$failed_jobs_md"
+  fi
+  if [[ -n "$fail_tests_md" ]]; then
+    echo
+    echo "### Failing Go E2E tests (first matches)"
+    echo
+    printf '%s' "$fail_tests_md"
+  fi
+  if [[ -n "${chainsaw_line:-}" ]]; then
+    echo
+    echo "### Chainsaw log hints"
+    echo
+    echo '```'
+    echo "$chainsaw_line"
+    echo '```'
+  fi
+  echo
+  echo "Check the workflow run and artifacts for full logs."
+} 

--- a/scripts/nightly_failure_jobs.py
+++ b/scripts/nightly_failure_jobs.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Format failed GitHub Actions jobs from jobs API JSON (stdin)."""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0
+    jobs = data
+    if isinstance(data, dict):
+        jobs = data.get("jobs") or []
+    if not isinstance(jobs, list):
+        return 0
+    lines: list[str] = []
+    for j in jobs:
+        if not isinstance(j, dict) or j.get("conclusion") != "failure":
+            continue
+        name = j.get("name") or "unknown"
+        steps = [
+            s.get("name")
+            for s in (j.get("steps") or [])
+            if isinstance(s, dict) and s.get("conclusion") == "failure" and s.get("name")
+        ]
+        if steps:
+            lines.append(f"- **{name}** (steps: {', '.join(steps)})")
+        else:
+            lines.append(f"- **{name}**")
+    sys.stdout.write("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_nightly_failure_issue_body.sh
+++ b/scripts/test_nightly_failure_issue_body.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/nightly-failure-issue-body.sh
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/scripts/nightly-failure-issue-body.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/art"
+printf '%s\n' '--- FAIL: TestE2E_NodeMemoryPressure_SkipsMemoryIncrease (1s)' >"$TMP/art/go-e2e.log"
+printf '%s\n' 'Tests Summary...' 'Failed  tests 1' >"$TMP/art/chainsaw.log"
+
+body=$("$SCRIPT" \
+  --run-url 'https://example.com/actions/runs/99' \
+  --e2e-result failure \
+  --fuzz-result success \
+  --artifact-dir "$TMP/art")
+
+echo "$body" | grep -q 'E2E result: `failure`'
+echo "$body" | grep -q 'Fuzz result: `success`'
+echo "$body" | grep -q 'TestE2E_NodeMemoryPressure_SkipsMemoryIncrease'
+echo "$body" | grep -q 'https://example.com/actions/runs/99'
+
+# Minimal path without artifacts still works
+body2=$("$SCRIPT" \
+  --run-url 'https://example.com/r/1' \
+  --e2e-result success \
+  --fuzz-result failure)
+echo "$body2" | grep -q 'Fuzz result: `failure`'
+echo "$body2" | grep -q 'Check the workflow run'
+
+echo "OK: nightly-failure-issue-body tests passed"


### PR DESCRIPTION
## Summary

### #483 Fail-closed when node status is unavailable
When `getNodeForResize` returns nil, request **increases** are skipped (was fail-open). Decreases still proceed. Live re-check path matches. Emits `ResizeSkipped` and `attune_capacity_skip_total{reason="unavailable"}`.

### #484 Enriched e2e-nightly failure issues
`Create issue on failure` builds a body with failed job/step names (Actions API) and first Go E2E `--- FAIL:` tests from downloaded artifacts. Best-effort: falls back to the previous minimal body if enrichment fails.

Closes #483
Closes #484

## Test plan
- [x] Unit tests: nil node increase blocked / decrease allowed; executeResizes event+metric; live re-check with stale cache
- [x] `scripts/test_nightly_failure_issue_body.sh`
- [x] `make verify-dashboard-metrics`
- [ ] PR CI