### PR TITLE
fix: harden helm tags, persist confirm, and defaults merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,8 @@ jobs:
               - 'charts/**'
               - 'hack/verify-helm-image-tag.sh'
               - 'scripts/test_verify_helm_image_tag.sh'
+              - 'hack/release-image-tags.sh'
+              - 'scripts/test_release_image_tags.sh'
             yaml:
               - 'config/**'
               - '.github/workflows/**'
@@ -785,6 +787,7 @@ jobs:
         run: |
           bash scripts/test_verify_helm_image_tag.sh
           bash hack/verify-helm-image-tag.sh
+          bash scripts/test_release_image_tags.sh
 
   build:
     name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -309,18 +309,12 @@ jobs:
         shell: bash
         run: |
           TAG="${{ steps.tag.outputs.name }}"
-          BARE="${TAG#v}"
-          NL=$'\n'
-          TAGS="${REGISTRY}/${IMAGE_NAME}:${TAG}${NL}docker.io/attuneio/attune:${TAG}"
-          # Also publish the bare SemVer tag so older charts that used
-          # Chart.appVersion (no v prefix) as the image tag still pull.
-          if [ "${BARE}" != "${TAG}" ]; then
-            TAGS="${TAGS}${NL}${REGISTRY}/${IMAGE_NAME}:${BARE}${NL}docker.io/attuneio/attune:${BARE}"
-          fi
-          # Skip :latest on re-releases to avoid overwriting a newer release
+          ARGS=(--tag "${TAG}" --registry "${REGISTRY}" --image "${IMAGE_NAME}")
+          # Skip :latest on re-releases to avoid overwriting a newer release.
           if [ -z "${{ inputs.tag }}" ]; then
-            TAGS="${TAGS}${NL}${REGISTRY}/${IMAGE_NAME}:latest${NL}docker.io/attuneio/attune:latest"
+            ARGS+=(--latest)
           fi
