### PR TITLE
fix: skip gitops PR when drift table is unchanged

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -53,12 +53,13 @@ const (
 	ReasonPodsInfeasible            = "PodsInfeasible"
 	ReasonPodsDeferredAndInfeasible = "PodsDeferredAndInfeasible"
 	// GitOps PR automation reasons.
-	ReasonGitOpsPROpen     = "PullRequestOpen"
-	ReasonGitOpsPRFailed   = "PullRequestFailed"
-	ReasonGitOpsPRNoDrift  = "NoDrift"
-	ReasonGitOpsPRCooldown = "PullRequestCooldown"
-	ReasonGitOpsPRDryRun   = "PullRequestDryRun"
-	ReasonGitOpsPRDisabled = "PullRequestDisabled"
+	ReasonGitOpsPROpen      = "PullRequestOpen"
+	ReasonGitOpsPRFailed    = "PullRequestFailed"
+	ReasonGitOpsPRNoDrift   = "NoDrift"
+	ReasonGitOpsPRCooldown  = "PullRequestCooldown"
+	ReasonGitOpsPRDryRun    = "PullRequestDryRun"
+	ReasonGitOpsPRDisabled  = "PullRequestDisabled"
+	ReasonGitOpsPRUnchanged = "PullRequestUnchanged"
 )
 
 // CanaryPhaseInProgress and CanaryPhaseFullRollout are now typed constants

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -142,7 +142,7 @@ make test-e2e-smoke
 | `test/e2e/startup-boost/` | (cross-cutting) | CPU startup boost is applied to new pods |
 | `test/e2e/configmap-export/` | (cross-cutting) | Recommendations are exported to a ConfigMap (`schema-version` + export-schema label) |
 | `test/e2e/fleet-report/` | (infra) | Fleet report ConfigMap is written when `fleetReport` is enabled in E2E Helm |
-| `test/e2e/gitops-pr-dry-run/` | (cross-cutting) | GitOps PR dry-run sets `PullRequestDryRun`/`PullRequestCooldown` without forge credentials |
+| `test/e2e/gitops-pr-dry-run/` | (cross-cutting) | GitOps PR dry-run sets `PullRequestDryRun`/`PullRequestUnchanged`/`PullRequestCooldown` without forge credentials |
 | `test/e2e/runtime-profile-defaults/` | (webhook + API) | `runtimeProfile: java` stored and accepted; java+allowDecrease warns at admission |
 | `test/e2e/runtime-profile-java-no-mem-decrease/` | Recommend | java profile applies memory overhead=40 in explanation; CR overhead/allowDecrease stay unset |
 | `test/e2e/resize-blocked-status/` | Recommend | Injected Deferred+Infeasible pod conditions surface `workloads.deferred`/`infeasible` and `ResizeBlocked` |

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -180,6 +180,7 @@ Condition type `GitOpsPullRequest`:
 |--------|---------|
 | `PullRequestDisabled` | Feature off |
 | `NoDrift` | Templates already near recommendations |
+| `PullRequestUnchanged` | Drift table matches the last PR; no new empty PR |
 | `PullRequestCooldown` | Waiting for cooldown |
 | `PullRequestDryRun` | Would open/update PR |
 | `PullRequestOpen` | PR URL in message |
@@ -237,7 +238,11 @@ Use this ordered path when turning on PR automation for the first time.
    without logging the token.
 
 Cooldown (default 24h) prevents PR thrash. After a merge, if the head branch
-is deleted, the next cycle may bootstrap again when drift returns.
+is deleted, the next cycle may bootstrap again **only when the drift table
+changed**. If template vs recommendation is the same set as the last PR,
+the condition is `PullRequestUnchanged` and Attune does not open another
+empty PR. Apply real template patches (`kubectl attune diff`) so drift
+clears (`NoDrift`).
 
 ### Branch bootstrap
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -968,6 +968,26 @@ If Argo CD / Flux reverts the template every sync, do **not** enable
 template persistence under unmanaged sync. Prefer `export.configMap` or
 `initialSizing` (see [GitOps integration](gitops-integration.md)).
 
