### PR TITLE
fix: prefix helm default image tag with v

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,8 @@ jobs:
               - 'Makefile'
             helm:
               - 'charts/**'
+              - 'hack/verify-helm-image-tag.sh'
+              - 'scripts/test_verify_helm_image_tag.sh'
             yaml:
               - 'config/**'
               - '.github/workflows/**'
@@ -777,6 +779,12 @@ jobs:
       - name: Verify Helm RBAC matches kustomize
         shell: bash -Eeuo pipefail {0}
         run: bash hack/verify-helm-rbac.sh
+
+      - name: Verify default image tag is v + appVersion
+        shell: bash -Eeuo pipefail {0}
+        run: |
+          bash scripts/test_verify_helm_image_tag.sh
+          bash hack/verify-helm-image-tag.sh
 
   build:
     name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -309,8 +309,14 @@ jobs:
         shell: bash
         run: |
           TAG="${{ steps.tag.outputs.name }}"
+          BARE="${TAG#v}"
           NL=$'\n'
           TAGS="${REGISTRY}/${IMAGE_NAME}:${TAG}${NL}docker.io/attuneio/attune:${TAG}"
+          # Also publish the bare SemVer tag so older charts that used
+          # Chart.appVersion (no v prefix) as the image tag still pull.
+          if [ "${BARE}" != "${TAG}" ]; then
+            TAGS="${TAGS}${NL}${REGISTRY}/${IMAGE_NAME}:${BARE}${NL}docker.io/attuneio/attune:${BARE}"
+          fi
           # Skip :latest on re-releases to avoid overwriting a newer release
           if [ -z "${{ inputs.tag }}" ]; then
             TAGS="${TAGS}${NL}${REGISTRY}/${IMAGE_NAME}:latest${NL}docker.io/attuneio/attune:latest"
@@ -498,6 +504,9 @@ jobs:
           sed -i "s/^appVersion:.*/appVersion: ${VERSION}/" charts/attune/Chart.yaml
 
           helm package charts/attune
+          # Fail closed if the packaged chart would pull a tag that does
+          # not exist (bare appVersion vs v-prefixed image tags, #546).
+          bash hack/verify-helm-image-tag.sh
           helm push attune-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
 
       - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2 (includes 1.3.2)

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ verify-prometheusrule-metrics: ## Verify PrometheusRule alert expressions use re
 verify-helm-schema-fields: ## Verify Helm values.schema.json field names match CRD field names
 	@bash hack/verify-helm-schema-fields.sh
 
+.PHONY: verify-helm-image-tag
+verify-helm-image-tag: ## Verify Helm default image tag is v + Chart.appVersion
+	@bash hack/verify-helm-image-tag.sh
+
 .PHONY: verify-release-artifacts
 verify-release-artifacts: kustomize ## Verify release artifacts generate cleanly and, if present, match current sources
 	@repo_root=$$(pwd); \
@@ -126,7 +130,7 @@ ci-runner-status: ## Show queued/in-progress CI runs
 	fi
 
 .PHONY: verify-quick
-verify-quick: lint yaml-lint lint-chainsaw test python-test helm-lint helm-docs-check helm-unittest verify-boilerplate tidy-check verify-doc-defaults verify-helm-rbac verify-dashboard-metrics verify-doc-tool-versions verify-go-version-sync verify-prometheusrule-metrics verify-helm-schema-fields verify-release-artifacts ## Fast pre-commit checks (no integration tests or govulncheck)
+verify-quick: lint yaml-lint lint-chainsaw test python-test helm-lint helm-docs-check helm-unittest verify-boilerplate tidy-check verify-doc-defaults verify-helm-rbac verify-dashboard-metrics verify-doc-tool-versions verify-go-version-sync verify-prometheusrule-metrics verify-helm-schema-fields verify-helm-image-tag verify-release-artifacts ## Fast pre-commit checks (no integration tests or govulncheck)
 
 .PHONY: verify
 verify: verify-quick test-integration govulncheck ## Run all CI checks locally (includes integration tests)
