### PR TITLE
docs: fix new-user install accuracy and onboarding polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,18 @@ In-place apply is the shared primitive (Kubernetes `/resize`). Attune is the
 - Kubernetes 1.32+ (1.32 requires enabling the `InPlacePodVerticalScaling` feature gate; 1.33–1.34 beta enabled by default; **1.35+ GA**)
 - Prometheus (for usage metrics)
 - Helm 3.16+ or 4.x
-- [cert-manager](https://cert-manager.io/docs/installation/) (for admission webhook TLS; to skip, install with `--set webhooks.enabled=false`)
+- [cert-manager](https://cert-manager.io/docs/installation/) (required for admission webhook TLS by default; to skip, install with `--set webhooks.enabled=false`)
 
 **Optional GitOps export mode**: Recommendations can be written to ConfigMaps instead of (or in addition to) direct resizing. Ideal for ArgoCD/Flux workflows. See the [Auto mode guide](docs/guides/auto-mode.md#exporting-recommendations-to-configmaps).
 
 ### Install
 
 ```bash
+# Requires cert-manager when webhooks stay enabled (the default).
+# First-run footguns:
+#   --set webhooks.enabled=false          # skip cert-manager
+#   --set networkPolicy.prometheusPort=80 # if Prometheus Service is on :80
+#                                         # (chart default allows only :9090)
 helm install attune oci://ghcr.io/attune-io/charts/attune \
   --namespace attune-system --create-namespace
 ```
@@ -101,6 +106,8 @@ spec:
   metricsSource:
     prometheus:
       address: http://prometheus-server.monitoring:80
+    # Optional: faster first look (~1h instead of ~4h at default queryStep: 5m)
+    # minimumDataPoints: 12
   cpu:
     percentile: 95
     overhead: "20"
@@ -204,20 +211,27 @@ sudo cp bin/kubectl-attune /usr/local/bin/
 kubectl attune status -n production
 kubectl attune savings -n production
 kubectl attune recommendations -n production
-kubectl attune export -n production          # GitOps ConfigMap exports + last-updated
+kubectl attune preview -n production api-services   # current vs recommended before promote
+kubectl attune export -n production                 # GitOps ConfigMap exports + last-updated
 kubectl attune history -n production
 kubectl attune explain -n production api-services
+kubectl attune wizard                               # interactive policy scaffolding
+kubectl attune version
 
 # All namespaces
 kubectl attune status -A
 ```
 
-Example output:
+Example output (`kubectl attune status`):
 
 ```
-NAMESPACE   NAME          TYPE    WORKLOADS  RESIZED  READY       AGE
-production  api-services  Canary  3          1        Monitoring  2d
+NAMESPACE    NAME           TYPE    WORKLOADS  PENDING  RESIZED  READY        RESIZING  DEGRADED  SCHEDULE  CANARY  EXPORT  AGE
+production   api-services   Canary  3          0        1        Monitoring   Idle      -         -         -       -       2d
+```
 
+Example output (`kubectl attune recommendations`):
+
+```
 NAMESPACE   POLICY        WORKLOAD    CONTAINER  CPU REQ  CPU REC  MEM REQ  MEM REC  CONFIDENCE
 production  api-services  api-server  app        500m     320m     512Mi    384Mi    92.0%
 ```
@@ -339,18 +353,25 @@ The dashboard includes:
 
 ## Documentation
 
+Full docs site: [attune-io.github.io/attune](https://attune-io.github.io/attune/)
+
 | Guide | Description |
 |-------|-------------|
 | [Why Attune?](docs/why-attune.md) | The problem, why VPA fails, and how in-place resize changes everything |
 | [Savings Calculator](docs/savings-calculator.md) | Estimate your monthly savings with an interactive calculator |
+| [Installation](docs/getting-started/installation.md) | Helm, OLM, and raw manifests |
 | [Quickstart](docs/getting-started/quickstart.md) | Get running in 5 minutes |
 | [First 30 Days](docs/getting-started/first-30-days.md) | Day-by-day guide from install to production Auto mode |
+| [Prometheus Setup](docs/guides/prometheus-setup.md) | Metrics source, ServiceMonitor, dashboards, alerts |
 | [Migrating from VPA](docs/guides/migrating-from-vpa.md) | Step-by-step VPA replacement |
 | [HPA Coexistence](docs/guides/hpa-coexistence.md) | Running alongside HPA |
+| [SLO Guardrails](docs/guides/slo-guardrails.md) | PromQL app-health checks after resize |
+| [Runtime Profiles](docs/guides/runtime-profiles.md) | Language-aware memory defaults |
 | [Multi-Cluster](docs/guides/multi-cluster.md) | Deployment patterns, cross-cluster operations, and graduated rollouts |
 | [Scaling Guide](docs/guides/scaling.md) | Cluster size presets, tuning, and HA deployment |
 | [Canary Rollout](docs/guides/canary-rollout.md) | Graduated rollout strategy |
 | [Startup Boost](docs/guides/startup-boost.md) | Temporary CPU headroom for cold starts |
+| [Upgrading](docs/guides/upgrading.md) | Version upgrades and CRD refresh |
 | [CLI Reference](docs/reference/cli.md) | kubectl plugin commands |
 | [API Reference](docs/reference/api.md) | CRD specification |
 | [Troubleshooting](docs/guides/troubleshooting.md) | Common issues and solutions |

--- a/docs/getting-started/first-30-days.md
+++ b/docs/getting-started/first-30-days.md
@@ -28,6 +28,8 @@ Verify the operator is running and picked up your policy:
 
 ```bash
 kubectl attune status -n my-app
+# Without the plugin:
+# kubectl get attunepolicy -n my-app
 ```
 
 You should see your policy with **Ready** showing `InsufficientData` or a
@@ -37,7 +39,9 @@ normal.
 !!! tip "Verify operator config"
     Check the operator logs to confirm it started with the right settings:
     ```bash
-    kubectl logs -n attune-system deploy/attune-controller-manager | head -5
+    # Helm release name "attune" → Deployment "attune".
+    # Raw manifests use "attune-controller-manager" instead.
+    kubectl logs -n attune-system deploy/attune | head -5
     ```
     The first line shows all configured parameters (Prometheus QPS,
     watch namespaces, webhooks, etc.).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,14 +20,24 @@
 
 ## Install with Helm (recommended)
 
-Create a namespace and install the chart from the OCI registry:
+Create a namespace and install the chart from the OCI registry.
+
+**cert-manager** is required by default (admission webhooks). Install it first,
+or disable webhooks for a quick local trial:
 
 ```bash
+# Option A: production path (webhooks on)
+# Install cert-manager if needed: https://cert-manager.io/docs/installation/
 kubectl create namespace attune-system
 
 helm install attune \
   oci://ghcr.io/attune-io/charts/attune \
   --namespace attune-system
+
+# Option B: skip webhooks (no cert-manager)
+# helm install attune oci://ghcr.io/attune-io/charts/attune \
+#   --namespace attune-system --create-namespace \
+#   --set webhooks.enabled=false
 ```
 
 !!! tip "Large or multi-tenant clusters"
@@ -35,6 +45,24 @@ helm install attune \
     live in only a few namespaces, set `watchNamespaces`. See the
     [Scaling Guide](../guides/scaling.md) ops checklist before production
     rollout.
+
+!!! warning "NetworkPolicy and Prometheus port"
+    The chart enables a NetworkPolicy by default. Egress to Prometheus is
+    allowed only on `networkPolicy.prometheusPort` (default **9090**).
+    Many examples use a Service URL on port **80**
+    (`http://prometheus-server.monitoring:80`). If the Service port is 80
+    (or anything other than 9090), set the chart value to match or you will
+    see `PrometheusUnavailable` / no data:
+
+    ```bash
+    helm upgrade attune oci://ghcr.io/attune-io/charts/attune \
+      --namespace attune-system \
+      --set networkPolicy.prometheusPort=80
+    ```
+
+    For a first install on a restrictive cluster, you can temporarily set
+    `--set networkPolicy.enabled=false` while you confirm connectivity.
+    See the [Helm chart NetworkPolicy notes](https://github.com/attune-io/attune/blob/main/charts/attune/README.md#networkpolicy).
 
 !!! tip "Prometheus address"
     The Prometheus address is configured per-policy in
@@ -76,7 +104,7 @@ installed, you can install Attune directly from
 
 **On OpenShift 4.19+**, the operator is in the built-in OperatorHub
 **Community** catalog under package name **`attune`** (display name
-**Attune**; CSV names look like `attune.v0.1.16`). Search for "Attune"
+**Attune**; CSV names look like `attune.vX.Y.Z`). Search for "Attune"
 in the web console under **Operators > OperatorHub**, or verify with:
 
 ```bash

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -18,7 +18,8 @@ recommendations, and promoting to Canary mode, all in about five minutes.
 !!! info "Prerequisites"
     - **Kubernetes 1.32+** — 1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33–1.34 beta enabled by default; **1.35+ GA**.
     - **A metrics source** — Prometheus (default), Datadog, or CloudWatch Container Insights. This guide uses Prometheus; see [Datadog Setup](../guides/datadog-setup.md) or [CloudWatch Setup](../guides/cloudwatch-setup.md) for alternatives.
-    - **Attune installed** — see [Installation](installation.md) for Helm and raw manifest options.
+    - **Attune installed** — see [Installation](installation.md) for Helm and raw manifest options. Default Helm install needs **cert-manager** (or `--set webhooks.enabled=false`).
+    - **Prometheus reachability** — the chart NetworkPolicy allows Prometheus egress on port **9090** by default. If your Service listens on port **80** (common with `prometheus-server.monitoring:80`), set `--set networkPolicy.prometheusPort=80` at install time or you will get no data.
 
 ## What else can Attune do?
 
@@ -56,6 +57,8 @@ spec:
   metricsSource:
     prometheus:
       address: http://prometheus-server.monitoring:80
+  # Optional: faster first look (~1h instead of ~4h at default queryStep: 5m)
+  # minimumDataPoints: 12
 ```
 
 !!! tip "Skip the Prometheus address on every policy"

--- a/docs/guides/cloudwatch-setup.md
+++ b/docs/guides/cloudwatch-setup.md
@@ -70,7 +70,7 @@ approaches:
     eksctl create iamserviceaccount \
       --cluster my-eks-cluster \
       --namespace attune-system \
-      --name attune-controller-manager \
+      --name attune \
       --attach-policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/AttuneCWReadOnly \
       --approve
     ```
@@ -91,7 +91,7 @@ approaches:
     aws eks create-pod-identity-association \
       --cluster-name my-eks-cluster \
       --namespace attune-system \
-      --service-account attune-controller-manager \
+      --service-account attune \
       --role-arn arn:aws:iam::<ACCOUNT_ID>:role/AttuneCWRole
     ```
 
@@ -157,7 +157,7 @@ kubectl get attunepolicy my-app -n production -o wide
 Check the operator logs for CloudWatch-specific messages:
 
 ```bash
-kubectl logs -n attune-system deployment/attune-controller-manager \
+kubectl logs -n attune-system deployment/attune \
   --tail=50 | grep -i cloudwatch
 ```
 

--- a/docs/guides/datadog-setup.md
+++ b/docs/guides/datadog-setup.md
@@ -115,7 +115,7 @@ If the condition message mentions a Datadog API error, check the
 operator logs:
 
 ```bash
-kubectl logs -n attune-system deployment/attune-controller-manager \
+kubectl logs -n attune-system deployment/attune \
   --tail=50 | grep -i datadog
 ```
 

--- a/docs/guides/fips-compliance.md
+++ b/docs/guides/fips-compliance.md
@@ -71,7 +71,7 @@ not a FIPS-approved algorithm, so `fips140=only` refuses to use it, causing
 Check the operator logs after deployment:
 
 ```bash
-kubectl logs -n attune-system deploy/attune-controller-manager | head -20
+kubectl logs -n attune-system deploy/attune | head -20
 ```
 
 When FIPS mode is active, the Go runtime logs:

--- a/docs/guides/openshift.md
+++ b/docs/guides/openshift.md
@@ -17,7 +17,7 @@ all CRDs, RBAC, and the operator deployment.
 |---|---|
 | **Display name** | Attune |
 | **Package name** | `attune` |
-| **CSV name** | `attune.vX.Y.Z` (for example `attune.v0.1.16`) |
+| **CSV name** | `attune.vX.Y.Z` (matches the release version) |
 | **Channel** | `stable` |
 | **Catalog** | Community Operators (`community-operator-index`) |
 | **OpenShift versions** | **4.19+** (Attune requires Kubernetes 1.32+) |

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -700,7 +700,7 @@ If the policy appears stuck in `Terminating`, check the operator logs for
 pod update errors during cleanup:
 
 ```bash
-kubectl logs -n attune-system deploy/attune-controller-manager | grep "deletion cleanup"
+kubectl logs -n attune-system deploy/attune | grep "deletion cleanup"
 ```
 
 ## Large cluster performance
@@ -754,7 +754,7 @@ time this happens. Common causes:
 To diagnose, enable debug logging and check the Prometheus query results:
 
 ```bash
-kubectl logs -n attune-system deploy/attune-controller-manager \
+kubectl logs -n attune-system deploy/attune \
   | grep -E "stale|Prometheus query returned no data"
 ```
 

--- a/examples/01-getting-started.yaml
+++ b/examples/01-getting-started.yaml
@@ -6,8 +6,8 @@
 #
 # All fields except targetRef and metricsSource.prometheus.address are
 # optional. The operator applies sensible built-in defaults (P95 CPU,
-# P99 memory, 20% overhead, Recommend mode). Override only what
-# you need.
+# P99 memory, 20% CPU / 30% memory overhead, Recommend mode). Override
+# only what you need.
 #
 # Prerequisites:
 #   - Kubernetes 1.32+ with In-Place Pod Resize enabled (1.32 requires InPlacePodVerticalScaling feature gate)

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -143,7 +143,7 @@ helm install attune ./charts/attune \
   --wait --timeout 2m >/dev/null
 
 wait_for "operator ready" 60 \
-  "kubectl wait --for=condition=Available deployment/attune-controller-manager -n attune-system --timeout=5s"
+  "kubectl wait --for=condition=Available deployment/attune -n attune-system --timeout=5s"
 run kubectl get pods -n attune-system
 echo
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,9 +44,9 @@ nav:
   - Specification: SPEC.md
   - Savings Calculator: savings-calculator.md
   - Getting Started:
-      - Core Concepts: getting-started/concepts.md
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
+      - Core Concepts: getting-started/concepts.md
       - Your First 30 Days: getting-started/first-30-days.md
   - Guides:
       - Recommend Mode: guides/recommend-mode.md


### PR DESCRIPTION
## Summary

Improves new-user documentation accuracy and first-run success for Attune.

### Fixes
- **P0:** Helm paths now use Deployment/SA `attune` (not legacy `attune-controller-manager`) in first-30-days, troubleshooting, FIPS, Datadog, CloudWatch, and `hack/demo.sh`. Notes raw-manifest name where relevant.
- **P1:** Installation and README call out cert-manager requirement and NetworkPolicy `prometheusPort` (default 9090 vs example `:80` Service URLs).
- **P2:** README `kubectl attune status` sample matches real CLI columns; examples/01 overhead comment is 20% CPU / 30% memory.
- **P3:** README docs table expanded (install, Prometheus, SLO, runtime profiles, upgrading); plugin docs include `preview` / `wizard` / `version`; docs site link; mkdocs Getting Started order is Installation → Quick Start → Concepts → First 30 Days; soft CSV version examples.

## Test plan

- [x] Grep: no incorrect `attune-controller-manager` remaining in docs/hack (OLM CSV packaging left as-is)
- [x] Em-dash assert on edited human-facing markdown
- [x] Manual re-read of install, quickstart, README install/plugin sections
- [ ] Docs CI / markdown lint green on PR