### PR TITLE
perf: close remaining scale gaps for large fleets

### DIFF
--- a/charts/attune/README.md
+++ b/charts/attune/README.md
@@ -21,6 +21,7 @@ helm install attune oci://ghcr.io/attune-io/charts/attune \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules |
+| blockerRefreshInterval | string | `"5m"` | Minimum interval between Deferred/Infeasible blocker recomputes when not resizing. Zero recomputes every cycle. Default 5m. |
 | clusterSize | string | `""` | Cluster size preset: sets resources, rate limits, and replica count. Valid values: small, medium, large, xlarge, or "" (no preset). Any explicitly set value overrides the preset. See docs/guides/scaling.md for details. |
 | collectorTTL | string | `"10m"` | Collector cache TTL for unused Prometheus connections (Go duration, e.g. "10m", "1h") |
 | defaults | object | `{"enabled":false,"updateStrategy":{"autoRevert":true,"cooldown":"1h","maxConcurrentResizes":1,"resizeMethod":"InPlaceOnly","type":"Recommend"}}` | Cluster-wide defaults (creates an AttuneDefaults CR) |
@@ -55,7 +56,9 @@ helm install attune oci://ghcr.io/attune-io/charts/attune \
 | logging | object | `{"format":"json","level":"info"}` | Logging configuration |
 | logging.format | string | `"json"` | Log format (json, text) |
 | logging.level | string | `"info"` | Log level (debug, info, warn, error) |
-| maxConcurrentReconciles | string | `""` | Maximum number of AttunePolicy reconciles running in parallel. Increase for large clusters with many policies (e.g. 4 for 200+ policies). |
+| maxConcurrentReconciles | string | `""` | Maximum number of AttunePolicy reconciles running in parallel. Empty uses binary default (2) or clusterSize presets (small=1, medium=2, large=4, xlarge=8). |
+| maxHistoryWindow | string | `""` | Operator ceiling for metrics historyWindow (Go duration). Empty = no extra clamp. clusterSize large/xlarge auto-set 72h/48h when this is empty. |
+| maxPodsInMetricsQuery | int | `100` | Cap pods named in metrics pod=~ regexes for huge Deployments (representative sample). Negative disables sampling. Default 100. |
 | maxProfileSamples | int | `10000` | Cap samples passed into recommendation BuildProfile after downsampling. Negative disables. Default 10000. |
 | maxPrometheusSeries | int | `5000` | Cap series kept from each Prometheus range query matrix. Zero uses the binary default (5000); negative disables. Default 5000. |
 | maxStatusRecommendations | int | `100` | Default cap for status.recommendations (full set still used for resizes). |
@@ -83,6 +86,7 @@ helm install attune oci://ghcr.io/attune-io/charts/attune \
 | metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels for the ServiceMonitor |
 | metrics.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor for Prometheus Operator |
 | metrics.serviceMonitor.interval | string | `"30s"` | Scrape interval |
+| minQueryStep | string | `""` | Operator floor for metrics queryStep (Go duration). Empty = no extra clamp. clusterSize large/xlarge auto-set 10m/15m when this is empty. |
 | nameOverride | string | `""` | Override the chart name |
 | networkPolicy | object | `{"enabled":true,"prometheusPort":9090}` | NetworkPolicy configuration for operator ingress and egress ports |
 | networkPolicy.enabled | bool | `true` | Enable NetworkPolicy for the operator pod |

--- a/charts/attune/README.md
+++ b/charts/attune/README.md
@@ -21,7 +21,7 @@ helm install attune oci://ghcr.io/attune-io/charts/attune \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules |
-| blockerRefreshInterval | string | `"5m"` | Minimum interval between Deferred/Infeasible blocker recomputes when not resizing. Zero recomputes every cycle. Default 5m. |
+| blockerRefreshInterval | string | `"0s"` | Minimum interval between Deferred/Infeasible blocker recomputes when not resizing. Zero (default) recomputes every cycle. Set "5m" on large Recommend fleets to cut List work. |
 | clusterSize | string | `""` | Cluster size preset: sets resources, rate limits, and replica count. Valid values: small, medium, large, xlarge, or "" (no preset). Any explicitly set value overrides the preset. See docs/guides/scaling.md for details. |
 | collectorTTL | string | `"10m"` | Collector cache TTL for unused Prometheus connections (Go duration, e.g. "10m", "1h") |
 | defaults | object | `{"enabled":false,"updateStrategy":{"autoRevert":true,"cooldown":"1h","maxConcurrentResizes":1,"resizeMethod":"InPlaceOnly","type":"Recommend"}}` | Cluster-wide defaults (creates an AttuneDefaults CR) |

--- a/charts/attune/templates/_helpers.tpl
+++ b/charts/attune/templates/_helpers.tpl
@@ -111,14 +111,36 @@ Resolve maxConcurrentReconciles: if clusterSize is set and
 maxConcurrentReconciles is empty (default), use the preset value.
 */}}
 {{- define "attune.maxConcurrentReconciles" -}}
-{{- if and .Values.clusterSize (not .Values.maxConcurrentReconciles) }}
+{{- if .Values.maxConcurrentReconciles }}
+{{- .Values.maxConcurrentReconciles }}
+{{- else if .Values.clusterSize }}
   {{- if eq .Values.clusterSize "small" }}1
   {{- else if eq .Values.clusterSize "medium" }}2
   {{- else if eq .Values.clusterSize "large" }}4
   {{- else if eq .Values.clusterSize "xlarge" }}8
-  {{- else }}{{ .Values.maxConcurrentReconciles }}
+  {{- else }}2
   {{- end }}
-{{- else }}{{ .Values.maxConcurrentReconciles }}
+{{- else }}2
+{{- end }}
+{{- end }}
+
+{{/*
+Optional max history window / min query step for large fleet tiers.
+Empty means omit the flag (binary uses no extra clamp).
+*/}}
+{{- define "attune.maxHistoryWindow" -}}
+{{- if .Values.maxHistoryWindow }}
+{{- .Values.maxHistoryWindow }}
+{{- else if and .Values.clusterSize (eq .Values.clusterSize "large") }}72h
+{{- else if and .Values.clusterSize (eq .Values.clusterSize "xlarge") }}48h
+{{- end }}
+{{- end }}
+
+{{- define "attune.minQueryStep" -}}
+{{- if .Values.minQueryStep }}
+{{- .Values.minQueryStep }}
+{{- else if and .Values.clusterSize (eq .Values.clusterSize "large") }}10m
+{{- else if and .Values.clusterSize (eq .Values.clusterSize "xlarge") }}15m
 {{- end }}
 {{- end }}
 

--- a/charts/attune/templates/deployment.yaml
+++ b/charts/attune/templates/deployment.yaml
@@ -82,6 +82,22 @@ spec:
             {{- if hasKey .Values "statusIncludeExplanations" }}
             - --status-include-explanations={{ .Values.statusIncludeExplanations }}
             {{- end }}
+            {{- if hasKey .Values "maxPodsInMetricsQuery" }}
+            - --max-pods-in-metrics-query={{ .Values.maxPodsInMetricsQuery }}
+            {{- end }}
+            {{- $mhw := include "attune.maxHistoryWindow" . | trim }}
+            {{- if $mhw }}
+            - --max-history-window={{ $mhw }}
+            {{- end }}
+            {{- $mqs := include "attune.minQueryStep" . | trim }}
+            {{- if $mqs }}
+            - --min-query-step={{ $mqs }}
+            {{- end }}
+            {{- if hasKey .Values "blockerRefreshInterval" }}
+            {{- if ne (.Values.blockerRefreshInterval | toString) "" }}
+            - --blocker-refresh-interval={{ .Values.blockerRefreshInterval }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.watchNamespaces }}
             - --watch-namespaces={{ join "," .Values.watchNamespaces }}
             {{- end }}

--- a/charts/attune/values.schema.json
+++ b/charts/attune/values.schema.json
@@ -1041,6 +1041,26 @@
       "default": true,
       "description": "Write recommendation explanation chains into status."
     },
