### PR TITLE
fix: do not revert resize when annotation persist already committed

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -62,7 +62,10 @@ Envtest has no kubelet and no cAdvisor. It cannot exercise in-place
 `test/e2e` and `test/e2e-go`. The interceptor tests cover status
 writes and annotation persist retry only. The persist cases call
 `persistResizeAnnotations` through an integration-tag helper; they
-do not go through `UpdateResize`.
+do not go through `UpdateResize`. After a committed persist plus a
+client timeout, persist confirms the tracking annotations with a
+Clientset Get and treats the write as success so `resizeContainer`
+does not revert.
 
 ## E2E tests (Chainsaw)
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -22,7 +22,7 @@ Total number of resize reverts triggered by the safety monitor.
 |-------|-------------|
 | `namespace` | Workload namespace |
 | `workload` | Workload name |
-| `reason` | `oomkill`, `throttle`, `restart`, `notready`, `slo:<name>`, `re-fetch-failed`, or `annotation-persist-failed` |
+| `reason` | `oomkill`, `throttle`, `restart`, `notready`, `slo:<name>`, `re-fetch-failed`, or `annotation-persist-failed` (write did not land; a timeout after a committed persist is treated as success and does not revert) |
 
 ### attune_revert_failures_total
 

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -7124,6 +7124,165 @@ func (f *failOnPodUpdateClient) Update(ctx context.Context, obj client.Object, o
 	return f.Client.Update(ctx, obj, opts...)
 }
 