+### GitOps PR opens empty PRs every cooldown
+
+**Symptom**: A new GitHub PR appears on each `pullRequest.cooldown` (default
+24h) with only an empty bootstrap commit. The description table matches
+the previous PR.
+
+**Cause**: GitOps PR automation writes the drift table in the PR body. It
+does not patch Deployment YAML. Merging that PR (and deleting the head
+branch) leaves the live template unchanged, so drift stays true.
+
+**Fix**:
+
+1. Do not merge empty notification PRs as the apply step.
+2. Apply a real patch: `kubectl attune diff -n <ns> -o yaml`, commit it
+   to git, let Flux/Argo sync. Wait for reason `NoDrift`.
+3. To stop new PRs immediately, set `export.pullRequest.enabled: false`
+   or `dryRun: true`.
+4. On Attune versions that include the unchanged-drift skip, the
+   condition is `PullRequestUnchanged` instead of another empty PR.
+
 ### GitOps PR failing
 
 **Symptom**: Status condition `GitOpsPullRequest` is `False` with reason

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -452,8 +452,9 @@ provider PRs when templates drift. Full cookbook:
 | `updateStrategy.export.pullRequest.dryRun` | bool | `false` | When true, set status only (`PullRequestDryRun`); no remote API call. |
 | `updateStrategy.export.pullRequest.labels` | []string | `[]` | Labels applied to the PR when the provider supports them (max 20). |
 
-Status condition `GitOpsPullRequest` reports dry-run, open, no-drift, cooldown,
-failed, or disabled. Metric: `attune_gitops_pr_total`. Inspect export ConfigMaps
+Status condition `GitOpsPullRequest` reports dry-run, open, no-drift,
+unchanged, cooldown, failed, or disabled. Metric: `attune_gitops_pr_total`.
+Inspect export ConfigMaps
 with `kubectl attune export list` and effective PR settings with
 `kubectl attune explain <policy>`.
 
@@ -567,7 +568,7 @@ The controller sets these conditions on each `AttunePolicy`:
 | `Degraded` | `HighRevertRate` | Set when 3+ of the last 5 resizes were reverted |
 | `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Set when `updateStrategy.schedule` is configured; indicates whether the current time is within an allowed resize window |
 | `ResizeBlocked` | `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Pods stuck Deferred or Infeasible; see troubleshooting "Deferred or Infeasible resize" |
-| `GitOpsPullRequest` | `PullRequestOpen`, `PullRequestFailed`, `NoDrift`, `PullRequestCooldown`, `PullRequestDryRun`, `PullRequestDisabled` | Opt-in `export.pullRequest` automation status (see [GitOps integration](../guides/gitops-integration.md)) |
+| `GitOpsPullRequest` | `PullRequestOpen`, `PullRequestFailed`, `NoDrift`, `PullRequestUnchanged`, `PullRequestCooldown`, `PullRequestDryRun`, `PullRequestDisabled` | Opt-in `export.pullRequest` automation status (see [GitOps integration](../guides/gitops-integration.md)) |
 
 ## Exponential Backoff
 

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -33,6 +33,7 @@ import (
 const (
 	annotationGitOpsPRLastAttempt = "attune.io/gitops-pr-last-attempt"
 	annotationGitOpsPRURL         = "attune.io/gitops-pr-url"
+	annotationGitOpsPRDrift       = "attune.io/gitops-pr-drift"
 	defaultGitOpsPRCooldown       = 24 * time.Hour
 	defaultGitOpsMinChangePct     = int32(10)
 )
@@ -79,6 +80,13 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 			"No recommendation drift above minChangePercent vs templates")
 		return
 	}
+	fp := gitops.DriftFingerprint(drifts)
+	if fp != "" && policy.Annotations[annotationGitOpsPRDrift] == fp {
+		logger.V(1).Info("GitOps PR skipped: drift table unchanged since last PR")
+		setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRUnchanged,
+			"Drift table unchanged since last pull request; not opening a new empty PR")
+		return
+	}
 
 	cooldown := defaultGitOpsPRCooldown
 	if cfg.Cooldown != nil && cfg.Cooldown.Duration > 0 {
@@ -114,6 +122,7 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 		setGitOpsPRCondition(policy, metav1.ConditionTrue, attunev1alpha1.ReasonGitOpsPRDryRun,
 			fmt.Sprintf("Dry-run: would open/update PR on %s (%d drifted resources)", cfg.Repository, len(drifts)))
 		r.touchGitOpsPRAnnotation(policy, "")
+		setGitOpsPRDriftAnnotation(policy, fp)
 		r.persistGitOpsPRAnnotations(ctx, policy)
 		operatormetrics.GitOpsPRTotal.WithLabelValues(policy.Namespace, policy.Name, "dry_run").Inc()
 		return
@@ -169,6 +178,7 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 	}
 	setGitOpsPRCondition(policy, metav1.ConditionTrue, attunev1alpha1.ReasonGitOpsPROpen, msg)
 	r.touchGitOpsPRAnnotation(policy, res.URL)
