### PR TITLE
fix: bump go to 1.26.6 and keep dockerfile in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Rebase when main moves so auto-merge is not stuck BEHIND.
+    rebase-strategy: auto
     labels:
       - dependencies
     open-pull-requests-limit: 5
@@ -14,18 +16,20 @@ updates:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
+      # First-match group order: k8s stays exclusive; remaining minor/patch
+      # land in one PR instead of N lockfile PRs.
       go-minor:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"
-        exclude-patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    rebase-strategy: auto
     labels:
       - dependencies
     open-pull-requests-limit: 5
@@ -40,6 +44,7 @@ updates:
     directory: /docs
     schedule:
       interval: monthly
+    rebase-strategy: auto
     labels:
       - dependencies
     open-pull-requests-limit: 3
@@ -50,6 +55,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    rebase-strategy: auto
     labels:
       - dependencies
     open-pull-requests-limit: 3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
               - 'go.sum'
               - 'Makefile'
               - 'Dockerfile'
+              - 'hack/verify-go-version-sync.sh'
               - '.github/workflows/ci.yaml'
             go-source:
               - '**/*.go'
@@ -133,6 +134,12 @@ jobs:
             git diff go.mod go.sum
             exit 1
           fi
+
+      - name: Verify go.mod matches Dockerfile golang tag
+        shell: bash -Eeuo pipefail {0}
+        run: |
+          bash scripts/test_verify_go_version_sync.sh
+          bash hack/verify-go-version-sync.sh
 
       - name: Check license boilerplate
         shell: bash -Eeuo pipefail {0}

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -62,6 +62,46 @@ jobs:
           gh pr merge --auto --squash "$PR_URL"
           echo "Auto-merge enabled for ${{ steps.metadata.outputs.update-type }} update"
 
+      # Dependabot docker PRs bump Dockerfile golang:X.Y.Z but not go.mod.
+      # setup-go / govulncheck read go.mod, so a Dockerfile-only bump stays
+      # red on stdlib CVEs. Copy the image tag into go.mod with the App
+      # token so the extra commit retriggers CI (GITHUB_TOKEN would not).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.metadata.outputs.package-ecosystem == 'docker'
+        with:
+          persist-credentials: false
+
+      - name: Sync go.mod with Dockerfile golang tag
+        if: steps.metadata.outputs.package-ecosystem == 'docker'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        shell: bash -Eeuo pipefail {0}
+        run: |
+          # Copy the script from this trusted main checkout before switching
+          # to the Dependabot branch (do not execute PR-controlled files).
+          if [[ ! -f hack/verify-go-version-sync.sh ]]; then
+            echo "OK: sync script not on this main yet; skip"
+            exit 0
+          fi
+          cp hack/verify-go-version-sync.sh /tmp/verify-go-version-sync.sh
+          git fetch origin "$PR_BRANCH"
+          git checkout -B "sync-go-version" "origin/${PR_BRANCH}"
+          bash /tmp/verify-go-version-sync.sh --write
+          if git diff --quiet -- go.mod; then
+            echo "OK: go.mod already matches Dockerfile"
+            exit 0
+          fi
+          git config user.name "attune-release-bot[bot]"
+          git config user.email "3904235+attune-release-bot[bot]@users.noreply.github.com"
+          git add go.mod
+          git commit -s -m "chore(deps): sync go.mod with Dockerfile golang tag"
+          git push \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
+            "HEAD:refs/heads/${PR_BRANCH}"
+          echo "OK: pushed go.mod sync to ${PR_BRANCH}"
+
   # NOTE: A rebase-dependabot job was removed here. It updated open
   # Dependabot PR branches on every push to main, but caused more harm
   # than good: GITHUB_TOKEN pushes do not trigger other workflows (GitHub

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,6 +389,13 @@ See also:
 
 When in doubt, prefer letting Dependabot open a fresh PR on conflict rather than force-updating an old one.
 
+**Go patch releases:** `go.mod` (`go X.Y.Z`) and the Dockerfile
+(`golang:X.Y.Z@sha256:...`) must stay on the same patch. `setup-go` and
+govulncheck read `go.mod`; Dependabot docker PRs only bump the image.
+`hack/verify-go-version-sync.sh` enforces the match. The Dependabot
+auto-merge workflow copies the Dockerfile tag into `go.mod` on docker
+PRs so those updates can go green without a human follow-up.
+
 ### Issue closure in PR descriptions
 
 Before running `gh pr create`, check open issues and include `Closes #N`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,7 +279,7 @@ Dependabot is configured for four ecosystems:
 | `gomod` | `/` | weekly | K8s deps grouped separately |
 | `github-actions` | `/` | weekly | All actions grouped |
 | `pip` | `/docs` | monthly | MkDocs site dependencies |
