### PR TITLE
fix: reject Inf fleet savings and document jitter skip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ make build-crds
 ### Running Tests
 
 ```bash
-# Unit tests (1100+ test functions, 80% coverage threshold enforced, currently ~92%)
+# Unit tests (1300+ test functions, 80% coverage threshold enforced, currently ~92%)
 make test
 
 # Integration tests (uses envtest, no cluster needed)
@@ -108,18 +108,24 @@ make docker-build IMG=attune:dev
 
 ### Pre-commit Checklist
 
-Run `make verify` before every commit. It covers:
-- golangci-lint (code quality + import alias enforcement)
-- Unit and integration tests with coverage threshold (80%)
-- Helm lint + template validation
-- Helm chart docs freshness and unit tests
-- CRD manifest freshness (`make manifests` output matches committed files)
-- Grafana dashboard sync (`deploy/grafana/dashboard.json` source and generated Helm dashboard stay aligned)
-- Documentation defaults consistency check
-- govulncheck for known vulnerabilities
+Run `make verify` before every commit. The Makefile `verify` and
+`verify-quick` targets are the source of truth (not this list). Today
+`make verify-quick` runs:
 
-For faster feedback on docs-only or YAML-only changes, use `make verify-quick`
-(skips integration tests and govulncheck).
+- golangci-lint, yaml-lint, Chainsaw lint, unit tests, Python tests
+- Helm lint, helm-docs freshness, Helm unit tests
+- boilerplate, `go mod tidy`, documentation defaults
+- Helm RBAC vs generated ClusterRole, Grafana dashboard sync
+- documentation tool versions, Go version sync (go.mod vs Dockerfile)
+- PrometheusRule metric names, Helm schema fields, release artifacts
+  (`dist/install.yaml` and `dist/crds.yaml`)
+
+`make verify` then adds integration tests, govulncheck, and a generated
+file freshness check (`make manifests generate` must not change CRDs,
+Helm CRDs, deepcopy, or RBAC).
+
+For faster feedback on docs-only or YAML-only changes, use
+`make verify-quick` (skips integration tests and govulncheck).
 
 If you changed CRD types (`api/v1alpha1/`), also run:
 ```bash

--- a/api/v1alpha1/attunepolicy_types_test.go
+++ b/api/v1alpha1/attunepolicy_types_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultConstants(t *testing.T) {
@@ -42,5 +44,34 @@ func TestDefaultConstants(t *testing.T) {
 	}
 	for _, r := range reasons {
 		assert.NotEmpty(t, r, "reason constant should not be empty")
+	}
+}
+
+func TestIsSupportedTargetKind(t *testing.T) {
+	t.Parallel()
+
+	supported := strings.Split(SupportedTargetKindsCSV, ", ")
+	require.NotEmpty(t, supported)
+	for _, kind := range supported {
+		assert.True(t, IsSupportedTargetKind(kind), "CSV kind %q must be accepted", kind)
+	}
+
+	// Must stay aligned with the kubebuilder Enum on TargetRef.Kind.
+	assert.Equal(t, []string{
+		"Deployment", "StatefulSet", "DaemonSet", "CronJob", "Job", "ReplicaSet",
+	}, supported)
+
+	rejects := []string{
+		"",
+		"deployment",
+		"DEPLOYMENT",
+		" Deployment",
+		"Pod",
+		"HorizontalPodAutoscaler",
+		"Rollout",
+		"ReplicaSet ",
+	}
+	for _, kind := range rejects {
+		assert.False(t, IsSupportedTargetKind(kind), "kind %q must be rejected", kind)
 	}
 }

--- a/charts/attune/README.md
+++ b/charts/attune/README.md
@@ -102,7 +102,7 @@ helm install attune oci://ghcr.io/attune-io/charts/attune \
 | prometheusQPS | int | `10` | Prometheus query rate limit (queries per second). Higher values reduce reconcile latency but increase Prometheus load. |
 | prometheusTimeout | string | `"5m"` | Maximum time for workload processing (including Prometheus queries) per reconciliation cycle (Go duration). If exceeded, partial results are used and the status condition indicates the timeout. |
 | replicaCount | int | `1` | Number of operator replicas (use 2 for HA with leader election) |
