### PR TITLE
fix: chunk batch throttle queries and harden E2E API wait

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -163,7 +163,21 @@ runs:
 
     - name: Wait for node Ready
       shell: bash -Eeuo pipefail -x {0}
-      run: kubectl wait --for=condition=Ready nodes --all --timeout=360s
+      run: |
+        # k3d --wait can return before the apiserver serves /readyz; PR CI
+        # has failed with ServiceUnavailable on the first kubectl wait.
+        for attempt in $(seq 1 60); do
+          if kubectl get --raw='/readyz' >/dev/null 2>&1; then
+            echo "API server ready after ${attempt} attempt(s)"
+            break
+          fi
+          if (( attempt == 60 )); then
+            echo "::error::API server never became ready (readyz)"
+            exit 1
+          fi
+          sleep 2
+        done
+        kubectl wait --for=condition=Ready nodes --all --timeout=360s
 
     - name: Load cert-manager images into cluster
       shell: bash -Eeuo pipefail -x {0}

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -279,7 +279,20 @@ jobs:
 
       - name: Wait for node Ready
         shell: bash -Eeuo pipefail -x {0}
-        run: kubectl wait --for=condition=Ready nodes --all --timeout=360s
+        run: |
+          # k3d --wait can return before the apiserver serves /readyz.
+          for attempt in $(seq 1 60); do
+            if kubectl get --raw='/readyz' >/dev/null 2>&1; then
+              echo "API server ready after ${attempt} attempt(s)"
+              break
+            fi
+            if (( attempt == 60 )); then
+              echo "::error::API server never became ready (readyz)"
+              exit 1
+            fi
+            sleep 2
+          done
+          kubectl wait --for=condition=Ready nodes --all --timeout=360s
 
       - name: Verify resize subresource (K8s 1.32)
         if: matrix.k8s-version == 'v1.32'
@@ -324,6 +337,16 @@ jobs:
               --kubeconfig-update-default=false \
               --kubeconfig-switch-context=false
             k3d kubeconfig merge "$CLUSTER_NAME" --output "$KUBECONFIG" --overwrite
+            for attempt in $(seq 1 60); do
+              if kubectl get --raw='/readyz' >/dev/null 2>&1; then
+                break
+              fi
+              if (( attempt == 60 )); then
+                echo "::error::API server never became ready after recreate"
+                exit 1
+              fi
+              sleep 2
+            done
             kubectl wait --for=condition=Ready nodes --all --timeout=360s
           }
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -206,3 +206,5 @@ auto-reverts the affected pods.
   ServiceMonitor, Grafana dashboard, and PrometheusRule alerts.
 - Explore the [Canary Rollout guide](../guides/canary-rollout.md) for
   production best practices.
+- For high-replica fleets, read [Scaling](../guides/scaling.md) (default
+  PromQL `podAggregation: Max` and large-fleet operator flags).

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -449,9 +449,45 @@ func (c *PrometheusCollector) GetThrottleRatio(ctx context.Context, namespace, p
 	return val, nil
 }
 
+// maxThrottleBatchKeys limits pod/container pairs per PromQL batch so the
+// pod=~|...| regex stays bounded for large safety observation sets.
+const maxThrottleBatchKeys = 64
+
 // GetThrottleRatios batch-queries throttle ratios for many pod/container pairs
 // in one PromQL vector (pod=~ and container=~). Implements throttle.BatchChecker.