-| `docker` | `/` | weekly | Base image updates |
+| `docker` | `/` | weekly | Base image updates (`golang:X.Y.Z` must match `go.mod`) |
 
 **If you add a new `go.mod`** (e.g., `tools/go.mod` for build tooling):
 
@@ -297,6 +297,12 @@ Dependabot is configured for four ecosystems:
 
 Currently there is no `go.work` file because the single-module layout does
 not require one.
+
+The Dockerfile `golang:X.Y.Z` tag and the `go.mod` `go X.Y.Z` directive
+must stay on the same patch. `make verify-go-version-sync` (and Lint CI)
+enforces this. Dependabot docker PRs only bump the image; the auto-merge
+workflow copies the new tag into `go.mod` so those PRs can pass
+govulncheck without a manual follow-up.
 
 ## Code of Conduct
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # BuildKit features (--platform, --mount) are supported natively since Docker 20.10.
 # No # syntax directive needed; it triggers a registry pull that fails on macOS
 # self-hosted runners where the keychain is locked in headless sessions.
-FROM --platform=$BUILDPLATFORM golang:1.26.5@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ verify-dashboard-metrics: ## Verify Helm dashboard stays synced with the standal
 verify-doc-tool-versions: ## Verify supported tool version references stay consistent in docs
 	@bash hack/verify-doc-tool-versions.sh
 
+.PHONY: verify-go-version-sync
+verify-go-version-sync: ## Verify go.mod go directive matches Dockerfile golang image tag
+	@bash hack/verify-go-version-sync.sh
+
 .PHONY: verify-prometheusrule-metrics
 verify-prometheusrule-metrics: ## Verify PrometheusRule alert expressions use real operator metrics
 	@bash hack/verify-prometheusrule-metrics.sh
@@ -122,7 +126,7 @@ ci-runner-status: ## Show queued/in-progress CI runs
 	fi
 
 .PHONY: verify-quick
-verify-quick: lint yaml-lint lint-chainsaw test python-test helm-lint helm-docs-check helm-unittest verify-boilerplate tidy-check verify-doc-defaults verify-helm-rbac verify-dashboard-metrics verify-doc-tool-versions verify-prometheusrule-metrics verify-helm-schema-fields verify-release-artifacts ## Fast pre-commit checks (no integration tests or govulncheck)
+verify-quick: lint yaml-lint lint-chainsaw test python-test helm-lint helm-docs-check helm-unittest verify-boilerplate tidy-check verify-doc-defaults verify-helm-rbac verify-dashboard-metrics verify-doc-tool-versions verify-go-version-sync verify-prometheusrule-metrics verify-helm-schema-fields verify-release-artifacts ## Fast pre-commit checks (no integration tests or govulncheck)
 
 .PHONY: verify
 verify: verify-quick test-integration govulncheck ## Run all CI checks locally (includes integration tests)
@@ -226,9 +230,10 @@ test-fuzz: ## Run fuzz tests (coverage-guided; FUZZTIME=30s default, deadline-fl
 	./scripts/run-fuzz.sh
 
 .PHONY: python-test
-python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier)
+python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync)
 	python3 scripts/test_fossa_filter.py -v
 	bash scripts/test_run_fuzz.sh
+	bash scripts/test_verify_go_version_sync.sh
 
 .PHONY: test-bench
 test-bench: ## Run benchmark tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/attune-io/attune
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4