@@ -230,10 +234,11 @@ test-fuzz: ## Run fuzz tests (coverage-guided; FUZZTIME=30s default, deadline-fl
 	./scripts/run-fuzz.sh
 
 .PHONY: python-test
-python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync)
+python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync, helm image tag)
 	python3 scripts/test_fossa_filter.py -v
 	bash scripts/test_run_fuzz.sh
 	bash scripts/test_verify_go_version_sync.sh
+	bash scripts/test_verify_helm_image_tag.sh
 
 .PHONY: test-bench
 test-bench: ## Run benchmark tests

--- a/charts/attune/README.md
+++ b/charts/attune/README.md
@@ -48,7 +48,7 @@ helm install attune oci://ghcr.io/attune-io/charts/attune \
 | grafanaFleetDashboard.enabled | bool | `false` | Create a ConfigMap with the multi-cluster fleet Grafana dashboard (cluster variable). Use with federated Prometheus that has external_labels.cluster on each scrape. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ghcr.io/attune-io/attune"` | Container image repository |
-| image.tag | string | `""` | Image tag (defaults to Chart appVersion) |
+| image.tag | string | `""` | Image tag. Empty uses a `v` prefix plus Chart appVersion (published images are tagged `vX.Y.Z`, not `X.Y.Z`). |
 | imagePullSecrets | list | `[]` | Image pull secrets |
 | initialSizing | object | `{"enabled":false}` | Initial sizing webhook configuration. When enabled, a mutating webhook sets pod resource requests at creation time based on existing AttunePolicy recommendations. Requires namespace label attune.io/initial-sizing=enabled and initialSizing: true on the policy. |
 | initialSizing.enabled | bool | `false` | Enable the pod initial sizing mutating webhook. |

--- a/charts/attune/templates/_helpers.tpl
+++ b/charts/attune/templates/_helpers.tpl
@@ -62,6 +62,18 @@ Create the name of the service account to use.
 {{- end }}
 
 {{/*
+Published images are vX.Y.Z; appVersion is SemVer without v.
+Prefix v when image.tag is empty. trimPrefix avoids vv.
+*/}}
+{{- define "attune.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{- .Values.image.tag -}}
+{{- else -}}
+{{- printf "v%s" (.Chart.AppVersion | trimPrefix "v") -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Cluster size preset defaults. Returns nothing if clusterSize is empty.
 Explicit values in values.yaml always override these presets.
 */}}

--- a/charts/attune/templates/deployment.yaml
+++ b/charts/attune/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: manager
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ include "attune.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --health-probe-bind-address=:8081

--- a/charts/attune/tests/deployment_test.yaml
+++ b/charts/attune/tests/deployment_test.yaml
@@ -9,12 +9,40 @@ tests:
       - equal:
           path: spec.replicas
           value: 1
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr\.io/attune-io/attune:v[0-9]+\.[0-9]+\.[0-9]+$
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: true
+
+  - it: should default image tag to v-prefixed appVersion not bare SemVer
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: :v[0-9]+\.[0-9]+\.[0-9]+$
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: :[0-9]+\.[0-9]+\.[0-9]+$
+
+  - it: should use explicit image.tag without adding a v prefix
+    set:
+      image.tag: e2e
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/attune-io/attune:e2e
+
+  - it: should keep an explicit v-prefixed image.tag unchanged
+    set:
+      image.tag: v0.1.23
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/attune-io/attune:v0.1.23
 
   - it: should set replicas from values
     set:

--- a/charts/attune/values.schema.json
+++ b/charts/attune/values.schema.json
@@ -29,7 +29,7 @@
         "tag": {
           "type": "string",
           "default": "",
-          "description": "Image tag (defaults to Chart appVersion)"
+          "description": "Image tag. Empty uses a v prefix plus Chart appVersion (published images are tagged vX.Y.Z)."
         }
       }
     },

