### PR TITLE
fix: mpi scale defaults coverage, explain, and docs

### DIFF
--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1094,6 +1094,11 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	printEffectiveField("Max concurrent resizes", formatInt64Field(item, "spec", "updateStrategy", "maxConcurrentResizes"), formatInt32Val(effective.Spec.UpdateStrategy.MaxConcurrentResizes), selected, updateDefaults != nil && updateDefaults.MaxConcurrentResizes != 0)
 	printEffectiveField("History window", getNestedString(item, "spec", "metricsSource", "historyWindow"), formatDurationPtr(effective.Spec.MetricsSource.HistoryWindow), selected, metricsDefaults != nil && metricsDefaults.HistoryWindow != nil)
 	printEffectiveField("Rate window", getNestedString(item, "spec", "metricsSource", "rateWindow"), formatDurationPtr(effective.Spec.MetricsSource.RateWindow), selected, metricsDefaults != nil && metricsDefaults.RateWindow != nil)
+	podAggEffective := effective.Spec.MetricsSource.PodAggregation
+	if podAggEffective == "" {
+		podAggEffective = attunev1alpha1.DefaultPodAggregation
+	}
+	printEffectiveField("Pod aggregation", getNestedString(item, "spec", "metricsSource", "podAggregation"), podAggEffective, selected, metricsDefaults != nil && metricsDefaults.PodAggregation != "")
 	printEffectiveField("Max total CPU increase", getNestedString(item, "spec", "updateStrategy", "maxTotalCPUIncrease"), formatQuantityPtr(effective.Spec.UpdateStrategy.MaxTotalCPUIncrease), selected, updateDefaults != nil && updateDefaults.MaxTotalCPUIncrease != nil)
 	printEffectiveField("Max total memory increase", getNestedString(item, "spec", "updateStrategy", "maxTotalMemoryIncrease"), formatQuantityPtr(effective.Spec.UpdateStrategy.MaxTotalMemoryIncrease), selected, updateDefaults != nil && updateDefaults.MaxTotalMemoryIncrease != nil)
 

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -2272,6 +2272,29 @@ func TestPrintEffectivePolicySummary_DoesNotPanic(t *testing.T) {
 	printEffectivePolicySummary(item, policy, selectedDefaults{defaults: defaults, source: "cluster"})
 }
 
