### PR TITLE
fix: complete batch throttle cache and e2e diag safety

### DIFF
--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -30,8 +30,8 @@ spec:
     podAggregation: None   # or Avg
 ```
 
-See [Scaling: PromQL aggregation](scaling.md#promql-aggregation) and the
-CHANGELOG behavioral notes for operator flags related to large fleets
+See [Scaling: PromQL aggregation](scaling.md#promql-aggregation) and
+[Scaling: large fleets](scaling.md) for operator flags related to large fleets
 (`maxPodsInMetricsQuery`, `maxProfileSamples`, informer field strip).
 
 ## v0.1.20 to v0.1.21

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -497,30 +497,30 @@ func (c *PrometheusCollector) GetThrottleRatios(ctx context.Context, namespace s
 			"warnings", strings.Join(warnings, "; "))
 	}
 	vec, ok := result.(model.Vector)
-	if !ok {
-		return out, nil
-	}
-	wanted := make(map[throttle.Key]bool, len(keys))
-	for _, k := range keys {
-		wanted[k] = true
-	}
-	for _, sample := range vec {
-		pod := string(sample.Metric[model.LabelName("pod")])
-		ctr := string(sample.Metric[model.LabelName("container")])
-		k := throttle.Key{Pod: pod, Container: ctr}
-		if !wanted[k] {
-			continue
+	if ok {
+		wanted := make(map[throttle.Key]bool, len(keys))
+		for _, k := range keys {
+			wanted[k] = true
 		}
-		v := float64(sample.Value)
-		if math.IsNaN(v) || math.IsInf(v, 0) {
-			out[k] = 0
-			continue
+		for _, sample := range vec {
+			pod := string(sample.Metric[model.LabelName("pod")])
+			ctr := string(sample.Metric[model.LabelName("container")])
+			k := throttle.Key{Pod: pod, Container: ctr}
+			if !wanted[k] {
+				continue
+			}
+			v := float64(sample.Value)
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				out[k] = 0
+				continue
+			}
+			out[k] = v
 		}
-		out[k] = v
 	}
 	// Match GetThrottleRatio empty/no-data semantics: every requested key is
 	// present so callers can install a complete throttleRatioCache without
 	// falling back to N per-pod queries for silent pods (no CFS series).
+	// Also applies when the result is not a vector (treat as no data).
 	for _, k := range keys {
 		if _, ok := out[k]; !ok {
 			out[k] = 0

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -518,6 +518,14 @@ func (c *PrometheusCollector) GetThrottleRatios(ctx context.Context, namespace s
 		}
 		out[k] = v
 	}
+	// Match GetThrottleRatio empty/no-data semantics: every requested key is
+	// present so callers can install a complete throttleRatioCache without
+	// falling back to N per-pod queries for silent pods (no CFS series).
+	for _, k := range keys {
+		if _, ok := out[k]; !ok {
+			out[k] = 0
+		}
+	}
 	return out, nil
 }
 

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -913,10 +913,10 @@ func TestGetThrottleRatios_MultiKeyBatch(t *testing.T) {
 	assert.InDelta(t, 0.1, out[throttle.Key{Pod: "pod-a", Container: "app"}], 1e-9)
 	assert.InDelta(t, 0.5, out[throttle.Key{Pod: "pod-b", Container: "app"}], 1e-9)
 	assert.Zero(t, out[throttle.Key{Pod: "pod-a", Container: "sidecar"}], "NaN must map to 0")
-	_, hasC := out[throttle.Key{Pod: "pod-c", Container: "worker"}]
-	assert.False(t, hasC, "missing series stays absent (caller treats as 0)")
+	assert.Zero(t, out[throttle.Key{Pod: "pod-c", Container: "worker"}], "missing series maps to 0 like GetThrottleRatio")
 	_, hasOther := out[throttle.Key{Pod: "other", Container: "app"}]
 	assert.False(t, hasOther, "unwanted series must be filtered")
+	assert.Len(t, out, 4, "every requested key is present")
 
 	// Batch path uses regex matchers with sorted unique pod/container sets.
 	assert.Contains(t, receivedQuery, `namespace="prod"`)

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -1025,7 +1025,9 @@ func TestGetThrottleRatios_NonVectorResult(t *testing.T) {
 	}
 	out, err := collector.GetThrottleRatios(context.Background(), "ns", keys, time.Now())
 	require.NoError(t, err)
-	assert.Empty(t, out, "non-vector success returns empty map without error")
+	require.Len(t, out, 2, "non-vector success still zero-fills requested keys")
+	assert.Zero(t, out[throttle.Key{Pod: "a", Container: "c"}])
+	assert.Zero(t, out[throttle.Key{Pod: "b", Container: "c"}])
 }
 
 func TestEffectiveMaxSeries(t *testing.T) {

--- a/internal/safety/monitor_test.go
+++ b/internal/safety/monitor_test.go
@@ -35,6 +35,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/throttle"
 )
 
 func TestCheckPod(t *testing.T) {
@@ -840,6 +841,78 @@ func (m *mockThrottleChecker) GetThrottleRatio(_ context.Context, ns, pod, ctr s
 	m.gotPod = pod
 	m.gotCtr = ctr
 	return m.ratio, m.err
+}
+
+func TestCheckPod_ThrottleRatioCacheHit(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-0", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 0},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(pod)
+	monitor := NewMonitor(clientset, testr.New(t))
+	// Checker would return low ratio; cache must win for the hit key.
+	checker := &mockThrottleChecker{ratio: 0.01}
+	monitor.WithThrottleChecker(checker, 0.5)
+	monitor.WithThrottleRatioCache(map[throttle.Key]float64{
+		{Pod: "web-0", Container: "app"}: 0.9,
+	})
+
+	record := ResizeRecord{
+		PodName:      "web-0",
+		Namespace:    "default",
+		Container:    "app",
+		ResizedAt:    time.Now().Add(-6 * time.Minute),
+		RestartCount: 0,
+	}
+	verdict, err := monitor.CheckPod(context.Background(), record, time.Now())
+	require.NoError(t, err)
+	assert.False(t, verdict.Safe)
+	assert.Equal(t, "throttle", verdict.Reason)
+	assert.Empty(t, checker.gotPod, "cache hit must not call GetThrottleRatio")
+}
+
+func TestCheckPod_ThrottleRatioCacheMissFallsBack(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-0", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 0},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(pod)
+	monitor := NewMonitor(clientset, testr.New(t))
+	checker := &mockThrottleChecker{ratio: 0.8}
+	monitor.WithThrottleChecker(checker, 0.5)
+	// Cache for a different pod only.
+	monitor.WithThrottleRatioCache(map[throttle.Key]float64{
+		{Pod: "other", Container: "app"}: 0.01,
+	})
+
+	record := ResizeRecord{
+		PodName:      "web-0",
+		Namespace:    "default",
+		Container:    "app",
+		ResizedAt:    time.Now().Add(-6 * time.Minute),
+		RestartCount: 0,
+	}
+	verdict, err := monitor.CheckPod(context.Background(), record, time.Now())
+	require.NoError(t, err)
+	assert.False(t, verdict.Safe)
+	assert.Equal(t, "throttle", verdict.Reason)
+	assert.Equal(t, "web-0", checker.gotPod, "cache miss must fall back to GetThrottleRatio")
 }
 
 func TestCheckPod_ThrottleDetected(t *testing.T) {

--- a/lychee.toml
+++ b/lychee.toml
@@ -14,6 +14,8 @@ exclude = [
   "cast\\.ai",
   "helm\\.sh",
   "cert-manager\\.io",
+  # AWS docs often return 403 to CI/link checkers (bot/WAF).
+  "docs\\.aws\\.amazon\\.com",
 ]
 exclude_loopback = true
 max_concurrency = 8

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -495,12 +495,12 @@ func waitForLiveCPUDecrease(t *testing.T, policyName, namespace, app string, ori
 				for _, c := range pod.Spec.Containers {
 					if c.Name == "app" {
 						cpu := c.Resources.Requests.Cpu()
-						milli := int64(-1)
-						if cpu != nil {
-							milli = cpu.MilliValue()
+						if cpu == nil {
+							t.Logf("  pod %s phase=%s cpu=<nil>", pod.Name, pod.Status.Phase)
+							continue
 						}
 						t.Logf("  pod %s phase=%s cpu=%s (%dm) cmpOrig=%d",
-							pod.Name, pod.Status.Phase, cpu.String(), milli, cpu.Cmp(origCPU))
+							pod.Name, pod.Status.Phase, cpu.String(), cpu.MilliValue(), cpu.Cmp(origCPU))
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

MPI cycle after v0.1.22 release-readiness. Product-focused fixes for the
batch safety throttle path landed in #502:

- **GetThrottleRatios** zero-fills every requested key (including missing
  series and non-vector success), matching `GetThrottleRatio` empty/no-data
  and enabling a complete `throttleRatioCache` without N fallback queries.
- **Monitor** unit tests for cache hit vs miss fallback.
- **E2E** `waitForLiveCPUDecrease` diagnostics are nil-safe on missing CPU
  requests.
- **Docs:** upgrading guide no longer points at a removed CHANGELOG
  Unreleased block.

## Test plan

- [x] `go test ./internal/metrics/ ./internal/safety/ ./internal/controller/ -race`
- [x] `make verify-quick`
- [ ] PR CI