-| requeueJitter | string | `"2m"` | Maximum deterministic requeue jitter to spread policies that share a cooldown. Set to "0s" to disable. Default 2m (empty omits the flag and keeps the binary default). |
+| requeueJitter | string | `"2m"` | Maximum extra delay added only to full cooldown requeues. Skipped while Ready is InsufficientData or PrometheusUnavailable so bootstrap is not delayed by jitter. Set to "0s" to disable. Default 2m (empty omits the flag and keeps the binary default). |
 | resources | object | `{}` | Operator pod resources. When empty, defaults are derived from clusterSize (or "small" if clusterSize is also empty). Set explicit values for production. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | Container security context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |

--- a/charts/attune/values.yaml
+++ b/charts/attune/values.yaml
@@ -321,8 +321,10 @@ blockerRefreshInterval: "0s"
 # Example: "attune.io/managed=true". Empty relies on dynamic policy selectors only.
 podLabelSelector: ""
 
-# -- Maximum deterministic requeue jitter to spread policies that share a cooldown.
-# Set to "0s" to disable. Default 2m (empty omits the flag and keeps the binary default).
+# -- Maximum extra delay added only to full cooldown requeues.
+# Skipped while Ready is InsufficientData or PrometheusUnavailable so
+# bootstrap is not delayed by jitter. Set to "0s" to disable. Default 2m
+# (empty omits the flag and keeps the binary default).
 requeueJitter: "2m"
 
 # -- Cap samples passed into recommendation BuildProfile after downsampling.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -106,7 +106,7 @@ func main() {
 	flag.IntVar(&maxWorkloadWorkers, "max-workload-workers", 10,
 		"Maximum parallel workers processing workloads within a single AttunePolicy reconcile.")
 	flag.DurationVar(&requeueJitter, "requeue-jitter", 2*time.Minute,
-		"Maximum deterministic jitter added to RequeueAfter to spread policies that share the same cooldown. Set to 0 to disable.")
+		"Maximum extra delay added only to full cooldown RequeueAfter values. Skipped while Ready is InsufficientData or PrometheusUnavailable. Set to 0 to disable.")
 	flag.IntVar(&maxProfileSamples, "max-profile-samples", 10000,
 		"Maximum samples passed to recommendation BuildProfile after downsampling. Negative disables the cap.")
 	flag.IntVar(&maxPrometheusSeries, "max-prometheus-series", 5000,

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -93,6 +93,10 @@ make kind-deploy IMG=attune:e2e
 make lint
 ```
 
+The full local gate is `make verify` (or `make verify-quick` without
+integration tests and govulncheck). Those Makefile targets are the
+source of truth for what CI runs. See CONTRIBUTING.md.
+
 Auto-fix lint issues:
 
 ```bash

--- a/docs/guides/multi-cluster.md
+++ b/docs/guides/multi-cluster.md
@@ -353,7 +353,7 @@ The leader writes a ConfigMap labeled `attune.io/fleet-report=true` with:
 | `workloadsDiscovered` | int | Sum of discovered workloads |
 | `workloadsWithRecommendations` | int | Sum with recommendations |
 | `workloadsResized` | int | Sum resized |
-| `estimatedMonthlySavingsUSD` | float | Sum of parseable policy savings |
+| `estimatedMonthlySavingsUSD` | float | Sum of parseable policy savings (empty, non-numeric, NaN, and Inf values count as 0) |
 | `reclaimedCpuRequestMilli` | int | Freeable CPU millicores (when present) |
 | `reclaimedMemoryRequestBytes` | int | Freeable memory bytes (when present) |
 

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -283,7 +283,7 @@ legacy behavior or richer status.
 | Status recommendation cap | 100 | `maxStatusRecommendations` | `updateStrategy.maxStatusRecommendations` |
 | Strip status explanations | Off (include) | `statusIncludeExplanations` | `updateStrategy.includeExplanationsInStatus` |
 | Workload workers per policy | 10 | `maxWorkloadWorkers` / `--max-workload-workers` | - |
-| Requeue jitter | 2m | `requeueJitter` / `--requeue-jitter` | - |
+| Requeue jitter | 2m | `requeueJitter` / `--requeue-jitter` | Applied only to full cooldown requeues; skipped during InsufficientData / PrometheusUnavailable |
 | Lazy pod lists | Observe skips full lists; Recommend still lists for Deferred/Infeasible UX | - | - |
 | Namespace-wide pod list + in-memory match | On | - | - |
 | Representative pod sample for metrics | 100 pods | `maxPodsInMetricsQuery` / `--max-pods-in-metrics-query` | - |

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -180,6 +180,10 @@ namespace. This is usually a typo in the workload name or an incorrect
 The default minimum is 48 Prometheus range-query samples. With the default
 `queryStep: 5m`, that is about 4 hours of data.
 
+During this state the operator requeues at `min(cooldown, queryStep)` and
+does **not** add `requeueJitter`. A policy with `cooldown: 1m` and the
+default 5m step therefore retries every minute, not every 1–3 minutes.
+
 **Fix**: Wait for more data to accumulate, or adjust these settings:
 
 - **`minimumDataPoints`**: Lower for faster (but less confident) recommendations.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -178,7 +178,7 @@ watchNamespaces:
 |-----|------|---------|-------------|
 | `maxConcurrentReconciles` | int/string | `""` (2) | Maximum number of AttunePolicy reconciles running in parallel. Maps to the `--max-concurrent-reconciles` manager flag (binary default 2). Empty Helm value uses 2, or clusterSize presets (small=1, medium=2, large=4, xlarge=8). The Prometheus rate limiter (`prometheusQPS`) is shared across all goroutines. |
 | `maxWorkloadWorkers` | int | `10` | Parallel workers for workloads inside one policy reconcile (`--max-workload-workers`). |
-| `requeueJitter` | string | `"2m"` | Max deterministic requeue jitter (`--requeue-jitter`). Set `"0s"` to disable. |
+| `requeueJitter` | string | `"2m"` | Max extra delay added only to full cooldown requeues (`--requeue-jitter`). Skipped while Ready is `InsufficientData` or `PrometheusUnavailable` so bootstrap is not delayed by up to 2m. Set `"0s"` to disable. |
 | `maxProfileSamples` | int | `10000` | Cap samples after downsampling before BuildProfile (`--max-profile-samples`). |
 | `maxPrometheusSeries` | int | `5000` | Cap series per Prometheus range query (`--max-prometheus-series`). |
 | `maxStatusRecommendations` | int | `100` | Default status.recommendations cap (`--max-status-recommendations`). |

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -151,9 +151,10 @@ type AttunePolicyReconciler struct {
 	// MaxWorkloadWorkers caps parallel workload processing within one reconcile
 	// (default: 10). Bounded further by the Prometheus rate limiter.
 	MaxWorkloadWorkers int
-	// RequeueJitter is the maximum extra delay added to RequeueAfter to spread
-	// policies that share the same cooldown (default: 0 = no jitter).
-	// Deterministic per policy UID so tests stay stable when set to 0.
+	// RequeueJitter is the maximum extra delay added only to full cooldown
+	// RequeueAfter values (default: 0 = no jitter). Skipped while Ready is
+	// InsufficientData or PrometheusUnavailable. Deterministic per policy UID
+	// so tests stay stable when set to 0.
 	RequeueJitter time.Duration
 	// MaxProfileSamples caps samples before BuildProfile (default: 10000).
 	// Zero uses metrics.DefaultMaxProfileSamples; negative disables.
@@ -696,8 +697,9 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
-// addRequeueJitter spreads RequeueAfter across policies that share a cooldown
-// so many AttunePolicies do not unlock on the same second.
+// addRequeueJitter spreads full cooldown RequeueAfter values so many
+// AttunePolicies do not unlock on the same second. Callers skip this during
+// InsufficientData / PrometheusUnavailable bootstrap.
 func (r *AttunePolicyReconciler) addRequeueJitter(base time.Duration, policy *attunev1alpha1.AttunePolicy) time.Duration {
 	if r.RequeueJitter <= 0 || base <= 0 {
 		return base

--- a/internal/controller/workload_test.go
+++ b/internal/controller/workload_test.go
@@ -105,6 +105,7 @@ func TestWorkload_IsBatchWorkload(t *testing.T) {
 		{"Job", &batchv1.Job{}, true},
 		{"CronJob", &batchv1.CronJob{}, true},
 		{"ReplicaSet", &appsv1.ReplicaSet{}, false},
+		{"unknown kind", &corev1.ConfigMap{}, false},
 	}
 
 	for _, tt := range tests {
@@ -281,6 +282,27 @@ func TestWorkload_IsRollingOut(t *testing.T) {
 			workload: &batchv1.CronJob{},
 			want:     false,
 		},
+		{
+			name: "ReplicaSet mid-rollout ReadyReplicas < spec",
+			workload: &appsv1.ReplicaSet{
+				Spec:   appsv1.ReplicaSetSpec{Replicas: int32Ptr(3)},
+				Status: appsv1.ReplicaSetStatus{ReadyReplicas: 1},
+			},
+			want: true,
+		},
+		{
+			name: "ReplicaSet fully rolled out",
+			workload: &appsv1.ReplicaSet{
+				Spec:   appsv1.ReplicaSetSpec{Replicas: int32Ptr(3)},
+				Status: appsv1.ReplicaSetStatus{ReadyReplicas: 3},
+			},
+			want: false,
+		},
+		{
+			name:     "unknown kind is not a rollout",
+			workload: &corev1.ConfigMap{},
+			want:     false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -370,6 +392,11 @@ func TestWorkload_GetPodSelectorLabels(t *testing.T) {
 		{
 			name:     "Deployment without selector returns nil",
 			workload: &appsv1.Deployment{},
+			want:     nil,
+		},
+		{
+			name:     "unknown kind returns nil",
+			workload: &corev1.ConfigMap{},
 			want:     nil,
 		},
 	}

--- a/internal/fleetreport/exporter_test.go
+++ b/internal/fleetreport/exporter_test.go
@@ -5,6 +5,7 @@ package fleetreport
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,10 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
@@ -97,4 +101,109 @@ func TestExporter_Start_StopsOnCancel(t *testing.T) {
 	err := c.Get(context.Background(), types.NamespacedName{Namespace: "attune-system", Name: "attune-fleet-report"}, &cm)
 	require.NoError(t, err, "Start should default Name and export ConfigMap")
 	assert.Equal(t, "v1", cm.Data["schema-version"])
+}
+
+func testExporter(c client.Client) *Exporter {
+	return &Exporter{
+		Client:    c,
+		Log:       logr.Discard(),
+		Namespace: "attune-system",
+		Name:      "attune-fleet-report",
+		ClusterID: "test-cluster",
+		Interval:  time.Hour,
+		Now:       func() time.Time { return time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC) },
+	}
+}
+
+func TestExporter_ExportOnce_ListErrorDoesNotWrite(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return fmt.Errorf("simulated list failure")
+			},
+		}).Build()
+
+	testExporter(c).ExportOnce(context.Background())
+
+	var cm corev1.ConfigMap
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: "attune-system", Name: "attune-fleet-report"}, &cm)
+	assert.True(t, apierrors.IsNotFound(err), "List failure must not write a fleet report ConfigMap")
+}
+
+func TestExporter_ExportOnce_CreateErrorDoesNotWrite(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "attune-system"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+				return fmt.Errorf("simulated create failure")
+			},
+		}).Build()
+
+	testExporter(c).ExportOnce(context.Background())
+
+	var cm corev1.ConfigMap
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: "attune-system", Name: "attune-fleet-report"}, &cm)
+	assert.True(t, apierrors.IsNotFound(err), "Create failure must not persist a fleet report ConfigMap")
+}
+
+func TestExporter_ExportOnce_GetErrorDoesNotWrite(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "attune-system"}}
+	gets := 0
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				gets++
+				if gets == 1 {
+					return fmt.Errorf("simulated get failure")
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+
+	testExporter(c).ExportOnce(context.Background())
+
+	var cm corev1.ConfigMap
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: "attune-system", Name: "attune-fleet-report"}, &cm)
+	assert.True(t, apierrors.IsNotFound(err), "Get failure must not persist a fleet report ConfigMap")
+}
+
+func TestExporter_ExportOnce_PatchErrorKeepsExistingData(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "attune-system"}}
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "attune-fleet-report",
+			Namespace: "attune-system",
+			Labels:    map[string]string{ConfigMapLabel: "true"},
+		},
+		Data: map[string]string{"schema-version": "stale"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				return fmt.Errorf("simulated patch failure")
+			},
+		}).Build()
+
+	testExporter(c).ExportOnce(context.Background())
+
+	var cm corev1.ConfigMap
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: "attune-system", Name: "attune-fleet-report"}, &cm)
+	require.NoError(t, err)
+	assert.Equal(t, "stale", cm.Data["schema-version"], "Patch failure must leave the existing ConfigMap unchanged")
 }