--- a/hack/verify-go-version-sync.sh
+++ b/hack/verify-go-version-sync.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Keep go.mod `go X.Y.Z` in sync with the Dockerfile `golang:X.Y.Z` pin.
+# setup-go and govulncheck read go.mod. Dependabot docker PRs only bump
+# the image tag, so the two pins drift unless something copies the tag
+# into go.mod (this script, or the Dependabot auto-merge workflow).
+
+set -euo pipefail
+
+MODE="check"
+ROOT=""
+
+usage() {
+  cat <<'EOF'
+Usage: verify-go-version-sync.sh [--check|--write] [--root DIR]
+
+--check  Fail if go.mod and Dockerfile Go versions differ (default).
+--write  Update go.mod `go` directive to match Dockerfile golang: tag.
+--root   Repository root (default: parent of this script's directory).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) MODE="check"; shift ;;
+    --write) MODE="write"; shift ;;
+    --root)
+      if [[ $# -lt 2 ]]; then
+        echo "FAIL: --root requires a directory argument" >&2
+        exit 1
+      fi
+      ROOT="$2"
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "FAIL: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$ROOT" ]]; then
+  ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+echo "PLAN: compare go.mod go directive with Dockerfile golang tag (mode=${MODE})"
+
+GOMOD="${ROOT}/go.mod"
+DOCKERFILE="${ROOT}/Dockerfile"
+
+if [[ ! -f "$GOMOD" ]]; then
+  echo "FAIL: go.mod not found at ${GOMOD}"
+  echo "DONE: ok=false reason=missing-go-mod"
+  exit 1
+fi
+if [[ ! -f "$DOCKERFILE" ]]; then
+  echo "FAIL: Dockerfile not found at ${DOCKERFILE}"
+  echo "DONE: ok=false reason=missing-dockerfile"
+  exit 1
+fi
+
+extract_go_mod_version() {
+  # First `go X.Y` or `go X.Y.Z` directive (not toolchain).
+  local line
+  line="$(grep -E '^go [0-9]+\.[0-9]+(\.[0-9]+)?[[:space:]]*$' "$1" | head -n 1 || true)"
+  if [[ -z "$line" ]]; then
+    echo ""
+    return 0
+  fi
+  echo "${line#go }"
+}
+
+extract_dockerfile_version() {
+  # First official golang:X.Y.Z image (digest suffix optional).
+  local line
+  line="$(grep -E 'golang:[0-9]+\.[0-9]+' "$1" | head -n 1 || true)"
+  if [[ -z "$line" ]]; then
+    echo ""
+    return 0
+  fi
+  echo "$line" | sed -E 's/.*golang:([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/'
+}
+
+echo "DO: read versions from ${GOMOD} and ${DOCKERFILE}"
+GO_MOD_VER="$(extract_go_mod_version "$GOMOD")"
+DOCKER_VER="$(extract_dockerfile_version "$DOCKERFILE")"
+
+if [[ -z "$GO_MOD_VER" ]]; then
+  echo "FAIL: no go X.Y.Z directive in ${GOMOD}"
+  echo "DONE: ok=false reason=unparseable-go-mod"
+  exit 1
+fi
+if [[ -z "$DOCKER_VER" ]]; then
+  echo "FAIL: no golang:X.Y.Z image in ${DOCKERFILE}"
+  echo "DONE: ok=false reason=unparseable-dockerfile"
+  exit 1
+fi
+
+echo "OK: go.mod=${GO_MOD_VER} dockerfile=${DOCKER_VER}"
+
+if [[ "$GO_MOD_VER" == "$DOCKER_VER" ]]; then
+  echo "DONE: ok=true synced=true go=${GO_MOD_VER}"
+  echo "NEXT: none"
+  exit 0
+fi
+
+if [[ "$MODE" != "write" ]]; then
+  echo "FAIL: go.mod go ${GO_MOD_VER} != Dockerfile golang:${DOCKER_VER}"
+  echo "HINT: run 'bash hack/verify-go-version-sync.sh --write' or let the Dependabot auto-merge workflow sync docker PRs."
+  echo "DONE: ok=false reason=mismatch go_mod=${GO_MOD_VER} dockerfile=${DOCKER_VER}"
+  echo "NEXT: bump the go.mod go directive to ${DOCKER_VER} (or the Dockerfile tag to ${GO_MOD_VER})"
+  exit 1
+fi
+
+echo "DO: write go ${DOCKER_VER} into ${GOMOD}"
+tmp="$(mktemp)"
+# Replace only the first `go X.Y[.Z]` directive. Leave toolchain and comments.
+awk -v ver="$DOCKER_VER" '
+  BEGIN { done = 0 }
+  /^go [0-9]+\.[0-9]+(\.[0-9]+)?[[:space:]]*$/ && !done {
+    print "go " ver
+    done = 1
+    next
+  }
+  { print }
+' "$GOMOD" > "$tmp"
+mv "$tmp" "$GOMOD"
+
+echo "OK: updated go.mod to go ${DOCKER_VER}"
+echo "DONE: ok=true synced=false wrote=true go=${DOCKER_VER}"
+echo "NEXT: commit go.mod"
+exit 0

