### PR TITLE
docs: add release notes for v0.1.23

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,31 @@
+## What's New in v0.1.23
+
+v0.1.23 is a reliability patch. Fleet savings totals stay finite, first recommendations no longer wait extra jitter while metrics are still collecting, and the operator image is built with Go 1.26.6.
+
+### Highlights
+
+- Fleet report monthly savings skip Inf, NaN, and other unparseable values, and count them in `unparseableSavings`.
+- Requeue jitter is skipped while Ready is `InsufficientData` or `PrometheusUnavailable`.
+
+### Fleet report
+
+- **Inf or NaN savings could make the fleet USD total Inf, or look like $0 after a silent drop.** `estimatedMonthlySavingsUSD` now adds only finite numbers. Unparseable values increment `unparseableSavings`. The operator logs at Info when that count is nonzero ([#532](https://github.com/attune-io/attune/pull/532), [#533](https://github.com/attune-io/attune/pull/533)).
+- **Huge or negative reclaim quantities could wrap to the wrong sign.** CPU and memory reclaim sums reject those Quantity values and saturate int64 addition ([#533](https://github.com/attune-io/attune/pull/533)).
+
+### Bootstrap timing
+
+- **First recommendations and ConfigMap export could wait up to cooldown plus `--requeue-jitter` (default 2m).** Jitter no longer applies while Ready is `InsufficientData` or `PrometheusUnavailable`. Helm values, `--requeue-jitter` help, and troubleshooting describe that skip ([#531](https://github.com/attune-io/attune/pull/531), [#532](https://github.com/attune-io/attune/pull/532)).
+
+### Build and security
+
+- Operator and `kubectl attune` now build with Go 1.26.6. `go.mod` and the Dockerfile stay on the same patch ([#524](https://github.com/attune-io/attune/pull/524)).
+
+### Upgrade notes
+
+1. If you read fleet `report.json`, treat `unparseableSavings` as additive. A successful export can still show `$0` when every savings field failed to parse.
+2. Short-cooldown policies collect first recommendations sooner. Steady-state cooldown jitter is unchanged.
+3. Pull `ghcr.io/attune-io/attune:v0.1.23` (or rebuild from the tag) for the Go 1.26.6 toolchain.
+
+### Full changelog
+
+https://github.com/attune-io/attune/compare/v0.1.22...v0.1.23

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -8,6 +8,25 @@ Maintainers: before publishing a release after multi-version product changes,
 run the full E2E Nightly matrix on tip of `main` (see
 [Releasing: full E2E matrix](../contributing/releasing.md#1b-full-e2e-matrix-required-before-tagging-a-product-release)).
 
+## v0.1.22 to v0.1.23
+
+v0.1.23 is a reliability patch. Existing policies keep working without YAML
+edits.
+
+### Requeue jitter is skipped during data collection
+
+While Ready is `InsufficientData` or `PrometheusUnavailable`, the operator
+no longer adds `--requeue-jitter` (default 2m) on top of the cooldown.
+First recommendations and ConfigMap export can land sooner. Jitter still
+applies to steady-state cooldown requeues.
+
+### Fleet report savings stay finite
+
+`estimatedMonthlySavingsUSD` adds only finite numbers. Unparseable values
+(NaN, Inf, or garbage) increment `unparseableSavings` and count as 0 in
+the USD total. Consumers of `report.json` should treat that field as
+additive.
+
 ## v0.1.21 to v0.1.22
 
 v0.1.22 ships scale defaults and capacity safety that were previously only on


### PR DESCRIPTION
## Summary

Curated GitHub Release notes for v0.1.23, plus a short upgrading section
for the two user-visible behavior shifts.

`RELEASE_NOTES.md` is the override the Release workflow applies to the
GitHub Release body. After v0.1.23 publishes, the existing cleanup job
removes the file.

## What is in the notes

- Fleet savings stay finite (`unparseableSavings`, reclaim wrap)
- Requeue jitter skipped during InsufficientData / PrometheusUnavailable
- Go 1.26.6 toolchain

## Validation

- Full changelog compare `v0.1.22...v0.1.23`
- Linked PRs #524, #531, #532, #533 are merged
- No em dash; PR links sit on the same line as the last sentence
- E2E Nightly 1.32-1.35 + fuzz green on `971b394` (run 32096595233)

Ref #525