--- a/internal/fleetreport/report.go
+++ b/internal/fleetreport/report.go
@@ -21,6 +21,7 @@ package fleetreport
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -177,7 +178,7 @@ func parseUSD(s string) float64 {
 		return 0
 	}
 	v, err := strconv.ParseFloat(s, 64)
-	if err != nil || v != v { // NaN check
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
 		return 0
 	}
 	return v

--- a/internal/fleetreport/report_test.go
+++ b/internal/fleetreport/report_test.go
@@ -80,6 +80,12 @@ func TestBuild_AggregatesPolicies(t *testing.T) {
 func TestParseHelpers(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, 12.5, parseUSD("$12.50"))
+	assert.Equal(t, 0.0, parseUSD(""))
+	assert.Equal(t, 0.0, parseUSD("not-a-number"))
+	assert.Equal(t, 0.0, parseUSD("NaN"))
+	assert.Equal(t, 0.0, parseUSD("Inf"))
+	assert.Equal(t, 0.0, parseUSD("+Inf"))
+	assert.Equal(t, 0.0, parseUSD("-Inf"))
 	m, ok := parseCPUMilli("250m")
 	assert.True(t, ok)
 	assert.Equal(t, int64(250), m)


### PR DESCRIPTION
Harden fleet report savings parsing, add missing unit tests, and document
the #531 requeue-jitter skip so Helm, `--help`, and troubleshooting match
runtime.

## Problem

`strconv.ParseFloat("Inf")` succeeds. Fleet report `parseUSD` only rejected
NaN (`v != v`), so one non-finite savings string could make
`estimatedMonthlySavingsUSD` Inf.

`IsSupportedTargetKind` had no direct tests. ReplicaSet rollout and
unknown-kind fallbacks on workload helpers were untested. Fleet
`ExportOnce` only covered the happy path.

Docs and `--requeue-jitter` still implied jitter applied to every
cooldown-length requeue, including InsufficientData bootstrap.

## Change

- Reject NaN and Inf in `parseUSD`
- Direct tests for target kinds (CSV vs kubebuilder enum)
- ReplicaSet `IsRollingOut` plus unknown-kind fallbacks
- `ExportOnce` List/Create/Get/Patch failure tests
- Helm values, configuration, scaling, troubleshooting, and flag help
  now say jitter is skipped during InsufficientData / PrometheusUnavailable
- CONTRIBUTING lists the real `make verify-quick` gate (Makefile is source
  of truth) and bumps the unit-test floor to 1300+

## Validation

- `make verify-quick` (lint 0, 1891 tests, helm-docs, CRD/RBAC/dashboard
  freshness, 90.6% internal coverage)

## Notes

Release PR #525 (v0.1.23) stays user-gated and is not part of this batch.
Issue #111 (Kubetools) was already complete and closed separately.
