### PR TITLE
test: guard mid-batch throttle failures and complete v0.1.22 docs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@ See [Upgrading](https://attune-io.github.io/attune/guides/upgrading/) and [Scali
 - PromQL Max aggregation by default, with status and docs for series caps and recording rules ([#488](https://github.com/attune-io/attune/pull/488), [#496](https://github.com/attune-io/attune/pull/496), [#499](https://github.com/attune-io/attune/pull/499)).
 - Large-fleet gaps closed: NS-wide pod list, metrics pod sampling, history and step clamps, blocker throttle status preservation, workload and HPA informer strip, batch safety throttle, default `--max-concurrent-reconciles=2` ([#490](https://github.com/attune-io/attune/pull/490), [#491](https://github.com/attune-io/attune/pull/491)).
 - Production `RateLimitedCollector` implements batch throttle so multi-pod safety uses one PromQL query instead of N rate-limited singles ([#502](https://github.com/attune-io/attune/pull/502), [#501](https://github.com/attune-io/attune/pull/501)).
+- Large observation sets chunk batch throttle PromQL into groups of 64 pod/container pairs, with one rate-limit token per chunk (not one token for the whole set) ([#507](https://github.com/attune-io/attune/pull/507), [#508](https://github.com/attune-io/attune/pull/508), [#511](https://github.com/attune-io/attune/pull/511)).
 
 ### Capacity and MemoryPressure
 
@@ -39,6 +40,7 @@ See [Upgrading](https://attune-io.github.io/attune/guides/upgrading/) and [Scali
 - Scaling ops checklist and high-replica guidance ([#487](https://github.com/attune-io/attune/pull/487)).
 - Docs Deploy no longer cancels in-flight main runs ([#489](https://github.com/attune-io/attune/pull/489)).
 - Enriched nightly failure GitHub issues with failed jobs and first Go E2E FAIL lines ([#485](https://github.com/attune-io/attune/pull/485)).
+- New-user install docs: cert-manager and NetworkPolicy Prometheus port footguns, Helm Deployment name `attune`, plugin status columns ([#512](https://github.com/attune-io/attune/pull/512)).
 
 ### Upgrade notes
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -155,14 +155,24 @@ Check that the operator pod is running:
 
 ```bash
 kubectl -n attune-system get pods
+kubectl -n attune-system get deploy
 ```
 
-Expected output:
+Expected output (Helm release name `attune`; Deployment name is **`attune`**):
 
 ```text
 NAME                              READY   STATUS    RESTARTS   AGE
 attune-6f8b4c7d9f-xk2pq  1/1     Running   0          30s
 ```
+
+!!! note "Deployment name by install path"
+    - **Helm** (recommended): Deployment and ServiceAccount are named after
+      the release (default `attune`). Logs:
+      `kubectl logs -n attune-system deploy/attune`
+    - **Raw manifests** (`install.yaml`): Deployment is
+      `attune-controller-manager`.
+    - **OLM / OperatorHub**: follows the CSV naming (often
+      `attune-controller-manager`).
 
 Verify that the three CRDs are registered:
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -34,6 +34,26 @@ See [Scaling: PromQL aggregation](scaling.md#promql-aggregation) and
 [Scaling: large fleets](scaling.md) for operator flags related to large fleets
 (`maxPodsInMetricsQuery`, `maxProfileSamples`, informer field strip).
 
+### Default max concurrent reconciles is 2
+
+The operator default for `--max-concurrent-reconciles` is **2** (was higher in
+some earlier builds). Helm `clusterSize` presets still override this when set.
+Large clusters that previously relied on more concurrent reconcilers should set
+the flag or a preset explicitly.
+
+### Request increases fail closed when node status is unavailable
+
+If the operator cannot read node status for a pod, it **skips request
+increases** (decreases still allowed) and increments
+`attune_capacity_skip_total{reason="unavailable"}`. This is protective if node
+API access or informer lag fails.
+
+### Batch throttle chunking (no config change)
+
+Safety observation batches CPU throttle PromQL queries and splits large
+pod/container sets into chunks of 64. No CRD field changes; Prometheus load
+for high-replica policies should drop further under rate limiting.
+
 ## v0.1.20 to v0.1.21
 
 v0.1.21 is a feature release. Existing policies keep working without YAML

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ real-world deployments:
 
 All examples assume:
 
-- Kubernetes 1.32+ (1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33+ enabled by default)
+- Kubernetes 1.32+ (1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33–1.34 beta enabled by default; 1.35+ GA)
 - Prometheus reachable inside the cluster
 - Attune operator installed:
 

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -1037,6 +1037,38 @@ func TestGetThrottleRatios_ChunksLargeKeySets(t *testing.T) {
 	}
 }
 
+// Second-chunk failure must not return a partial map (safety would treat
+// missing keys as "no throttle" if the caller installed a partial cache).
+func TestGetThrottleRatios_SecondChunkQueryError(t *testing.T) {
+	var queryCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryCount++
+		if queryCount == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"status":"error","errorType":"server","error":"boom"}`))
+	}))
+	defer server.Close()
+
+	collector, err := NewPrometheusCollector(server.URL, logr.Discard(), http.DefaultTransport)
+	require.NoError(t, err)
+
+	n := maxThrottleBatchKeys + 2
+	keys := make([]throttle.Key, n)
+	for i := range keys {
+		keys[i] = throttle.Key{Pod: fmt.Sprintf("pod-%d", i), Container: "app"}
+	}
+	out, err := collector.GetThrottleRatios(context.Background(), "ns", keys, time.Now())
+	require.Error(t, err)
+	assert.Nil(t, out)
+	assert.Contains(t, err.Error(), "batch throttle query failed")
+	assert.Equal(t, 2, queryCount)
+}
+
 func TestGetThrottleRatios_NonVectorResult(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/metrics/ratelimit_test.go
+++ b/internal/metrics/ratelimit_test.go
@@ -131,6 +131,9 @@ type mockThrottleCollector struct {
 	throttleRatio float64
 	batchCalls    int
 	batchOut      map[throttle.Key]float64
+	// batchFailOnCall, when >0, returns an error on that batchCalls count
+	// (1-based) so multi-chunk wrappers can prove they do not return partial maps.
+	batchFailOnCall int
 }
 
 func (m *mockThrottleCollector) GetThrottleRatio(_ context.Context, _, _, _ string, _ time.Time) (float64, error) {
@@ -140,8 +143,17 @@ func (m *mockThrottleCollector) GetThrottleRatio(_ context.Context, _, _, _ stri
 
 func (m *mockThrottleCollector) GetThrottleRatios(_ context.Context, _ string, keys []throttle.Key, _ time.Time) (map[throttle.Key]float64, error) {
 	m.batchCalls++
+	if m.batchFailOnCall > 0 && m.batchCalls == m.batchFailOnCall {
+		return nil, fmt.Errorf("simulated batch failure on call %d", m.batchCalls)
+	}
 	if m.batchOut != nil {
-		return m.batchOut, nil
+		part := make(map[throttle.Key]float64, len(keys))
+		for _, k := range keys {
+			if v, ok := m.batchOut[k]; ok {
+				part[k] = v
+			}
+		}
+		return part, nil
 	}
 	out := make(map[throttle.Key]float64, len(keys))
 	for _, k := range keys {
@@ -234,6 +246,24 @@ func TestRateLimitedCollector_GetThrottleRatios_ChunksLargeSets(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, out, n)
 	assert.Equal(t, 3, inner.batchCalls, "expect one batch call per chunk")
+}
+
+func TestRateLimitedCollector_GetThrottleRatios_SecondChunkError(t *testing.T) {
+	n := maxThrottleBatchKeys + 3
+	keys := make([]throttle.Key, n)
+	batchOut := make(map[throttle.Key]float64, n)
+	for i := range keys {
+		keys[i] = throttle.Key{Pod: fmt.Sprintf("pod-%d", i), Container: "app"}
+		batchOut[keys[i]] = 0.1
+	}
+	inner := &mockThrottleCollector{batchOut: batchOut, batchFailOnCall: 2}
+	rl := NewRateLimitedCollector(inner, 1000, 1000)
+
+	out, err := rl.GetThrottleRatios(context.Background(), "ns", keys, time.Now())
+	require.Error(t, err)
+	assert.Nil(t, out)
+	assert.Contains(t, err.Error(), "simulated batch failure")
+	assert.Equal(t, 2, inner.batchCalls)
 }
 
 func TestRateLimitedCollector_GetThrottleRatios_FallbackPerKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle on a mature codebase after the new-user docs pass (#512).

### QA / Adversarial
- Unit tests: second PromQL chunk failure returns **no partial** throttle map for both `PrometheusCollector` and `RateLimitedCollector` (safety must not treat missing keys as zero throttle when the batch aborts mid-flight).

### Docs / Maintainer
- `RELEASE_NOTES.md`: document batch throttle chunking (#507/#508/#511) and new-user install polish (#512).
- `docs/guides/upgrading.md`: expand v0.1.21→v0.1.22 with concurrent reconciles default, fail-closed node status, and throttle chunking.
- `docs/getting-started/installation.md`: Helm vs raw vs OLM Deployment names under Verify.
- `examples/README.md`: In-Place Resize version notes match product docs (1.35 GA).

### Gate notes
- Open PR **#477** (`chore(main): release 0.1.22`) left user-gated (not merged).
- Open issues remain community/outreach or postponed / #90 not due until 2026-08-25.

## Test plan

- [x] `go test ./internal/metrics/ -race -count=1`
- [x] Em-dash check on edited human-facing markdown
- [ ] CI green on PR