### PR TITLE
test: scale path coverage and Max aggregation docs

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -8,6 +8,26 @@ Check the policy's conditions for a quick diagnosis:
 kubectl get attunepolicy <name> -o jsonpath='{.status.conditions}' | jq .
 ```
 
+### PrometheusSeriesCapped
+
+**Symptom:** Ready is True with reason `PrometheusSeriesCapped`, or logs show
+"Prometheus range query series capped".
+
+**Cause:** A range query returned more series than `--max-prometheus-series`
+(default 5000). Attune keeps partial data (preferring at least one series per
+container) and continues.
+
+**Fix:**
+
+1. Keep the default `metricsSource.podAggregation: Max` (or set it explicitly)
+   so series count tracks containers, not pods.
+2. Raise `maxPrometheusSeries` / `--max-prometheus-series` if you need more
+   series under `None` or `Avg`.
+3. Use recording rules (`cpuRecordingMetric` / `memoryRecordingMetric`) for
+   pre-aggregated metrics.
+
+See [Scaling: PrometheusSeriesCapped](scaling.md#ready-reason-prometheusseriescapped).
+
 ### PrometheusUnavailable
 
 **Symptom**: Ready condition is `False` with reason `PrometheusUnavailable`.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -62,6 +62,7 @@ spec:
     minimumDataPoints: 48                  # min samples before recommending (default: 48)
     queryStep: 5m                          # Prometheus range query step interval (default: 5m)
     rateWindow: 5m                         # PromQL rate() window for CPU queries (default: queryStep)
+    podAggregation: Max                    # Max (default) | Avg | None; max by (container) for scale
 
   # CPU recommendation parameters.
   cpu:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -10,7 +10,7 @@
 Fields are defaulted in three layers. Only `weight` and `maxConcurrentResizes`
 appear in the stored spec when omitted by the user (they are CRD schema or
 webhook defaults). All other defaultable fields (`type`, `controlledValues`,
-`cooldown`, `historyWindow`, `minimumDataPoints`, `queryStep`, `rateWindow`, `autoRevert`,
+`cooldown`, `historyWindow`, `minimumDataPoints`, `queryStep`, `rateWindow`, `podAggregation`, `autoRevert`,
 `resizeMethod`, `cpu.maxChangePercent`, `memory.maxChangePercent`,
 `safetyObservationPeriod`, `excludeKnownSidecars`) are applied
 by the controller at reconcile time so that cluster-wide `AttuneDefaults`
@@ -278,6 +278,7 @@ spec:
     minimumDataPoints: 48
     queryStep: 5m
     rateWindow: 5m
+    podAggregation: Max
   cpu:              # same structure as AttunePolicy.spec.cpu
     percentile: 95
     overhead: "20"

--- a/internal/controller/pod_list_test.go
+++ b/internal/controller/pod_list_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestLabelsMatch(t *testing.T) {
@@ -100,4 +101,90 @@ func TestMetricsPodRegex_SamplesWhenLarge(t *testing.T) {
 	// Unlimited path keeps workload regex.
 	r.MaxPodsInMetricsQuery = -1
 	assert.Equal(t, r.getPodRegex(d), r.metricsPodRegex(d, pods))
+}
+
+func TestListPodsForWorkloads_Empty(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	r.Client = fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	out := r.listPodsForWorkloads(context.Background(), nil)
+	assert.Empty(t, out)
+	out = r.listPodsForWorkloads(context.Background(), []client.Object{})
+	assert.Empty(t, out)
+}
+
+func TestListPodsForWorkloads_SkipsEmptySelector(t *testing.T) {
+	scheme := testScheme()
+	// Deployment without MatchLabels has empty pod selector.
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nosel", Namespace: "ns"},
+		Spec:       appsv1.DeploymentSpec{},
+	}
+	p := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", Labels: map[string]string{"app": "x"}}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(d, p).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	out := r.listPodsForWorkloads(context.Background(), []client.Object{d})
+	_, ok := out["nosel"]
+	assert.False(t, ok, "workload without selector labels must be skipped")
+}
+
+func TestListPodsForWorkloads_NSListErrorFallsBackPerWorkload(t *testing.T) {
+	scheme := testScheme()
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "ns"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "app"}},
+		},
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns", Labels: map[string]string{"app": "app"}}}
+
+	// Base client has objects; interceptor fails only the namespace-wide Pod list
+	// (no MatchingLabels), then getPodsForWorkload succeeds with MatchingLabels.
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(d, pod).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(d, pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.PodList); ok {
+					// Fail only bare namespace lists (no MatchingLabels option).
+					// Heuristic: if MatchingLabels is absent from opts, fail.
+					hasMatch := false
+					for _, o := range opts {
+						if _, ok := o.(client.MatchingLabels); ok {
+							hasMatch = true
+							break
+						}
+						if _, ok := o.(client.MatchingLabelsSelector); ok {
+							hasMatch = true
+							break
+						}
+					}
+					if !hasMatch {
+						return fmt.Errorf("simulated ns list failure")
+					}
+				}
+				return base.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	out := r.listPodsForWorkloads(context.Background(), []client.Object{d})
+	require.Len(t, out["app"], 1)
+	assert.Equal(t, "p1", out["app"][0].Name)
+}
+
+func TestMaxWorkloadWorkers(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	assert.Equal(t, defaultMaxWorkloadWorkers, r.maxWorkloadWorkers())
+	r.MaxWorkloadWorkers = 8
+	assert.Equal(t, 8, r.maxWorkloadWorkers())
+	r.MaxWorkloadWorkers = 0
+	assert.Equal(t, defaultMaxWorkloadWorkers, r.maxWorkloadWorkers())
+}
+
+func TestAbsInt64(t *testing.T) {
+	assert.Equal(t, int64(0), absInt64(0))
+	assert.Equal(t, int64(5), absInt64(5))
+	assert.Equal(t, int64(5), absInt64(-5))
 }

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -943,3 +943,39 @@ func TestApplyTemplatePersistence_DisabledByDefault(t *testing.T) {
 		attunev1alpha1.TemplatePersistenceOnRecommendation, nil)
 	assert.Empty(t, history)
 }
+
+func TestMergeTemplateResources_NilRequestsAndLimits(t *testing.T) {
+	want := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+	got := mergeTemplateResources(corev1.ResourceRequirements{}, want)
+	require.NotNil(t, got.Requests)
+	assert.Equal(t, "100m", got.Requests.Cpu().String())
+	assert.Equal(t, "128Mi", got.Requests.Memory().String())
+	assert.Nil(t, got.Limits)
+
+	// Limits filled only when want has limits; existing limits preserved for other keys.
+	current := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")},
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+	}
+	want2 := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("400m")},
+	}
+	got2 := mergeTemplateResources(current, want2)
+	assert.Equal(t, "200m", got2.Requests.Cpu().String())
+	assert.Equal(t, "400m", got2.Limits.Cpu().String())
+	assert.Equal(t, "256Mi", got2.Limits.Memory().String(), "unrelated existing limit kept")
+}
+
+func TestWorkloadKindName(t *testing.T) {
+	assert.Equal(t, "Deployment", workloadKindName(&appsv1.Deployment{}))
+	assert.Equal(t, "StatefulSet", workloadKindName(&appsv1.StatefulSet{}))
+	assert.Equal(t, "DaemonSet", workloadKindName(&appsv1.DaemonSet{}))
+	// Unknown object falls back to GVK kind (empty when unset).
+	assert.Equal(t, "", workloadKindName(&corev1.Pod{}))
+}

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -837,3 +837,45 @@ func TestGetThrottleRatios_EmptyKeys(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
+
+func TestEffectiveMaxSeries(t *testing.T) {
+	c := &PrometheusCollector{}
+	assert.Equal(t, DefaultMaxPrometheusSeries, c.effectiveMaxSeries())
+	c.maxSeries = 42
+	assert.Equal(t, 42, c.effectiveMaxSeries())
+	c.maxSeries = -1
+	assert.Equal(t, 0, c.effectiveMaxSeries(), "negative is unlimited")
+	c.maxSeries = 0
+	assert.Equal(t, DefaultMaxPrometheusSeries, c.effectiveMaxSeries())
+}
+
+func TestCapMatrixByContainer_EdgeCases(t *testing.T) {
+	// limit <= 0 or under limit returns input unchanged.
+	s := &model.SampleStream{Metric: model.Metric{"container": "c"}}
+	m := model.Matrix{s}
+	assert.Same(t, m[0], capMatrixByContainer(m, 0)[0])
+	assert.Same(t, m[0], capMatrixByContainer(m, -1)[0])
+	assert.Len(t, capMatrixByContainer(m, 5), 1)
+
+	// Prefer one series per container then fill remaining.
+	matrix := model.Matrix{
+		{Metric: model.Metric{"container": "a", "pod": "p1"}},
+		{Metric: model.Metric{"container": "a", "pod": "p2"}},
+		{Metric: model.Metric{"container": "b", "pod": "p1"}},
+		{Metric: model.Metric{"container": "c", "pod": "p1"}},
+	}
+	out := capMatrixByContainer(matrix, 3)
+	require.Len(t, out, 3)
+	containers := map[string]int{}
+	for _, series := range out {
+		containers[string(series.Metric["container"])]++
+	}
+	// Pass 1 takes a, b, c (3 distinct) — no room for second "a".
+	assert.Equal(t, 1, containers["a"])
+	assert.Equal(t, 1, containers["b"])
+	assert.Equal(t, 1, containers["c"])
+
+	// limit 2: only first two distinct containers.
+	out2 := capMatrixByContainer(matrix, 2)
+	require.Len(t, out2, 2)
+}

--- a/internal/metrics/query_builder_test.go
+++ b/internal/metrics/query_builder_test.go
@@ -221,3 +221,12 @@ func TestDownsampleSamples(t *testing.T) {
 	// No-op when under cap
 	assert.Equal(t, samples, DownsampleSamples(samples, 200))
 }
+
+func TestApplyPodAggregation(t *testing.T) {
+	inner := `rate(container_cpu_usage_seconds_total{namespace="ns"}[5m])`
+	assert.Equal(t, inner, applyPodAggregation(inner, PodAggregationNone))
+	assert.Equal(t, `avg by (container) (`+inner+`)`, applyPodAggregation(inner, PodAggregationAvg))
+	assert.Equal(t, `max by (container) (`+inner+`)`, applyPodAggregation(inner, PodAggregationMax))
+	assert.Equal(t, `max by (container) (`+inner+`)`, applyPodAggregation(inner, ""))
+	assert.Equal(t, `max by (container) (`+inner+`)`, applyPodAggregation(inner, PodAggregationMode("Weird")))
+}


### PR DESCRIPTION
## Summary

Second multi-perspective improve cycle after #496/#498. Focus on residual scale-path test gaps and operator docs for Max aggregation / series caps.

## Changes

**Tests**
- `listPodsForWorkloads`: empty input, empty selector skip, NS list error fallback to per-workload List
- `maxWorkloadWorkers`, `absInt64`
- `applyPodAggregation` Max/Avg/None/default
- `effectiveMaxSeries` and `capMatrixByContainer` edges
- `mergeTemplateResources` nil maps; `workloadKindName`

**Docs**
- `api.md`: `podAggregation` in field list, policy example, and AttuneDefaults example
- `troubleshooting.md`: Ready reason `PrometheusSeriesCapped` with scale-oriented fixes

## Test plan

- [x] `make verify-quick` (1862 unit tests, lint, helm)
- [x] Targeted race tests for new cases

## Notes

- Release PR #477 remains user-gated (not touched).
- Open issues remain community/tracking only.