+// Large key sets are split into chunks of maxThrottleBatchKeys.
 func (c *PrometheusCollector) GetThrottleRatios(ctx context.Context, namespace string, keys []throttle.Key, ts time.Time) (map[throttle.Key]float64, error) {
+	out := make(map[throttle.Key]float64, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+	if len(keys) == 1 {
+		v, err := c.GetThrottleRatio(ctx, namespace, keys[0].Pod, keys[0].Container, ts)
+		if err != nil {
+			return nil, err
+		}
+		out[keys[0]] = v
+		return out, nil
+	}
+	for i := 0; i < len(keys); i += maxThrottleBatchKeys {
+		end := i + maxThrottleBatchKeys
+		if end > len(keys) {
+			end = len(keys)
+		}
+		chunk := keys[i:end]
+		part, err := c.getThrottleRatiosChunk(ctx, namespace, chunk, ts)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range part {
+			out[k] = v
+		}
+	}
+	return out, nil
+}
+
+// getThrottleRatiosChunk runs one PromQL vector query for a bounded key set.
+func (c *PrometheusCollector) getThrottleRatiosChunk(ctx context.Context, namespace string, keys []throttle.Key, ts time.Time) (map[throttle.Key]float64, error) {
 	out := make(map[throttle.Key]float64, len(keys))
 	if len(keys) == 0 {
 		return out, nil

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1005,6 +1006,35 @@ func TestGetThrottleRatios_QueryError(t *testing.T) {
 	_, err = collector.GetThrottleRatios(context.Background(), "ns", keys, time.Now())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "batch throttle query failed")
+}
+
+func TestGetThrottleRatios_ChunksLargeKeySets(t *testing.T) {
+	var queryCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Empty vector: all keys zero-filled.
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer server.Close()
+
+	collector, err := NewPrometheusCollector(server.URL, logr.Discard(), http.DefaultTransport)
+	require.NoError(t, err)
+
+	// Two full batches + remainder → three PromQL queries.
+	n := maxThrottleBatchKeys*2 + 3
+	keys := make([]throttle.Key, n)
+	for i := range keys {
+		keys[i] = throttle.Key{Pod: fmt.Sprintf("pod-%d", i), Container: "app"}
+	}
+	out, err := collector.GetThrottleRatios(context.Background(), "ns", keys, time.Now())
+	require.NoError(t, err)
+	require.Len(t, out, n)
+	assert.Equal(t, 3, queryCount, "large key sets must be chunked")
+	for _, k := range keys {
+		assert.Zero(t, out[k])
+	}
 }
 
 func TestGetThrottleRatios_NonVectorResult(t *testing.T) {

--- a/internal/metrics/ratelimit.go
+++ b/internal/metrics/ratelimit.go
@@ -84,16 +84,36 @@ func (c *RateLimitedCollector) GetThrottleRatio(ctx context.Context, namespace, 
 }
 
 // GetThrottleRatios delegates to the inner collector if it implements
-// throttle.BatchChecker. One rate-limit token covers the whole batch
-// query (not one token per key). Without this method, the production
-// RateLimitedCollector wrapper does not satisfy BatchChecker and the
-// safety path falls back to N per-pod GetThrottleRatio calls.
+// throttle.BatchChecker. One rate-limit token covers each PromQL chunk
+// (maxThrottleBatchKeys keys), not one token per key. Without this method,
+// the production RateLimitedCollector wrapper does not satisfy BatchChecker
+// and the safety path falls back to N per-pod GetThrottleRatio calls.
 func (c *RateLimitedCollector) GetThrottleRatios(ctx context.Context, namespace string, keys []throttle.Key, ts time.Time) (map[throttle.Key]float64, error) {
 	if bc, ok := c.inner.(throttle.BatchChecker); ok {
-		if err := c.limiter.Wait(ctx); err != nil {
-			return nil, err
+		if len(keys) <= maxThrottleBatchKeys {
+			if err := c.limiter.Wait(ctx); err != nil {
+				return nil, err
+			}
+			return bc.GetThrottleRatios(ctx, namespace, keys, ts)
 		}
-		return bc.GetThrottleRatios(ctx, namespace, keys, ts)
+		out := make(map[throttle.Key]float64, len(keys))
+		for i := 0; i < len(keys); i += maxThrottleBatchKeys {
+			end := i + maxThrottleBatchKeys
+			if end > len(keys) {
+				end = len(keys)
+			}
+			if err := c.limiter.Wait(ctx); err != nil {
+				return nil, err
+			}
+			part, err := bc.GetThrottleRatios(ctx, namespace, keys[i:end], ts)
+			if err != nil {
+				return nil, err
+			}
+			for k, v := range part {
+				out[k] = v
+			}
+		}
+		return out, nil
 	}
 	// Inner is Checker-only: fall back to per-key (still rate-limited).
 	out := make(map[throttle.Key]float64, len(keys))


### PR DESCRIPTION
## Summary

MPI cycle on tip after #507. Two product/CI themes:

1. **Batch throttle at scale:** `GetThrottleRatios` chunks key sets into
   `maxThrottleBatchKeys` (64) so PromQL `pod=~` regexes stay bounded.
   `RateLimitedCollector` takes one limiter token per chunk.
2. **E2E API readiness:** wait for apiserver `/readyz` before `kubectl wait`
   for nodes (setup-e2e-cluster + e2e-nightly, including v1.32 recreate).
3. **Docs:** quickstart next steps link to the scaling guide (Max aggregation).

## Test plan

- [x] `go test ./internal/metrics/ -race` (includes chunk unit test)
- [x] `make verify-quick`
- [ ] PR CI