+func TestPrintEffectivePolicySummary_PodAggregationDefault(t *testing.T) {
+	policy := &attunev1alpha1.AttunePolicy{
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{Type: attunev1alpha1.UpdateTypeAuto},
+			// PodAggregation intentionally empty: explain should show Max default.
+		},
+	}
+	item := unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{},
+	}}
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	old := os.Stdout
+	os.Stdout = w
+	printEffectivePolicySummary(item, policy, selectedDefaults{})
+	_ = w.Close()
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "Pod aggregation")
+	assert.Contains(t, string(out), attunev1alpha1.DefaultPodAggregation)
+}
+
 func TestPrintEffectivePolicySummary_GitOpsPR(t *testing.T) {
 	en := true
 	dry := true

--- a/docs/architecture/algorithm.md
+++ b/docs/architecture/algorithm.md
@@ -16,6 +16,16 @@ flowchart LR
 The chain is constructed in `recommendation.NewEngine()` and invoked via
 `Recommend(profile, current)`.
 
+## Metrics input (before the chain)
+
+Prometheus queries feed the profile builder. By default,
+`metricsSource.podAggregation` is **Max** (`max by (container)`), so each
+container name contributes one series (the hottest pod) before percentiles
+run. Set `podAggregation: None` or `Avg` only when you need the legacy
+multi-pod sample pool. Caps such as `maxPodsInMetricsQuery` and
+`maxProfileSamples` further bound query and memory cost; see the
+[scaling guide](../guides/scaling.md).
+
 ## 1. Percentile Estimator
 
 Selects the configured percentile from the usage profile. Usage data is

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -8,6 +8,33 @@ Maintainers: before publishing a release after multi-version product changes,
 run the full E2E Nightly matrix on tip of `main` (see
 [Releasing: full E2E matrix](../contributing/releasing.md#1b-full-e2e-matrix-required-before-tagging-a-product-release)).
 
+## Unreleased (scale defaults on main)
+
+These changes are already on `main` and will ship in the next feature release
+after v0.1.21. Review before upgrading operators built from tip or from that
+tag.
+
+### Default PromQL pod aggregation is Max
+
+When `metricsSource.podAggregation` is unset, Attune now defaults to **Max**
+(`max by (container)` over the selected series) instead of leaving series
+unaggregated. Recommendations then follow the hottest pod for each container
+name, and Prometheus query cost stays proportional to containers rather than
+replicas.
+
+**If you relied on multi-pod sample pools (legacy unaggregated behavior),** set
+explicitly:
+
+```yaml
+spec:
+  metricsSource:
+    podAggregation: None   # or Avg
+```
+
+See [Scaling: PromQL aggregation](scaling.md#promql-aggregation) and the
+CHANGELOG behavioral notes for operator flags related to large fleets
+(`maxPodsInMetricsQuery`, `maxProfileSamples`, informer field strip).
+
 ## v0.1.20 to v0.1.21
 
 v0.1.21 is a feature release. Existing policies keep working without YAML

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -315,10 +315,12 @@ pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via mkdocs-material
-pymdown-extensions==11.0 \
-    --hash=sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589 \
-    --hash=sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6
-    # via mkdocs-material
+pymdown-extensions==11.0.1 \
+    --hash=sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2 \
+    --hash=sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0
+    # via
+    #   -r /tmp/requirements.in
+    #   mkdocs-material
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -632,7 +632,7 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				Type:               attunev1alpha1.ConditionReady,
 				Status:             metav1.ConditionTrue,
 				Reason:             attunev1alpha1.ReasonSeriesCapped,
-				Message:            "Prometheus range query hit series cap; recommendations used partial series (raise --max-prometheus-series or enable PodAggregation Max)",
+				Message:            "Prometheus range query hit series cap; recommendations used partial series (raise --max-prometheus-series, keep podAggregation Max, or use recording rules)",
 				ObservedGeneration: policy.Generation,
 				LastTransitionTime: metav1.NewTime(r.now()),
 			})

--- a/internal/controller/pod_list_test.go
+++ b/internal/controller/pod_list_test.go
@@ -41,6 +41,11 @@ func TestSamplePodsForMetrics_EvenSpacing(t *testing.T) {
 	// Under limit returns all
 	assert.Len(t, samplePodsForMetrics(pods[:3], 5), 3)
 	assert.Equal(t, pods, samplePodsForMetrics(pods, 0))
+	// Empty / nil input stays empty (no panic, no synthetic pods).
+	assert.Empty(t, samplePodsForMetrics(nil, 5))
+	assert.Empty(t, samplePodsForMetrics([]corev1.Pod{}, 5))
+	// Negative max is treated as unlimited (return input unchanged).
+	assert.Equal(t, pods[:2], samplePodsForMetrics(pods[:2], -1))
 }
 
 func TestPodRegexFromNames(t *testing.T) {

--- a/internal/controller/scale_clamp_test.go
+++ b/internal/controller/scale_clamp_test.go
@@ -9,9 +9,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	rsmetrics "github.com/attune-io/attune/internal/metrics"
 )
 
 func TestParseHistoryWindow_OperatorMaxClamp(t *testing.T) {
@@ -49,4 +53,34 @@ func TestShouldRefreshBlockers(t *testing.T) {
 	assert.True(t, r.shouldRefreshBlockers(p, true))
 	r.SetNowFunc(func() time.Time { return fixed.Add(6 * time.Minute) })
 	assert.True(t, r.shouldRefreshBlockers(p, false))
+}
+
+func TestMaxProfileSamples(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	assert.Equal(t, rsmetrics.DefaultMaxProfileSamples, r.maxProfileSamples())
+	r.MaxProfileSamples = 500
+	assert.Equal(t, 500, r.maxProfileSamples())
+	r.MaxProfileSamples = -1
+	assert.Equal(t, 0, r.maxProfileSamples(), "negative disables (unlimited)")
+	r.MaxProfileSamples = 0
+	assert.Equal(t, rsmetrics.DefaultMaxProfileSamples, r.maxProfileSamples())
+}
+
+func TestLiveReader_FallsBackToClient(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	assert.Same(t, c, r.liveReader())
+
+	api := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r.APIReader = api
+	assert.Same(t, api, r.liveReader())
+}
+
+func TestJoinSampleNames(t *testing.T) {
+	assert.Equal(t, "none", joinSampleNames(nil))
+	assert.Equal(t, "none", joinSampleNames([]string{}))
+	assert.Equal(t, "a, b", joinSampleNames([]string{"a", "b"}))
 }

--- a/internal/transform/pod_filter_test.go
+++ b/internal/transform/pod_filter_test.go
@@ -84,3 +84,29 @@ func TestPodCacheFilter_DisabledKeepsAll(t *testing.T) {
 	assert.Empty(t, out.(*corev1.Pod).Spec.Containers[0].Image)
 	assert.Len(t, out.(*corev1.Pod).Spec.Containers, 1)
 }
+
+func TestPodCacheFilter_SetEnabled(t *testing.T) {
+	f := NewPodCacheFilter(nil)
+	f.UpdateDynamic([]labels.Selector{SelectorFromMap(map[string]string{"app": "api"})})
+	other := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Labels: map[string]string{"app": "other"}},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+	}
+	assert.False(t, f.Keep(other), "enabled after UpdateDynamic should drop non-matches")
+	f.SetEnabled(false)
+	assert.True(t, f.Keep(other), "SetEnabled(false) keeps all for diagnostics")
+	f.SetEnabled(true)
+	assert.False(t, f.Keep(other))
+	// nil receiver is a no-op (must not panic).
+	var nilF *PodCacheFilter
+	nilF.SetEnabled(true)
+	assert.True(t, nilF.Keep(other))
+}
+
+func TestSelectorFromMap_Empty(t *testing.T) {
+	assert.Nil(t, SelectorFromMap(nil))
+	assert.Nil(t, SelectorFromMap(map[string]string{}))
+	sel := SelectorFromMap(map[string]string{"app": "x"})
+	require.NotNil(t, sel)
+	assert.True(t, sel.Matches(labels.Set{"app": "x"}))
+}

--- a/internal/transform/workload_test.go
+++ b/internal/transform/workload_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -75,4 +76,183 @@ func TestStripHPAFields_PreservesSpec(t *testing.T) {
 	assert.Equal(t, "app", stripped.Spec.ScaleTargetRef.Name)
 	assert.Equal(t, "b", stripped.Annotations["a"])
 	assert.Nil(t, stripped.Status.Conditions)
+}
+
+func TestStripStatefulSetFields_PreservesSelectorAndReplicas(t *testing.T) {
+	replicas := int32(3)
+	s := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "sts",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubectl"}},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sts"}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c",
+						Image: "busybox",
+						Env:   []corev1.EnvVar{{Name: "A", Value: "1"}},
+					}},
+				},
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "data"}}},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 3,
+			Conditions:    []appsv1.StatefulSetCondition{{Type: "Ready"}},
+		},
+	}
+	out, err := StripStatefulSetFields(s)
+	require.NoError(t, err)
+	stripped := out.(*appsv1.StatefulSet)
+	assert.Nil(t, stripped.ManagedFields)
+	assert.Equal(t, int32(3), *stripped.Spec.Replicas)
+	assert.Equal(t, map[string]string{"app": "sts"}, stripped.Spec.Selector.MatchLabels)
+	require.Len(t, stripped.Spec.Template.Spec.Containers, 1)
+	assert.Equal(t, "c", stripped.Spec.Template.Spec.Containers[0].Name)
+	assert.Empty(t, stripped.Spec.Template.Spec.Containers[0].Image)
+	assert.Nil(t, stripped.Spec.VolumeClaimTemplates)
+	assert.Equal(t, int32(3), stripped.Status.ReadyReplicas)
+	assert.Nil(t, stripped.Status.Conditions)
+}
+
+func TestStripDaemonSetFields_PreservesSelector(t *testing.T) {
+	d := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "ds",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "x"}},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "ds"}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img", Env: []corev1.EnvVar{{Name: "E"}}}},
+				},
+			},
+		},
+		Status: appsv1.DaemonSetStatus{
+			NumberReady: 2,
+			Conditions:  []appsv1.DaemonSetCondition{{Type: "Available"}},
+		},
+	}
+	out, err := StripDaemonSetFields(d)
+	require.NoError(t, err)
+	stripped := out.(*appsv1.DaemonSet)
+	assert.Nil(t, stripped.ManagedFields)
+	assert.Equal(t, map[string]string{"app": "ds"}, stripped.Spec.Selector.MatchLabels)
+	require.Len(t, stripped.Spec.Template.Spec.Containers, 1)
+	assert.Empty(t, stripped.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, int32(2), stripped.Status.NumberReady)
+	assert.Nil(t, stripped.Status.Conditions)
+}
+
+func TestStripReplicaSetFields_PreservesSelector(t *testing.T) {
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "rs",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "x"}},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "rs"}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+		Status: appsv1.ReplicaSetStatus{
+			ReadyReplicas: 1,
+			Conditions:    []appsv1.ReplicaSetCondition{{Type: "ReplicaFailure"}},
+		},
+	}
+	out, err := StripReplicaSetFields(rs)
+	require.NoError(t, err)
+	stripped := out.(*appsv1.ReplicaSet)
+	assert.Nil(t, stripped.ManagedFields)
+	assert.Equal(t, map[string]string{"app": "rs"}, stripped.Spec.Selector.MatchLabels)
+	require.Len(t, stripped.Spec.Template.Spec.Containers, 1)
+	assert.Empty(t, stripped.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, int32(1), stripped.Status.ReadyReplicas)
+	assert.Nil(t, stripped.Status.Conditions)
+}
+
+func TestStripJobFields_PreservesSelector(t *testing.T) {
+	j := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "job",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "x"}},
+		},
+		Spec: batchv1.JobSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"job": "j"}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img", Env: []corev1.EnvVar{{Name: "E"}}}},
+				},
+			},
+		},
+		Status: batchv1.JobStatus{
+			Succeeded:  1,
+			Conditions: []batchv1.JobCondition{{Type: batchv1.JobComplete}},
+		},
+	}
+	out, err := StripJobFields(j)
+	require.NoError(t, err)
+	stripped := out.(*batchv1.Job)
+	assert.Nil(t, stripped.ManagedFields)
+	assert.Equal(t, map[string]string{"job": "j"}, stripped.Spec.Selector.MatchLabels)
+	require.Len(t, stripped.Spec.Template.Spec.Containers, 1)
+	assert.Empty(t, stripped.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, int32(1), stripped.Status.Succeeded)
+	assert.Nil(t, stripped.Status.Conditions)
+}
+
+func TestStripCronJobFields_PreservesSchedule(t *testing.T) {
+	c := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "cj",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "x"}},
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "0 * * * *",
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "c", Image: "img"}},
+						},
+					},
+				},
+			},
+		},
+		Status: batchv1.CronJobStatus{
+			Active: []corev1.ObjectReference{{Name: "job-1"}},
+		},
+	}
+	out, err := StripCronJobFields(c)
+	require.NoError(t, err)
+	stripped := out.(*batchv1.CronJob)
+	assert.Nil(t, stripped.ManagedFields)
+	assert.Equal(t, "0 * * * *", stripped.Spec.Schedule)
+	require.Len(t, stripped.Spec.JobTemplate.Spec.Template.Spec.Containers, 1)
+	assert.Empty(t, stripped.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
+	assert.Nil(t, stripped.Status.Active)
+}
+
+func TestStripWorkloadFields_WrongTypePassthrough(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}
+	for _, fn := range []func(any) (any, error){
+		StripStatefulSetFields,
+		StripDaemonSetFields,
+		StripReplicaSetFields,
+		StripJobFields,
+		StripCronJobFields,
+		StripDeploymentFields,
+		StripHPAFields,
+	} {
+		out, err := fn(pod)
+		require.NoError(t, err)
+		assert.Same(t, pod, out)
+	}
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -78,6 +78,9 @@ func ApplyBuiltInDefaults(policy *attunev1alpha1.AttunePolicy) {
 	if policy.Spec.MetricsSource.QueryStep == nil {
 		policy.Spec.MetricsSource.QueryStep = &metav1.Duration{Duration: attunev1alpha1.DefaultQueryStep}
 	}
+	if policy.Spec.MetricsSource.PodAggregation == "" {
+		policy.Spec.MetricsSource.PodAggregation = attunev1alpha1.DefaultPodAggregation
+	}
 	if policy.Spec.CPU.ControlledValues == nil {
 		cv := attunev1alpha1.DefaultControlledValues
 		policy.Spec.CPU.ControlledValues = &cv

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -57,6 +57,7 @@ func TestApplyBuiltInDefaults_FillsAllFields(t *testing.T) {
 	assert.NotNil(t, policy.Spec.MetricsSource.HistoryWindow)
 	assert.NotNil(t, policy.Spec.MetricsSource.QueryStep)
 	assert.Equal(t, attunev1alpha1.DefaultQueryStep, policy.Spec.MetricsSource.QueryStep.Duration)
+	assert.Equal(t, attunev1alpha1.DefaultPodAggregation, policy.Spec.MetricsSource.PodAggregation)
 	assert.NotNil(t, policy.Spec.CPU.ControlledValues)
 	assert.Equal(t, attunev1alpha1.DefaultControlledValues, *policy.Spec.CPU.ControlledValues)
 	assert.NotNil(t, policy.Spec.Memory.ControlledValues)
@@ -78,6 +79,9 @@ func TestApplyBuiltInDefaults_DoesNotOverrideExistingValues(t *testing.T) {
 			CPU: attunev1alpha1.ResourceConfig{
 				MaxChangePercent: &maxCPU,
 			},
+			MetricsSource: attunev1alpha1.MetricsSource{
+				PodAggregation: "None",
+			},
 			ExcludeKnownSidecars: &falseVal,
 		},
 	}
@@ -85,6 +89,7 @@ func TestApplyBuiltInDefaults_DoesNotOverrideExistingValues(t *testing.T) {
 
 	assert.Equal(t, mode, policy.Spec.UpdateStrategy.Type)
 	assert.Equal(t, int32(25), *policy.Spec.CPU.MaxChangePercent)
+	assert.Equal(t, "None", policy.Spec.MetricsSource.PodAggregation)
 	require.NotNil(t, policy.Spec.ExcludeKnownSidecars)
 	assert.False(t, *policy.Spec.ExcludeKnownSidecars)
 }


### PR DESCRIPTION
## Summary

Multi-perspective improvement batch after the scale + nightly E2E wave (#490–#495).

- **QA / Developer:** unit coverage for workload informer strip helpers (StatefulSet, DaemonSet, ReplicaSet, Job, CronJob), `PodCacheFilter.SetEnabled`, `maxProfileSamples`, `liveReader`, `joinSampleNames`, and empty/negative `samplePodsForMetrics`.
- **Spec / CLI:** `ApplyBuiltInDefaults` now fills `metricsSource.podAggregation` with `Max` when unset (matches `promQLBuilder` runtime default); `kubectl attune explain` prints Pod aggregation.
- **Observability:** `PrometheusSeriesCapped` status message no longer says "enable PodAggregation Max" (it is already the default).
- **Docs:** upgrade note for Max aggregation default; architecture algorithm section for metrics input aggregation.

## Test plan

- [x] `make verify-quick` (lint, unit, helm, docs checks)
- [x] `go test ./internal/transform/ ./internal/controller/ ./pkg/defaults/ ./cmd/kubectl-attune/ -race`

## Notes

- Release PR #477 remains user-gated (not touched).
- No product issue closed; this is coverage + consistency for already-landed scale behavior.