+	setGitOpsPRDriftAnnotation(policy, fp)
 	r.persistGitOpsPRAnnotations(ctx, policy)
 }
 
@@ -211,6 +221,16 @@ func (r *AttunePolicyReconciler) touchGitOpsPRAnnotation(policy *attunev1alpha1.
 	}
 }
 
+func setGitOpsPRDriftAnnotation(policy *attunev1alpha1.AttunePolicy, fingerprint string) {
+	if fingerprint == "" {
+		return
+	}
+	if policy.Annotations == nil {
+		policy.Annotations = map[string]string{}
+	}
+	policy.Annotations[annotationGitOpsPRDrift] = fingerprint
+}
+
 // persistGitOpsPRAnnotations patches policy annotations so cooldown survives restarts.
 // Best-effort; failures do not fail reconcile but are logged at V(1).
 func (r *AttunePolicyReconciler) persistGitOpsPRAnnotations(ctx context.Context, policy *attunev1alpha1.AttunePolicy) {
@@ -233,6 +253,9 @@ func (r *AttunePolicyReconciler) persistGitOpsPRAnnotations(ctx context.Context,
 	}
 	if v, ok := policy.Annotations[annotationGitOpsPRURL]; ok {
 		latest.Annotations[annotationGitOpsPRURL] = v
+	}
+	if v, ok := policy.Annotations[annotationGitOpsPRDrift]; ok {
+		latest.Annotations[annotationGitOpsPRDrift] = v
 	}
 	if err := r.Patch(ctx, latest, client.MergeFrom(base)); err != nil {
 		logger.V(1).Info("GitOps PR: failed to patch cooldown annotations",

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -392,6 +392,91 @@ func TestReconcileGitOpsPullRequest_DryRunIncrementsMetric(t *testing.T) {
 	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRDryRun, reason)
 }
 
+func TestReconcileGitOpsPullRequest_UnchangedDriftSkipsAfterCooldown(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	dry := true
+	start := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "authentik", Namespace: "authentik"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &dry,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "tok", Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "authentik"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	now := start
+	r.SetNowFunc(func() time.Time { return now })
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("100m"),
+			},
+		}},
+	}}
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	require.Equal(t, attunev1alpha1.ReasonGitOpsPRDryRun, gitOpsPRReason(policy))
+	require.NotEmpty(t, policy.Annotations[annotationGitOpsPRDrift])
+	firstFP := policy.Annotations[annotationGitOpsPRDrift]
+
+	// Cooldown expired; same recommendation vs same template must not open again.
+	now = start.Add(25 * time.Hour)
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
+	assert.Equal(t, firstFP, policy.Annotations[annotationGitOpsPRDrift])
+
+	// New recommendation is a different fingerprint: proceed after cooldown.
+	recs[0].Containers[0].Recommended.CPURequest = resource.MustParse("200m")
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRDryRun, gitOpsPRReason(policy))
+	assert.NotEqual(t, firstFP, policy.Annotations[annotationGitOpsPRDrift])
+}
+
+func gitOpsPRReason(policy *attunev1alpha1.AttunePolicy) string {
+	for _, cond := range policy.Status.Conditions {
+		if cond.Type == attunev1alpha1.ConditionGitOpsPullRequest {
+			return cond.Reason
+		}
+	}
+	return ""
+}
+
 func TestReconcileGitOpsPullRequest_IncompleteConfig(t *testing.T) {
 	t.Parallel()
 	scheme := runtime.NewScheme()

--- a/internal/gitops/drift.go
+++ b/internal/gitops/drift.go
@@ -19,7 +19,10 @@ limitations under the License.
 package gitops
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -90,6 +93,24 @@ func ComputeDrift(
 		}
 	}
 	return out
