### PR TITLE
docs: tighten homepage industry stats and version history

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@
 
 Attune is a Kubernetes operator that automatically right-sizes pod
 resource requests and limits using [In-Place Pod Resize](https://kubernetes.io/blog/2025/12/19/kubernetes-v1-35-in-place-pod-resize-ga/)
-(**GA** in Kubernetes 1.35, beta and enabled by default in 1.33–1.34, alpha with feature gate in 1.32). In-place by default, optional eviction fallback for infeasible resizes, and no HPA conflicts.
+(**GA** in Kubernetes 1.35; beta and enabled by default in 1.33–1.34; alpha
+since 1.27, still feature-gated on 1.32). Attune requires **Kubernetes 1.32+**
+for the `/resize` subresource path. In-place by default, optional eviction
+fallback for infeasible resizes, and no HPA conflicts.
 
 ---
 
@@ -31,10 +34,10 @@ resource requests and limits using [In-Place Pod Resize](https://kubernetes.io/b
 
 | Problem | Impact |
 |---------|--------|
-| Average CPU utilization is **8%** | Billions wasted industry-wide ([CAST AI 2026](https://cast.ai/reports/state-of-kubernetes-optimization/)) |
-| **70%** cite overprovisioning as #1 cost driver | Resources allocated "just in case" never reclaimed ([CNCF 2023](https://www.cncf.io/blog/2023/12/20/cncf-cloud-native-finops-cloud-financial-management-microsurvey/)) |
-| **<1%** run VPA fully automated | VPA often evicts pods, conflicts with HPA, and is hard to run unattended ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)) |
-| In-Place Pod Resize is **GA** (K8s 1.35; beta 1.33–1.34; alpha 1.32) | Non-disruptive right-sizing is a stable Kubernetes primitive |
+| Average CPU utilization is **8%** | Most requested compute sits idle ([CAST AI 2026](https://cast.ai/reports/state-of-kubernetes-optimization/)) |
+| **70%** cite overprovisioning among top cost drivers | Resources allocated "just in case" never reclaimed ([CNCF 2023](https://www.cncf.io/blog/2023/12/20/cncf-cloud-native-finops-cloud-financial-management-microsurvey/)) |
+| **<1%** run VPA in production | VPA historically evicts pods, conflicts with HPA, and is hard to run unattended ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)) |
+| In-Place Pod Resize is **GA** (K8s 1.35; beta 1.33–1.34; alpha since 1.27) | Non-disruptive right-sizing is a stable Kubernetes primitive |
 
 ## How It's Different
 
@@ -49,7 +52,7 @@ In-place apply is the shared primitive (Kubernetes `/resize`). Attune is the
 | Blast radius | All targeted pods | N/A | **Canary** fraction with observation and optional auto-promote |
 | Cold start | None | N/A | **Startup boost** (temporary CPU headroom, then scale back) |
 | Algorithm | Backward-looking histograms | VPA recommender | **Time-of-day-aware + burst detection + confidence scaling** |
-| Production path | <1% run fully automated | Manual apply | **Observe → Recommend → Canary → Auto** |
+| Production path | <1% run in production | Manual apply | **Observe → Recommend → Canary → Auto** |
 
 > **Migrating from VPA?** See the step-by-step [migration guide](docs/guides/migrating-from-vpa.md) for field-by-field mapping, mode matrix, side-by-side YAML, and zero-downtime cutover.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,9 +16,10 @@ Safe, in-place Kubernetes pod resource right-sizing. VPA done right.
 ## What is Attune?
 
 Attune is a Kubernetes operator that automatically right-sizes pod resource
-requests and limits using In-Place Pod Resize (**GA** in Kubernetes 1.35, beta
-enabled by default in 1.33–1.34, alpha with feature gate in 1.32). No pod
-restarts by default, no HPA conflicts, graduated safety controls.
+requests and limits using In-Place Pod Resize (**GA** in Kubernetes 1.35; beta
+enabled by default in 1.33–1.34; alpha since 1.27, still feature-gated on 1.32;
+Attune requires 1.32+ for `/resize`). No pod restarts by default, no HPA
+conflicts, graduated safety controls.
 
 ## Supported tags
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -32,14 +32,15 @@
 
 99.94% of Kubernetes clusters are over-provisioned. Average CPU utilization is 8%, memory 20%
 ([CAST AI 2026](https://cast.ai/reports/state-of-kubernetes-optimization/)). VPA, the tool designed to fix this, is universally feared: fewer than 1% of
-organizations run it fully automated ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)). VPA evicts pods, conflicts with HPA, and
-has caused cluster-wide outages.
+organizations run it in production ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)).
+VPA historically evicts pods (newer modes can attempt in-place where supported),
+conflicts with HPA on the same metrics, and has caused cluster-wide outages.
 
 In December 2025, In-Place Pod Resize graduated to **GA** in Kubernetes 1.35
 ([KEP-1287](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources);
-beta and enabled by default in 1.33–1.34; alpha with feature gate in 1.32).
-CPU and memory can be changed on running pods without restarts. That unlocks a
-ground-up redesign of resource right-sizing.
+alpha since 1.27, feature-gated through 1.32; beta and enabled by default in
+1.33–1.34). CPU and memory can be changed on running pods without restarts.
+That unlocks a ground-up redesign of resource right-sizing.
 
 ### Mission
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,26 +5,34 @@
 Attune is a Kubernetes operator that automatically right-sizes pod
 resource requests and limits using
 [In-Place Pod Resize](https://kubernetes.io/blog/2025/12/19/kubernetes-v1-35-in-place-pod-resize-ga/)
-(**GA** in Kubernetes 1.35, beta and enabled by default in 1.33–1.34, alpha with
-feature gate in 1.32). In-place by default, optional eviction fallback for
-infeasible resizes, and no HPA conflicts.
+(**GA** in Kubernetes 1.35; beta and enabled by default in 1.33–1.34; alpha
+since 1.27, still feature-gated on 1.32). Attune requires **Kubernetes 1.32+**
+for the `/resize` subresource path. In-place by default, optional eviction
+fallback for infeasible resizes, and no HPA conflicts.
 
 ## The Problem
 
-Average Kubernetes CPU utilization is **8%**. That means 92% of the compute
-you're paying for is idle. Industry-wide, this adds up to
-**$44.5 billion** in projected cloud waste ([Harness 2025](https://www.harness.io/finops-in-focus)), and **70%** of
-organizations cite overprovisioning as their #1 cost driver ([CNCF 2023](https://www.cncf.io/blog/2023/12/20/cncf-cloud-native-finops-cloud-financial-management-microsurvey/)).
+Average Kubernetes CPU utilization is about **8%**
+([CAST AI 2026](https://cast.ai/reports/state-of-kubernetes-optimization/)):
+most of the compute you request sits idle. Separately, industry projections put
+**$44.5 billion** of enterprise cloud infrastructure waste in 2025
+([Harness 2025](https://www.harness.io/finops-in-focus)), and **70%** of
+organizations cite overprovisioning among top cost drivers
+([CNCF 2023](https://www.cncf.io/blog/2023/12/20/cncf-cloud-native-finops-cloud-financial-management-microsurvey/)).
 
-The existing tool for this, VPA, evicts pods to resize them. It conflicts
-with HPA, causes cascading failures, and fewer than **1%** of teams run
-it fully automated ([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/)). Recommendation-only tools like
-Goldilocks show you the numbers but leave you with hundreds of YAML edits
-that sit in the backlog for months.
+The existing tool for this, VPA, historically resized by evicting pods. It
+conflicts with HPA on the same metrics, and fewer than **1%** of organizations
+run it in production
+([ScaleOps 2026](https://scaleops.com/blog/why-pod-rightsizing-fails-in-production-a-deep-dive-into-vpa-and-what-actually-works/),
+citing Datadog Container Report lineage). Newer VPA modes can attempt in-place
+resize where the cluster supports it; Attune is built around that path from
+the start, with canary, auto-revert, and SLO guardrails for unattended use.
+Recommendation-only tools like Goldilocks show you the numbers but leave you
+with hundreds of YAML edits that sit in the backlog for months.
 
 Kubernetes 1.35 graduated In-Place Pod Resize to **GA** (stable). The feature
-was beta and enabled by default from 1.33, and available as alpha with a
-feature gate on 1.32. The foundation for non-disruptive right-sizing is stable.
+was alpha from 1.27 (feature-gated through 1.32), then beta and enabled by
+default from 1.33. The foundation for non-disruptive right-sizing is stable.
 Attune is the operator built for the safe unattended loop on top of that
 primitive.
 
@@ -41,7 +49,7 @@ path: canary blast-radius control, startup boost, and SLO-backed auto-revert.
 | Blast radius | All targeted pods | N/A | **Canary** with observation and optional auto-promote |
 | Cold start | None | N/A | **Startup boost**, then scale back |
 | Algorithm | Backward-looking histograms | VPA recommender | **Time-of-day-aware + burst detection + confidence** |
-| Production path | <1% use automated | Manual apply | **Observe → Recommend → Canary → Auto** |
+| Production path | <1% use in production | Manual apply | **Observe → Recommend → Canary → Auto** |
 
 ## Who Is This For?
 

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -26,10 +26,12 @@ The Kubernetes ecosystem has had a tool for this since 2018: the **Vertical Pod
 Autoscaler (VPA)**. So why does less than 1% of the industry run it in
 production?
 
-### VPA evicts your pods
+### VPA historically evicts your pods
 
-VPA's "Auto" mode works by **evicting pods and recreating them** with new
-resource values. In theory, this sounds fine. In practice, it means:
+Classic VPA Auto mode works by **evicting pods and recreating them** with new
+resource values. Newer modes (for example `InPlaceOrRecreate`) can attempt
+in-place resize where the cluster supports it, but production adoption remains
+very low and eviction is still a common fallback. In practice, eviction means:
 
 - **Pod restarts during traffic spikes.** VPA sees high usage, recommends more
   resources, and evicts the pod to apply them. The pod restarts, loses its


### PR DESCRIPTION
## Summary

Fact-check pass on marketing docs against primary sources and the Kubernetes blog. No product behavior changes.

- **8% CPU**: cite CAST AI on the homepage (was uncited there; README already had it)
- **$44.5B**: keep Harness figure, but separate it from the K8s utilization sentence so we do not imply one study
- **70% overprovisioning**: softer "among top cost drivers" (CNCF multi-select wording)
- **VPA <1%**: "in production" instead of "fully automated" (matches ScaleOps / Datadog lineage)
- **Version history**: alpha since 1.27, still gated on 1.32; Attune requires 1.32+ for `/resize`
- **VPA in-place**: acknowledge newer modes (e.g. `InPlaceOrRecreate`) while keeping the historical eviction story

Files: `docs/index.md`, `README.md`, `docs/SPEC.md`, `docs/why-attune.md`, `docker/README.md`

## Test plan

- [ ] Read homepage "The Problem" and comparison table for accuracy and tone
- [ ] Confirm CAST AI / Harness / CNCF / ScaleOps links open
- [ ] Spot-check MkDocs build if docs deploy runs on this PR
- [ ] Intentionally **not** merging; human review first