### PR TITLE
test: pin GuaranteedQoS memory min=max at 256Mi

### DIFF
--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -1175,8 +1175,10 @@ func TestE2E_GuaranteedQoS_CPUResizeWithMemoryHeld(t *testing.T) {
 				Overhead:         "30",
 				AllowDecrease:    boolPtr(false),
 				ControlledValues: &controlled,
+				// Pin min=max so a memory *increase* cannot break Guaranteed
+				// 256Mi while we only assert CPU decrease (nightly saw 512Mi).
 				MinAllowed:       quantityPtr("256Mi"),
-				MaxAllowed:       quantityPtr("8Gi"),
+				MaxAllowed:       quantityPtr("256Mi"),
 				MaxChangePercent: int32Ptr(100),
 			},
 			UpdateStrategy: &attunev1alpha1.UpdateStrategy{


### PR DESCRIPTION
## Summary

Second full nightly on `b773c0e` failed GuaranteedQoS when CPU correctly fell to 50m but memory rose to **512Mi**. `allowDecrease: false` does not block increases. Pin memory `MinAllowed=MaxAllowed=256Mi`.

Nightly #1 on the same SHA was fully green (1.32–1.35 + fuzz).

## Test plan

- [x] compile e2e package
- [ ] PR CI
- [ ] two sequential nightlies after merge