--- a/scripts/test_verify_go_version_sync.sh
+++ b/scripts/test_verify_go_version_sync.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Unit tests for hack/verify-go-version-sync.sh.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT}/hack/verify-go-version-sync.sh"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+assert_eq() {
+  local want="$1" got="$2" name="$3"
+  if [[ "$want" != "$got" ]]; then
+    echo "FAIL: $name: want=$want got=$got" >&2
+    exit 1
+  fi
+  echo "ok: $name"
+}
+
+assert_contains() {
+  local needle="$1" haystack="$2" name="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "FAIL: $name: missing '${needle}' in: ${haystack}" >&2
+    exit 1
+  fi
+  echo "ok: $name"
+}
+
+write_pair() {
+  local dir="$1" go_ver="$2" docker_ver="$3"
+  mkdir -p "$dir"
+  printf 'module example.com/x\n\ngo %s\n' "$go_ver" >"${dir}/go.mod"
+  printf 'FROM --platform=$BUILDPLATFORM golang:%s@sha256:deadbeef AS builder\n' \
+    "$docker_ver" >"${dir}/Dockerfile"
+}
+
+echo "PLAN: exercise verify-go-version-sync check/write modes"
+
+# Matching versions: success.
+pair="${tmpdir}/match"
+write_pair "$pair" "1.26.6" "1.26.6"
+out="$("$SCRIPT" --check --root "$pair")"
+assert_contains "DONE: ok=true" "$out" "match prints ok=true"
+"$SCRIPT" --check --root "$pair" >/dev/null
+echo "ok: match exits 0"
+
+# Mismatch: check fails, write updates go.mod.
+pair="${tmpdir}/mismatch"
+write_pair "$pair" "1.26.5" "1.26.6"
+set +e
+out="$("$SCRIPT" --check --root "$pair" 2>&1)"
+rc=$?
+set -e
+assert_eq "1" "$rc" "mismatch check exit 1"
+assert_contains "reason=mismatch" "$out" "mismatch names reason"
+"$SCRIPT" --write --root "$pair" >/dev/null
+got="$(grep -E '^go ' "${pair}/go.mod")"
+assert_eq "go 1.26.6" "$got" "write updates go.mod"
+"$SCRIPT" --check --root "$pair" >/dev/null
+echo "ok: write then check exits 0"
+
+# Missing Dockerfile.
+pair="${tmpdir}/nodocker"
+mkdir -p "$pair"
+printf 'module example.com/x\n\ngo 1.26.6\n' >"${pair}/go.mod"
+set +e
+out="$("$SCRIPT" --check --root "$pair" 2>&1)"
+rc=$?
+set -e
+assert_eq "1" "$rc" "missing Dockerfile exit 1"
+assert_contains "missing-dockerfile" "$out" "missing Dockerfile reason"
+
+# Unparseable Dockerfile.
+pair="${tmpdir}/badimage"
+mkdir -p "$pair"
+printf 'module example.com/x\n\ngo 1.26.6\n' >"${pair}/go.mod"
+printf 'FROM alpine:3.22\n' >"${pair}/Dockerfile"
+set +e
+out="$("$SCRIPT" --check --root "$pair" 2>&1)"
+rc=$?
+set -e
+assert_eq "1" "$rc" "unparseable Dockerfile exit 1"
+assert_contains "unparseable-dockerfile" "$out" "unparseable Dockerfile reason"
+
+echo "DONE: verify-go-version-sync tests passed"


### PR DESCRIPTION
## Summary

Unblock Dependabot auto-merge. Weekly Security and the three open dependency PRs (#521, #522, #523) are red because govulncheck reports six Go 1.26.5 standard-library CVEs that are already fixed in 1.26.6.

Auto-merge was already enabled and the PRs are approved. They cannot merge while Govulncheck (a required check) fails.

## Problem

Dependabot is working as designed:

- `dependabot-auto-merge.yaml` approved the PRs and armed squash auto-merge
- Grouped updates and the App-token merge path are in place

What broke the loop is a pin split:

1. Dependabot docker opened #521 to bump `Dockerfile` to `golang:1.26.6`
2. `actions/setup-go` and govulncheck read `go.mod`, which still said `go 1.26.5`
3. So #521, the go-minor PR, and the actions PR all fail the same scan that failed on `main` this morning (scheduled Security run)

Without a matching `go.mod` bump, every future Go patch will produce the same pile of red PRs.

## Change

- Bump `go.mod` and `Dockerfile` to 1.26.6 (image digest checked against `golang:1.26.6`)
- Add `hack/verify-go-version-sync.sh` so the two pins cannot drift (`make verify-go-version-sync`, Lint CI)
- On Dependabot docker PRs, the auto-merge workflow copies the Dockerfile tag into `go.mod` with the release App token so CI retriggers
- Set `rebase-strategy: auto` on every Dependabot ecosystem so PRs do not sit BEHIND after a peer merge

#521 (Dockerfile-only 1.26.6) is superseded by this PR and can be closed after merge.

## Validation

- `bash scripts/test_verify_go_version_sync.sh` (match, mismatch, `--write`, missing/unparseable Dockerfile)
- `bash hack/verify-go-version-sync.sh` on the live tree
- `GOTOOLCHAIN=go1.26.6 govulncheck ./...` → `No vulnerabilities found`
- Image digest `sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6` matches `crane digest golang:1.26.6`
