### PR TITLE
docs: curated release notes for v0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,25 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * harden GitOps paths, SSRF apiUrl, and refresh dist manifests ([#455](https://github.com/attune-io/attune/issues/455)) ([f4ec8dd](https://github.com/attune-io/attune/commit/f4ec8ddd188ec40eb0ff9d9c15224c4b56997b9c))
 
-## [Unreleased]
-
-### Features
-
-* **Scale:** default PromQL `podAggregation: Max` (`max by (container)`) so recommendation
-  range queries are O(containers), not O(pods). Override with `Avg` or `None` for the
-  legacy multi-pod sample pool. Status recommendation caps, sample downsampling, series
-  caps, requeue jitter, configurable workload workers, namespace-wide pod lists,
-  representative pod sampling for metrics, optional history/step clamps, batch safety
-  throttle queries, and informer field stripping for pods/workloads/HPAs. Optional
-  `--pod-label-selector` plus dynamic keep rules from active policy target selectors.
-  Default `--max-concurrent-reconciles` is now 2 (Helm `clusterSize` presets still apply).
-
-### Breaking / behavioral notes
-
-* **Default metrics aggregation is Max.** Operators who relied on unaggregated
-  per-pod series for percentile estimates should set
-  `spec.metricsSource.podAggregation: None` (or `Avg`) explicitly after upgrade.
-
 ## [0.1.20](https://github.com/attune-io/attune/compare/v0.1.19...v0.1.20) (2026-07-14)
 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,59 @@
+## What's New in v0.1.22
+
+v0.1.22 is a scale and safety release. Large fleets get cheaper Prometheus queries by default, the operator uses less API and informer memory, and node pressure or missing node status no longer allows unsafe request increases. If you run high-replica Deployments or multi-pod policies, read the upgrade notes before rolling out.
+
+### Highlights
+
+- Default PromQL aggregation is **Max** (`max by (container)`), so recommendation cost tracks containers rather than every pod replica.
+- Scale hot paths: namespace-wide pod lists, sample pods for metrics, batch throttle queries, informer field stripping, default max concurrent reconciles of 2.
+- Stronger MemoryPressure and capacity skip behavior, including fail-closed when node status is unavailable for request increases.
+
+### Behavioral change: default pod aggregation is Max
+
+When `metricsSource.podAggregation` is unset, Attune now defaults to **Max**. Recommendations follow the hottest pod for each container name, and range query series counts stay proportional to containers.
+
+If you relied on the legacy multi-pod sample pool (unaggregated series), set:
+
+```yaml
+spec:
+  metricsSource:
+    podAggregation: None   # or Avg
+```
+
+See [Upgrading](https://attune-io.github.io/attune/guides/upgrading/) and [Scaling](https://attune-io.github.io/attune/guides/scaling/).
+
+### Scale and performance
+
+- PromQL Max aggregation by default, with status and docs for series caps and recording rules ([#488](https://github.com/attune-io/attune/pull/488), [#496](https://github.com/attune-io/attune/pull/496), [#499](https://github.com/attune-io/attune/pull/499)).
+- Large-fleet gaps closed: NS-wide pod list, metrics pod sampling, history and step clamps, blocker throttle status preservation, workload and HPA informer strip, batch safety throttle, default `--max-concurrent-reconciles=2` ([#490](https://github.com/attune-io/attune/pull/490), [#491](https://github.com/attune-io/attune/pull/491)).
+- Production `RateLimitedCollector` implements batch throttle so multi-pod safety uses one PromQL query instead of N rate-limited singles ([#502](https://github.com/attune-io/attune/pull/502), [#501](https://github.com/attune-io/attune/pull/501)).
+
+### Capacity and MemoryPressure
+
+- Hold the MemoryPressure gate against stale node cache; live Clientset re-check before `UpdateResize` ([#476](https://github.com/attune-io/attune/pull/476), [#479](https://github.com/attune-io/attune/pull/479)).
+- Fail-closed on request increases when node status is unavailable (`attune_capacity_skip_total{reason="unavailable"}`) ([#485](https://github.com/attune-io/attune/pull/485)).
+- Hardened MemoryPressure E2E against kubelet inject races ([#482](https://github.com/attune-io/attune/pull/482)).
+
+### Docs and operations
+
+- Scaling ops checklist and high-replica guidance ([#487](https://github.com/attune-io/attune/pull/487)).
+- Docs Deploy no longer cancels in-flight main runs ([#489](https://github.com/attune-io/attune/pull/489)).
+- Enriched nightly failure GitHub issues with failed jobs and first Go E2E FAIL lines ([#485](https://github.com/attune-io/attune/pull/485)).
+
+### Upgrade notes
+
+1. **Review Max aggregation.** Existing policies with unset `podAggregation` switch from unaggregated series to Max. Set `None` or `Avg` only if you need the previous multi-pod sample pool.
+2. **Default concurrency is 2** for reconciles (`--max-concurrent-reconciles`). Helm `clusterSize` presets still override when set.
+3. Refresh CRDs with the release install path (`helm upgrade` or `dist/crds.yaml` / `dist/install.yaml` from the tag).
+4. Re-apply Grafana dashboard and PrometheusRule assets if you manage them out of band.
+
+```bash
+kubectl attune status -A
+kubectl attune explain -n <namespace> <policy>
+```
+
+Full upgrade detail: [Upgrading](https://attune-io.github.io/attune/guides/upgrading/).
+
+### Full changelog
+
+https://github.com/attune-io/attune/compare/v0.1.21...v0.1.22

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -8,11 +8,10 @@ Maintainers: before publishing a release after multi-version product changes,
 run the full E2E Nightly matrix on tip of `main` (see
 [Releasing: full E2E matrix](../contributing/releasing.md#1b-full-e2e-matrix-required-before-tagging-a-product-release)).
 
-## Unreleased (scale defaults on main)
+## v0.1.21 to v0.1.22
 
-These changes are already on `main` and will ship in the next feature release
-after v0.1.21. Review before upgrading operators built from tip or from that
-tag.
+v0.1.22 ships scale defaults and capacity safety that were previously only on
+`main`. Review before upgrading from v0.1.21.
 
 ### Default PromQL pod aggregation is Max
 


### PR DESCRIPTION
## Summary

Curated user-facing notes for the upcoming **v0.1.22** release (scale defaults + capacity safety).

- `RELEASE_NOTES.md` for GitHub Release override
- `docs/guides/upgrading.md`: Unreleased → v0.1.21 to v0.1.22
- Drop hand-written CHANGELOG `[Unreleased]` block (duplicated; release-please owns 0.1.22 section)

## Test plan

- [x] No em dashes / banned words in notes
- [ ] Merge before release PR #477 so the tag includes notes