### PR TITLE
fix: apply policy metrics field rules to AttuneDefaults

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -223,7 +223,7 @@ CR manually but managed through Helm values.
 | `defaults.costPricing.cpuPerCoreHour` | string | `"0.031"` | Cost per vCPU-hour for savings estimates |
 | `defaults.costPricing.memoryPerGiBHour` | string | `"0.004"` | Cost per GiB-hour for savings estimates |
 | `defaults.excludeKnownSidecars` | bool | (operator default `true` if unset) | When set on the AttuneDefaults CR, policies that leave the field unset inherit this value. `false` restores exclude-only-via-`excludedContainers`. |
-| `defaults.metricsSource.*` | object | | Default metrics source (e.g., shared Prometheus address). At most one of prometheus, datadog, cloudwatch, or vpa. |
+| `defaults.metricsSource.*` | object | | Default metrics source (e.g., shared Prometheus address). At most one of prometheus, datadog, cloudwatch, or vpa. Provider field rules match policies (Datadog API key, CloudWatch region and cluster, VPA name, recording-metric names). |
 | `defaults.updateStrategy.*` | object | | Default update strategy (type, cooldown, autoRevert, etc.) |
 
 The rendered CR has the same spec as a manually created `AttuneDefaults`

--- a/internal/webhook/defaults_validation.go
+++ b/internal/webhook/defaults_validation.go
@@ -90,6 +90,9 @@ func validateDefaultsSpec(spec attunev1alpha1.AttuneDefaultsSpec) (admission.War
 	if err := exclusiveMetricsProviderError(spec.MetricsSource); err != nil {
 		return nil, err
 	}
+	if err := validateMetricsSourceProviderFields(spec.MetricsSource); err != nil {
+		return nil, err
+	}
 
 	// Validate Prometheus settings if provided.
 	if spec.MetricsSource != nil && spec.MetricsSource.Prometheus != nil {

--- a/internal/webhook/defaults_validation_test.go
+++ b/internal/webhook/defaults_validation_test.go
@@ -887,16 +887,171 @@ func TestDefaultsValidate_HistoryWindowInvalid(t *testing.T) {
 
 func TestDefaultsValidator_RejectsMultipleMetricsProviders(t *testing.T) {
 	v := &AttuneDefaultsValidator{}
-	defaults := &attunev1alpha1.AttuneDefaults{
-		ObjectMeta: metav1.ObjectMeta{Name: "default"},
-		Spec: attunev1alpha1.AttuneDefaultsSpec{
-			MetricsSource: &attunev1alpha1.MetricsSource{
+	tests := []struct {
+		name string
+		ms   *attunev1alpha1.MetricsSource
+	}{
+		{
+			name: "prometheus and datadog",
+			ms: &attunev1alpha1.MetricsSource{
 				Prometheus: &attunev1alpha1.PrometheusConfig{Address: "http://prom:9090"},
 				Datadog:    &attunev1alpha1.DatadogConfig{Site: "datadoghq.com"},
 			},
 		},
+		{
+			name: "datadog and cloudwatch",
+			ms: &attunev1alpha1.MetricsSource{
+				Datadog:    &attunev1alpha1.DatadogConfig{Site: "datadoghq.com"},
+				CloudWatch: &attunev1alpha1.CloudWatchConfig{Region: "us-east-1", ClusterName: "prod"},
+			},
+		},
+		{
+			name: "cloudwatch and vpa",
+			ms: &attunev1alpha1.MetricsSource{
+				CloudWatch: &attunev1alpha1.CloudWatchConfig{Region: "us-east-1", ClusterName: "prod"},
+				VPA:        &attunev1alpha1.VPAConfig{Name: "workload-vpa"},
+			},
+		},
 	}
-	_, err := v.ValidateCreate(context.Background(), defaults)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "at most one of prometheus, datadog, cloudwatch, or vpa")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defaults := &attunev1alpha1.AttuneDefaults{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       attunev1alpha1.AttuneDefaultsSpec{MetricsSource: tc.ms},
+			}
+			_, err := v.ValidateCreate(context.Background(), defaults)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "at most one of prometheus, datadog, cloudwatch, or vpa")
+		})
+	}
+}
+
+func TestDefaultsValidator_ProviderFieldConstraints(t *testing.T) {
+	v := &AttuneDefaultsValidator{}
+	tests := []struct {
+		name    string
+		ms      *attunev1alpha1.MetricsSource
+		wantErr string
+	}{
+		{
+			name: "datadog missing api key name",
+			ms: &attunev1alpha1.MetricsSource{
+				Datadog: &attunev1alpha1.DatadogConfig{
+					Site:            "datadoghq.com",
+					APIKeySecretRef: attunev1alpha1.SecretKeyRef{Key: "api-key"},
+				},
+			},
+			wantErr: "metricsSource.datadog.apiKeySecretRef.name is required",
+		},
+		{
+			name: "datadog missing api key key",
+			ms: &attunev1alpha1.MetricsSource{
+				Datadog: &attunev1alpha1.DatadogConfig{
+					Site:            "datadoghq.com",
+					APIKeySecretRef: attunev1alpha1.SecretKeyRef{Name: "dd-key"},
+				},
+			},
+			wantErr: "metricsSource.datadog.apiKeySecretRef.key is required",
+		},
+		{
+			name: "datadog unrecognized site",
+			ms: &attunev1alpha1.MetricsSource{
+				Datadog: &attunev1alpha1.DatadogConfig{
+					Site:            "not-a-datadog-site.example",
+					APIKeySecretRef: attunev1alpha1.SecretKeyRef{Name: "dd-key", Key: "api-key"},
+				},
+			},
+			wantErr: "is not a recognized Datadog site",
+		},
+		{
+			name: "cloudwatch missing region",
+			ms: &attunev1alpha1.MetricsSource{
+				CloudWatch: &attunev1alpha1.CloudWatchConfig{ClusterName: "prod"},
+			},
+			wantErr: "metricsSource.cloudwatch.region is required",
+		},
+		{
+			name: "cloudwatch missing cluster name",
+			ms: &attunev1alpha1.MetricsSource{
+				CloudWatch: &attunev1alpha1.CloudWatchConfig{Region: "us-east-1"},
+			},
+			wantErr: "metricsSource.cloudwatch.clusterName is required",
+		},
+		{
+			name:    "vpa missing name",
+			ms:      &attunev1alpha1.MetricsSource{VPA: &attunev1alpha1.VPAConfig{}},
+			wantErr: "metricsSource.vpa.name is required",
+		},
+		{
+			name: "prometheus bearer token slash",
+			ms: &attunev1alpha1.MetricsSource{
+				Prometheus: &attunev1alpha1.PrometheusConfig{
+					Address:           "http://prom:9090",
+					BearerTokenSecret: &attunev1alpha1.SecretKeyRef{Name: "other-ns/token", Key: "token"},
+				},
+			},
+			wantErr: "bearerTokenSecret.name must not contain '/'",
+		},
+		{
+			name: "invalid cpu recording metric",
+			ms: &attunev1alpha1.MetricsSource{
+				CPURecordingMetric: "has space",
+			},
+			wantErr: "metricsSource.cpuRecordingMetric: invalid metric name",
+		},
+		{
+			name:    "invalid pod aggregation",
+			ms:      &attunev1alpha1.MetricsSource{PodAggregation: "Median"},
+			wantErr: "metricsSource.podAggregation: must be Max, Avg, or None",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defaults := &attunev1alpha1.AttuneDefaults{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       attunev1alpha1.AttuneDefaultsSpec{MetricsSource: tc.ms},
+			}
+			_, err := v.ValidateCreate(context.Background(), defaults)
+			require.Error(t, err, "invalid provider fields on AttuneDefaults must be rejected")
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestDefaultsValidator_ValidSingleProviders(t *testing.T) {
+	v := &AttuneDefaultsValidator{}
+	tests := []struct {
+		name string
+		ms   *attunev1alpha1.MetricsSource
+	}{
+		{
+			name: "datadog",
+			ms: &attunev1alpha1.MetricsSource{
+				Datadog: &attunev1alpha1.DatadogConfig{
+					Site:            "datadoghq.eu",
+					APIKeySecretRef: attunev1alpha1.SecretKeyRef{Name: "dd-key", Key: "api-key"},
+				},
+			},
+		},
+		{
+			name: "cloudwatch",
+			ms: &attunev1alpha1.MetricsSource{
+				CloudWatch: &attunev1alpha1.CloudWatchConfig{Region: "eu-west-1", ClusterName: "prod"},
+			},
+		},
+		{
+			name: "vpa",
+			ms:   &attunev1alpha1.MetricsSource{VPA: &attunev1alpha1.VPAConfig{Name: "workload-vpa"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defaults := &attunev1alpha1.AttuneDefaults{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       attunev1alpha1.AttuneDefaultsSpec{MetricsSource: tc.ms},
+			}
+			_, err := v.ValidateCreate(context.Background(), defaults)
+			require.NoError(t, err)
+		})
+	}
 }

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -228,12 +228,8 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 	if err := exclusiveMetricsProviderError(&policy.Spec.MetricsSource); err != nil {
 		return warnings, err
 	}
-
-	// Validate VPA settings if specified.
-	if vpa := policy.Spec.MetricsSource.VPA; vpa != nil {
-		if vpa.Name == "" {
-			return warnings, fmt.Errorf("metricsSource.vpa.name is required")
-		}
+	if err := validateMetricsSourceProviderFields(&policy.Spec.MetricsSource); err != nil {
+		return warnings, err
 	}
 
 	// Validate Prometheus settings if specified.
@@ -245,59 +241,6 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 		}
 		if err := validation.PrometheusQueryParameters(prometheus.QueryParameters); err != nil {
 			return warnings, fmt.Errorf("metricsSource.prometheus.queryParameters: %w", err)
-		}
-		// Reject bearer token secret names containing "/" to prevent
-		// cross-namespace secret references. The secret is always read
-		// from the policy's own namespace.
-		if prometheus.BearerTokenSecret != nil {
-			if strings.Contains(prometheus.BearerTokenSecret.Name, "/") {
-				return warnings, fmt.Errorf("metricsSource.prometheus.bearerTokenSecret.name must not contain '/'; secrets are read from the policy's namespace")
-			}
-		}
-	}
-
-	// Recording-rule metric names must be PromQL identifiers (no selector injection).
-	if m := policy.Spec.MetricsSource.CPURecordingMetric; m != "" && !rsmetrics.ValidRecordingMetricName(m) {
-		return warnings, fmt.Errorf("metricsSource.cpuRecordingMetric: invalid metric name %q", m)
-	}
-	if m := policy.Spec.MetricsSource.MemoryRecordingMetric; m != "" && !rsmetrics.ValidRecordingMetricName(m) {
-		return warnings, fmt.Errorf("metricsSource.memoryRecordingMetric: invalid metric name %q", m)
-	}
-	switch policy.Spec.MetricsSource.PodAggregation {
-	case "", "Max", "Avg", "None":
-		// ok
-	default:
-		return warnings, fmt.Errorf("metricsSource.podAggregation: must be Max, Avg, or None, got %q", policy.Spec.MetricsSource.PodAggregation)
-	}
-
-	// Validate Datadog settings if specified.
-	if dd := policy.Spec.MetricsSource.Datadog; dd != nil {
-		validSites := map[string]bool{
-			"datadoghq.com": true, "datadoghq.eu": true,
-			"us3.datadoghq.com": true, "us5.datadoghq.com": true,
-			"ap1.datadoghq.com": true, "ddog-gov.com": true,
-		}
-		if dd.Site != "" && !validSites[dd.Site] {
-			return warnings, fmt.Errorf("metricsSource.datadog.site %q is not a recognized Datadog site", dd.Site)
-		}
-		if dd.APIKeySecretRef.Name == "" {
-			return warnings, fmt.Errorf("metricsSource.datadog.apiKeySecretRef.name is required")
-		}
-		if dd.APIKeySecretRef.Key == "" {
-			return warnings, fmt.Errorf("metricsSource.datadog.apiKeySecretRef.key is required")
-		}
-		if strings.Contains(dd.APIKeySecretRef.Name, "/") {
-			return warnings, fmt.Errorf("metricsSource.datadog.apiKeySecretRef.name must not contain '/'; secrets are read from the policy's namespace")
-		}
-	}
-
-	// Validate CloudWatch settings if specified.
-	if cw := policy.Spec.MetricsSource.CloudWatch; cw != nil {
-		if cw.Region == "" {
-			return warnings, fmt.Errorf("metricsSource.cloudwatch.region is required")
-		}
-		if cw.ClusterName == "" {
-			return warnings, fmt.Errorf("metricsSource.cloudwatch.clusterName is required")
 		}
 	}
 
@@ -627,6 +570,61 @@ func exclusiveMetricsProviderError(ms *attunev1alpha1.MetricsSource) error {
 	}
 	if n > 1 {
 		return fmt.Errorf("metricsSource: at most one of prometheus, datadog, cloudwatch, or vpa may be set")
+	}
+	return nil
+}
+
+func validateMetricsSourceProviderFields(ms *attunev1alpha1.MetricsSource) error {
+	if ms == nil {
+		return nil
+	}
+	if vpa := ms.VPA; vpa != nil {
+		if vpa.Name == "" {
+			return fmt.Errorf("metricsSource.vpa.name is required")
+		}
+	}
+	if prometheus := ms.Prometheus; prometheus != nil && prometheus.BearerTokenSecret != nil {
+		if strings.Contains(prometheus.BearerTokenSecret.Name, "/") {
+			return fmt.Errorf("metricsSource.prometheus.bearerTokenSecret.name must not contain '/'; secrets are read from the policy's namespace")
+		}
+	}
+	if dd := ms.Datadog; dd != nil {
+		validSites := map[string]bool{
+			"datadoghq.com": true, "datadoghq.eu": true,
+			"us3.datadoghq.com": true, "us5.datadoghq.com": true,
+			"ap1.datadoghq.com": true, "ddog-gov.com": true,
+		}
+		if dd.Site != "" && !validSites[dd.Site] {
+			return fmt.Errorf("metricsSource.datadog.site %q is not a recognized Datadog site", dd.Site)
+		}
+		if dd.APIKeySecretRef.Name == "" {
+			return fmt.Errorf("metricsSource.datadog.apiKeySecretRef.name is required")
+		}
+		if dd.APIKeySecretRef.Key == "" {
+			return fmt.Errorf("metricsSource.datadog.apiKeySecretRef.key is required")
+		}
+		if strings.Contains(dd.APIKeySecretRef.Name, "/") {
+			return fmt.Errorf("metricsSource.datadog.apiKeySecretRef.name must not contain '/'; secrets are read from the policy's namespace")
+		}
+	}
+	if cw := ms.CloudWatch; cw != nil {
+		if cw.Region == "" {
+			return fmt.Errorf("metricsSource.cloudwatch.region is required")
+		}
+		if cw.ClusterName == "" {
+			return fmt.Errorf("metricsSource.cloudwatch.clusterName is required")
+		}
+	}
+	if m := ms.CPURecordingMetric; m != "" && !rsmetrics.ValidRecordingMetricName(m) {
+		return fmt.Errorf("metricsSource.cpuRecordingMetric: invalid metric name %q", m)
+	}
+	if m := ms.MemoryRecordingMetric; m != "" && !rsmetrics.ValidRecordingMetricName(m) {
+		return fmt.Errorf("metricsSource.memoryRecordingMetric: invalid metric name %q", m)
+	}
+	switch ms.PodAggregation {
+	case "", "Max", "Avg", "None":
+	default:
+		return fmt.Errorf("metricsSource.podAggregation: must be Max, Avg, or None, got %q", ms.PodAggregation)
 	}
 	return nil
 }


### PR DESCRIPTION
## What This PR Does

`AttuneDefaults` and `AttuneNamespaceDefaults` now use the same metrics
provider field rules as `AttunePolicy`: Datadog API key and site,
CloudWatch region and cluster, VPA name, Prometheus bearer-token
secret names, and recording-metric / podAggregation values.

Exclusive-provider admission from PR #550 is covered with extra pairs
and valid single-provider cases.

## Why

After #550, two providers were rejected, but a single invalid
Datadog, CloudWatch, or VPA block on cluster defaults was still
stored. Merge copies that pointer onto every policy that did not set
a provider. Policy admission never sees the merged spec, so those
fields reached runtime.

## How to Test

```text
go test ./internal/webhook/ -race -count=1
make verify-quick
```

Red check: `TestDefaultsValidator_ProviderFieldConstraints` fails
before `validateMetricsSourceProviderFields` is called from
`validateDefaultsSpec`.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] CRD changes regenerated (`make manifests`)
- [x] Documentation updated (if user-facing)
- [ ] Helm chart updated (if applicable)
- [x] No breaking API changes (or documented in CHANGELOG)