+// commitThenTimeoutPodClient commits the pod Update, mirrors it into the
+// Clientset (persist confirm Get is a Clientset read), then returns timeout
+// on the first N pod Updates.
+type commitThenTimeoutPodClient struct {
+	client.Client
+	cs           *kubefake.Clientset
+	timeoutsLeft int
+	timeoutsSeen int
+}
+
+func (c *commitThenTimeoutPodClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return c.Client.Update(ctx, obj, opts...)
+	}
+	if err := c.Client.Update(ctx, obj, opts...); err != nil {
+		return err
+	}
+	if _, err := c.cs.CoreV1().Pods(pod.Namespace).Update(ctx, pod.DeepCopy(), metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+	if c.timeoutsLeft > 0 {
+		c.timeoutsLeft--
+		c.timeoutsSeen++
+		return apierrors.NewTimeoutError("injected timeout after committed annotation persist", 0)
+	}
+	return nil
+}
+
+func persistMainRec(t *testing.T) attunev1alpha1.ContainerRecommendation {
+	t.Helper()
+	parse := func(s string) resource.Quantity {
+		t.Helper()
+		q, err := resource.ParseQuantity(s)
+		require.NoError(t, err, "parse quantity %q", s)
+		return q
+	}
+	return attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    parse("500m"),
+			CPULimit:      parse("1000m"),
+			MemoryRequest: parse("512Mi"),
+			MemoryLimit:   parse("1Gi"),
+		},
+	}
+}
+
+func TestPersistResizeAnnotations_TimeoutAfterCommitTreatsAsSuccess(t *testing.T) {
+	pod := newResizePodWithStatus("api-server", "500m", "512Mi", "1000m", "1Gi", 3)
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod.DeepCopy()).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	wrapped := &commitThenTimeoutPodClient{Client: fakeClient, cs: clientset, timeoutsLeft: 1}
+
+	r := NewAttunePolicyReconciler()
+	r.Client = wrapped
+	r.Scheme = scheme
+	r.Clientset = clientset
+
+	now := metav1.NewTime(time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC))
+	working := pod.DeepCopy()
+	reason, err := r.persistResizeAnnotations(context.Background(), working, persistMainRec(t),
+		"test-policy", "api-server", now, 3)
+	require.NoError(t, err, "committed persist plus client timeout must be treated as success")
+	assert.Empty(t, reason)
+	assert.Equal(t, 1, wrapped.timeoutsSeen)
+
+	var stored corev1.Pod
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: pod.Name, Namespace: pod.Namespace,
+	}, &stored))
+	assert.Equal(t, "main", stored.Annotations[annotationResizedContainers])
+	assert.Equal(t, now.UTC().Format(time.RFC3339), stored.Annotations[annotationResizedAt])
+	assert.Equal(t, "test-policy", stored.Annotations[annotationPolicy])
+	assert.Equal(t, "true", stored.Labels[labelTracked])
+	assert.Equal(t, now.UTC().Format(time.RFC3339), working.Annotations[annotationResizedAt],
+		"in-memory pod must receive the confirmed annotations")
+}
+
+func TestExecuteResizes_TimeoutAfterCommitDoesNotRevert(t *testing.T) {
+	pod := newResizePodWithStatus("api-server", "500m", "512Mi", "1000m", "1Gi", 3)
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod.DeepCopy()).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	wrapped := &commitThenTimeoutPodClient{Client: fakeClient, cs: clientset, timeoutsLeft: 1}
+
+	r := NewAttunePolicyReconciler()
+	r.Client = wrapped
+	r.Scheme = scheme
+	r.Clientset = clientset
+	r.Recorder = events.NewFakeRecorder(10)
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeOneShot
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("api-server", "500m", "512Mi", "1000m", "1Gi", "750m", "384Mi", "1500m", "768Mi"),
+	}
+
+	count, history := r.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recommendations, podMap("api-server", pod), nil, nil)
+	require.Equal(t, 1, count, "resize must stick when persist committed before the timeout")
+	require.NotEmpty(t, history)
+	for _, h := range history {
+		assert.NotEqual(t, attunev1alpha1.ResizeResultReverted, h.Result,
+			"must not revert a resize whose tracking annotations already landed")
+	}
+
+	var resizeCalls int
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			resizeCalls++
+		}
+	}
+	assert.Equal(t, 1, resizeCalls, "only the original UpdateResize; no revert")
+	assert.Equal(t, 1, wrapped.timeoutsSeen)
+}
+
+func TestTrackingAnnotationsApplied(t *testing.T) {
+	intended := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{labelTracked: "true"},
+			Annotations: map[string]string{
+				annotationResizedAt:                           "2026-03-01T12:00:00Z",
+				annotationResizedWorkload:                     "api-server",
+				annotationPolicy:                              "test-policy",
+				annotationResizedContainers:                   "main",
+				annotationOriginalCPUPrefix + "main":          "500m",
+				annotationOriginalMemoryPrefix + "main":       "512Mi",
+				annotationOriginalCPULimitPrefix + "main":     "1000m",
+				annotationOriginalMemoryLimitPrefix + "main":  "1Gi",
+				annotationOriginalRestartCountPrefix + "main": "3",
+			},
+		},
+	}
+	clone := func() *corev1.Pod { return intended.DeepCopy() }
+
+	t.Run("match", func(t *testing.T) {
+		assert.True(t, trackingAnnotationsApplied(clone(), intended, "main"))
+	})
+	t.Run("stale resized-at is not this persist", func(t *testing.T) {
+		got := clone()
+		got.Annotations[annotationResizedAt] = "2026-01-01T00:00:00Z"
+		assert.False(t, trackingAnnotationsApplied(got, intended, "main"))
+	})
+	t.Run("missing container", func(t *testing.T) {
+		got := clone()
+		got.Annotations[annotationResizedContainers] = "sidecar"
+		assert.False(t, trackingAnnotationsApplied(got, intended, "main"))
+	})
+	t.Run("container listed among others", func(t *testing.T) {
+		got := clone()
+		got.Annotations[annotationResizedContainers] = "sidecar,main"
+		assert.True(t, trackingAnnotationsApplied(got, intended, "main"))
+	})
+}
+
 type failOnNamedPodUpdateClient struct {
 	client.Client
 	failPodName string

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -698,6 +698,11 @@ func (r *AttunePolicyReconciler) resizeContainer(
 // pod status (conditions, containerStatuses) after a resize, bumping
 // resourceVersion. In multi-container pods the second container's annotation
 // persist races with the kubelet's status write from the first resize.
+//
+// A non-conflict write error (timeout after the apiserver committed) is not
+// treated as failure when a follow-up Get shows this persist's tracking
+// annotations already landed. Reverting in that case would roll the spec
+// back and leave stale tracking annotations.
 func (r *AttunePolicyReconciler) persistResizeAnnotations(
 	ctx context.Context,
 	pod *corev1.Pod,
@@ -746,14 +751,88 @@ func (r *AttunePolicyReconciler) persistResizeAnnotations(
 			*pod = *freshPod
 			return "", nil
 		}
-		if !apierrors.IsConflict(updateErr) {
-			logger.Error(updateErr, "Failed to persist resize tracking annotations, reverting resize", "pod", pod.Name)
+		if apierrors.IsConflict(updateErr) {
+			logger.Info("Annotation update conflict, retrying", "pod", pod.Name, "attempt", attempt+1, "maxRetries", maxRetries)
+			continue
+		}
+		// Timeout and other non-conflict errors can race a successful write.
+		// Confirm via Clientset Get (not the informer cache) before revert.
+		confirmed, confirmErr := r.confirmTrackingAnnotations(ctx, pod.Namespace, pod.Name, freshPod, containerRec.Name)
+		if confirmErr != nil {
+			logger.Error(confirmErr, "Failed to confirm annotation persist after write error",
+				"pod", pod.Name, "writeError", updateErr.Error())
 			return "annotation-persist-failed", updateErr
 		}
-		logger.Info("Annotation update conflict, retrying", "pod", pod.Name, "attempt", attempt+1, "maxRetries", maxRetries)
+		if confirmed != nil {
+			logger.Info("Annotation persist write error after committed tracking annotations; treating as success",
+				"pod", pod.Name, "writeError", updateErr.Error())
+			*pod = *confirmed
+			return "", nil
+		}
+		logger.Error(updateErr, "Failed to persist resize tracking annotations, reverting resize", "pod", pod.Name)
+		return "annotation-persist-failed", updateErr
 	}
 	logger.Error(nil, "Exhausted annotation persist retries, reverting resize", "pod", pod.Name, "maxRetries", maxRetries)
 	return "annotation-persist-conflict", fmt.Errorf("exhausted %d annotation persist retries", maxRetries)
+}
+
+// confirmTrackingAnnotations returns the live pod when a Clientset Get shows
+// that intended tracking annotations from this persist attempt already landed.
+// A nil pod and nil error means the write did not land.
+func (r *AttunePolicyReconciler) confirmTrackingAnnotations(
+	ctx context.Context, namespace, name string, intended *corev1.Pod, container string,
+) (*corev1.Pod, error) {
+	got, err := r.Clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if trackingAnnotationsApplied(got, intended, container) {
+		return got, nil
+	}
+	return nil, nil
+}
+
+func trackingAnnotationsApplied(got, intended *corev1.Pod, container string) bool {
+	if got == nil || intended == nil || got.Annotations == nil || intended.Annotations == nil {
+		return false
+	}
+	keys := []string{
+		annotationResizedAt,
+		annotationResizedWorkload,
+		annotationPolicy,
+		annotationOriginalCPUPrefix + container,
+		annotationOriginalMemoryPrefix + container,
+		annotationOriginalRestartCountPrefix + container,
+	}
+	for _, k := range keys {
+		if intended.Annotations[k] == "" || got.Annotations[k] != intended.Annotations[k] {
+			return false
+		}
+	}
+	if lim := intended.Annotations[annotationOriginalCPULimitPrefix+container]; lim != "" &&
+		got.Annotations[annotationOriginalCPULimitPrefix+container] != lim {
+		return false
+	}
+	if lim := intended.Annotations[annotationOriginalMemoryLimitPrefix+container]; lim != "" &&
+		got.Annotations[annotationOriginalMemoryLimitPrefix+container] != lim {
+		return false
+	}
+	if !resizedContainersContains(got.Annotations[annotationResizedContainers], container) {
+		return false
+	}
+	if got.Labels[labelTracked] != "true" {
+		return false
+	}
+	return true
+}
+
+func resizedContainersContains(list, container string) bool {
+	for _, name := range strings.Split(list, ",") {
+		if strings.TrimSpace(name) == container {
+			return true
+		}
+	}
+	return false
 }
 
 // buildResizeTarget constructs the target ResourceRequirements from a container recommendation.

--- a/test/integration/api_fault_test.go
+++ b/test/integration/api_fault_test.go
@@ -504,9 +504,10 @@ func TestAPIFault_ManagerRestartMidReconcile(t *testing.T) {
 
 // TestAPIFault_TimeoutAfterCommittedAnnotationPersist lets the apiserver
 // commit a pod Update that writes resize-tracking annotations, then returns
-// a timeout to persistResizeAnnotations. A retry must not duplicate
-// resized-containers. This is persist only; envtest still has no kubelet
-// /resize.
+// a timeout to persistResizeAnnotations. Persist must treat the landed
+// write as success so resizeContainer does not revert. A second persist
+// must not duplicate resized-containers. This is persist only; envtest
+// still has no kubelet /resize.
 func TestAPIFault_TimeoutAfterCommittedAnnotationPersist(t *testing.T) {
 	cfg, plain := startIsolatedEnvtest(t)
 	pod := createPersistPod(t, plain, "fault-persist-timeout", "persist-app")
@@ -533,8 +534,8 @@ func TestAPIFault_TimeoutAfterCommittedAnnotationPersist(t *testing.T) {
 	working := pod.DeepCopy()
 	reason, firstErr := r.PersistResizeAnnotationsForTest(
 		context.Background(), working, rec, "policy-persist", "persist-app", now, 3)
-	require.Error(t, firstErr, "first persist must surface the injected timeout")
-	assert.Equal(t, "annotation-persist-failed", reason)
+	require.NoError(t, firstErr, "committed persist plus client timeout must succeed after confirm GET")
+	assert.Empty(t, reason)
 	assert.GreaterOrEqual(t, podUpdates.Load(), int32(1), "interceptor must commit then fail")
 
 	var afterTimeout corev1.Pod
@@ -547,7 +548,7 @@ func TestAPIFault_TimeoutAfterCommittedAnnotationPersist(t *testing.T) {
 	working = afterTimeout.DeepCopy()
 	reason, retryErr := r.PersistResizeAnnotationsForTest(
 		context.Background(), working, rec, "policy-persist", "persist-app", now, 3)
-	require.NoError(t, retryErr, "retry after persist timeout must succeed")
+	require.NoError(t, retryErr, "second persist must stay idempotent")
 	assert.Empty(t, reason)
 
 	var final corev1.Pod


### PR DESCRIPTION
## Summary

Stop reverting an in-place resize when tracking annotations already landed and the persist client only saw a timeout.

## Problem

`persistResizeAnnotations` treated every non-conflict `Update` error as failure. `resizeContainer` then reverted. After a committed write plus a client timeout, the pod spec rolled back while `attune.io/resized-*` annotations stayed. Safety and the next reconcile saw a tracked resize that was no longer the live spec.

[#543](https://github.com/attune-io/attune/pull/543) documented that hole. This PR closes it.

## Change

After a non-conflict persist error, Get the pod via Clientset (not the informer cache). If this persist's tracking keys are present (`resized-at` matches this attempt, container listed, policy and original-request keys match), treat persist as success and do not revert.

A write that never landed still returns `annotation-persist-failed` and still reverts.

## Validation

```text
go test ./internal/controller/ -race -count=1 \
  -run 'TestPersistResizeAnnotations_|TestExecuteResizes_TimeoutAfterCommitDoesNotRevert|TestExecuteResizes_RevertsOnAnnotationUpdateFailure|TestTrackingAnnotationsApplied|TestExecuteResizes_PersistsAnnotations'
# ok

golangci-lint run --build-tags=integration ./internal/controller/ ./test/integration/
# 0 issues

KUBEBUILDER_ASSETS=... go test ./test/integration/ -tags=integration -race -count=1 \
  -run 'TestAPIFault_TimeoutAfterCommittedAnnotationPersist|TestAPIFault_AnnotationPersist409ThenSuccess'
# ok
```

Closes #544

Ref #542
