### PR TITLE
test: count gitops CreateOrUpdate after merge

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -143,6 +143,13 @@ make test-e2e-smoke
 | `test/e2e/configmap-export/` | (cross-cutting) | Recommendations are exported to a ConfigMap (`schema-version` + export-schema label) |
 | `test/e2e/fleet-report/` | (infra) | Fleet report ConfigMap is written when `fleetReport` is enabled in E2E Helm |
 | `test/e2e/gitops-pr-dry-run/` | (cross-cutting) | GitOps PR dry-run sets `PullRequestDryRun`/`PullRequestUnchanged`/`PullRequestCooldown` without forge credentials |
+
+GitOps PR unit tests must cover the **second cycle** after merge, not only
+the first open. `TestReconcileGitOpsPullRequest_LivePathDoesNotRecreateAfterMerge`
+injects a fake `PullRequestClient` and asserts `CreateOrUpdate` is not
+called again when the drift table is unchanged after the head branch is
+gone. `TestGitHubClient_Create_AgainAfterHeadDeleted` documents that the
+GitHub client *will* bootstrap another empty PR if the reconciler asks.
 | `test/e2e/runtime-profile-defaults/` | (webhook + API) | `runtimeProfile: java` stored and accepted; java+allowDecrease warns at admission |
 | `test/e2e/runtime-profile-java-no-mem-decrease/` | Recommend | java profile applies memory overhead=40 in explanation; CR overhead/allowDecrease stay unset |
 | `test/e2e/resize-blocked-status/` | Recommend | Injected Deferred+Infeasible pod conditions surface `workloads.deferred`/`infeasible` and `ResizeBlocked` |

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -46,6 +46,7 @@ import (
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/attune-io/attune/internal/conflict"
+	"github.com/attune-io/attune/internal/gitops"
 	rsmetrics "github.com/attune-io/attune/internal/metrics"
 	"github.com/attune-io/attune/internal/operatormetrics"
 	"github.com/attune-io/attune/internal/resize"
@@ -200,6 +201,10 @@ type AttunePolicyReconciler struct {
 	// so persistent conditions are periodically surfaced without flooding.
 	// Always initialized by NewAttunePolicyReconciler.
 	eventDedup *eventDedup
+
+	// gitopsPRClient, when set, is used instead of constructing a GitHub/GitLab
+	// client. Tests inject a fake to count CreateOrUpdate without forge HTTP.
+	gitopsPRClient gitops.PullRequestClient
 
 	// discoveredPromMu guards the cached Prometheus auto-discovery result.
 	discoveredPromMu   sync.Mutex

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -129,7 +129,9 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 	}
 
 	var prClient gitops.PullRequestClient
-	{
+	if r.gitopsPRClient != nil {
+		prClient = r.gitopsPRClient
+	} else {
 		token, err := r.readSecretKey(ctx, policy.Namespace, cfg.TokenSecretRef.Name, cfg.TokenSecretRef.Key)
 		if err != nil {
 			// Do not include secret name details that might confuse with token material.

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/gitops"
 	"github.com/attune-io/attune/internal/operatormetrics"
 )
 
@@ -392,6 +394,41 @@ func TestReconcileGitOpsPullRequest_DryRunIncrementsMetric(t *testing.T) {
 	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRDryRun, reason)
 }
 
+// recordingPRClient is a fake forge. After SimulateMerge, the next
+// CreateOrUpdate would open a new PR (empty list + missing head), matching
+// GitHub after squash-merge deletes the recommendation branch.
+type recordingPRClient struct {
+	calls         []gitops.PRRequest
+	merged        bool
+	createsAfter  int // CreateOrUpdate calls after SimulateMerge
+	createsBefore int
+}
+
+func (c *recordingPRClient) CreateOrUpdate(_ context.Context, req gitops.PRRequest) (gitops.PRResult, error) {
+	c.calls = append(c.calls, req)
+	if c.merged {
+		c.createsAfter++
+		n := c.createsBefore + c.createsAfter
+		return gitops.PRResult{
+			URL: "https://github.com/org/repo/pull/" + itoaPR(n), Number: n, Updated: false,
+		}, nil
+	}
+	c.createsBefore++
+	return gitops.PRResult{
+		URL:    "https://github.com/org/repo/pull/" + itoaPR(c.createsBefore),
+		Number: c.createsBefore, Updated: c.createsBefore > 1,
+	}, nil
+}
+
+func (c *recordingPRClient) SimulateMerge() { c.merged = true }
+
+func itoaPR(n int) string {
+	if n < 0 {
+		n = 0
+	}
+	return strconv.Itoa(n)
+}
+
 func TestReconcileGitOpsPullRequest_UnchangedDriftSkipsAfterCooldown(t *testing.T) {
 	t.Parallel()
 	scheme := runtime.NewScheme()
@@ -475,6 +512,88 @@ func gitOpsPRReason(policy *attunev1alpha1.AttunePolicy) string {
 		}
 	}
 	return ""
+}
+
+func TestReconcileGitOpsPullRequest_LivePathDoesNotRecreateAfterMerge(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	dry := false
+	start := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "authentik", Namespace: "authentik"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &dry,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "tok", Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "authentik"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).Build()
+	fakeForge := &recordingPRClient{}
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	r.gitopsPRClient = fakeForge
+	now := start
+	r.SetNowFunc(func() time.Time { return now })
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("100m"),
+			},
+		}},
+	}}
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	require.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy))
+	require.Equal(t, 1, fakeForge.createsBefore, "first cycle opens one PR")
+	require.Equal(t, 0, fakeForge.createsAfter)
+
+	// User merged the empty PR; GitHub deleted the head branch.
+	fakeForge.SimulateMerge()
+	now = start.Add(25 * time.Hour)
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
+	assert.Equal(t, 0, fakeForge.createsAfter, "same drift after merge must not CreateOrUpdate")
+	assert.Equal(t, 1, len(fakeForge.calls))
+
+	// Real new drift still opens after cooldown.
+	recs[0].Containers[0].Recommended.CPURequest = resource.MustParse("200m")
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy))
+	assert.Equal(t, 1, fakeForge.createsAfter, "changed drift may open a new PR")
+	assert.Equal(t, 2, len(fakeForge.calls))
 }
 
 func TestReconcileGitOpsPullRequest_IncompleteConfig(t *testing.T) {

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -130,6 +130,52 @@ func TestGitHubClient_Create_BootstrapsMissingHead(t *testing.T) {
 	assert.Contains(t, joined, "POST /repos/org/repo/pulls")
 }
 
+func TestGitHubClient_Create_AgainAfterHeadDeleted(t *testing.T) {
+	t.Parallel()
+	var pullCreates int
+	client := &GitHubClient{
+		Token:      "tok",
+		Repository: "org/repo",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			path := r.URL.Path
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(path, "/pulls"):
+				// Merged + branch deleted: no open PR.
+				return jsonResp(200, "[]"), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/git/ref/heads/attune/x"):
+				return jsonResp(404, `{"message":"Not Found"}`), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/git/ref/heads/main"):
+				return jsonResp(200, map[string]interface{}{
+					"object": map[string]string{"sha": "base-sha"},
+				}), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/git/commits/base-sha"):
+				return jsonResp(200, map[string]interface{}{
+					"tree": map[string]string{"sha": "tree-sha"},
+				}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/git/commits"):
+				return jsonResp(201, map[string]string{"sha": "new-commit-sha"}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/git/refs"):
+				return jsonResp(201, map[string]interface{}{
+					"ref": "refs/heads/attune/x",
+				}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/pulls"):
+				pullCreates++
+				return jsonResp(201, map[string]interface{}{
+					"number": pullCreates, "html_url": "https://github.com/org/repo/pull/1",
+				}), nil
+			default:
+				return jsonResp(500, `{"message":"unexpected `+r.Method+` `+path+`"}`), nil
+			}
+		}),
+	}
+	req := PRRequest{Title: "t", Body: "same table", Head: "attune/x", Base: "main"}
+	_, err := client.CreateOrUpdate(context.Background(), req)
+	require.NoError(t, err)
+	_, err = client.CreateOrUpdate(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, 2, pullCreates, "client will open a second empty PR if asked after merge")
+}
+
 func TestGitLabClient_Create_BootstrapsMissingHead(t *testing.T) {
 	t.Parallel()
 	var methods []string


### PR DESCRIPTION
## Summary

Add a live-path GitOps PR test that counts `CreateOrUpdate` after merge, so the empty-PR loop cannot come back without a red test.

## The problem

#537 (daily empty PRs) was not caught because tests only asserted the first successful open (dry-run, cooldown, bootstrap). They never asked the forge how many times `CreateOrUpdate` ran after the user merged and GitHub deleted the head branch.

## The change

- Inject an optional test `PullRequestClient` on the reconciler
- `TestReconcileGitOpsPullRequest_LivePathDoesNotRecreateAfterMerge`: first cycle creates once; after `SimulateMerge` + 25h + same drift, create count stays 1
- `TestGitHubClient_Create_AgainAfterHeadDeleted`: the GitHub client still opens a second PR if asked (so the skip must stay in the reconciler)
- Note in `docs/contributing/testing.md`

Red without the fingerprint skip: `createsAfter` is 1 and reason is `PullRequestOpen`. Green with the skip: `createsAfter` is 0.

## Validation

`go test ./internal/controller/ ./internal/gitops/ -race -count=1`

## Issue

Ref #537