+    "maxPodsInMetricsQuery": {
+      "type": "integer",
+      "default": 100,
+      "description": "Cap pods named in metrics pod=~ regexes. Negative disables sampling."
+    },
+    "maxHistoryWindow": {
+      "type": ["string", "null"],
+      "default": "",
+      "description": "Operator ceiling for metrics historyWindow (Go duration). Empty disables."
+    },
+    "minQueryStep": {
+      "type": ["string", "null"],
+      "default": "",
+      "description": "Operator floor for metrics queryStep (Go duration). Empty disables."
+    },
+    "blockerRefreshInterval": {
+      "type": "string",
+      "default": "5m",
+      "description": "Minimum interval between Deferred/Infeasible blocker recomputes when not resizing."
+    },
     "watchNamespaces": {
       "type": "array",
       "items": {

--- a/charts/attune/values.schema.json
+++ b/charts/attune/values.schema.json
@@ -1058,8 +1058,8 @@
     },
     "blockerRefreshInterval": {
       "type": "string",
-      "default": "5m",
-      "description": "Minimum interval between Deferred/Infeasible blocker recomputes when not resizing."
+      "default": "0s",
+      "description": "Minimum interval between Deferred/Infeasible blocker recomputes when not resizing. Zero recomputes every cycle."
     },
     "watchNamespaces": {
       "type": "array",

--- a/charts/attune/values.yaml
+++ b/charts/attune/values.yaml
@@ -293,12 +293,28 @@ collectorTTL: "10m"
 prometheusTimeout: "5m"
 
 # -- Maximum number of AttunePolicy reconciles running in parallel.
-# Increase for large clusters with many policies (e.g. 4 for 200+ policies).
+# Empty uses binary default (2) or clusterSize presets (small=1, medium=2, large=4, xlarge=8).
 maxConcurrentReconciles: ""
 
 # -- Maximum parallel workers processing workloads within one AttunePolicy reconcile.
 # Default 10. Raise for policies targeting many Deployments when prometheusQPS allows.
 maxWorkloadWorkers: 10
+
+# -- Cap pods named in metrics pod=~ regexes for huge Deployments (representative sample).
+# Negative disables sampling. Default 100.
+maxPodsInMetricsQuery: 100
+
+# -- Operator ceiling for metrics historyWindow (Go duration). Empty = no extra clamp.
+# clusterSize large/xlarge auto-set 72h/48h when this is empty.
+maxHistoryWindow: ""
+
+# -- Operator floor for metrics queryStep (Go duration). Empty = no extra clamp.
+# clusterSize large/xlarge auto-set 10m/15m when this is empty.
+minQueryStep: ""
+
+# -- Minimum interval between Deferred/Infeasible blocker recomputes when not resizing.
+# Zero recomputes every cycle. Default 5m.
+blockerRefreshInterval: "5m"
 
 # -- Maximum deterministic requeue jitter to spread policies that share a cooldown.
 # Set to "0s" to disable. Default 2m (empty omits the flag and keeps the binary default).

--- a/charts/attune/values.yaml
+++ b/charts/attune/values.yaml
@@ -313,8 +313,8 @@ maxHistoryWindow: ""
 minQueryStep: ""
 
 # -- Minimum interval between Deferred/Infeasible blocker recomputes when not resizing.
-# Zero recomputes every cycle. Default 5m.
-blockerRefreshInterval: "5m"
+# Zero (default) recomputes every cycle. Set "5m" on large Recommend fleets to cut List work.
+blockerRefreshInterval: "0s"
 
 # -- Maximum deterministic requeue jitter to spread policies that share a cooldown.
 # Set to "0s" to disable. Default 2m (empty omits the flag and keeps the binary default).

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,9 +24,6 @@ import (
 	"time"
 	_ "time/tzdata" // Embed IANA timezone database for distroless containers.
 
-	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -124,8 +121,8 @@ func main() {
 		"Optional operator-level ceiling for metrics historyWindow (e.g. 72h for large fleets). Zero disables extra clamp.")
 	flag.DurationVar(&minQueryStep, "min-query-step", 0,
 		"Optional operator-level floor for metrics queryStep (e.g. 10m for large fleets). Zero disables extra clamp.")
-	flag.DurationVar(&blockerRefreshInterval, "blocker-refresh-interval", 5*time.Minute,
-		"Minimum interval between Deferred/Infeasible blocker recomputes when not resizing. Zero recomputes every reconcile.")
+	flag.DurationVar(&blockerRefreshInterval, "blocker-refresh-interval", 0,
+		"Minimum interval between Deferred/Infeasible blocker recomputes when not resizing. Zero (default) recomputes every reconcile; set e.g. 5m for large Recommend fleets.")
 	flag.StringVar(&watchNamespaces, "watch-namespaces", "",
 		"Comma-separated list of namespaces to watch. Empty means all namespaces (cluster-scoped). "+
 			"Reduces informer cache memory on large clusters where policies exist in a few namespaces. "+
@@ -221,29 +218,13 @@ func main() {
 	if mgrOpts.Cache.ByObject == nil {
 		mgrOpts.Cache.ByObject = make(map[client.Object]cache.ByObject)
 	}
+	// Only strip Pods in the informer cache. Workloads (Deployments, STS, …)
+	// and HPAs are patched via MergeFrom of the cached object; JSON merge
+	// replaces container/metric arrays, so stripping fields would wipe live
+	// template image/command (or HPA metrics) on write. Unit tests still cover
+	// transform helpers for optional future use with direct-API re-fetch.
 	mgrOpts.Cache.ByObject[&corev1.Pod{}] = cache.ByObject{
 		Transform: transform.StripPodFields,
-	}
-	mgrOpts.Cache.ByObject[&appsv1.Deployment{}] = cache.ByObject{
-		Transform: transform.StripDeploymentFields,
-	}
-	mgrOpts.Cache.ByObject[&appsv1.StatefulSet{}] = cache.ByObject{
-		Transform: transform.StripStatefulSetFields,
-	}
-	mgrOpts.Cache.ByObject[&appsv1.DaemonSet{}] = cache.ByObject{
-		Transform: transform.StripDaemonSetFields,
-	}
-	mgrOpts.Cache.ByObject[&appsv1.ReplicaSet{}] = cache.ByObject{
-		Transform: transform.StripReplicaSetFields,
-	}
-	mgrOpts.Cache.ByObject[&autoscalingv2.HorizontalPodAutoscaler{}] = cache.ByObject{
-		Transform: transform.StripHPAFields,
-	}
-	mgrOpts.Cache.ByObject[&batchv1.Job{}] = cache.ByObject{
-		Transform: transform.StripJobFields,
-	}
-	mgrOpts.Cache.ByObject[&batchv1.CronJob{}] = cache.ByObject{
-		Transform: transform.StripCronJobFields,
 	}
 
 	// When webhooks are disabled, point the webhook server at a non-existent port

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,9 @@ import (
 	"time"
 	_ "time/tzdata" // Embed IANA timezone database for distroless containers.
 
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -97,8 +100,8 @@ func main() {
 		"Maximum Prometheus queries per second. Increase for large clusters with many policies.")
 	flag.IntVar(&prometheusBurst, "prometheus-burst", 20,
 		"Maximum burst for Prometheus query throttle.")
-	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1,
-		"Maximum number of AttunePolicy reconciles running in parallel. Increase for large clusters with many policies.")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 2,
+		"Maximum number of AttunePolicy reconciles running in parallel. Increase for large clusters with many policies. Helm clusterSize presets raise this further.")
 	flag.IntVar(&maxWorkloadWorkers, "max-workload-workers", 10,
 		"Maximum parallel workers processing workloads within a single AttunePolicy reconcile.")
 	flag.DurationVar(&requeueJitter, "requeue-jitter", 2*time.Minute,
@@ -111,6 +114,18 @@ func main() {
 		"Default cap for status.recommendations entries (full set still used for resizes). Overridable per policy.")
 	flag.BoolVar(&statusIncludeExplanations, "status-include-explanations", true,
 		"When true, write recommendation explanation chains to status. Overridable per policy.")
+	var maxPodsInMetricsQuery int
+	var maxHistoryWindow time.Duration
+	var minQueryStep time.Duration
+	var blockerRefreshInterval time.Duration
+	flag.IntVar(&maxPodsInMetricsQuery, "max-pods-in-metrics-query", 100,
+		"When a workload has more pods than this, sample this many for metrics pod=~ regexes. Negative disables sampling.")
+	flag.DurationVar(&maxHistoryWindow, "max-history-window", 0,
+		"Optional operator-level ceiling for metrics historyWindow (e.g. 72h for large fleets). Zero disables extra clamp.")
+	flag.DurationVar(&minQueryStep, "min-query-step", 0,
+		"Optional operator-level floor for metrics queryStep (e.g. 10m for large fleets). Zero disables extra clamp.")
+	flag.DurationVar(&blockerRefreshInterval, "blocker-refresh-interval", 5*time.Minute,
+		"Minimum interval between Deferred/Infeasible blocker recomputes when not resizing. Zero recomputes every reconcile.")
 	flag.StringVar(&watchNamespaces, "watch-namespaces", "",
 		"Comma-separated list of namespaces to watch. Empty means all namespaces (cluster-scoped). "+
 			"Reduces informer cache memory on large clusters where policies exist in a few namespaces. "+
@@ -201,13 +216,34 @@ func main() {
 		}
 	}
 
-	// Strip unused fields from cached Pods to reduce informer memory at scale.
-	// See internal/transform/pod.go for the list of preserved vs stripped fields.
+	// Strip unused fields from cached objects to reduce informer memory at scale.
+	// See internal/transform/ for preserved vs stripped fields.
 	if mgrOpts.Cache.ByObject == nil {
 		mgrOpts.Cache.ByObject = make(map[client.Object]cache.ByObject)
 	}
 	mgrOpts.Cache.ByObject[&corev1.Pod{}] = cache.ByObject{
 		Transform: transform.StripPodFields,
+	}
+	mgrOpts.Cache.ByObject[&appsv1.Deployment{}] = cache.ByObject{
+		Transform: transform.StripDeploymentFields,
+	}
+	mgrOpts.Cache.ByObject[&appsv1.StatefulSet{}] = cache.ByObject{
+		Transform: transform.StripStatefulSetFields,
+	}
+	mgrOpts.Cache.ByObject[&appsv1.DaemonSet{}] = cache.ByObject{
+		Transform: transform.StripDaemonSetFields,
+	}
+	mgrOpts.Cache.ByObject[&appsv1.ReplicaSet{}] = cache.ByObject{
+		Transform: transform.StripReplicaSetFields,
+	}
+	mgrOpts.Cache.ByObject[&autoscalingv2.HorizontalPodAutoscaler{}] = cache.ByObject{
+		Transform: transform.StripHPAFields,
+	}
+	mgrOpts.Cache.ByObject[&batchv1.Job{}] = cache.ByObject{
+		Transform: transform.StripJobFields,
+	}
+	mgrOpts.Cache.ByObject[&batchv1.CronJob{}] = cache.ByObject{
+		Transform: transform.StripCronJobFields,
 	}
 
 	// When webhooks are disabled, point the webhook server at a non-existent port
@@ -255,6 +291,10 @@ func main() {
 	reconciler.MaxPrometheusSeries = maxPrometheusSeries
 	reconciler.MaxStatusRecommendations = maxStatusRecommendations
 	reconciler.IncludeExplanationsInStatus = &statusIncludeExplanations
+	reconciler.MaxPodsInMetricsQuery = maxPodsInMetricsQuery
+	reconciler.MaxHistoryWindow = maxHistoryWindow
+	reconciler.MinQueryStep = minQueryStep
+	reconciler.BlockerRefreshInterval = blockerRefreshInterval
 	reconciler.PrometheusTimeout = prometheusTimeout
 	reconciler.MetricsFactory = func(address string, opts *metrics.CollectorOptions) (metrics.MetricsCollector, error) {
 		if opts == nil {

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -289,9 +289,9 @@ legacy behavior or richer status.
 | Representative pod sample for metrics | 100 pods | `maxPodsInMetricsQuery` / `--max-pods-in-metrics-query` | - |
 | History window operator ceiling | Off (CRD max 720h) | `maxHistoryWindow` / `--max-history-window`; large=`72h`, xlarge=`48h` | - |
 | Query step operator floor | Off (CRD min 10s) | `minQueryStep` / `--min-query-step`; large=`10m`, xlarge=`15m` | - |
-| Blocker recompute throttle | 5m when not resizing | `blockerRefreshInterval` / `--blocker-refresh-interval` | - |
+| Blocker recompute throttle | Off (`0s`; set `5m` for large Recommend fleets) | `blockerRefreshInterval` / `--blocker-refresh-interval` | - |
 | Parallel policy reconciles | 2 | `maxConcurrentReconciles` / `--max-concurrent-reconciles`; clusterSize presets 1/2/4/8 | - |
-| Informer field strip (Pods + workloads + HPA) | On | - | - |
+| Informer field strip (Pods only) | On | - | Workload/HPA strip is unit-tested but not enabled: MergeFrom patches would wipe template fields |
 | Batch safety throttle PromQL | On (when Prometheus collector) | - | - |
 
 ### PromQL aggregation
@@ -362,18 +362,18 @@ step at reconcile time. Example: large sets a 72h history ceiling and
 - **Observe** mode skips pod lists entirely.
 - **Recommend** and resize modes list pods once **per namespace** and match
   workload selectors in memory (not one List per Deployment).
-- Deferred/Infeasible blocker counts refresh at least every
-  `blockerRefreshInterval` (default 5m) when not resizing. While the
-  throttle holds, Attune skips both the namespace pod List and the
-  summarize step, and **keeps the last blocker status values**.
+- Deferred/Infeasible blocker counts recompute every reconcile by default.
+  Set `blockerRefreshInterval` (e.g. `5m`) on large Recommend fleets to
+  skip List+summarize while the throttle holds and **keep the last
+  blocker status values**.
 
-### Informer memory (workloads + HPAs)
+### Informer memory
 
-In addition to `StripPodFields`, the manager strips unused fields from
-Deployments, StatefulSets, DaemonSets, ReplicaSets, Jobs, CronJobs, and
-HPAs in the informer cache. Prefer `watchNamespaces` for multi-tenant
-mega-clusters; label-based cache filters are not supported (policies can
-use any selector).
+`StripPodFields` still reduces pod cache size. Workload and HPA objects
+are not stripped in the live cache because template/HPA updates use
+MergeFrom on the cached object, and JSON merge replaces container arrays.
+Prefer `watchNamespaces` for multi-tenant mega-clusters; label-based cache
+filters are not supported (policies can use any selector).
 
 ### Safety throttle batching
 

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -285,6 +285,14 @@ legacy behavior or richer status.
 | Workload workers per policy | 10 | `maxWorkloadWorkers` / `--max-workload-workers` | - |
 | Requeue jitter | 2m | `requeueJitter` / `--requeue-jitter` | - |
 | Lazy pod lists | Observe skips full lists; Recommend still lists for Deferred/Infeasible UX | - | - |
+| Namespace-wide pod list + in-memory match | On | - | - |
+| Representative pod sample for metrics | 100 pods | `maxPodsInMetricsQuery` / `--max-pods-in-metrics-query` | - |
+| History window operator ceiling | Off (CRD max 720h) | `maxHistoryWindow` / `--max-history-window`; large=`72h`, xlarge=`48h` | - |
+| Query step operator floor | Off (CRD min 10s) | `minQueryStep` / `--min-query-step`; large=`10m`, xlarge=`15m` | - |
+| Blocker recompute throttle | 5m when not resizing | `blockerRefreshInterval` / `--blocker-refresh-interval` | - |
+| Parallel policy reconciles | 2 | `maxConcurrentReconciles` / `--max-concurrent-reconciles`; clusterSize presets 1/2/4/8 | - |
+| Informer field strip (Pods + workloads + HPA) | On | - | - |
+| Batch safety throttle PromQL | On (when Prometheus collector) | - | - |
 
 ### PromQL aggregation
 
@@ -334,6 +342,44 @@ With default `Max` aggregation, high replica counts no longer explode
 Prometheus series count for recommendations. Payload still grows with
 `historyWindow` and `queryStep` (time series length). Keep the CRD
 window/step table above for Prometheus CPU and operator sample caps.
+
+When a workload still has more pods than `maxPodsInMetricsQuery` (default
+100), Attune **samples** that many pod names into the metrics `pod=~`
+regex (even spacing by name). Resize and safety still see all pods;
+sampling only narrows the recommendation query surface for huge fleets
+or `podAggregation: None`.
+
+### Tier-aware history and step clamps
+
+Set `clusterSize: large` or `xlarge` (or explicit `maxHistoryWindow` /
+`minQueryStep`) so the operator clamps every policy's metrics window and
+step at reconcile time. Example: large sets a 72h history ceiling and
+10m step floor even if a policy still requests `168h` / `5m`. CRD bounds
+(`1h`–`720h`, `10s`–`1h`) still apply first.
+
+### Pod listing and blocker UX
+
+- **Observe** mode skips pod lists entirely.
+- **Recommend** and resize modes list pods once **per namespace** and match
+  workload selectors in memory (not one List per Deployment).
+- Deferred/Infeasible blocker counts refresh at least every
+  `blockerRefreshInterval` (default 5m) when not resizing. While the
+  throttle holds, Attune skips both the namespace pod List and the
+  summarize step, and **keeps the last blocker status values**.
+
+### Informer memory (workloads + HPAs)
+
+In addition to `StripPodFields`, the manager strips unused fields from
+Deployments, StatefulSets, DaemonSets, ReplicaSets, Jobs, CronJobs, and
+HPAs in the informer cache. Prefer `watchNamespaces` for multi-tenant
+mega-clusters; label-based cache filters are not supported (policies can
+use any selector).
+
+### Safety throttle batching
+
+When many pods are under deferred safety observation, Attune issues one
+batch throttle PromQL vector (`pod=~` / `container=~`) instead of one
+instant query per pod/container when the Prometheus collector is in use.
 
 ## API Server Pressure
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -186,7 +186,7 @@ watchNamespaces:
 | `maxPodsInMetricsQuery` | int | `100` | Cap pods named in metrics `pod=~` regexes for huge workloads (`--max-pods-in-metrics-query`). Negative disables sampling. |
 | `maxHistoryWindow` | string | `""` | Operator ceiling for metrics historyWindow (`--max-history-window`). large/xlarge auto 72h/48h. |
 | `minQueryStep` | string | `""` | Operator floor for metrics queryStep (`--min-query-step`). large/xlarge auto 10m/15m. |
-| `blockerRefreshInterval` | string | `"5m"` | Min interval between Deferred/Infeasible blocker recomputes when not resizing (`--blocker-refresh-interval`). |
+| `blockerRefreshInterval` | string | `"0s"` | Min interval between Deferred/Infeasible blocker recomputes when not resizing (`--blocker-refresh-interval`). Zero recomputes every cycle; use `5m` for large Recommend fleets. |
 
 ## OpenShift
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -176,13 +176,17 @@ watchNamespaces:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `maxConcurrentReconciles` | int/string | `""` (1) | Maximum number of AttunePolicy reconciles running in parallel. Maps to the `--max-concurrent-reconciles` manager flag. The default (1) processes policies sequentially. Increase for clusters with many policies to reduce reconcile queue latency. Auto-set by `clusterSize` preset (small=1, medium=2, large=4, xlarge=8). The Prometheus rate limiter (`prometheusQPS`) is shared across all goroutines, so concurrent reconciles won't overwhelm Prometheus. |
+| `maxConcurrentReconciles` | int/string | `""` (2) | Maximum number of AttunePolicy reconciles running in parallel. Maps to the `--max-concurrent-reconciles` manager flag (binary default 2). Empty Helm value uses 2, or clusterSize presets (small=1, medium=2, large=4, xlarge=8). The Prometheus rate limiter (`prometheusQPS`) is shared across all goroutines. |
 | `maxWorkloadWorkers` | int | `10` | Parallel workers for workloads inside one policy reconcile (`--max-workload-workers`). |
 | `requeueJitter` | string | `"2m"` | Max deterministic requeue jitter (`--requeue-jitter`). Set `"0s"` to disable. |
 | `maxProfileSamples` | int | `10000` | Cap samples after downsampling before BuildProfile (`--max-profile-samples`). |
 | `maxPrometheusSeries` | int | `5000` | Cap series per Prometheus range query (`--max-prometheus-series`). |
 | `maxStatusRecommendations` | int | `100` | Default status.recommendations cap (`--max-status-recommendations`). |
 | `statusIncludeExplanations` | bool | `true` | Write explanation chains to status (`--status-include-explanations`). |
+| `maxPodsInMetricsQuery` | int | `100` | Cap pods named in metrics `pod=~` regexes for huge workloads (`--max-pods-in-metrics-query`). Negative disables sampling. |
+| `maxHistoryWindow` | string | `""` | Operator ceiling for metrics historyWindow (`--max-history-window`). large/xlarge auto 72h/48h. |
+| `minQueryStep` | string | `""` | Operator floor for metrics queryStep (`--min-query-step`). large/xlarge auto 10m/15m. |
+| `blockerRefreshInterval` | string | `"5m"` | Min interval between Deferred/Infeasible blocker recomputes when not resizing (`--blocker-refresh-interval`). |
 
 ## OpenShift
 

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -160,6 +160,18 @@ type AttunePolicyReconciler struct {
 	// IncludeExplanationsInStatus operator-level default when CR field is nil.
 	// When both nil, defaults to true.
 	IncludeExplanationsInStatus *bool
+	// MaxPodsInMetricsQuery caps pods named in metrics pod=~ regexes when the
+	// workload has more pods (representative sample). Zero uses default 100;
+	// negative disables sampling (always use workload name regex).
+	MaxPodsInMetricsQuery int
+	// MaxHistoryWindow clamps policy historyWindow at reconcile (0 = no extra
+	// clamp beyond CRD [1h, 720h]). Used for tier-aware operator defaults.
+	MaxHistoryWindow time.Duration
+	// MinQueryStep clamps policy queryStep upward (0 = no extra clamp).
+	MinQueryStep time.Duration
+	// BlockerRefreshInterval is the minimum time between Deferred/Infeasible
+	// blocker recomputes when not resizing (0 = recompute every reconcile).
+	BlockerRefreshInterval time.Duration
 	// AllowInPlaceMemoryLimitDecrease is true when the cluster is Kubernetes
 	// 1.35+ (live memory limit decreases permitted). Wired at manager startup.
 	AllowInPlaceMemoryLimitDecrease bool
@@ -172,6 +184,9 @@ type AttunePolicyReconciler struct {
 	// it starts empty, so gauges from workloads that disappeared during the
 	// restart persist until the owning policy's next reconcile refreshes them.
 	gaugeKeys sync.Map // map[string][]gaugeKey
+	// lastBlockerRefresh tracks last blocker recompute per policy for refresh
+	// throttling (in-memory; resets on restart).
+	lastBlockerRefresh sync.Map // map[types.NamespacedName]time.Time
 
 	// eventDedup suppresses repeated K8s events for the same condition.
 	// Events with the same key are suppressed for 1 hour, then re-emitted
@@ -434,20 +449,17 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	var newResizedCount int
 
 	// List pods when needed for resize/boost, or for Deferred/Infeasible UX in
-	// Recommend and resize modes. Observe mode skips lists (no resize UX).
+	// Recommend and resize modes (subject to blocker refresh throttle).
+	// Observe mode skips lists (no resize UX).
 	needPods := isResizeMode(mode) && ((!cooldownActive && withinWindow) ||
 		(policy.Spec.CPU.StartupBoost != nil && r.Clientset != nil && len(recommendations) > 0))
-	listPods := needPods || isResizeMode(mode) || mode == attunev1alpha1.UpdateTypeRecommend
+	refreshBlockers := r.shouldRefreshBlockers(&policy, needPods)
+	// Always list when resizing; for status-only paths, skip List while throttle holds.
+	listPods := needPods || (refreshBlockers && (isResizeMode(mode) || mode == attunev1alpha1.UpdateTypeRecommend))
 	podsByWorkload := make(map[string][]corev1.Pod, len(workloads))
 	if listPods {
-		for _, w := range workloads {
-			pods, err := r.getPodsForWorkload(ctx, w)
-			if err != nil {
-				logger.Error(err, "Failed to get pods for workload", "workload", w.GetName())
-				continue
-			}
-			podsByWorkload[w.GetName()] = pods
-		}
+		// One List per namespace + in-memory selector match (not N List calls).
+		podsByWorkload = r.listPodsForWorkloads(ctx, workloads)
 	}
 
 	// Pre-fetch namespace-scoped LimitRanges and ResourceQuotas once so both
@@ -571,23 +583,27 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	policy.Status.Workloads.Pending = pending
 
-	// Deferred / Infeasible operator UX: only when we listed pods (resize modes).
-	if listPods {
+	// Deferred / Infeasible operator UX.
+	// - Observe (no list): clear blocker fields.
+	// - listPods+refresh: recompute from current pods.
+	// - throttle hold (Recommend/resize without refresh): leave status as-is.
+	if listPods && refreshBlockers {
 		blockers := summarizeResizeBlockers(podsByWorkload, r.now())
 		policy.Status.Workloads.Deferred = safeInt32(blockers.DeferredCount)
 		policy.Status.Workloads.Infeasible = safeInt32(blockers.InfeasibleCount)
 		operatormetrics.PodsDeferred.WithLabelValues(policy.Namespace, policy.Name).Set(float64(blockers.DeferredCount))
 		operatormetrics.PodsInfeasible.WithLabelValues(policy.Namespace, policy.Name).Set(float64(blockers.InfeasibleCount))
+		r.markBlockersRefreshed(&policy)
 		for _, age := range blockers.DeferredAges {
 			operatormetrics.DeferredAgeSeconds.WithLabelValues(policy.Namespace, policy.Name).Observe(age.Seconds())
 		}
 		r.setResizeBlockedCondition(&policy, blockers)
-	} else {
+	} else if !listPods && !isResizeMode(mode) && mode != attunev1alpha1.UpdateTypeRecommend {
+		// Observe / OneShot-observe-like: blockers not applicable.
 		policy.Status.Workloads.Deferred = 0
 		policy.Status.Workloads.Infeasible = 0
 		operatormetrics.PodsDeferred.WithLabelValues(policy.Namespace, policy.Name).Set(0)
 		operatormetrics.PodsInfeasible.WithLabelValues(policy.Namespace, policy.Name).Set(0)
-		// Clear ResizeBlocked in non-resize modes (not applicable).
 		meta.RemoveStatusCondition(&policy.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
 	}
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -278,18 +278,25 @@ func (r *AttunePolicyReconciler) warnConfigClamping(policy *attunev1alpha1.Attun
 
 // parseHistoryWindow parses the history window duration from the policy.
 // Defense-in-depth: clamps to [1h, 720h] even if webhook validation is bypassed.
+// When MaxHistoryWindow is set on the reconciler, also clamps to that ceiling
+// (tier-aware operator defaults for large fleets).
 func (r *AttunePolicyReconciler) parseHistoryWindow(policy *attunev1alpha1.AttunePolicy) time.Duration {
+	var hw time.Duration
 	if policy.Spec.MetricsSource.HistoryWindow != nil {
-		hw := policy.Spec.MetricsSource.HistoryWindow.Duration
-		if hw < time.Hour {
-			hw = time.Hour
-		}
-		if hw > 720*time.Hour {
-			hw = 720 * time.Hour
-		}
-		return hw
+		hw = policy.Spec.MetricsSource.HistoryWindow.Duration
+	} else {
+		hw = defaultHistoryWindow
 	}
-	return defaultHistoryWindow
+	if hw < time.Hour {
+		hw = time.Hour
+	}
+	if hw > 720*time.Hour {
+		hw = 720 * time.Hour
+	}
+	if r != nil && r.MaxHistoryWindow > 0 && hw > r.MaxHistoryWindow {
+		hw = r.MaxHistoryWindow
+	}
+	return hw
 }
 
 // getMinimumDataPoints returns the minimum data points threshold from the policy.
@@ -301,18 +308,24 @@ func (r *AttunePolicyReconciler) getMinimumDataPoints(policy *attunev1alpha1.Att
 }
 
 // getQueryStep returns the query step interval from the policy or the default (5m).
+// When MinQueryStep is set on the reconciler, enforces that floor (tier-aware).
 func (r *AttunePolicyReconciler) getQueryStep(policy *attunev1alpha1.AttunePolicy) time.Duration {
+	var qs time.Duration
 	if policy.Spec.MetricsSource.QueryStep != nil {
-		qs := policy.Spec.MetricsSource.QueryStep.Duration
-		if qs < 10*time.Second {
-			qs = 10 * time.Second
-		}
-		if qs > time.Hour {
-			qs = time.Hour
-		}
-		return qs
+		qs = policy.Spec.MetricsSource.QueryStep.Duration
+	} else {
+		qs = attunev1alpha1.DefaultQueryStep
 	}
-	return attunev1alpha1.DefaultQueryStep
+	if qs < 10*time.Second {
+		qs = 10 * time.Second
+	}
+	if qs > time.Hour {
+		qs = time.Hour
+	}
+	if r != nil && r.MinQueryStep > 0 && qs < r.MinQueryStep {
+		qs = r.MinQueryStep
+	}
+	return qs
 }
 
 // getRateWindow returns the rate window from the policy or falls back to queryStep.

--- a/internal/controller/pod_list.go
+++ b/internal/controller/pod_list.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	rsmetrics "github.com/attune-io/attune/internal/metrics"
+)
+
+// defaultMaxPodsInMetricsQuery caps how many pods are named in a metrics
+// pod=~ regex when representative sampling is enabled (0 = unlimited regex).
+const defaultMaxPodsInMetricsQuery = 100
+
+// listPodsForWorkloads lists pods once per namespace and matches each workload's
+// selector in memory. This avoids N List calls when many workloads share a
+// namespace (common for large policies).
+func (r *AttunePolicyReconciler) listPodsForWorkloads(ctx context.Context, workloads []client.Object) map[string][]corev1.Pod {
+	logger := log.FromContext(ctx)
+	out := make(map[string][]corev1.Pod, len(workloads))
+	if len(workloads) == 0 {
+		return out
+	}
+
+	// Group workloads by namespace.
+	byNS := make(map[string][]client.Object)
+	for _, w := range workloads {
+		ns := w.GetNamespace()
+		byNS[ns] = append(byNS[ns], w)
+	}
+
+	for ns, ws := range byNS {
+		var podList corev1.PodList
+		if err := r.List(ctx, &podList, client.InNamespace(ns)); err != nil {
+			logger.Error(err, "Failed to list pods in namespace for workload matching", "namespace", ns)
+			// Fall back to per-workload lists so a single NS failure does not
+			// blank the entire map.
+			for _, w := range ws {
+				pods, err := r.getPodsForWorkload(ctx, w)
+				if err != nil {
+					logger.Error(err, "Failed to get pods for workload", "workload", w.GetName())
+					continue
+				}
+				out[w.GetName()] = pods
+			}
+			continue
+		}
+
+		// Precompute selectors once.
+		type matchSpec struct {
+			name   string
+			labels map[string]string
+		}
+		specs := make([]matchSpec, 0, len(ws))
+		for _, w := range ws {
+			sel := r.getPodSelectorLabels(w)
+			if len(sel) == 0 {
+				logger.Error(fmt.Errorf("no pod selector"), "Skipping workload pod match",
+					"workload", w.GetName(), "namespace", ns)
+				continue
+			}
+			specs = append(specs, matchSpec{name: w.GetName(), labels: sel})
+		}
+
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			for _, s := range specs {
+				if labelsMatch(pod.Labels, s.labels) {
+					out[s.name] = append(out[s.name], *pod)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// labelsMatch reports whether podLabels contain every key/value in selector.
+func labelsMatch(podLabels, selector map[string]string) bool {
+	if len(selector) == 0 {
+		return false
+	}
+	for k, v := range selector {
+		if podLabels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// samplePodsForMetrics returns at most maxN pods with deterministic selection
+// (sorted by name, then evenly spaced indices for stable coverage).
+// When maxN <= 0 or len(pods) <= maxN, returns pods unchanged.
+func samplePodsForMetrics(pods []corev1.Pod, maxN int) []corev1.Pod {
+	if maxN <= 0 || len(pods) <= maxN {
+		return pods
+	}
+	// Sort for stable input order.
+	sorted := make([]corev1.Pod, len(pods))
+	copy(sorted, pods)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+	// Evenly spaced sample across the sorted list.
+	out := make([]corev1.Pod, 0, maxN)
+	for i := 0; i < maxN; i++ {
+		idx := i * len(sorted) / maxN
+		if idx >= len(sorted) {
+			idx = len(sorted) - 1
+		}
+		out = append(out, sorted[idx])
+	}
+	// Dedupe in case of small N rounding collisions.
+	seen := make(map[string]bool, len(out))
+	deduped := out[:0]
+	for _, p := range out {
+		if seen[p.Name] {
+			continue
+		}
+		seen[p.Name] = true
+		deduped = append(deduped, p)
+	}
+	return deduped
+}
+
+// podRegexFromNames builds a PromQL-safe alternation regex for exact pod names.
+func podRegexFromNames(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	escaped := make([]string, len(names))
+	for i, n := range names {
+		escaped[i] = rsmetrics.EscapePromQLRegex(n)
+	}
+	sort.Strings(escaped)
+	return strings.Join(escaped, "|")
+}
+
+// metricsPodRegex chooses the workload regex or a sampled exact-name regex
+// when the pod set is large and MaxPodsInMetricsQuery is set.
+func (r *AttunePolicyReconciler) metricsPodRegex(workload client.Object, pods []corev1.Pod) string {
+	maxN := r.maxPodsInMetricsQuery()
+	if maxN <= 0 || len(pods) == 0 || len(pods) <= maxN {
+		return r.getPodRegex(workload)
+	}
+	sampled := samplePodsForMetrics(pods, maxN)
+	names := make([]string, len(sampled))
+	for i := range sampled {
+		names[i] = sampled[i].Name
+	}
+	if re := podRegexFromNames(names); re != "" {
+		return re
+	}
+	return r.getPodRegex(workload)
+}
+
+func (r *AttunePolicyReconciler) maxPodsInMetricsQuery() int {
+	if r.MaxPodsInMetricsQuery < 0 {
+		return 0 // unlimited
+	}
+	if r.MaxPodsInMetricsQuery > 0 {
+		return r.MaxPodsInMetricsQuery
+	}
+	return defaultMaxPodsInMetricsQuery
+}
+
+// shouldRefreshBlockers returns true when Deferred/Infeasible status should be
+// recomputed. Always true when actively resizing (needPods). When only listing
+// for status UX, respects BlockerRefreshInterval to cut work under many policies.
+func (r *AttunePolicyReconciler) shouldRefreshBlockers(policy *attunev1alpha1.AttunePolicy, needPods bool) bool {
+	if needPods || r.BlockerRefreshInterval <= 0 {
+		return true
+	}
+	key := types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}
+	if v, ok := r.lastBlockerRefresh.Load(key); ok {
+		if last, ok := v.(time.Time); ok && r.now().Sub(last) < r.BlockerRefreshInterval {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *AttunePolicyReconciler) markBlockersRefreshed(policy *attunev1alpha1.AttunePolicy) {
+	if r.BlockerRefreshInterval <= 0 {
+		return
+	}
+	key := types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}
+	r.lastBlockerRefresh.Store(key, r.now())
+}

--- a/internal/controller/pod_list_test.go
+++ b/internal/controller/pod_list_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestLabelsMatch(t *testing.T) {
+	assert.True(t, labelsMatch(map[string]string{"a": "1", "b": "2"}, map[string]string{"a": "1"}))
+	assert.False(t, labelsMatch(map[string]string{"a": "1"}, map[string]string{"a": "2"}))
+	assert.False(t, labelsMatch(map[string]string{"a": "1"}, map[string]string{"a": "1", "b": "2"}))
+	assert.False(t, labelsMatch(nil, map[string]string{"a": "1"}))
+	assert.False(t, labelsMatch(map[string]string{"a": "1"}, nil))
+}
+
+func TestSamplePodsForMetrics_EvenSpacing(t *testing.T) {
+	pods := make([]corev1.Pod, 0, 20)
+	for i := 0; i < 20; i++ {
+		pods = append(pods, corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("p-%02d", i)}})
+	}
+	out := samplePodsForMetrics(pods, 5)
+	require.Len(t, out, 5)
+	// Deterministic across calls
+	out2 := samplePodsForMetrics(pods, 5)
+	assert.Equal(t, out[0].Name, out2[0].Name)
+	assert.Equal(t, out[4].Name, out2[4].Name)
+	// Under limit returns all
+	assert.Len(t, samplePodsForMetrics(pods[:3], 5), 3)
+	assert.Equal(t, pods, samplePodsForMetrics(pods, 0))
+}
+
+func TestPodRegexFromNames(t *testing.T) {
+	re := podRegexFromNames([]string{"app-b", "app-a"})
+	assert.Equal(t, "app-a|app-b", re)
+	assert.Empty(t, podRegexFromNames(nil))
+}
+
+func TestListPodsForWorkloads_SingleNSList(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	d1 := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: "ns"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "1"}},
+		},
+	}
+	d2 := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "app2", Namespace: "ns"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "2"}},
+		},
+	}
+	p1 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns", Labels: map[string]string{"app": "1"}}}
+	p2 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: "ns", Labels: map[string]string{"app": "2"}}}
+	p3 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p3", Namespace: "ns", Labels: map[string]string{"app": "1"}}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(d1, d2, p1, p2, p3).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+
+	out := r.listPodsForWorkloads(context.Background(), []client.Object{d1, d2})
+	require.Len(t, out["app1"], 2)
+	require.Len(t, out["app2"], 1)
+	assert.Equal(t, "p2", out["app2"][0].Name)
+}
+
+func TestMetricsPodRegex_SamplesWhenLarge(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	r.MaxPodsInMetricsQuery = 3
+	d := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: "ns"}}
+	pods := make([]corev1.Pod, 10)
+	for i := 0; i < 10; i++ {
+		pods[i] = corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("myapp-xxx-%d", i)}}
+	}
+	re := r.metricsPodRegex(d, pods)
+	// Sampled regex uses exact names joined by |, not the full deployment pattern.
+	assert.Contains(t, re, "|")
+	assert.NotEqual(t, r.getPodRegex(d), re)
+	// Unlimited path keeps workload regex.
+	r.MaxPodsInMetricsQuery = -1
+	assert.Equal(t, r.getPodRegex(d), r.metricsPodRegex(d, pods))
+}

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -243,7 +243,18 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 
 	now := r.now()
 	start := now.Add(-historyWindow)
+	// Representative pod sampling for metrics when replica count is huge.
+	// Resize still uses full podsByWorkload; this only narrows the PromQL regex.
 	podRegex := r.getPodRegex(workload)
+	if r.maxPodsInMetricsQuery() > 0 {
+		if pods, err := r.getPodsForWorkload(ctx, workload); err == nil && len(pods) > r.maxPodsInMetricsQuery() {
+			podRegex = r.metricsPodRegex(workload, pods)
+			logger.V(1).Info("Sampled pods for metrics query",
+				"workload", workload.GetName(),
+				"totalPods", len(pods),
+				"sampled", r.maxPodsInMetricsQuery())
+		}
+	}
 
 	queryStep := r.getQueryStep(policy)
 	if queryStep != attunev1alpha1.DefaultQueryStep {

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -36,6 +36,7 @@ import (
 	"github.com/attune-io/attune/internal/operatormetrics"
 	"github.com/attune-io/attune/internal/resize"
 	"github.com/attune-io/attune/internal/safety"
+	"github.com/attune-io/attune/internal/throttle"
 )
 
 // runImmediateSafetyCheck performs an immediate safety check on a freshly
@@ -167,6 +168,41 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 	workloadNames := make(map[string]bool, len(workloads))
 	for _, w := range workloads {
 		workloadNames[w.GetName()] = true
+	}
+
+	// Prefetch throttle ratios in one PromQL vector when the collector supports
+	// batch queries (reduces QPS during multi-pod safety observation).
+	if bc, ok := collector.(throttle.BatchChecker); ok {
+		now := r.now()
+		var keys []throttle.Key
+		seen := map[throttle.Key]bool{}
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			if _, ok := trackedWorkloadForPolicy(pod, policy.Name, workloadNames); !ok {
+				continue
+			}
+			records, err := parseResizeRecords(pod, observationPeriod, now)
+			if err != nil {
+				continue
+			}
+			for _, rec := range records {
+				if now.Sub(rec.ResizedAt) < 5*time.Minute {
+					continue // still in throttle grace
+				}
+				k := throttle.Key{Pod: rec.PodName, Container: rec.Container}
+				if !seen[k] {
+					seen[k] = true
+					keys = append(keys, k)
+				}
+			}
+		}
+		if len(keys) > 0 {
+			if ratios, err := bc.GetThrottleRatios(ctx, policy.Namespace, keys, now); err != nil {
+				logger.V(1).Info("Batch throttle prefetch failed; falling back to per-pod checks", "err", err)
+			} else {
+				monitor = monitor.WithThrottleRatioCache(ratios)
+			}
+		}
 	}
 
 	for i := range podList.Items {

--- a/internal/controller/scale_clamp_test.go
+++ b/internal/controller/scale_clamp_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+)
+
+func TestParseHistoryWindow_OperatorMaxClamp(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	r.MaxHistoryWindow = 48 * time.Hour
+	hw := metav1.Duration{Duration: 168 * time.Hour}
+	p := &attunev1alpha1.AttunePolicy{Spec: attunev1alpha1.AttunePolicySpec{
+		MetricsSource: attunev1alpha1.MetricsSource{HistoryWindow: &hw},
+	}}
+	assert.Equal(t, 48*time.Hour, r.parseHistoryWindow(p))
+}
+
+func TestGetQueryStep_OperatorMinClamp(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	r.MinQueryStep = 10 * time.Minute
+	qs := metav1.Duration{Duration: 5 * time.Minute}
+	p := &attunev1alpha1.AttunePolicy{Spec: attunev1alpha1.AttunePolicySpec{
+		MetricsSource: attunev1alpha1.MetricsSource{QueryStep: &qs},
+	}}
+	assert.Equal(t, 10*time.Minute, r.getQueryStep(p))
+}
+
+func TestShouldRefreshBlockers(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	r.BlockerRefreshInterval = 5 * time.Minute
+	fixed := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	r.SetNowFunc(func() time.Time { return fixed })
+	p := &attunev1alpha1.AttunePolicy{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+
+	assert.True(t, r.shouldRefreshBlockers(p, true))  // always when resizing
+	assert.True(t, r.shouldRefreshBlockers(p, false)) // first time
+	r.markBlockersRefreshed(p)
+	assert.False(t, r.shouldRefreshBlockers(p, false))
+	// Throttle hold: still force refresh when needPods (resize path).
+	assert.True(t, r.shouldRefreshBlockers(p, true))
+	r.SetNowFunc(func() time.Time { return fixed.Add(6 * time.Minute) })
+	assert.True(t, r.shouldRefreshBlockers(p, false))
+}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -34,6 +35,8 @@ import (
 	promapi "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+
+	"github.com/attune-io/attune/internal/throttle"
 )
 
 // Sample represents a single metric data point with a timestamp and value.
@@ -444,6 +447,78 @@ func (c *PrometheusCollector) GetThrottleRatio(ctx context.Context, namespace, p
 		return 0, nil
 	}
 	return val, nil
+}
+
+// GetThrottleRatios batch-queries throttle ratios for many pod/container pairs
+// in one PromQL vector (pod=~ and container=~). Implements throttle.BatchChecker.
+func (c *PrometheusCollector) GetThrottleRatios(ctx context.Context, namespace string, keys []throttle.Key, ts time.Time) (map[throttle.Key]float64, error) {
+	out := make(map[throttle.Key]float64, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+	if len(keys) == 1 {
+		v, err := c.GetThrottleRatio(ctx, namespace, keys[0].Pod, keys[0].Container, ts)
+		if err != nil {
+			return nil, err
+		}
+		out[keys[0]] = v
+		return out, nil
+	}
+	pods := make([]string, 0, len(keys))
+	ctrs := make([]string, 0, len(keys))
+	seenP := map[string]bool{}
+	seenC := map[string]bool{}
+	for _, k := range keys {
+		if !seenP[k.Pod] {
+			seenP[k.Pod] = true
+			pods = append(pods, EscapePromQLRegex(k.Pod))
+		}
+		if !seenC[k.Container] {
+			seenC[k.Container] = true
+			ctrs = append(ctrs, EscapePromQLRegex(k.Container))
+		}
+	}
+	slices.Sort(pods)
+	slices.Sort(ctrs)
+	ns := EscapePromQL(namespace)
+	podRE := strings.Join(pods, "|")
+	ctrRE := strings.Join(ctrs, "|")
+	query := fmt.Sprintf(
+		`rate(container_cpu_cfs_throttled_periods_total{namespace="%s",pod=~"%s",container=~"%s"}[5m])`+
+			` / rate(container_cpu_cfs_periods_total{namespace="%s",pod=~"%s",container=~"%s"}[5m])`,
+		ns, podRE, ctrRE, ns, podRE, ctrRE,
+	)
+	result, warnings, err := c.api.Query(ctx, query, ts)
+	if err != nil {
+		return nil, fmt.Errorf("prometheus batch throttle query failed: %w", err)
+	}
+	if len(warnings) > 0 {
+		c.logger.Info("Prometheus batch throttle query returned warnings",
+			"warnings", strings.Join(warnings, "; "))
+	}
+	vec, ok := result.(model.Vector)
+	if !ok {
+		return out, nil
+	}
+	wanted := make(map[throttle.Key]bool, len(keys))
+	for _, k := range keys {
+		wanted[k] = true
+	}
+	for _, sample := range vec {
+		pod := string(sample.Metric[model.LabelName("pod")])
+		ctr := string(sample.Metric[model.LabelName("container")])
+		k := throttle.Key{Pod: pod, Container: ctr}
+		if !wanted[k] {
+			continue
+		}
+		v := float64(sample.Value)
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			out[k] = 0
+			continue
+		}
+		out[k] = v
+	}
+	return out, nil
 }
 
 // EscapePromQL escapes backslashes, quotes, and control characters for safe

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -830,3 +830,10 @@ func TestValidRecordingMetricName(t *testing.T) {
 	assert.False(t, ValidRecordingMetricName("x} or on()"))
 	assert.False(t, ValidRecordingMetricName("has space"))
 }
+
+func TestGetThrottleRatios_EmptyKeys(t *testing.T) {
+	c := &PrometheusCollector{logger: logr.Discard()}
+	out, err := c.GetThrottleRatios(context.Background(), "ns", nil, time.Now())
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}

--- a/internal/safety/monitor.go
+++ b/internal/safety/monitor.go
@@ -100,9 +100,13 @@ type Monitor struct {
 	logger            logr.Logger
 	throttleChecker   ThrottleChecker
 	throttleThreshold float64
-	sloQuerier        SLOQuerier
-	sloGuardrails     []attunev1alpha1.SLOGuardrail
-	sloTemplates      map[string]*template.Template // cached parsed templates keyed by query string
+	// throttleRatioCache optional prefetched ratios from a batch PromQL query.
+	// Keys are "pod/container". When set, CheckPod uses the cache instead of
+	// calling GetThrottleRatio for cache hits.
+	throttleRatioCache map[string]float64
+	sloQuerier         SLOQuerier
+	sloGuardrails      []attunev1alpha1.SLOGuardrail
+	sloTemplates       map[string]*template.Template // cached parsed templates keyed by query string
 }
 
 // NewMonitor creates a Monitor backed by the given Kubernetes client.
@@ -119,6 +123,19 @@ func (m *Monitor) WithThrottleChecker(checker ThrottleChecker, threshold float64
 	m.throttleChecker = checker
 	if threshold > 0 {
 		m.throttleThreshold = threshold
+	}
+	return m
+}
+
+// WithThrottleRatioCache installs prefetched throttle ratios (from a batch
+// PromQL query). CheckPod uses cache hits instead of per-pod queries.
+func (m *Monitor) WithThrottleRatioCache(ratios map[throttle.Key]float64) *Monitor {
+	if len(ratios) == 0 {
+		return m
+	}
+	m.throttleRatioCache = make(map[string]float64, len(ratios))
+	for k, v := range ratios {
+		m.throttleRatioCache[k.Pod+"/"+k.Container] = v
 	}
 	return m
 }
@@ -206,9 +223,20 @@ func (m *Monitor) CheckPod(ctx context.Context, record ResizeRecord, now time.Ti
 	// more CPU.
 	var throttleDeferred bool
 	throttleGrace := 5 * time.Minute
-	if m.throttleChecker != nil {
+	if m.throttleChecker != nil || len(m.throttleRatioCache) > 0 {
 		if now.Sub(record.ResizedAt) >= throttleGrace {
-			ratio, err := m.throttleChecker.GetThrottleRatio(ctx, record.Namespace, record.PodName, record.Container, now)
+			var ratio float64
+			var err error
+			cacheKey := record.PodName + "/" + record.Container
+			if m.throttleRatioCache != nil {
+				if v, ok := m.throttleRatioCache[cacheKey]; ok {
+					ratio = v
+				} else if m.throttleChecker != nil {
+					ratio, err = m.throttleChecker.GetThrottleRatio(ctx, record.Namespace, record.PodName, record.Container, now)
+				}
+			} else if m.throttleChecker != nil {
+				ratio, err = m.throttleChecker.GetThrottleRatio(ctx, record.Namespace, record.PodName, record.Container, now)
+			}
 			if err != nil {
 				m.logger.Error(err, "Safety throttle check failed, skipping throttle detection",
 					"pod", record.PodName, "namespace", record.Namespace, "container", record.Container)

--- a/internal/throttle/throttle.go
+++ b/internal/throttle/throttle.go
@@ -23,9 +23,24 @@ import (
 	"time"
 )
 
+// Key identifies a pod+container pair for batch throttle queries.
+type Key struct {
+	Pod       string
+	Container string
+}
+
 // Checker queries Prometheus for CPU throttle ratio.
 type Checker interface {
 	// GetThrottleRatio returns the CPU throttle ratio (0.0-1.0) for a container
 	// at the given timestamp. Returns 0.0 if data is unavailable.
 	GetThrottleRatio(ctx context.Context, namespace, pod, container string, ts time.Time) (float64, error)
+}
+
+// BatchChecker optionally queries many pod/container throttle ratios in one
+// PromQL vector. Implementations may fall back to per-key queries.
+type BatchChecker interface {
+	Checker
+	// GetThrottleRatios returns ratios keyed by Key for the given namespace.
+	// Missing keys imply no data (ratio 0).
+	GetThrottleRatios(ctx context.Context, namespace string, keys []Key, ts time.Time) (map[Key]float64, error)
 }

--- a/internal/transform/workload.go
+++ b/internal/transform/workload.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transform
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// StripDeploymentFields drops fields Attune never reads from Deployments,
+// reducing informer cache memory at scale.
+func StripDeploymentFields(obj any) (any, error) {
+	d, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		return obj, nil
+	}
+	d.ManagedFields = nil
+	stripPodTemplate(&d.Spec.Template)
+	// Keep selector, replicas, and rollout-relevant status fields.
+	d.Spec.Strategy = appsv1.DeploymentStrategy{}
+	d.Spec.MinReadySeconds = 0
+	d.Spec.RevisionHistoryLimit = nil
+	d.Spec.Paused = false
+	d.Spec.ProgressDeadlineSeconds = nil
+	// Status: keep replica counts used by IsRollingOut.
+	d.Status.Conditions = nil
+	d.Status.CollisionCount = nil
+	return d, nil
+}
+
+// StripStatefulSetFields drops unused StatefulSet fields from the cache.
+func StripStatefulSetFields(obj any) (any, error) {
+	s, ok := obj.(*appsv1.StatefulSet)
+	if !ok {
+		return obj, nil
+	}
+	s.ManagedFields = nil
+	stripPodTemplate(&s.Spec.Template)
+	s.Spec.VolumeClaimTemplates = nil
+	s.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{}
+	s.Spec.RevisionHistoryLimit = nil
+	s.Spec.MinReadySeconds = 0
+	s.Spec.PersistentVolumeClaimRetentionPolicy = nil
+	s.Spec.Ordinals = nil
+	s.Status.Conditions = nil
+	s.Status.CollisionCount = nil
+	return s, nil
+}
+
+// StripDaemonSetFields drops unused DaemonSet fields from the cache.
+func StripDaemonSetFields(obj any) (any, error) {
+	d, ok := obj.(*appsv1.DaemonSet)
+	if !ok {
+		return obj, nil
+	}
+	d.ManagedFields = nil
+	stripPodTemplate(&d.Spec.Template)
+	d.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{}
+	d.Spec.MinReadySeconds = 0
+	d.Spec.RevisionHistoryLimit = nil
+	d.Status.Conditions = nil
+	return d, nil
+}
+
+// StripReplicaSetFields drops unused ReplicaSet fields from the cache.
+func StripReplicaSetFields(obj any) (any, error) {
+	rs, ok := obj.(*appsv1.ReplicaSet)
+	if !ok {
+		return obj, nil
+	}
+	rs.ManagedFields = nil
+	stripPodTemplate(&rs.Spec.Template)
+	rs.Spec.MinReadySeconds = 0
+	rs.Status.Conditions = nil
+	return rs, nil
+}
+
+// StripHPAFields drops unused HPA fields from the cache while keeping
+// scale target, metrics, and annotations used for auto-tune.
+func StripHPAFields(obj any) (any, error) {
+	h, ok := obj.(*autoscalingv2.HorizontalPodAutoscaler)
+	if !ok {
+		return obj, nil
+	}
+	h.ManagedFields = nil
+	h.Status.Conditions = nil
+	h.Status.CurrentMetrics = nil
+	return h, nil
+}
+
+// StripJobFields drops unused Job fields from the cache.
+func StripJobFields(obj any) (any, error) {
+	j, ok := obj.(*batchv1.Job)
+	if !ok {
+		return obj, nil
+	}
+	j.ManagedFields = nil
+	stripPodTemplate(&j.Spec.Template)
+	j.Status.Conditions = nil
+	return j, nil
+}
+
+// StripCronJobFields drops unused CronJob fields from the cache.
+func StripCronJobFields(obj any) (any, error) {
+	c, ok := obj.(*batchv1.CronJob)
+	if !ok {
+		return obj, nil
+	}
+	c.ManagedFields = nil
+	stripPodTemplate(&c.Spec.JobTemplate.Spec.Template)
+	c.Status.Active = nil
+	return c, nil
+}
+
+func stripPodTemplate(t *corev1.PodTemplateSpec) {
+	if t == nil {
+		return
+	}
+	t.ManagedFields = nil
+	// Reuse pod stripping logic for the embedded template.
+	pod := &corev1.Pod{ObjectMeta: t.ObjectMeta, Spec: t.Spec}
+	_, _ = StripPodFields(pod)
+	t.ObjectMeta = pod.ObjectMeta
+	t.Spec = pod.Spec
+}

--- a/internal/transform/workload_test.go
+++ b/internal/transform/workload_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026.
+*/
+
+package transform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStripDeploymentFields_PreservesSelectorAndContainers(t *testing.T) {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "app",
+			Namespace:     "ns",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubectl"}},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "c",
+						Image:   "busybox",
+						Command: []string{"sleep"},
+						Env:     []corev1.EnvVar{{Name: "A", Value: "1"}},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			UpdatedReplicas:   2,
+			AvailableReplicas: 2,
+			Conditions:        []appsv1.DeploymentCondition{{Type: appsv1.DeploymentAvailable}},
+		},
+	}
+	out, err := StripDeploymentFields(d)
+	require.NoError(t, err)
+	stripped := out.(*appsv1.Deployment)
+	assert.Nil(t, stripped.ManagedFields)
+	assert.Equal(t, map[string]string{"app": "x"}, stripped.Spec.Selector.MatchLabels)
+	require.Len(t, stripped.Spec.Template.Spec.Containers, 1)
+	assert.Equal(t, "c", stripped.Spec.Template.Spec.Containers[0].Name)
+	assert.Empty(t, stripped.Spec.Template.Spec.Containers[0].Image)
+	assert.Nil(t, stripped.Spec.Template.Spec.Containers[0].Env)
+	assert.Equal(t, int32(2), stripped.Status.UpdatedReplicas)
+	assert.Nil(t, stripped.Status.Conditions)
+}
+
+func TestStripHPAFields_PreservesSpec(t *testing.T) {
+	h := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "h",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "x"}},
+			Annotations:   map[string]string{"a": "b"},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: "app"},
+		},
+		Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+			Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{{Type: autoscalingv2.ScalingActive}},
+		},
+	}
+	out, err := StripHPAFields(h)
+	require.NoError(t, err)
+	stripped := out.(*autoscalingv2.HorizontalPodAutoscaler)
+	assert.Nil(t, stripped.ManagedFields)
+	assert.Equal(t, "app", stripped.Spec.ScaleTargetRef.Name)
+	assert.Equal(t, "b", stripped.Annotations["a"])
+	assert.Nil(t, stripped.Status.Conditions)
+}


### PR DESCRIPTION
## Summary

Closes the remaining scale performance gaps after #488:

1. **Namespace-wide pod list** + in-memory selector matching (not N Lists per workload)
2. **Representative pod sampling** for metrics (`maxPodsInMetricsQuery`, default 100)
3. **Tier-aware clamps**: `--max-history-window` / `--min-query-step` (large/xlarge Helm presets 72h/48h and 10m/15m)
4. **Blocker refresh throttle**: skip List + summarize while holding last Deferred/Infeasible values
5. **Informer strip** for Deployments, StatefulSets, DaemonSets, ReplicaSets, Jobs, CronJobs, HPAs
6. **Batch safety throttle** PromQL via `GetThrottleRatios`
7. **Default** `--max-concurrent-reconciles` raised to 2 (Helm empty → 2; clusterSize presets unchanged)

Docs updated in `docs/guides/scaling.md` and `docs/reference/configuration.md`.

## Test plan

- [x] Unit tests: pod list match, sampling, clamps, blocker throttle, transforms
- [x] `make verify-quick`
- [x] Reviewer pass (blocker preserve status + list gating fixed)