### PR TITLE
fix: skip requeue jitter during InsufficientData bootstrap

### DIFF
--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -674,15 +674,21 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	// During data collection, use a shorter interval so new policies bootstrap
 	// faster. The cooldown is designed to space out resizes, not data collection.
-	if readyCond := meta.FindStatusCondition(policy.Status.Conditions, attunev1alpha1.ConditionReady); readyCond != nil && readyCond.Reason == attunev1alpha1.ReasonInsufficientData {
+	readyCond := meta.FindStatusCondition(policy.Status.Conditions, attunev1alpha1.ConditionReady)
+	if readyCond != nil && readyCond.Reason == attunev1alpha1.ReasonInsufficientData {
 		dataInterval := r.getQueryStep(&policy)
 		if dataInterval < requeueAfter {
 			requeueAfter = dataInterval
 		}
 	}
 	// Only jitter full cooldown requeues so bootstrap / observation short
-	// intervals stay tight for data collection and e2e.
-	if requeueAfter == cooldown {
+	// intervals stay tight for data collection and e2e. When cooldown is
+	// already shorter than queryStep (for example cooldown 1m vs 5m step),
+	// InsufficientData still uses cooldown. Jittering that wait delayed
+	// first recommendations by up to RequeueJitter (nightly #520).
+	bootstrap := readyCond != nil && (readyCond.Reason == attunev1alpha1.ReasonInsufficientData ||
+		readyCond.Reason == attunev1alpha1.ReasonPrometheusUnavailable)
+	if requeueAfter == cooldown && !bootstrap {
 		requeueAfter = r.addRequeueJitter(requeueAfter, &policy)
 	}
 	logger.Info("Reconciliation complete, requeueing", "requeueAfter", requeueAfter)

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -11403,6 +11403,33 @@ func TestReconcile_InsufficientDataRequeuesAtQueryStep(t *testing.T) {
 		"InsufficientData should requeue at queryStep interval, not cooldown")
 }
 
+// Nightly #520: cooldown 1m is shorter than default queryStep 5m, so the
+// InsufficientData shortcut leaves requeueAfter == cooldown. Jitter must
+// not apply or first recommendations wait up to cooldown+jitter (3m with
+// the default 2m jitter), which races the configmap-export 3m timeout.
+func TestReconcile_InsufficientDataShortCooldownDoesNotJitter(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	policy.UID = "e2e-configmap-export-uid"
+	policy.Spec.UpdateStrategy.Cooldown = &metav1.Duration{Duration: 1 * time.Minute}
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	pod := newTestPod("api-server-abc-1", "default", map[string]string{"app": "api-server"})
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return generateSamples(20, 0.1), nil // below 48 threshold
+		},
+	}
+	reconciler, _ := newReconcilerForReconcile(mc, policy, deploy, pod)
+	reconciler.RequeueJitter = 2 * time.Minute
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1*time.Minute, result.RequeueAfter,
+		"InsufficientData must not add RequeueJitter when cooldown < queryStep")
+}
+
 func TestReconcile_SufficientDataRequeuesAtCooldown(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	policy.Spec.UpdateStrategy.Cooldown = &metav1.Duration{Duration: 2 * time.Hour}

--- a/scripts/nightly-failure-issue-body.sh
+++ b/scripts/nightly-failure-issue-body.sh
@@ -71,10 +71,24 @@ if [[ -n "$ARTIFACT_DIR" && -d "$ARTIFACT_DIR" ]]; then
   if ((${#fails[@]} > 0)); then
     fail_tests_md=$(printf -- '- `%s`\n' "${fails[@]}")
   fi
-  # Chainsaw summary if present
-  chainsaw_line=$(find "$ARTIFACT_DIR" -type f -name 'chainsaw*.log' 2>/dev/null | head -1 | while read -r f; do
-    grep -E 'Failed\s+tests|FAIL\s|Tests Summary' "$f" 2>/dev/null | tail -5
-  done || true)
+  # Chainsaw summary: prefer a log that actually failed tests. find | head -1
+  # is filesystem-order and can pick a passing matrix variant ("Failed tests 0")
+  # while another variant failed (nightly #520).
+  chainsaw_line=""
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    snippet=$(grep -E 'Failed[[:space:]]+tests[[:space:]]+[1-9]|--- FAIL: chainsaw/' "$f" 2>/dev/null | tail -8 || true)
+    if [ -n "$snippet" ]; then
+      chainsaw_line="$snippet"
+      break
+    fi
+  done < <(find "$ARTIFACT_DIR" -type f -name 'chainsaw*.log' 2>/dev/null | sort)
+  if [ -z "$chainsaw_line" ]; then
+    first=$(find "$ARTIFACT_DIR" -type f -name 'chainsaw*.log' 2>/dev/null | sort | head -1)
+    if [ -n "$first" ]; then
+      chainsaw_line=$(grep -E 'Failed[[:space:]]+tests|Tests Summary|--- FAIL:' "$first" 2>/dev/null | tail -8 || true)
+    fi
+  fi
 fi
 
 {

--- a/scripts/test_nightly_failure_issue_body.sh
+++ b/scripts/test_nightly_failure_issue_body.sh
@@ -8,7 +8,10 @@ trap 'rm -rf "$TMP"' EXIT
 
 mkdir -p "$TMP/art"
 printf '%s\n' '--- FAIL: TestE2E_NodeMemoryPressure_SkipsMemoryIncrease (1s)' >"$TMP/art/go-e2e.log"
-printf '%s\n' 'Tests Summary...' 'Failed  tests 1' >"$TMP/art/chainsaw.log"
+# Passing variant sorts first; the reporter must still surface the failing cell.
+printf '%s\n' 'Tests Summary...' '- Failed  tests 0' >"$TMP/art/chainsaw-v1.32.log"
+printf '%s\n' '--- FAIL: chainsaw/configmap-export (200.33s)' 'Tests Summary...' '- Failed  tests 1' \
+  >"$TMP/art/chainsaw-v1.34.log"
 
 body=$("$SCRIPT" \
   --run-url 'https://example.com/actions/runs/99' \
@@ -20,6 +23,8 @@ echo "$body" | grep -q 'E2E result: `failure`'
 echo "$body" | grep -q 'Fuzz result: `success`'
 echo "$body" | grep -q 'TestE2E_NodeMemoryPressure_SkipsMemoryIncrease'
 echo "$body" | grep -q 'https://example.com/actions/runs/99'
+echo "$body" | grep -q 'configmap-export'
+echo "$body" | grep -q 'Failed  tests 1'
 
 # Minimal path without artifacts still works
 body2=$("$SCRIPT" \

--- a/test/e2e/configmap-export/chainsaw-test.yaml
+++ b/test/e2e/configmap-export/chainsaw-test.yaml
@@ -6,10 +6,10 @@ spec:
   description: Verify that recommendations are exported to a ConfigMap when export.configMap is enabled
   timeouts:
     apply: 30s
-    assert: 3m
+    assert: 5m
     delete: 30s
   steps:
-    - name: create-resources
+    - name: create-namespace-and-deployment
       try:
         - apply:
             resource:
@@ -41,6 +41,19 @@ spec:
                           requests:
                             cpu: 100m
                             memory: 128Mi
+    - name: verify-deployment-ready
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: export-app
+                namespace: e2e-configmap-export
+              status:
+                readyReplicas: 1
+    - name: create-policy
+      try:
         - apply:
             resource:
               apiVersion: attune.io/v1alpha1
@@ -68,23 +81,12 @@ spec:
                   cooldown: 1m
                   export:
                     configMap: true
-    - name: verify-deployment-ready
-      try:
-        - assert:
-            resource:
-              apiVersion: apps/v1
-              kind: Deployment
-              metadata:
-                name: export-app
-                namespace: e2e-configmap-export
-              status:
-                readyReplicas: 1
     - name: verify-configmap-created
       try:
         - script:
-            timeout: 3m
+            timeout: 5m
             content: |
-              for i in $(seq 1 36); do
+              for i in $(seq 1 60); do
                 CM=$(kubectl get configmap -n e2e-configmap-export \
                   -l attune.io/policy=export-test \
                   -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
@@ -127,6 +129,8 @@ spec:
         apiVersion: attune.io/v1alpha1
         kind: AttunePolicy
         namespace: e2e-configmap-export
+    - script:
+        content: kubectl get configmap -n e2e-configmap-export -o yaml
     - podLogs:
         namespace: attune-system
         selector: app.kubernetes.io/name=attune


### PR DESCRIPTION
Skip requeue jitter while a policy is still collecting data, so first recommendations and ConfigMap export are not delayed by up to `cooldown + requeue-jitter`.

## Problem

Nightly 2026-08-14 (run 31771015863) failed only on K8s v1.34. The single failed test was `chainsaw/configmap-export` (`verify-configmap-created`, `signal: killed` at 200s).

The operator was not stuck. Timeline:

1. Policy was created together with the Deployment, so the first reconcile skipped the workload (`RolloutInProgress`).
2. Ready stayed `InsufficientData`. Cooldown is 1m and default `queryStep` is 5m, so the bootstrap shortcut left `requeueAfter == cooldown`.
3. The "only jitter full cooldown" guard then added `RequeueJitter` (default 2m). Next attempt waited up to 3m.
4. Recommendations (and export) landed at 05:03:21. Chainsaw killed the 3m poll at 05:03:25.

Export itself is correct: `exportRecommendationConfigMaps` runs in the same reconcile once recommendations exist. The same SHA passed nightlies on 11-13 and 15-17 Aug. Sibling `configmap-orphan-cleanup` (5m timeout) passed in 202s on the failing run.

The issue body said `Failed tests 0` because `nightly-failure-issue-body.sh` took `find | head -1` and could pick a passing matrix log.

## Change

- Do not add `RequeueJitter` when Ready is `InsufficientData` or `PrometheusUnavailable`.
- Unit test: 1m cooldown + 2m jitter + insufficient samples must requeue at exactly 1m.
- `configmap-export` E2E: create the policy after the Deployment is Ready; raise the wait to 5m; dump ConfigMaps on catch.
- Nightly issue body: prefer a Chainsaw log that actually failed tests.

## Validation

- `go test ./internal/controller/ -race -count=1 -run TestReconcile_InsufficientDataShortCooldownDoesNotJitter` (red before the fix: 1m2s; green after: 1m)
- Related requeue tests (`InsufficientDataRequeuesAtQueryStep`, `SufficientDataRequeuesAtCooldown`, `PrometheusUnavailable`, `SkipsMidRollout`)
- `bash scripts/test_nightly_failure_issue_body.sh`
- `golangci-lint run ./internal/controller/`

Closes #520
