### PR TITLE
fix: reject multi-provider AttuneDefaults at admission

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -223,7 +223,7 @@ CR manually but managed through Helm values.
 | `defaults.costPricing.cpuPerCoreHour` | string | `"0.031"` | Cost per vCPU-hour for savings estimates |
 | `defaults.costPricing.memoryPerGiBHour` | string | `"0.004"` | Cost per GiB-hour for savings estimates |
 | `defaults.excludeKnownSidecars` | bool | (operator default `true` if unset) | When set on the AttuneDefaults CR, policies that leave the field unset inherit this value. `false` restores exclude-only-via-`excludedContainers`. |
-| `defaults.metricsSource.*` | object | | Default metrics source (e.g., shared Prometheus address) |
+| `defaults.metricsSource.*` | object | | Default metrics source (e.g., shared Prometheus address). At most one of prometheus, datadog, cloudwatch, or vpa. |
 | `defaults.updateStrategy.*` | object | | Default update strategy (type, cooldown, autoRevert, etc.) |
 
 The rendered CR has the same spec as a manually created `AttuneDefaults`
@@ -379,9 +379,10 @@ All fields from `AttuneDefaults` are available in
 ## Alternative Metrics Sources
 
 By default, Attune queries Prometheus for CPU and memory usage data.
-The CRD also supports Datadog and CloudWatch Container Insights as
-alternative metrics sources. **At most one** of `prometheus`, `datadog`, or
-`cloudwatch` may be set per policy.
+The CRD also supports Datadog, CloudWatch Container Insights, and VPA
+as alternative metrics sources. **At most one** of `prometheus`,
+`datadog`, `cloudwatch`, or `vpa` may be set on a policy or on
+`AttuneDefaults` / `AttuneNamespaceDefaults`.
 
 > The Datadog collector queries the `/api/v1/query` endpoint and converts
 > nanocores to cores automatically. The CloudWatch collector uses the
@@ -549,7 +550,8 @@ updateStrategy:
 | `metricsSource.vpa.name` | string | (required) | Name of the VerticalPodAutoscaler object to consume recommendations from |
 | `metricsSource.vpa.namespace` | string | (policy namespace) | Namespace of the VPA. Defaults to the policy's namespace. |
 
-At most one of `prometheus`, `datadog`, `cloudwatch`, or `vpa` may be set per policy.
+At most one of `prometheus`, `datadog`, `cloudwatch`, or `vpa` may be set
+on a policy or on `AttuneDefaults` / `AttuneNamespaceDefaults`.
 
 ### Initial Sizing
 

--- a/internal/webhook/defaults_validation.go
+++ b/internal/webhook/defaults_validation.go
@@ -87,6 +87,10 @@ func (v *AttuneNamespaceDefaultsValidator) ValidateDelete(_ context.Context, _ *
 }
 
 func validateDefaultsSpec(spec attunev1alpha1.AttuneDefaultsSpec) (admission.Warnings, error) {
+	if err := exclusiveMetricsProviderError(spec.MetricsSource); err != nil {
+		return nil, err
+	}
+
 	// Validate Prometheus settings if provided.
 	if spec.MetricsSource != nil && spec.MetricsSource.Prometheus != nil {
 		prometheus := spec.MetricsSource.Prometheus

--- a/internal/webhook/defaults_validation_test.go
+++ b/internal/webhook/defaults_validation_test.go
@@ -884,3 +884,19 @@ func TestDefaultsValidate_HistoryWindowInvalid(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultsValidator_RejectsMultipleMetricsProviders(t *testing.T) {
+	v := &AttuneDefaultsValidator{}
+	defaults := &attunev1alpha1.AttuneDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: attunev1alpha1.AttuneDefaultsSpec{
+			MetricsSource: &attunev1alpha1.MetricsSource{
+				Prometheus: &attunev1alpha1.PrometheusConfig{Address: "http://prom:9090"},
+				Datadog:    &attunev1alpha1.DatadogConfig{Site: "datadoghq.com"},
+			},
+		},
+	}
+	_, err := v.ValidateCreate(context.Background(), defaults)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at most one of prometheus, datadog, cloudwatch, or vpa")
+}

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -225,22 +225,8 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 		}
 	}
 
