### PR TITLE
fix: trigger main CI after Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -35,12 +35,30 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-commit-verification: true
 
-      - name: Approve and enable auto-merge
+      # Approve with GITHUB_TOKEN (satisfies required-review rulesets).
+      # Enable auto-merge with the release App token so the eventual squash
+      # merge to main is NOT attributed to GITHUB_TOKEN. Merges created with
+      # GITHUB_TOKEN do not re-trigger push workflows on main (GitHub
+      # infinite-loop prevention), which left go.mod and Actions bumps without
+      # CI/Security/Docs on the merge commit (observed after #515/#516).
+      # Same App-token pattern as auto-approve.yaml for non-Dependabot PRs.
+      - name: Approve PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "$PR_URL"
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"
           echo "Auto-merge enabled for ${{ steps.metadata.outputs.update-type }} update"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,10 +359,15 @@ Dependabot PRs (#348, #349 etc.) are important for **Dependency-Update-Tool (10)
 3. The DCO workflow now explicitly skips merge commits (in addition to `[bot]` authors) so that occasional update accidents don't block PRs, while the meaningful diff commit still satisfies the spirit of the rule.
 4. After a clean rebase/push, new workflow runs will use the latest workflow definitions.
 5. Let `dependabot-auto-merge.yaml` (`pull_request_target`) handle approval
-   and auto-merge. It approves and enables `--auto --squash` for all semver
-   types (patch, minor, and major). `auto-approve.yaml` (`pull_request`)
+   and auto-merge. It approves with `GITHUB_TOKEN` and enables
+   `--auto --squash` with the release App token for all semver types
+   (patch, minor, and major). The App token is required so the squash
+   merge to main is not a `GITHUB_TOKEN` push (those do not re-trigger
+   CI/Security/Docs on main). `auto-approve.yaml` (`pull_request`)
    excludes `dependabot[bot]` because secrets are unavailable in that context.
 6. If the PR is behind and you want it to move faster, the rebase above + `gh pr comment` or just wait is preferred over broad CI skips.
+7. After a Dependabot merge, if main has no CI/Security runs for the merge
+   SHA, dispatch them: `gh workflow run CI --ref main` (and Security/Docs).
 
 **Grouped updates and semver classification:** `dependabot/fetch-metadata`
 classifies grouped updates by the **highest** semver type in the group. If

--- a/internal/metrics/datadog_test.go
+++ b/internal/metrics/datadog_test.go
@@ -360,5 +360,22 @@ func TestLatestSampleValue(t *testing.T) {
 	}
 }
 
+func TestNewDatadogCollector_Defaults(t *testing.T) {
+	c := NewDatadogCollector("", "api", "app", logr.Discard())
+	require.NotNil(t, c)
+	assert.Equal(t, "https://api.datadoghq.com", c.baseURL)
+	assert.Equal(t, "api", c.apiKey)
+	assert.Equal(t, "app", c.appKey)
+	assert.Equal(t, "kubernetes.cpu.usage.total", c.cpuMetricName)
+	require.NotNil(t, c.httpClient)
+	assert.Equal(t, 30*time.Second, c.httpClient.Timeout)
+}
+
+func TestNewDatadogCollector_CustomSite(t *testing.T) {
+	c := NewDatadogCollector("datadoghq.eu", "k", "a", logr.Discard())
+	require.NotNil(t, c)
+	assert.Equal(t, "https://api.datadoghq.eu", c.baseURL)
+}
+
 // Verify DatadogCollector implements MetricsCollector.
 var _ MetricsCollector = &DatadogCollector{}

--- a/internal/metrics/ratelimit_test.go
+++ b/internal/metrics/ratelimit_test.go
@@ -207,6 +207,23 @@ func TestRateLimitedCollector_GetThrottleRatio_CancelledContext(t *testing.T) {
 	assert.Equal(t, 0, inner.throttleCalls)
 }
 
+func TestRateLimitedCollector_GetThrottleRatios_CancelledContext(t *testing.T) {
+	inner := &mockThrottleCollector{throttleRatio: 0.5}
+	rl := NewRateLimitedCollector(inner, 10, 20)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	keys := []throttle.Key{
+		{Pod: "a", Container: "c"},
+		{Pod: "b", Container: "c"},
+	}
+	out, err := rl.GetThrottleRatios(ctx, "ns", keys, time.Now())
+	assert.Error(t, err)
+	assert.Nil(t, out)
+	assert.Equal(t, 0, inner.batchCalls)
+}
+
 func TestRateLimitedCollector_ImplementsBatchChecker(t *testing.T) {
 	// Production wraps Prometheus in RateLimitedCollector; safety casts to
 	// BatchChecker. Without GetThrottleRatios on the wrapper, batch is dead.


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle after Dependabot #515/#516.

### Ops / Maintainer (root cause from last session)
Squash merges of Dependabot PRs did not start CI/Security/Docs on main
because auto-merge was enabled with `GITHUB_TOKEN` (GitHub does not re-fire
workflows for `GITHUB_TOKEN` pushes).

**Fix:** `dependabot-auto-merge.yaml` now:
- Approves with `GITHUB_TOKEN` (ruleset review)
- Enables auto-merge with the release App token (same pattern as `auto-approve.yaml`)

Also documents the pattern and manual `gh workflow run` recovery in AGENTS.md.

### QA
- `TestRateLimitedCollector_GetThrottleRatios_CancelledContext`
- `TestNewDatadogCollector_Defaults` / `CustomSite`

### Gate notes
- Release **#477** left user-gated
- Open issues remain community/postponed or #90 (due 2026-08-25)

## Test plan

- [x] `go test ./internal/metrics/ -race -count=1`
- [ ] CI green on PR
- [ ] After next Dependabot merge, confirm push CI runs on main tip