### PR TITLE
ci: do not cancel in-progress Docs deploys on main

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,9 +13,11 @@ on:
 permissions:
   contents: read
 
+# Do not cancel in-progress deploys on main: cancel-in-progress:true caused
+# Deploy to be cancelled for consecutive docs merges (see 5e92edb, f032245).
 concurrency:
   group: docs
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Main commit [5e92edb](https://github.com/attune-io/attune/commit/5e92edb0bc4e592952b2943fe1c0f79a49316ec3) had **CI success** but **Docs Deploy cancelled**. Same pattern on the previous docs merge (f032245).

Root cause: `.github/workflows/docs.yaml` uses:

```yaml
concurrency:
  group: docs
  cancel-in-progress: true
```

Any second Docs run (re-run, dispatch, or another docs merge) cancels the in-flight Deploy. That leaves GitHub Pages stale while required CI looks fine.

Fix: `cancel-in-progress: false` so deploys finish serially (same posture as main CI concurrency).

## Test plan

- [ ] Merge this PR
- [ ] `gh workflow run Docs --ref main` (or push any docs change) and confirm Build + Deploy both succeed
- [ ] Confirm [attune-io.github.io/attune](https://attune-io.github.io/attune/) updates