+          TAGS="$(bash hack/release-image-tags.sh "${ARGS[@]}")"
           {
             echo "tags<<EOF"
             echo "$TAGS"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,9 @@ Run `make verify` before every commit. The Makefile `verify` and
 - boilerplate, `go mod tidy`, documentation defaults
 - Helm RBAC vs generated ClusterRole, Grafana dashboard sync
 - documentation tool versions, Go version sync (go.mod vs Dockerfile)
-- PrometheusRule metric names, Helm schema fields, release artifacts
-  (`dist/install.yaml` and `dist/crds.yaml`)
+- PrometheusRule metric names, Helm schema fields, Helm default image
+  tag vs `appVersion`, release artifacts (`dist/install.yaml` and
+  `dist/crds.yaml`)
 
 `make verify` then adds integration tests, govulncheck, and a generated
 file freshness check (`make manifests generate` must not change CRDs,

--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-v
 	bash scripts/test_run_fuzz.sh
 	bash scripts/test_verify_go_version_sync.sh
 	bash scripts/test_verify_helm_image_tag.sh
+	bash scripts/test_release_image_tags.sh
 
 .PHONY: test-bench
 test-bench: ## Run benchmark tests

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ In-place apply is the shared primitive (Kubernetes `/resize`). Attune is the
 #   --set webhooks.enabled=false          # skip cert-manager
 #   --set networkPolicy.prometheusPort=80 # if Prometheus Service is on :80
 #                                         # (chart default allows only :9090)
+# Chart 0.1.23 pulls :0.1.23 (missing). Pin until 0.1.24+.
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace
+  --namespace attune-system --create-namespace \
+  --set image.tag=v0.1.23
 ```
 
 Also available via [OperatorHub.io](https://operatorhub.io/operator/attune)

--- a/charts/attune/README.md
+++ b/charts/attune/README.md
@@ -12,8 +12,10 @@ Safe, in-place Kubernetes pod resource right-sizing operator
 ## Installation
 
 ```bash
+# Chart 0.1.23 pulls :0.1.23 (missing). Pin until 0.1.24+.
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace
+  --namespace attune-system --create-namespace \
+  --set image.tag=v0.1.23
 ```
 
 ## Values

--- a/charts/attune/README.md.gotmpl
+++ b/charts/attune/README.md.gotmpl
@@ -12,8 +12,10 @@
 ## Installation
 
 ```bash
+# Chart 0.1.23 pulls :0.1.23 (missing). Pin until 0.1.24+.
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace
+  --namespace attune-system --create-namespace \
+  --set image.tag=v0.1.23
 ```
 
 {{ template "chart.valuesSection" . }}

--- a/charts/attune/templates/_helpers.tpl
+++ b/charts/attune/templates/_helpers.tpl
@@ -66,8 +66,9 @@ Published images are vX.Y.Z; appVersion is SemVer without v.
 Prefix v when image.tag is empty. trimPrefix avoids vv.
 */}}
 {{- define "attune.imageTag" -}}
-{{- if .Values.image.tag -}}
-{{- .Values.image.tag -}}
+{{- $tag := .Values.image.tag | toString | trim -}}
+{{- if $tag -}}
+{{- $tag -}}
 {{- else -}}
 {{- printf "v%s" (.Chart.AppVersion | trimPrefix "v") -}}
 {{- end -}}

--- a/charts/attune/tests/deployment_test.yaml
+++ b/charts/attune/tests/deployment_test.yaml
@@ -44,6 +44,14 @@ tests:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/attune-io/attune:v0.1.23
 
+  - it: should treat whitespace-only image.tag as unset
+    set:
+      image.tag: "   "
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: :v[0-9]+\.[0-9]+\.[0-9]+$
+
   - it: should set replicas from values
     set:
       replicaCount: 3

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -371,7 +371,7 @@ func fetchPolicies(ctx context.Context, dynClient dynamic.Interface, namespace s
 		if apierrors.IsNotFound(err) || isNoResourceMatch(err) {
 			fmt.Fprintln(os.Stderr, "Error: Attune CRDs are not installed in this cluster.")
 			fmt.Fprintln(os.Stderr, "Install the operator first:")
-			fmt.Fprintln(os.Stderr, "  helm install attune oci://ghcr.io/attune-io/charts/attune")
+			fmt.Fprintln(os.Stderr, "  helm install attune oci://ghcr.io/attune-io/charts/attune --set image.tag=v0.1.23")
 			os.Exit(1)
 		}
 		fmt.Fprintf(os.Stderr, "Error listing policies: %v\n", err)

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1050,6 +1050,12 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	printEffectiveField("Type", getNestedString(item, "spec", "updateStrategy", "type"), string(effective.Spec.UpdateStrategy.Type), selected, updateDefaults != nil && updateDefaults.Type != "")
 	printEffectiveField("Cooldown", getNestedString(item, "spec", "updateStrategy", "cooldown"), formatDurationPtr(effective.Spec.UpdateStrategy.Cooldown), selected, updateDefaults != nil && updateDefaults.Cooldown != nil)
 	printEffectiveField("Query step", getNestedString(item, "spec", "metricsSource", "queryStep"), formatDurationPtr(effective.Spec.MetricsSource.QueryStep), selected, metricsDefaults != nil && metricsDefaults.QueryStep != nil)
+	providerConfigured := metricsProviderConfigured(item)
+	providerEffective := metricsProviderLabel(effective.Spec.MetricsSource)
+	providerInherited := metricsDefaults != nil && providerConfigured == unsetValue &&
+		(metricsDefaults.Prometheus != nil || metricsDefaults.Datadog != nil ||
+			metricsDefaults.CloudWatch != nil || metricsDefaults.VPA != nil)
+	printEffectiveField("Metrics source", providerConfigured, providerEffective, selected, providerInherited)
 	printEffectiveField("Minimum data points", formatInt64Ptr(rawInt64Field(item, "spec", "metricsSource", "minimumDataPoints")), formatInt32Ptr(effective.Spec.MetricsSource.MinimumDataPoints), selected, metricsDefaults != nil && metricsDefaults.MinimumDataPoints != nil)
 	printEffectiveField("Paused", formatBoolField(item, "spec", "paused"), formatBoolPtr(effective.Spec.Paused), selected, false)
 	printEffectiveField("Weight", formatInt64Field(item, "spec", "weight"), formatInt32Val(effective.Spec.Weight), selected, false)
@@ -1226,6 +1232,37 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 		} else {
 			fmt.Printf("Note: Export to ConfigMaps is enabled alongside %s mode (resizes will occur; ConfigMaps provide additional GitOps handoff).\n", mode)
 		}
+	}
+}
+
+func metricsProviderLabel(ms attunev1alpha1.MetricsSource) string {
+	switch {
+	case ms.Datadog != nil:
+		return "datadog"
+	case ms.CloudWatch != nil:
+		return "cloudwatch"
+	case ms.VPA != nil:
+		return "vpa"
+	case ms.Prometheus != nil:
+		return "prometheus"
+	default:
+		return "prometheus (auto-discover)"
+	}
+}
+
+func metricsProviderConfigured(item unstructured.Unstructured) string {
+	switch {
+	case getNestedString(item, "spec", "metricsSource", "datadog", "site") != "" ||
+		getNestedString(item, "spec", "metricsSource", "datadog", "apiKeySecretRef", "name") != "":
+		return "datadog"
+	case getNestedString(item, "spec", "metricsSource", "cloudwatch", "region") != "":
+		return "cloudwatch"
+	case getNestedString(item, "spec", "metricsSource", "vpa", "name") != "":
+		return "vpa"
+	case getNestedString(item, "spec", "metricsSource", "prometheus", "address") != "":
+		return "prometheus"
+	default:
+		return unsetValue
 	}
 }
 

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -1837,6 +1837,7 @@ func TestPrintExplain_NoRecommendations(t *testing.T) {
 	assert.Contains(t, output, "default/new-policy has no recommendations yet (Not enough data).")
 	assert.Contains(t, output, "Effective values:")
 	assert.Contains(t, output, "Type: Recommend (source: built-in default, configured: <unset>)")
+	assert.Contains(t, output, "Metrics source: prometheus (auto-discover)")
 }
 
 func TestPrintExplain_ShowsPolicyNamespaceAndBuiltInEffectiveValues(t *testing.T) {

--- a/docker/README.md
+++ b/docker/README.md
@@ -46,7 +46,8 @@ conflicts, graduated safety controls.
 
 ```bash
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace
+  --namespace attune-system --create-namespace \
+  --set image.tag=v0.1.23
 ```
 
 ### Pull from Docker Hub

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -251,6 +251,12 @@ Fuzz targets are defined in `internal/recommendation/fuzz_test.go`
 (float-field parsing via `strconv.ParseFloat`). Classifier unit tests:
 `bash scripts/test_run_fuzz.sh` (also via `make python-test`).
 
+`make python-test` also runs the Helm default-image-tag classifier
+(`scripts/test_verify_helm_image_tag.sh`) and the release dual-tag
+classifier (`scripts/test_release_image_tags.sh`). Those catch a
+missing `v` prefix on the operator image and a dropped bare SemVer
+alias on the next release.
+
 ## Running all tests
 
 Run everything in one command:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -65,6 +65,7 @@ helm install attune \
     ```bash
     helm upgrade attune oci://ghcr.io/attune-io/charts/attune \
       --namespace attune-system \
+      --reuse-values \
       --set networkPolicy.prometheusPort=80
     ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -32,13 +32,21 @@ kubectl create namespace attune-system
 
 helm install attune \
   oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system
+  --namespace attune-system \
+  --set image.tag=v0.1.23
 
 # Option B: skip webhooks (no cert-manager)
 # helm install attune oci://ghcr.io/attune-io/charts/attune \
 #   --namespace attune-system --create-namespace \
-#   --set webhooks.enabled=false
+#   --set webhooks.enabled=false \
+#   --set image.tag=v0.1.23
 ```
+
+!!! warning "Chart 0.1.23 pulls a missing image tag"
+    The published 0.1.23 chart defaults to `ghcr.io/attune-io/attune:0.1.23`,
+    which does not exist. Keep `--set image.tag=v0.1.23` until you install
+    chart 0.1.24 or newer. If the pod is already `ImagePullBackOff`, see
+    [Helm install ImagePullBackOff](../guides/troubleshooting.md#helm-install-imagepullbackoff).
 
 !!! tip "Large or multi-tenant clusters"
     Size the operator with a Helm `clusterSize` preset and, when policies
@@ -93,7 +101,8 @@ helm install attune \
 ```bash
 helm upgrade attune \
   oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system
+  --namespace attune-system \
+  --set image.tag=v0.1.23
 ```
 
 ## Install with OLM (OperatorHub)

--- a/docs/guides/multi-cluster.md
+++ b/docs/guides/multi-cluster.md
@@ -30,18 +30,21 @@ cluster-specific values:
 kubectl config use-context dev
 helm install attune oci://ghcr.io/attune-io/charts/attune \
   -n attune-system --create-namespace \
+  --set image.tag=v0.1.23 \
   -f values-dev.yaml
 
 # Staging cluster: Canary mode for validation
 kubectl config use-context staging
 helm install attune oci://ghcr.io/attune-io/charts/attune \
   -n attune-system --create-namespace \
+  --set image.tag=v0.1.23 \
   -f values-staging.yaml
 
 # Prod cluster: Auto mode with conservative settings
 kubectl config use-context prod
 helm install attune oci://ghcr.io/attune-io/charts/attune \
   -n attune-system --create-namespace \
+  --set image.tag=v0.1.23 \
   -f values-prod.yaml
 ```
 

--- a/docs/guides/openshift.md
+++ b/docs/guides/openshift.md
@@ -56,7 +56,8 @@ kubectl create namespace attune-system
 helm install attune \
   oci://ghcr.io/attune-io/charts/attune \
   --namespace attune-system \
-  --set openshift.enabled=true
+  --set openshift.enabled=true \
+  --set image.tag=v0.1.23
 ```
 
 The `openshift.enabled=true` flag adds OpenShift-specific RBAC (read

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -434,7 +434,8 @@ It takes less than 5 minutes to start seeing recommendations.
 
 ```bash
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace
+  --namespace attune-system --create-namespace \
+  --set image.tag=v0.1.23
 ```
 
 ### 2. Create your first policy

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,7 +55,8 @@ All examples assume:
 
 ```bash
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace
+  --namespace attune-system --create-namespace \
+  --set image.tag=v0.1.23
 ```
 
 ## kubectl plugin (optional)

--- a/hack/release-image-tags.sh
+++ b/hack/release-image-tags.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Print newline-separated container tags for a release.
+# Always emit the git tag as-is. When the tag starts with v, also emit
+# the bare SemVer alias so older Helm charts that used Chart.appVersion
+# as the image tag (issue #546) can still pull.
+
+set -euo pipefail
+
+TAG=""
+REGISTRY="ghcr.io"
+IMAGE="attune-io/attune"
+DOCKER="docker.io/attuneio/attune"
+INCLUDE_LATEST=0
+
+usage() {
+  cat <<'EOF'
+Usage: release-image-tags.sh --tag TAG [--registry REG] [--image NAME] [--docker REF] [--latest]
+
+Print one image reference per line (GHCR then Docker Hub).
+--tag       Git tag or SemVer (v0.1.23 or 0.1.23). Required.
+--registry  GHCR registry host (default: ghcr.io).
+--image     GHCR repository path (default: attune-io/attune).
+--docker    Docker Hub repository (default: docker.io/attuneio/attune).
+--latest    Also emit :latest on both registries.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      [[ $# -ge 2 ]] || { echo "FAIL: --tag requires a value" >&2; exit 1; }
+      TAG="$2"
+      shift 2
+      ;;
+    --registry)
+      [[ $# -ge 2 ]] || { echo "FAIL: --registry requires a value" >&2; exit 1; }
+      REGISTRY="$2"
+      shift 2
+      ;;
+    --image)
+      [[ $# -ge 2 ]] || { echo "FAIL: --image requires a value" >&2; exit 1; }
+      IMAGE="$2"
+      shift 2
+      ;;
+    --docker)
+      [[ $# -ge 2 ]] || { echo "FAIL: --docker requires a value" >&2; exit 1; }
+      DOCKER="$2"
+      shift 2
+      ;;
+    --latest)
+      INCLUDE_LATEST=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "FAIL: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${TAG}" ]]; then
+  echo "FAIL: --tag is required" >&2
+  usage >&2
+  exit 1
+fi
+
+echo "PLAN: compute release image tags for ${TAG}" >&2
+
+GHCR="${REGISTRY}/${IMAGE}"
+BARE="${TAG#v}"
+
+echo "DO: emit ${TAG} on GHCR and Docker Hub" >&2
+printf '%s\n' "${GHCR}:${TAG}"
+printf '%s\n' "${DOCKER}:${TAG}"
+
+if [[ "${BARE}" != "${TAG}" ]]; then
+  echo "DO: emit bare SemVer alias ${BARE}" >&2
+  printf '%s\n' "${GHCR}:${BARE}"
+  printf '%s\n' "${DOCKER}:${BARE}"
+fi
+
+if [[ "${INCLUDE_LATEST}" -eq 1 ]]; then
+  echo "DO: emit latest" >&2
+  printf '%s\n' "${GHCR}:latest"
+  printf '%s\n' "${DOCKER}:latest"
+fi
+
+echo "DONE: ok=true tag=${TAG} bare=${BARE} latest=${INCLUDE_LATEST}" >&2
+echo "NEXT: none" >&2

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -7244,6 +7244,102 @@ func TestExecuteResizes_TimeoutAfterCommitDoesNotRevert(t *testing.T) {
 	assert.Equal(t, 1, wrapped.timeoutsSeen)
 }
 
+func TestPersistResizeAnnotations_ConfirmGetRetryThenSuccess(t *testing.T) {
+	pod := newResizePodWithStatus("api-server", "500m", "512Mi", "1000m", "1Gi", 3)
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod.DeepCopy()).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	wrapped := &commitThenTimeoutPodClient{Client: fakeClient, cs: clientset, timeoutsLeft: 1}
+
+	var confirmGets atomic.Int32
+	clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		n := confirmGets.Add(1)
+		// Get 1 is persist re-fetch; Get 2 is the first confirm.
+		if n == 2 {
+			return true, nil, apierrors.NewTimeoutError("injected confirm Get timeout", 0)
+		}
+		return false, nil, nil
+	})
+
+	r := NewAttunePolicyReconciler()
+	r.Client = wrapped
+	r.Scheme = scheme
+	r.Clientset = clientset
+
+	now := metav1.NewTime(time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC))
+	working := pod.DeepCopy()
+	reason, err := r.persistResizeAnnotations(context.Background(), working, persistMainRec(t),
+		"test-policy", "api-server", now, 3)
+	require.NoError(t, err, "confirm Get timeout then success must not revert")
+	assert.Empty(t, reason)
+	assert.GreaterOrEqual(t, confirmGets.Load(), int32(3), "re-fetch plus failed confirm plus retry")
+	assert.Equal(t, now.UTC().Format(time.RFC3339), working.Annotations[annotationResizedAt])
+}
+
+func TestPersistResizeAnnotations_ConfirmUsesDetachedContext(t *testing.T) {
+	pod := newResizePodWithStatus("api-server", "500m", "512Mi", "1000m", "1Gi", 3)
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod.DeepCopy()).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	wrapped := &commitThenTimeoutPodClient{Client: fakeClient, cs: clientset, timeoutsLeft: 1}
+
+	r := NewAttunePolicyReconciler()
+	r.Client = wrapped
+	r.Scheme = scheme
+	r.Clientset = clientset
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	now := metav1.NewTime(time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC))
+	working := pod.DeepCopy()
+	reason, err := r.persistResizeAnnotations(ctx, working, persistMainRec(t),
+		"test-policy", "api-server", now, 3)
+	require.NoError(t, err, "cancelled parent ctx must not skip confirm after a committed write")
+	assert.Empty(t, reason)
+	assert.Equal(t, now.UTC().Format(time.RFC3339), working.Annotations[annotationResizedAt])
+}
+
+func TestPersistResizeAnnotations_ConfirmGetAlwaysErrorsReverts(t *testing.T) {
+	pod := newResizePodWithStatus("api-server", "500m", "512Mi", "1000m", "1Gi", 3)
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod.DeepCopy()).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	wrapped := &commitThenTimeoutPodClient{Client: fakeClient, cs: clientset, timeoutsLeft: 1}
+
+	clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ga, ok := action.(k8stesting.GetAction)
+		if !ok {
+			return false, nil, nil
+		}
+		// Allow the persist re-fetch; fail every confirm Get.
+		obj, err := clientset.Tracker().Get(ga.GetResource(), ga.GetNamespace(), ga.GetName())
+		if err != nil {
+			return true, nil, err
+		}
+		live, ok := obj.(*corev1.Pod)
+		if !ok {
+			return false, nil, nil
+		}
+		if live.Annotations[annotationResizedAt] != "" {
+			return true, nil, apierrors.NewInternalError(fmt.Errorf("injected confirm Get 500"))
+		}
+		return false, nil, nil
+	})
+
+	r := NewAttunePolicyReconciler()
+	r.Client = wrapped
+	r.Scheme = scheme
+	r.Clientset = clientset
+
+	now := metav1.NewTime(time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC))
+	working := pod.DeepCopy()
+	reason, err := r.persistResizeAnnotations(context.Background(), working, persistMainRec(t),
+		"test-policy", "api-server", now, 3)
+	require.Error(t, err)
+	assert.Equal(t, "annotation-persist-failed", reason)
+}
+
 func TestTrackingAnnotationsApplied(t *testing.T) {
 	intended := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -792,6 +792,7 @@ const (
 func (r *AttunePolicyReconciler) confirmTrackingAnnotations(
 	ctx context.Context, namespace, name string, intended *corev1.Pod, container string,
 ) (*corev1.Pod, error) {
+	logger := log.FromContext(ctx)
 	confirmCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), confirmTrackingTimeout)
 	defer cancel()
 
@@ -810,6 +811,8 @@ func (r *AttunePolicyReconciler) confirmTrackingAnnotations(
 		got, err := r.Clientset.CoreV1().Pods(namespace).Get(confirmCtx, name, metav1.GetOptions{})
 		if err != nil {
 			lastErr = err
+			logger.V(1).Info("Annotation persist confirm Get failed, retrying",
+				"pod", name, "attempt", attempt+1, "maxAttempts", confirmTrackingAttempts, "error", err.Error())
 			continue
 		}
 		if trackingAnnotationsApplied(got, intended, container) {
@@ -819,6 +822,8 @@ func (r *AttunePolicyReconciler) confirmTrackingAnnotations(
 		// the write is still in flight; lastErr stays nil so a clean miss
 		// after retries means revert, not a Get error.
 		lastErr = nil
+		logger.V(1).Info("Annotation persist confirm Get missed this persist, retrying",
+			"pod", name, "attempt", attempt+1, "maxAttempts", confirmTrackingAttempts)
 	}
 	if lastErr != nil {
 		return nil, lastErr

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -776,18 +776,52 @@ func (r *AttunePolicyReconciler) persistResizeAnnotations(
 	return "annotation-persist-conflict", fmt.Errorf("exhausted %d annotation persist retries", maxRetries)
 }
 
+// Confirm uses a detached budget so a cancelled or timed-out persist ctx
+// cannot force a revert after the write may already have committed.
+const (
+	confirmTrackingAttempts = 3
+	confirmTrackingTimeout  = 5 * time.Second
+	confirmTrackingBackoff  = 50 * time.Millisecond
+)
+
 // confirmTrackingAnnotations returns the live pod when a Clientset Get shows
 // that intended tracking annotations from this persist attempt already landed.
-// A nil pod and nil error means the write did not land.
+// A nil pod and nil error means the write did not land after retries.
+// Get errors are retried; the parent ctx is not used so a dead deadline
+// cannot skip confirmation.
 func (r *AttunePolicyReconciler) confirmTrackingAnnotations(
 	ctx context.Context, namespace, name string, intended *corev1.Pod, container string,
 ) (*corev1.Pod, error) {
-	got, err := r.Clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
+	confirmCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), confirmTrackingTimeout)
+	defer cancel()
+
+	var lastErr error
+	for attempt := 0; attempt < confirmTrackingAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-confirmCtx.Done():
+				if lastErr != nil {
+					return nil, lastErr
+				}
+				return nil, confirmCtx.Err()
+			case <-time.After(confirmTrackingBackoff):
+			}
+		}
+		got, err := r.Clientset.CoreV1().Pods(namespace).Get(confirmCtx, name, metav1.GetOptions{})
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if trackingAnnotationsApplied(got, intended, container) {
+			return got, nil
+		}
+		// Object is visible but this persist's keys are not. Retry in case
+		// the write is still in flight; lastErr stays nil so a clean miss
+		// after retries means revert, not a Get error.
+		lastErr = nil
 	}
-	if trackingAnnotationsApplied(got, intended, container) {
-		return got, nil
+	if lastErr != nil {
+		return nil, lastErr
 	}
 	return nil, nil
 }

--- a/internal/resize/engine_test.go
+++ b/internal/resize/engine_test.go
@@ -19,6 +19,7 @@ package resize
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,9 +27,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -429,6 +432,56 @@ func TestResizePod_UpdateResizeAPIError(t *testing.T) {
 	assert.Equal(t, "web-0", results[0].PodName)
 	assert.Equal(t, "app", results[0].Container)
 	assert.Equal(t, "InPlace", results[0].Method)
+}
+
+func TestResizePod_ConflictThenSuccess(t *testing.T) {
+	pod := newTestPod("web-0", "default", "app", "100m", "128Mi", "200m", "256Mi")
+	fakeClient := fake.NewSimpleClientset(pod)
+	var updates atomic.Int32
+	fakeClient.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "resize" {
+			return false, nil, nil
+		}
+		if updates.Add(1) == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Resource: "pods"}, "web-0", fmt.Errorf("resourceVersion changed"))
+		}
+		return false, nil, nil
+	})
+
+	resizer := NewPodResizer(fakeClient, testr.New(t))
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	results, err := resizer.ResizePod(context.Background(), pod, "app", target)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), updates.Load(), "first UpdateResize 409 must retry")
+	require.NotEmpty(t, results)
+	assert.True(t, results[0].Success)
+	assert.Equal(t, "app", results[0].Container)
+	assert.Equal(t, "InPlace", results[0].Method)
+}
+
+func TestResizePod_GetNotFound(t *testing.T) {
+	pod := newTestPod("web-0", "default", "app", "100m", "128Mi", "200m", "256Mi")
+	fakeClient := fake.NewSimpleClientset()
+	resizer := NewPodResizer(fakeClient, testr.New(t))
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	results, err := resizer.ResizePod(context.Background(), pod, "app", target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "re-fetching pod default/web-0")
+	require.Len(t, results, 2)
+	assert.False(t, results[0].Success)
 }
 
 // ---------- findContainer ----------

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -381,6 +381,29 @@ func MergeMetricsSource(policy *attunev1alpha1.MetricsSource, defaults *attunev1
 		policy.MemoryRecordingMetric = defaults.MemoryRecordingMetric
 		inherited = append(inherited, "memoryRecordingMetric")
 	}
+	// Provider blocks are mutually exclusive. Inherit only when the policy
+	// did not set any of them so a cluster Datadog/CloudWatch/VPA/Prometheus
+	// default is not dropped (and we never add a second provider).
+	policyHasProvider := policy.Prometheus != nil || policy.Datadog != nil ||
+		policy.CloudWatch != nil || policy.VPA != nil
+	if !policyHasProvider {
+		if defaults.Prometheus != nil {
+			policy.Prometheus = defaults.Prometheus
+			inherited = append(inherited, "prometheus")
+		}
+		if defaults.Datadog != nil {
+			policy.Datadog = defaults.Datadog
+			inherited = append(inherited, "datadog")
+		}
+		if defaults.CloudWatch != nil {
+			policy.CloudWatch = defaults.CloudWatch
+			inherited = append(inherited, "cloudwatch")
+		}
+		if defaults.VPA != nil {
+			policy.VPA = defaults.VPA
+			inherited = append(inherited, "vpa")
+		}
+	}
 	return inherited
 }
 

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -802,6 +802,41 @@ func TestMergeMetricsSource_PodAggregationAndRecording(t *testing.T) {
 	assert.Equal(t, "None", policy2.PodAggregation)
 }
 
+func TestMergeMetricsSource_ProviderBlocks(t *testing.T) {
+	defaults := &attunev1alpha1.MetricsSource{
+		Datadog: &attunev1alpha1.DatadogConfig{Site: "datadoghq.eu"},
+	}
+	policy := &attunev1alpha1.MetricsSource{}
+	inherited := MergeMetricsSource(policy, defaults)
+	assert.Contains(t, inherited, "datadog")
+	require.NotNil(t, policy.Datadog)
+	assert.Equal(t, "datadoghq.eu", policy.Datadog.Site)
+
+	policyProm := &attunev1alpha1.MetricsSource{
+		Prometheus: &attunev1alpha1.PrometheusConfig{Address: "http://prom:9090"},
+	}
+	inherited = MergeMetricsSource(policyProm, defaults)
+	assert.NotContains(t, inherited, "datadog")
+	assert.Nil(t, policyProm.Datadog)
+	require.NotNil(t, policyProm.Prometheus)
+	assert.Equal(t, "http://prom:9090", policyProm.Prometheus.Address)
+
+	promDefaults := &attunev1alpha1.MetricsSource{
+		Prometheus: &attunev1alpha1.PrometheusConfig{Address: "http://defaults:9090"},
+		CloudWatch: &attunev1alpha1.CloudWatchConfig{Region: "us-east-1"},
+		VPA:        &attunev1alpha1.VPAConfig{},
+		Datadog:    &attunev1alpha1.DatadogConfig{Site: "datadoghq.com"},
+	}
+	empty := &attunev1alpha1.MetricsSource{}
+	inherited = MergeMetricsSource(empty, promDefaults)
+	assert.Contains(t, inherited, "prometheus")
+	assert.Contains(t, inherited, "datadog")
+	assert.Contains(t, inherited, "cloudwatch")
+	assert.Contains(t, inherited, "vpa")
+	require.NotNil(t, empty.Prometheus)
+	assert.Equal(t, "http://defaults:9090", empty.Prometheus.Address)
+}
+
 func TestMergeUpdateStrategy_StatusBudget(t *testing.T) {
 	max := int32(50)
 	inc := false

--- a/scripts/test_release_image_tags.sh
+++ b/scripts/test_release_image_tags.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Classifier for hack/release-image-tags.sh: v-prefixed tags must emit
+# both vX.Y.Z and X.Y.Z; already-bare tags must not emit vv or a
+# duplicate v alias.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT}/hack/release-image-tags.sh"
+
+echo "PLAN: classify release-image-tags.sh"
+
+fail() {
+  echo "FAIL: $*"
+  echo "DONE: ok=false"
+  exit 1
+}
+
+expect_lines() {
+  local desc="$1"
+  shift
+  local got
+  got="$(bash "${SCRIPT}" "$@")"
+  echo "DO: ${desc}"
+  echo "${got}" | sed 's/^/  /'
+  local want
+  for want in "${expected[@]}"; do
+    echo "${got}" | grep -Fxq "${want}" || fail "${desc}: missing ${want}"
+  done
+  local extra
+  extra="$(echo "${got}" | grep -v '^$' | wc -l | tr -d ' ')"
+  if [[ "${extra}" -ne "${#expected[@]}" ]]; then
+    fail "${desc}: got ${extra} tags, want ${#expected[@]}"
+  fi
+  echo "OK: ${desc}"
+}
+
+expected=(
+  "ghcr.io/attune-io/attune:v0.1.23"
+  "docker.io/attuneio/attune:v0.1.23"
+  "ghcr.io/attune-io/attune:0.1.23"
+  "docker.io/attuneio/attune:0.1.23"
+)
+expect_lines "v-prefixed tag emits v and bare aliases" --tag v0.1.23
+
+expected=(
+  "ghcr.io/attune-io/attune:v0.1.23"
+  "docker.io/attuneio/attune:v0.1.23"
+  "ghcr.io/attune-io/attune:0.1.23"
+  "docker.io/attuneio/attune:0.1.23"
+  "ghcr.io/attune-io/attune:latest"
+  "docker.io/attuneio/attune:latest"
+)
+expect_lines "v-prefixed tag with --latest" --tag v0.1.23 --latest
+
+expected=(
+  "ghcr.io/attune-io/attune:0.1.23"
+  "docker.io/attuneio/attune:0.1.23"
+)
+expect_lines "already-bare tag does not add a v prefix" --tag 0.1.23
+
+if bash "${SCRIPT}" --tag v0.1.23 | grep -q ':vv'; then
+  fail "v-prefixed tag emitted vv"
+fi
+echo "OK: no vv prefix"
+
+echo "DONE: ok=true"
+echo "NEXT: none"

--- a/scripts/test_verify_helm_image_tag.sh
+++ b/scripts/test_verify_helm_image_tag.sh
@@ -38,6 +38,21 @@ if bash "${SCRIPT}" --root "${TMP}"; then
 fi
 echo "OK: broken chart failed as expected"
 
+# Chart.appVersion is normally bare SemVer. A future chart that already
+# stores vX.Y.Z must still render one v, not vv.
+echo "DO: chart with v-prefixed appVersion must still render a single v"
+TMPV="$(mktemp -d)"
+trap 'rm -rf "${TMP}" "${TMPV}"' EXIT
+cp -R "${ROOT}/charts" "${TMPV}/"
+sed -i.bak 's/^appVersion: .*/appVersion: v0.1.23/' "${TMPV}/charts/attune/Chart.yaml"
+rm -f "${TMPV}/charts/attune/Chart.yaml.bak"
+if ! bash "${SCRIPT}" --root "${TMPV}"; then
+  echo "FAIL: v-prefixed appVersion must render v0.1.23, not vv0.1.23"
+  echo "DONE: ok=false reason=double-v-prefix"
+  exit 1
+fi
+echo "OK: v-prefixed appVersion rendered a single v"
+
 echo "DONE: ok=true"
 echo "NEXT: none"
 exit 0


### PR DESCRIPTION
This MPI cycle hardens the Helm image-tag fix from #547 and the persist-confirm path from #545, plus a defaults merge hole that dropped cluster Datadog/CloudWatch.

## Problem

- Confirm after a committed annotation write used one Clientset Get on the persist context. A timeout or already-dead deadline still returned `annotation-persist-failed` and reverted the spec.
- Published chart 0.1.23 still pulls `:0.1.23`. Install copy-paste in README, examples, and `kubectl attune` pointed users at that missing tag.
- Dual-tag publish (`vX.Y.Z` plus bare SemVer) lived only in `release.yaml` with no classifier.
- `MergeMetricsSource` copied query windows but ignored `prometheus` / `datadog` / `cloudwatch` / `vpa` on AttuneDefaults.

## Change

- Retry persist confirm on `context.WithoutCancel` with a short budget. Log retries at V(1).
- Pin `--set image.tag=v0.1.23` on user-facing OCI install commands until 0.1.24. Trim whitespace-only Helm `image.tag`.
- Extract `hack/release-image-tags.sh` and classify v-prefix, `--latest`, and already-bare tags.
- Inherit metrics provider blocks only when the policy set none of them. Show the effective provider in `kubectl attune explain`.
- Add ResizePod tests for 409-then-success and Get 404.

## Validation

- `make verify-quick` green (1909 unit tests, 116 helm-unittest, helm image-tag + release dual-tag classifiers)
- Persist confirm: retry after Get timeout, cancelled parent ctx, confirm 500 still reverts
- ResizePod: 409 retry, Get 404
- Helm: default `v` + appVersion, no `vv`, whitespace tag treated as unset

Release PR #539 (v0.1.24) is still user-gated. Merging that release is what publishes the fixed chart; this PR does not replace it.