+}
+
+// DriftFingerprint is a stable hash of the drift table. Same template vs
+// recommendation set yields the same value regardless of slice order.
+func DriftFingerprint(drifts []ContainerDrift) string {
+	if len(drifts) == 0 {
+		return ""
+	}
+	lines := make([]string, len(drifts))
+	for i, d := range drifts {
+		lines[i] = strings.Join([]string{
+			d.Kind, d.Workload, d.Container, d.Resource, d.Template, d.Recommended,
+			strconv.FormatFloat(d.ChangePercent, 'f', 3, 64),
+		}, "\x1f")
+	}
+	sort.Strings(lines)
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return hex.EncodeToString(sum[:])
 }
 
 func driftOne(workload, kind, container, resName string, template, recommended *resource.Quantity, minPct float64) (ContainerDrift, bool) {

--- a/internal/gitops/drift_test.go
+++ b/internal/gitops/drift_test.go
@@ -97,6 +97,21 @@ func TestBranchName(t *testing.T) {
 	assert.Equal(t, "attune/recommendations-ns-with-dots-pol", BranchName("ns.with.dots", "pol"))
 }
 
+func TestDriftFingerprint_StableAndOrderIndependent(t *testing.T) {
+	t.Parallel()
+	a := []ContainerDrift{
+		{Workload: "api", Kind: "Deployment", Container: "app", Resource: "cpu", Template: "1", Recommended: "100m", ChangePercent: 90},
+		{Workload: "api", Kind: "Deployment", Container: "app", Resource: "memory", Template: "1Gi", Recommended: "512Mi", ChangePercent: 50},
+	}
+	b := []ContainerDrift{a[1], a[0]}
+	assert.Equal(t, DriftFingerprint(a), DriftFingerprint(b))
+	assert.NotEmpty(t, DriftFingerprint(a))
+	assert.Empty(t, DriftFingerprint(nil))
+	c := append([]ContainerDrift{}, a...)
+	c[0].Recommended = "200m"
+	assert.NotEqual(t, DriftFingerprint(a), DriftFingerprint(c))
+}
+
 func TestComputeDrift_StatefulSetAndDaemonSet(t *testing.T) {
 	t.Parallel()
 	sts := &appsv1.StatefulSet{

--- a/test/e2e/gitops-pr-dry-run/chainsaw-test.yaml
+++ b/test/e2e/gitops-pr-dry-run/chainsaw-test.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   description: >
     Verify opt-in GitOps PR automation dry-run sets status condition
-    PullRequestDryRun (or subsequent PullRequestCooldown) without forge
+    PullRequestDryRun (or subsequent PullRequestUnchanged/Cooldown) without forge
     credentials or outbound HTTP. Missing-secret path is unit-tested.
   timeouts:
     apply: 30s
@@ -131,11 +131,11 @@ spec:
                   -o jsonpath='{.metadata.annotations.attune\.io/gitops-pr-last-attempt}' 2>/dev/null || true)
                 recs=$(kubectl -n "$NS" get attunepolicy "$POL" \
                   -o jsonpath='{.status.recommendations[*].workload}' 2>/dev/null || true)
-                # Dry-run sets PullRequestDryRun + last-attempt annotation, then the
-                # next reconcile often switches to PullRequestCooldown (default 24h)
-                # with status False. Both prove the dry-run path ran without forge HTTP.
+                # Dry-run sets PullRequestDryRun + last-attempt annotation. The next
+                # reconcile is PullRequestUnchanged (same drift table) or
+                # PullRequestCooldown. All prove the path ran without forge HTTP.
                 if [ -n "$ann" ]; then
-                  if [ "$reason" = "PullRequestDryRun" ] || [ "$reason" = "PullRequestCooldown" ]; then
+                  if [ "$reason" = "PullRequestDryRun" ] || [ "$reason" = "PullRequestCooldown" ] || [ "$reason" = "PullRequestUnchanged" ]; then
                     echo "OK: GitOpsPullRequest reason=$reason status=$status (post dry-run)"
                     echo "message=$msg"
                     echo "annotation last-attempt=$ann"


### PR DESCRIPTION
## Summary

Stop GitOps automation from opening a new empty pull request when the recommendation drift table has not changed.

## The problem

`export.pullRequest` compares live workload templates to recommendations, then opens a GitHub PR. The PR body has the drift table. The only git commit is an empty bootstrap so GitHub will accept the PR. Merging that PR does not change Deployment YAML.

After merge, the head branch is usually deleted. The cluster template is unchanged, so after `cooldown` (default 24h) Attune bootstrapped another empty branch and opened another PR. Reported in #537.

## The change

- Hash the drift table (`gitops.DriftFingerprint`)
- Persist it on `attune.io/gitops-pr-drift`
- If the next cycle has the same fingerprint, set `GitOpsPullRequest` reason `PullRequestUnchanged` and do not open a PR
- Docs and the dry-run E2E accept the new reason

Applying real templates (`kubectl attune diff`) is still required to reach `NoDrift`. This PR only stops the empty-PR loop.

## Validation

- `go test ./internal/controller/ ./internal/gitops/ -race -count=1`
- `TestReconcileGitOpsPullRequest_UnchangedDriftSkipsAfterCooldown`
- `TestDriftFingerprint_StableAndOrderIndependent`

## Issue

Closes #537
