### PR TITLE
test: cover rate-limited throttle chunking and document batch size

### DIFF
--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -393,9 +393,12 @@ deliberate semantic change from pre-#488 unaggregated series. Set
 
 ### Safety throttle batching
 
-When many pods are under deferred safety observation, Attune issues one
+When many pods are under deferred safety observation, Attune issues a
 batch throttle PromQL vector (`pod=~` / `container=~`) instead of one
 instant query per pod/container when the Prometheus collector is in use.
+Large observation sets are split into chunks of 64 pod/container pairs so
+the regex stays bounded; the Prometheus rate limiter spends one token per
+chunk.
 
 ## API Server Pressure
 

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -469,6 +469,10 @@ func (c *PrometheusCollector) GetThrottleRatios(ctx context.Context, namespace s
 		out[keys[0]] = v
 		return out, nil
 	}
+	if len(keys) > maxThrottleBatchKeys {
+		c.logger.V(1).Info("Chunking batch throttle query",
+			"keys", len(keys), "chunkSize", maxThrottleBatchKeys)
+	}
 	for i := 0; i < len(keys); i += maxThrottleBatchKeys {
 		end := i + maxThrottleBatchKeys
 		if end > len(keys) {

--- a/internal/metrics/ratelimit_test.go
+++ b/internal/metrics/ratelimit_test.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -214,6 +215,25 @@ func TestRateLimitedCollector_GetThrottleRatios_Delegates(t *testing.T) {
 	assert.Equal(t, 0, inner.throttleCalls)
 	assert.InDelta(t, 0.2, out[k1], 1e-9)
 	assert.InDelta(t, 0.4, out[k2], 1e-9)
+}
+
+func TestRateLimitedCollector_GetThrottleRatios_ChunksLargeSets(t *testing.T) {
+	// RateLimitedCollector must issue one Wait+batch call per chunk so
+	// large fleets do not bypass the limiter with a single token.
+	n := maxThrottleBatchKeys*2 + 5
+	keys := make([]throttle.Key, n)
+	batchOut := make(map[throttle.Key]float64, n)
+	for i := range keys {
+		keys[i] = throttle.Key{Pod: fmt.Sprintf("pod-%d", i), Container: "app"}
+		batchOut[keys[i]] = 0.1
+	}
+	inner := &mockThrottleCollector{batchOut: batchOut}
+	rl := NewRateLimitedCollector(inner, 1000, 1000) // high QPS so Wait never blocks
+
+	out, err := rl.GetThrottleRatios(context.Background(), "ns", keys, time.Now())
+	require.NoError(t, err)
+	require.Len(t, out, n)
+	assert.Equal(t, 3, inner.batchCalls, "expect one batch call per chunk")
 }
 
 func TestRateLimitedCollector_GetThrottleRatios_FallbackPerKey(t *testing.T) {


### PR DESCRIPTION
## Summary

MPI rotation after gate fix #510:

- Unit test: `RateLimitedCollector` issues one batch call per 64-key chunk
- V(1) log when `GetThrottleRatios` chunks large key sets
- Docs: scaling guide documents 64-pair batch throttle chunk size

Gate work in #510 (already on main): OOMKill E2E first-resize stabilization + lychee kind docs exclude; closed #509.

## Test plan

- [x] `go test ./internal/metrics/ -race`
- [x] `make verify-quick`
- [ ] PR CI