-	// Validate at most one metrics source is configured.
-	sourceCount := 0
-	if policy.Spec.MetricsSource.Prometheus != nil {
-		sourceCount++
-	}
-	if policy.Spec.MetricsSource.Datadog != nil {
-		sourceCount++
-	}
-	if policy.Spec.MetricsSource.CloudWatch != nil {
-		sourceCount++
-	}
-	if policy.Spec.MetricsSource.VPA != nil {
-		sourceCount++
-	}
-	if sourceCount > 1 {
-		return warnings, fmt.Errorf("metricsSource: at most one of prometheus, datadog, cloudwatch, or vpa may be set")
+	if err := exclusiveMetricsProviderError(&policy.Spec.MetricsSource); err != nil {
+		return warnings, err
 	}
 
 	// Validate VPA settings if specified.
@@ -618,6 +604,29 @@ func validateSLOGuardrails(guardrails []attunev1alpha1.SLOGuardrail) error {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+func exclusiveMetricsProviderError(ms *attunev1alpha1.MetricsSource) error {
+	if ms == nil {
+		return nil
+	}
+	n := 0
+	if ms.Prometheus != nil {
+		n++
+	}
+	if ms.Datadog != nil {
+		n++
+	}
+	if ms.CloudWatch != nil {
+		n++
+	}
+	if ms.VPA != nil {
+		n++
+	}
+	if n > 1 {
+		return fmt.Errorf("metricsSource: at most one of prometheus, datadog, cloudwatch, or vpa may be set")
 	}
 	return nil
 }

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -835,6 +835,22 @@ func TestMergeMetricsSource_ProviderBlocks(t *testing.T) {
 	assert.Nil(t, empty.Datadog)
 	assert.Nil(t, empty.CloudWatch)
 	assert.Nil(t, empty.VPA)
+
+	cwOnly := &attunev1alpha1.MetricsSource{}
+	inherited = MergeMetricsSource(cwOnly, &attunev1alpha1.MetricsSource{
+		CloudWatch: &attunev1alpha1.CloudWatchConfig{Region: "eu-west-1"},
+	})
+	assert.Equal(t, []string{"cloudwatch"}, inherited)
+	require.NotNil(t, cwOnly.CloudWatch)
+	assert.Equal(t, "eu-west-1", cwOnly.CloudWatch.Region)
+
+	vpaOnly := &attunev1alpha1.MetricsSource{}
+	inherited = MergeMetricsSource(vpaOnly, &attunev1alpha1.MetricsSource{
+		VPA: &attunev1alpha1.VPAConfig{Name: "workload-vpa"},
+	})
+	assert.Equal(t, []string{"vpa"}, inherited)
+	require.NotNil(t, vpaOnly.VPA)
+	assert.Equal(t, "workload-vpa", vpaOnly.VPA.Name)
 }
 
 func TestMergeUpdateStrategy_StatusBudget(t *testing.T) {


### PR DESCRIPTION
## What This PR Does

Reject `AttuneDefaults` and `AttuneNamespaceDefaults` that set more than
one metrics provider. Policy admission already required a single
provider. Cluster defaults did not.

The exclusive check now lives in `exclusiveMetricsProviderError` and is
used by both validators. Tests also cover CloudWatch-only and VPA-only
inherit from defaults.

## Why

After PR #549, merge copies at most one provider. An invalid
`AttuneDefaults` object could still be stored. The next edit of that
object, or any operator that applied it, kept a two-provider spec that
admission should have refused.

## How to Test

```text
go test ./internal/webhook/ ./pkg/defaults/ -race -count=1
make verify-quick
```

Red check: `TestDefaultsValidator_RejectsMultipleMetricsProviders` fails
before `exclusiveMetricsProviderError` is called from
`validateDefaultsSpec`.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] CRD changes regenerated (`make manifests`)
- [x] Documentation updated (if user-facing)
- [ ] Helm chart updated (if applicable)
- [x] No breaking API changes (or documented in CHANGELOG)