--- a/charts/attune/values.yaml
+++ b/charts/attune/values.yaml
@@ -9,7 +9,8 @@ image:
   repository: ghcr.io/attune-io/attune
   # -- Image pull policy
   pullPolicy: IfNotPresent
-  # -- Image tag (defaults to Chart appVersion)
+  # -- Image tag. Empty uses a `v` prefix plus Chart appVersion
+  # (published images are tagged `vX.Y.Z`, not `X.Y.Z`).
   tag: ""
 
 # -- Image pull secrets

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1219,7 +1219,7 @@ charts/attune/
 
 **Key values.yaml fields**:
 - `replicaCount` (default: 1, HA: 2 with leader election)
-- `image.repository`, `image.tag`
+- `image.repository`, `image.tag` (empty tag renders `v` plus `appVersion`)
 - `resources` (operator pod resources)
 - `metrics.enabled` (expose /metrics)
 - `securityContext` (non-root, read-only root filesystem, drop all capabilities)

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -1,7 +1,10 @@
 ## Version scheme
 
 Attune follows [Semantic Versioning](https://semver.org/). The Helm
-chart version and `appVersion` are kept in sync in `charts/attune/Chart.yaml`.
+chart version and `appVersion` are kept in sync in `charts/attune/Chart.yaml`
+as bare SemVer (`0.1.23`, no `v`). Git tags and container images use the
+`v` prefix (`v0.1.23`). The chart templates `v` plus `appVersion` when
+`image.tag` is empty so a default install pulls a published image.
 
 ## Release process
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1024,6 +1024,28 @@ update a PR. Common cases:
 
 See [GitOps integration: pull request automation](gitops-integration.md#pull-request-automation-opt-in-phase-b).
 
+## Helm install ImagePullBackOff
+
+**Symptom:** After `helm install` from `oci://ghcr.io/attune-io/charts/attune`,
+the operator pod stays `0/1` with `ErrImagePull` or `ImagePullBackOff` for
+`ghcr.io/attune-io/attune:0.1.x` (no `v` prefix).
+
+**Cause:** Chart `appVersion` is SemVer without `v`. Release images are
+tagged `vX.Y.Z`. Charts through 0.1.23 used bare `appVersion` as the
+image tag when `image.tag` was empty.
+
+**Fix:** Pin a published tag, then upgrade:
+
+```bash
+helm upgrade attune oci://ghcr.io/attune-io/charts/attune \
+  --namespace attune-system \
+  --reuse-values \
+  --set image.tag=v0.1.23
+```
+
+Newer charts default to `v` plus `appVersion`. You can still override
+`image.tag` for local or E2E images.
+
 ## Debug commands
 
 Operator logs:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,7 +7,7 @@ This page documents every value in the Helm chart's `values.yaml`.
 | `replicaCount` | int | `1` | Number of operator replicas. Set to `2` for HA with leader election. |
 | `image.repository` | string | `ghcr.io/attune-io/attune` | Container image repository |
 | `image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
-| `image.tag` | string | `""` | Image tag. Defaults to the chart's `appVersion`. |
+| `image.tag` | string | `""` | Image tag. When empty, the chart uses `v` plus `appVersion` so the pull matches published tags such as `v0.1.23`. |
 | `imagePullSecrets` | list | `[]` | Image pull secrets for private registries |
 | `nameOverride` | string | `""` | Override the chart name |
 | `fullnameOverride` | string | `""` | Override the fully qualified app name |

--- a/hack/verify-helm-image-tag.sh
+++ b/hack/verify-helm-image-tag.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify the Helm chart default image tag matches published operator
+# tags (vX.Y.Z). Chart.appVersion is SemVer without v; the template
+# must prefix v when image.tag is empty.
+#
+# This is the gate that would have caught attune-io/attune#546:
+# helm lint and helm-unittest did not assert the default image, and
+# E2E always --set image.tag= from a locally built image.
+
+set -euo pipefail
+
+ROOT=""
+
+usage() {
+  cat <<'EOF'
+Usage: verify-helm-image-tag.sh [--root DIR]
+
+Fail if helm template default image is not v + Chart.appVersion.
+--root   Repository root (default: parent of this script's directory).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --root)
+      if [[ $# -lt 2 ]]; then
+        echo "FAIL: --root requires a directory argument" >&2
+        exit 1
+      fi
+      ROOT="$2"
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "FAIL: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${ROOT}" ]]; then
+  ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+echo "PLAN: assert default Helm image tag is v + Chart.appVersion"
+
+CHART="${ROOT}/charts/attune"
+CHART_YAML="${CHART}/Chart.yaml"
+
+if [[ ! -f "${CHART_YAML}" ]]; then
+  echo "FAIL: Chart.yaml not found at ${CHART_YAML}"
+  echo "DONE: ok=false reason=missing-chart"
+  exit 1
+fi
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "FAIL: helm is required"
+  echo "DONE: ok=false reason=missing-helm"
+  exit 1
+fi
+
+echo "DO: read appVersion from ${CHART_YAML}"
+APP_VERSION="$(awk '/^appVersion:/{print $2; exit}' "${CHART_YAML}" | tr -d '"')"
+if [[ -z "${APP_VERSION}" ]]; then
+  echo "FAIL: no appVersion in ${CHART_YAML}"
+  echo "DONE: ok=false reason=unparseable-appversion"
+  exit 1
+fi
+
+BARE="${APP_VERSION#v}"
+EXPECTED_TAG="v${BARE}"
+echo "OK: appVersion=${APP_VERSION} expected_tag=${EXPECTED_TAG}"
+
+echo "DO: helm template default image"
+RENDERED="$(helm template attune "${CHART}" --set webhooks.enabled=false)"
+DEFAULT_IMAGE="$(printf '%s\n' "${RENDERED}" | awk '/image:/{gsub(/"/, "", $2); print $2; exit}')"
+if [[ -z "${DEFAULT_IMAGE}" ]]; then
+  echo "FAIL: helm template produced no image:"
+  echo "DONE: ok=false reason=no-image"
+  exit 1
+fi
+echo "OK: default_image=${DEFAULT_IMAGE}"
+
+DEFAULT_TAG="${DEFAULT_IMAGE##*:}"
+REPO="${DEFAULT_IMAGE%:*}"
+if [[ "${DEFAULT_TAG}" != "${EXPECTED_TAG}" ]]; then
+  echo "FAIL: default image tag ${DEFAULT_TAG} != ${EXPECTED_TAG} (repo=${REPO})"
+  echo "HINT: attune.imageTag must prefix v onto Chart.appVersion when image.tag is empty."
+  echo "DONE: ok=false reason=wrong-default-tag got=${DEFAULT_TAG} want=${EXPECTED_TAG}"
+  echo "NEXT: fix charts/attune/templates/_helpers.tpl attune.imageTag"
+  exit 1
+fi
+
+echo "DO: helm template with explicit image.tag=e2e"
+OVERRIDE_IMAGE="$(helm template attune "${CHART}" --set webhooks.enabled=false --set image.tag=e2e \
+  | awk '/image:/{gsub(/"/, "", $2); print $2; exit}')"
+if [[ "${OVERRIDE_IMAGE}" != "${REPO}:e2e" ]]; then
+  echo "FAIL: explicit image.tag=e2e rendered ${OVERRIDE_IMAGE}, want ${REPO}:e2e"
+  echo "DONE: ok=false reason=override-mutated"
+  exit 1
+fi
+echo "OK: explicit tag e2e left unchanged"
+
+echo "DONE: ok=true default=${DEFAULT_IMAGE}"
+echo "NEXT: none"
+exit 0

--- a/scripts/test_verify_helm_image_tag.sh
+++ b/scripts/test_verify_helm_image_tag.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Classifier for hack/verify-helm-image-tag.sh: the live chart must pass,
+# and a chart that falls back to bare appVersion (issue #546) must fail.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT}/hack/verify-helm-image-tag.sh"
+
+echo "PLAN: classify verify-helm-image-tag.sh against live and broken charts"
+
+echo "DO: live chart must pass"
+if ! bash "${SCRIPT}" --root "${ROOT}"; then
+  echo "FAIL: live chart failed verify-helm-image-tag.sh"
+  echo "DONE: ok=false reason=live-chart-failed"
+  exit 1
+fi
+echo "OK: live chart passed"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+echo "DO: copy chart to ${TMP} and restore the bare-appVersion default"
+cp -R "${ROOT}/charts" "${TMP}/"
+# Recreate the #546 template: default image.tag to Chart.AppVersion with no v.
+sed -i.bak \
+  's#{{ include "attune.imageTag" . }}#{{ .Values.image.tag | default .Chart.AppVersion }}#' \
+  "${TMP}/charts/attune/templates/deployment.yaml"
+rm -f "${TMP}/charts/attune/templates/deployment.yaml.bak"
+
+echo "DO: broken chart must fail"
+if bash "${SCRIPT}" --root "${TMP}"; then
+  echo "FAIL: bare-appVersion chart passed; the script would not have caught #546"
+  echo "DONE: ok=false reason=false-negative"
+  exit 1
+fi
+echo "OK: broken chart failed as expected"
+
+echo "DONE: ok=true"
+echo "NEXT: none"
+exit 0


### PR DESCRIPTION
## Summary

Default Helm installs now pull `ghcr.io/attune-io/attune:vX.Y.Z`, matching the tags we actually publish.

## Problem

`helm install attune oci://ghcr.io/attune-io/charts/attune` rendered
`ghcr.io/attune-io/attune:0.1.23`. Release images are tagged `v0.1.23`
(and `latest`). The operator pod stayed `0/1` with `ErrImagePull`.

Chart `appVersion` is bare SemVer (release-please extra-files and the
helm-release job strip the `v`). The Deployment used
`image.tag | default .Chart.AppVersion` with an empty tag.

## Workaround (already on #546)

```bash
helm upgrade --install attune oci://ghcr.io/attune-io/charts/attune \
  --namespace attune-system --create-namespace \
  --set image.tag=v0.1.23
```

## Change

- `attune.imageTag` prefixes `v` onto `appVersion` when `image.tag` is empty
- Explicit tags (`e2e`, `v0.1.23`) are left unchanged
- Helm unittests assert the default image is `v` plus SemVer
- `hack/verify-helm-image-tag.sh` compares the rendered tag to `v` + `appVersion`
- Classifier proves the old template fails that script
- Helm Lint CI runs both scripts
- Release publishes a bare SemVer image alias (`0.1.23`) and runs the
  verifier before `helm push`

## Why we did not catch this

1. Helm unittests never asserted `containers[0].image`.
2. `helm lint` / `helm template` do not pull images.
3. E2E always `--set image.tag=` from a locally built image (`attune:e2e`).
4. Chart version and `appVersion` follow Helm SemVer without `v`; Docker
   tags follow the git tag with `v`. Nothing compared those two.
5. We never installed the published OCI chart without overrides.

The new verifier is the missing gate: it fails if the default pull is
not `v` plus `appVersion`. The classifier fails if that script would
accept the old template.

## Validation

- `helm template` default image is `ghcr.io/attune-io/attune:v0.1.23`
- `helm unittest charts/attune` (115 tests)
- `bash scripts/test_verify_helm_image_tag.sh` (live pass, old template fail)
- Reviewer: 0 bugs; CI wiring, unused `--check`, and test placement addressed

Closes #546
