### PR TITLE
ci: group pip docs minor/patch into one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,15 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      # One docs PR per month for minor/patch. Majors (e.g. backrefs 7->8)
+      # stay ungrouped so a docs API break is reviewed alone.
+      docs-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: docker
     directory: /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,7 +278,7 @@ Dependabot is configured for four ecosystems:
 |-----------|-----------|----------|-------|
 | `gomod` | `/` | weekly | K8s deps grouped separately |
 | `github-actions` | `/` | weekly | All actions grouped |
-| `pip` | `/docs` | monthly | MkDocs site dependencies |
+| `pip` | `/docs` | monthly | One `docs-minor-patch` PR; majors stay solo |
 | `docker` | `/` | weekly | Base image updates (`golang:X.Y.Z` must match `go.mod`) |
 
 **If you add a new `go.mod`** (e.g., `tools/go.mod` for build tooling):


### PR DESCRIPTION
## Summary

Put monthly docs pip minor and patch bumps in one Dependabot PR, matching Go and Actions.

## Problem

This morning certifi (#526), packaging (#528), and backrefs (#527) each opened as their own PR. Each merge moved `main` and knocked the actions bump (#523) `BEHIND`, so it had to be rebased three times before it could merge.

## Change

Add a `docs-minor-patch` group on the pip `/docs` ecosystem (`patterns: ["*"]`, minor and patch only). Majors stay ungrouped so a docs API break (backrefs 7 to 8) is still a separate review.

## Validation

Config-only. Dependabot grouping is first-match, same pattern as `go-minor`.
