### PR TITLE
fix: default helm image tag to bare appVersion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ verify-helm-schema-fields: ## Verify Helm values.schema.json field names match C
 	@bash hack/verify-helm-schema-fields.sh
 
 .PHONY: verify-helm-image-tag
-verify-helm-image-tag: ## Verify Helm default image tag is v + Chart.appVersion
+verify-helm-image-tag: ## Verify Helm default image tag is Chart.appVersion (bare SemVer)
 	@bash hack/verify-helm-image-tag.sh
 
 .PHONY: verify-release-artifacts

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ In-place apply is the shared primitive (Kubernetes `/resize`). Attune is the
 #   --set webhooks.enabled=false          # skip cert-manager
 #   --set networkPolicy.prometheusPort=80 # if Prometheus Service is on :80
 #                                         # (chart default allows only :9090)
-# Chart 0.1.23 pulls :0.1.23 (missing). Pin until 0.1.24+.
+# Chart 0.1.23 defaults to :0.1.23 (never published). Pin that
+# chart with --set image.tag=v0.1.23. 0.1.24+ can omit the pin.
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace \
-  --set image.tag=v0.1.23
+  --namespace attune-system --create-namespace
 ```
 
 Also available via [OperatorHub.io](https://operatorhub.io/operator/attune)

--- a/charts/attune/README.md
+++ b/charts/attune/README.md
@@ -12,10 +12,10 @@ Safe, in-place Kubernetes pod resource right-sizing operator
 ## Installation
 
 ```bash
-# Chart 0.1.23 pulls :0.1.23 (missing). Pin until 0.1.24+.
+# Chart 0.1.23 defaults to :0.1.23 (never published). Pin that
+# chart with --set image.tag=v0.1.23. 0.1.24+ can omit the pin.
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace \
-  --set image.tag=v0.1.23
+  --namespace attune-system --create-namespace
 ```
 
 ## Values
@@ -50,7 +50,7 @@ helm install attune oci://ghcr.io/attune-io/charts/attune \
 | grafanaFleetDashboard.enabled | bool | `false` | Create a ConfigMap with the multi-cluster fleet Grafana dashboard (cluster variable). Use with federated Prometheus that has external_labels.cluster on each scrape. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ghcr.io/attune-io/attune"` | Container image repository |
-| image.tag | string | `""` | Image tag. Empty uses a `v` prefix plus Chart appVersion (published images are tagged `vX.Y.Z`, not `X.Y.Z`). |
+| image.tag | string | `""` | Image tag. Empty uses Chart appVersion (bare SemVer). Releases also publish the `vX.Y.Z` alias. Set this to pin `v0.1.24` or an E2E/local tag. |
 | imagePullSecrets | list | `[]` | Image pull secrets |
 | initialSizing | object | `{"enabled":false}` | Initial sizing webhook configuration. When enabled, a mutating webhook sets pod resource requests at creation time based on existing AttunePolicy recommendations. Requires namespace label attune.io/initial-sizing=enabled and initialSizing: true on the policy. |
 | initialSizing.enabled | bool | `false` | Enable the pod initial sizing mutating webhook. |

--- a/charts/attune/README.md.gotmpl
+++ b/charts/attune/README.md.gotmpl
@@ -12,10 +12,10 @@
 ## Installation
 
 ```bash
-# Chart 0.1.23 pulls :0.1.23 (missing). Pin until 0.1.24+.
+# Chart 0.1.23 defaults to :0.1.23 (never published). Pin that
+# chart with --set image.tag=v0.1.23. 0.1.24+ can omit the pin.
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace \
-  --set image.tag=v0.1.23
+  --namespace attune-system --create-namespace
 ```
 
 {{ template "chart.valuesSection" . }}

--- a/charts/attune/templates/_helpers.tpl
+++ b/charts/attune/templates/_helpers.tpl
@@ -62,15 +62,17 @@ Create the name of the service account to use.
 {{- end }}
 
 {{/*
-Published images are vX.Y.Z; appVersion is SemVer without v.
-Prefix v when image.tag is empty. trimPrefix avoids vv.
+Releases publish both vX.Y.Z and X.Y.Z. Chart.appVersion is SemVer
+without v. Empty image.tag uses that bare tag. trimPrefix avoids a
+leading v if appVersion is ever stored as vX.Y.Z. Explicit image.tag
+is used as-is (E2E, local, or a v-prefixed pin).
 */}}
 {{- define "attune.imageTag" -}}
 {{- $tag := .Values.image.tag | toString | trim -}}
 {{- if $tag -}}
 {{- $tag -}}
 {{- else -}}
-{{- printf "v%s" (.Chart.AppVersion | trimPrefix "v") -}}
+{{- .Chart.AppVersion | trimPrefix "v" -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/attune/tests/deployment_test.yaml
+++ b/charts/attune/tests/deployment_test.yaml
@@ -11,7 +11,7 @@ tests:
           value: 1
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: ^ghcr\.io/attune-io/attune:v[0-9]+\.[0-9]+\.[0-9]+$
+          pattern: ^ghcr\.io/attune-io/attune:[0-9]+\.[0-9]+\.[0-9]+$
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
@@ -19,14 +19,14 @@ tests:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: true
 
-  - it: should default image tag to v-prefixed appVersion not bare SemVer
+  - it: should default image tag to bare appVersion not a v prefix
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: :v[0-9]+\.[0-9]+\.[0-9]+$
+          pattern: :[0-9]+\.[0-9]+\.[0-9]+$
       - notMatchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: :[0-9]+\.[0-9]+\.[0-9]+$
+          pattern: :v[0-9]+\.[0-9]+\.[0-9]+$
 
   - it: should use explicit image.tag without adding a v prefix
     set:
@@ -50,7 +50,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: :v[0-9]+\.[0-9]+\.[0-9]+$
+          pattern: :[0-9]+\.[0-9]+\.[0-9]+$
 
   - it: should set replicas from values
     set:

--- a/charts/attune/values.schema.json
+++ b/charts/attune/values.schema.json
@@ -29,7 +29,7 @@
         "tag": {
           "type": "string",
           "default": "",
-          "description": "Image tag. Empty uses a v prefix plus Chart appVersion (published images are tagged vX.Y.Z)."
+          "description": "Image tag. Empty uses Chart appVersion (bare SemVer). Releases also publish the vX.Y.Z alias."
         }
       }
     },

--- a/charts/attune/values.yaml
+++ b/charts/attune/values.yaml
@@ -9,8 +9,9 @@ image:
   repository: ghcr.io/attune-io/attune
   # -- Image pull policy
   pullPolicy: IfNotPresent
-  # -- Image tag. Empty uses a `v` prefix plus Chart appVersion
-  # (published images are tagged `vX.Y.Z`, not `X.Y.Z`).
+  # -- Image tag. Empty uses Chart appVersion (bare SemVer). Releases
+  # also publish the `vX.Y.Z` alias. Set this to pin `v0.1.24` or an
+  # E2E/local tag.
   tag: ""
 
 # -- Image pull secrets

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -371,7 +371,7 @@ func fetchPolicies(ctx context.Context, dynClient dynamic.Interface, namespace s
 		if apierrors.IsNotFound(err) || isNoResourceMatch(err) {
 			fmt.Fprintln(os.Stderr, "Error: Attune CRDs are not installed in this cluster.")
 			fmt.Fprintln(os.Stderr, "Install the operator first:")
-			fmt.Fprintln(os.Stderr, "  helm install attune oci://ghcr.io/attune-io/charts/attune --set image.tag=v0.1.23")
+			fmt.Fprintln(os.Stderr, "  helm install attune oci://ghcr.io/attune-io/charts/attune")
 			os.Exit(1)
 		}
 		fmt.Fprintf(os.Stderr, "Error listing policies: %v\n", err)

--- a/docker/README.md
+++ b/docker/README.md
@@ -46,8 +46,7 @@ conflicts, graduated safety controls.
 
 ```bash
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace \
-  --set image.tag=v0.1.23
+  --namespace attune-system --create-namespace
 ```
 
 ### Pull from Docker Hub

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1219,7 +1219,7 @@ charts/attune/
 
 **Key values.yaml fields**:
 - `replicaCount` (default: 1, HA: 2 with leader election)
-- `image.repository`, `image.tag` (empty tag renders `v` plus `appVersion`)
+- `image.repository`, `image.tag` (empty tag renders `appVersion`, bare SemVer)
 - `resources` (operator pod resources)
 - `metrics.enabled` (expose /metrics)
 - `securityContext` (non-root, read-only root filesystem, drop all capabilities)

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -2,9 +2,9 @@
 
 Attune follows [Semantic Versioning](https://semver.org/). The Helm
 chart version and `appVersion` are kept in sync in `charts/attune/Chart.yaml`
-as bare SemVer (`0.1.23`, no `v`). Git tags and container images use the
-`v` prefix (`v0.1.23`). The chart templates `v` plus `appVersion` when
-`image.tag` is empty so a default install pulls a published image.
+as bare SemVer (`0.1.23`, no `v`). Git tags stay `vX.Y.Z`. Container
+images publish both `vX.Y.Z` and `X.Y.Z` (same digest). Empty
+`image.tag` uses `appVersion` so a default install pulls the bare tag.
 
 ## Release process
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -253,9 +253,8 @@ Fuzz targets are defined in `internal/recommendation/fuzz_test.go`
 
 `make python-test` also runs the Helm default-image-tag classifier
 (`scripts/test_verify_helm_image_tag.sh`) and the release dual-tag
-classifier (`scripts/test_release_image_tags.sh`). Those catch a
-missing `v` prefix on the operator image and a dropped bare SemVer
-alias on the next release.
+classifier (`scripts/test_release_image_tags.sh`). Those catch a `v`-prefix regression on the default Helm image tag and a
+dropped bare SemVer alias on the next release.
 
 ## Running all tests
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -32,20 +32,19 @@ kubectl create namespace attune-system
 
 helm install attune \
   oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system \
-  --set image.tag=v0.1.23
+  --namespace attune-system
 
 # Option B: skip webhooks (no cert-manager)
 # helm install attune oci://ghcr.io/attune-io/charts/attune \
 #   --namespace attune-system --create-namespace \
-#   --set webhooks.enabled=false \
-#   --set image.tag=v0.1.23
+#   --set webhooks.enabled=false
 ```
 
 !!! warning "Chart 0.1.23 pulls a missing image tag"
     The published 0.1.23 chart defaults to `ghcr.io/attune-io/attune:0.1.23`,
-    which does not exist. Keep `--set image.tag=v0.1.23` until you install
-    chart 0.1.24 or newer. If the pod is already `ImagePullBackOff`, see
+    which does not exist. Keep `--set image.tag=v0.1.23` if you install
+    that chart. Chart 0.1.24 and newer can omit the pin. If the pod is
+    already `ImagePullBackOff`, see
     [Helm install ImagePullBackOff](../guides/troubleshooting.md#helm-install-imagepullbackoff).
 
 !!! tip "Large or multi-tenant clusters"
@@ -102,8 +101,7 @@ helm install attune \
 ```bash
 helm upgrade attune \
   oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system \
-  --set image.tag=v0.1.23
+  --namespace attune-system
 ```
 
 ## Install with OLM (OperatorHub)

--- a/docs/guides/multi-cluster.md
+++ b/docs/guides/multi-cluster.md
@@ -30,21 +30,18 @@ cluster-specific values:
 kubectl config use-context dev
 helm install attune oci://ghcr.io/attune-io/charts/attune \
   -n attune-system --create-namespace \
-  --set image.tag=v0.1.23 \
   -f values-dev.yaml
 
 # Staging cluster: Canary mode for validation
 kubectl config use-context staging
 helm install attune oci://ghcr.io/attune-io/charts/attune \
   -n attune-system --create-namespace \
-  --set image.tag=v0.1.23 \
   -f values-staging.yaml
 
 # Prod cluster: Auto mode with conservative settings
 kubectl config use-context prod
 helm install attune oci://ghcr.io/attune-io/charts/attune \
   -n attune-system --create-namespace \
-  --set image.tag=v0.1.23 \
   -f values-prod.yaml
 ```
 

--- a/docs/guides/openshift.md
+++ b/docs/guides/openshift.md
@@ -56,8 +56,7 @@ kubectl create namespace attune-system
 helm install attune \
   oci://ghcr.io/attune-io/charts/attune \
   --namespace attune-system \
-  --set openshift.enabled=true \
-  --set image.tag=v0.1.23
+  --set openshift.enabled=true
 ```
 
 The `openshift.enabled=true` flag adds OpenShift-specific RBAC (read

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1030,9 +1030,9 @@ See [GitOps integration: pull request automation](gitops-integration.md#pull-req
 the operator pod stays `0/1` with `ErrImagePull` or `ImagePullBackOff` for
 `ghcr.io/attune-io/attune:0.1.x` (no `v` prefix).
 
-**Cause:** Chart `appVersion` is SemVer without `v`. Release images are
-tagged `vX.Y.Z`. Charts through 0.1.23 used bare `appVersion` as the
-image tag when `image.tag` was empty.
+**Cause:** Chart `appVersion` is SemVer without `v`. Releases through
+0.1.23 published only `vX.Y.Z`. Chart 0.1.23 used bare `appVersion` as
+the image tag when `image.tag` was empty.
 
 **Fix:** Pin a published tag, then upgrade:
 
@@ -1043,8 +1043,8 @@ helm upgrade attune oci://ghcr.io/attune-io/charts/attune \
   --set image.tag=v0.1.23
 ```
 
-Newer charts default to `v` plus `appVersion`. You can still override
-`image.tag` for local or E2E images.
+From 0.1.24, releases publish both `vX.Y.Z` and `X.Y.Z`. You can still
+override `image.tag` for local or E2E images.
 
 ## Debug commands
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,7 +7,7 @@ This page documents every value in the Helm chart's `values.yaml`.
 | `replicaCount` | int | `1` | Number of operator replicas. Set to `2` for HA with leader election. |
 | `image.repository` | string | `ghcr.io/attune-io/attune` | Container image repository |
 | `image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
-| `image.tag` | string | `""` | Image tag. When empty, the chart uses `v` plus `appVersion` so the pull matches published tags such as `v0.1.23`. |
+| `image.tag` | string | `""` | Image tag. When empty, the chart uses `appVersion` (bare SemVer). Releases also publish the `vX.Y.Z` alias. |
 | `imagePullSecrets` | list | `[]` | Image pull secrets for private registries |
 | `nameOverride` | string | `""` | Override the chart name |
 | `fullnameOverride` | string | `""` | Override the fully qualified app name |

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -434,8 +434,7 @@ It takes less than 5 minutes to start seeing recommendations.
 
 ```bash
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace \
-  --set image.tag=v0.1.23
+  --namespace attune-system --create-namespace
 ```
 
 ### 2. Create your first policy

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,8 +55,7 @@ All examples assume:
 
 ```bash
 helm install attune oci://ghcr.io/attune-io/charts/attune \
-  --namespace attune-system --create-namespace \
-  --set image.tag=v0.1.23
+  --namespace attune-system --create-namespace
 ```
 
 ## kubectl plugin (optional)

--- a/hack/verify-helm-image-tag.sh
+++ b/hack/verify-helm-image-tag.sh
@@ -2,13 +2,14 @@
 # Copyright 2026 attune Authors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Verify the Helm chart default image tag matches published operator
-# tags (vX.Y.Z). Chart.appVersion is SemVer without v; the template
-# must prefix v when image.tag is empty.
+# Verify the Helm chart default image tag is Chart.appVersion (bare
+# SemVer). Releases publish both vX.Y.Z and X.Y.Z. Empty image.tag
+# must not add a v prefix.
 #
-# This is the gate that would have caught attune-io/attune#546:
-# helm lint and helm-unittest did not assert the default image, and
-# E2E always --set image.tag= from a locally built image.
+# This is the gate that would have caught attune-io/attune#546 (and
+# a later v-prefix regression): helm lint and helm-unittest did not
+# assert the default image, and E2E always --set image.tag= from a
+# locally built image.
 
 set -euo pipefail
 
@@ -18,7 +19,7 @@ usage() {
   cat <<'EOF'
 Usage: verify-helm-image-tag.sh [--root DIR]
 
-Fail if helm template default image is not v + Chart.appVersion.
+Fail if helm template default image is not Chart.appVersion (bare SemVer).
 --root   Repository root (default: parent of this script's directory).
 EOF
 }
@@ -46,7 +47,7 @@ if [[ -z "${ROOT}" ]]; then
   ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 
-echo "PLAN: assert default Helm image tag is v + Chart.appVersion"
+echo "PLAN: assert default Helm image tag is Chart.appVersion (bare SemVer)"
 
 CHART="${ROOT}/charts/attune"
 CHART_YAML="${CHART}/Chart.yaml"
@@ -72,7 +73,7 @@ if [[ -z "${APP_VERSION}" ]]; then
 fi
 
 BARE="${APP_VERSION#v}"
-EXPECTED_TAG="v${BARE}"
+EXPECTED_TAG="${BARE}"
 echo "OK: appVersion=${APP_VERSION} expected_tag=${EXPECTED_TAG}"
 
 echo "DO: helm template default image"
@@ -89,7 +90,7 @@ DEFAULT_TAG="${DEFAULT_IMAGE##*:}"
 REPO="${DEFAULT_IMAGE%:*}"
 if [[ "${DEFAULT_TAG}" != "${EXPECTED_TAG}" ]]; then
   echo "FAIL: default image tag ${DEFAULT_TAG} != ${EXPECTED_TAG} (repo=${REPO})"
-  echo "HINT: attune.imageTag must prefix v onto Chart.appVersion when image.tag is empty."
+  echo "HINT: attune.imageTag must use Chart.appVersion (no v prefix) when image.tag is empty."
   echo "DONE: ok=false reason=wrong-default-tag got=${DEFAULT_TAG} want=${EXPECTED_TAG}"
   echo "NEXT: fix charts/attune/templates/_helpers.tpl attune.imageTag"
   exit 1

--- a/scripts/test_verify_helm_image_tag.sh
+++ b/scripts/test_verify_helm_image_tag.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Classifier for hack/verify-helm-image-tag.sh: the live chart must pass,
-# and a chart that falls back to bare appVersion (issue #546) must fail.
+# and a chart that still prefixes v onto appVersion must fail.
 
 set -euo pipefail
 
@@ -22,36 +22,41 @@ echo "OK: live chart passed"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
-echo "DO: copy chart to ${TMP} and restore the bare-appVersion default"
+echo "DO: copy chart to ${TMP} and restore the v-prefix helper"
 cp -R "${ROOT}/charts" "${TMP}/"
-# Recreate the #546 template: default image.tag to Chart.AppVersion with no v.
+# Recreate the post-#546 helper: prefix v onto Chart.AppVersion.
 sed -i.bak \
-  's#{{ include "attune.imageTag" . }}#{{ .Values.image.tag | default .Chart.AppVersion }}#' \
-  "${TMP}/charts/attune/templates/deployment.yaml"
-rm -f "${TMP}/charts/attune/templates/deployment.yaml.bak"
+  's#{{- .Chart.AppVersion | trimPrefix "v" -}}#{{- printf "v%s" (.Chart.AppVersion | trimPrefix "v") -}}#' \
+  "${TMP}/charts/attune/templates/_helpers.tpl"
+if ! grep -q 'printf "v%s"' "${TMP}/charts/attune/templates/_helpers.tpl"; then
+  echo "FAIL: could not inject v-prefix helper into copied chart"
+  echo "DONE: ok=false reason=fixture-not-mutated"
+  exit 1
+fi
+rm -f "${TMP}/charts/attune/templates/_helpers.tpl.bak"
 
-echo "DO: broken chart must fail"
+echo "DO: v-prefix chart must fail"
 if bash "${SCRIPT}" --root "${TMP}"; then
-  echo "FAIL: bare-appVersion chart passed; the script would not have caught #546"
+  echo "FAIL: v-prefix chart passed; the script would not catch a helper regression"
   echo "DONE: ok=false reason=false-negative"
   exit 1
 fi
-echo "OK: broken chart failed as expected"
+echo "OK: v-prefix chart failed as expected"
 
 # Chart.appVersion is normally bare SemVer. A future chart that already
-# stores vX.Y.Z must still render one v, not vv.
-echo "DO: chart with v-prefixed appVersion must still render a single v"
+# stores vX.Y.Z must still render the bare tag, not vX.Y.Z.
+echo "DO: chart with v-prefixed appVersion must still render bare SemVer"
 TMPV="$(mktemp -d)"
 trap 'rm -rf "${TMP}" "${TMPV}"' EXIT
 cp -R "${ROOT}/charts" "${TMPV}/"
 sed -i.bak 's/^appVersion: .*/appVersion: v0.1.23/' "${TMPV}/charts/attune/Chart.yaml"
 rm -f "${TMPV}/charts/attune/Chart.yaml.bak"
 if ! bash "${SCRIPT}" --root "${TMPV}"; then
-  echo "FAIL: v-prefixed appVersion must render v0.1.23, not vv0.1.23"
-  echo "DONE: ok=false reason=double-v-prefix"
+  echo "FAIL: v-prefixed appVersion must render 0.1.23, not v0.1.23"
+  echo "DONE: ok=false reason=v-prefix-not-stripped"
   exit 1
 fi
-echo "OK: v-prefixed appVersion rendered a single v"
+echo "OK: v-prefixed appVersion rendered bare SemVer"
 
 echo "DONE: ok=true"
 echo "NEXT: none"


### PR DESCRIPTION
## Summary

Default Helm installs now pull `ghcr.io/attune-io/attune:<appVersion>` (bare SemVer) instead of adding a `v` prefix.

## Problem

Chart `appVersion` is bare SemVer. Git tags stay `vX.Y.Z`. Through 0.1.23 the published image was only `vX.Y.Z`, so an empty `image.tag` that used `appVersion` caused ImagePullBackOff (#546). After that, the helper prefixed `v`. v0.1.24 publishes both tags at the same digest, so the `v` workaround is no longer needed.

## Change

- `attune.imageTag` uses `Chart.AppVersion` (trim a leading `v` if present) when `image.tag` is empty
- Explicit `image.tag` (including `v0.1.23` and E2E tags) is unchanged
- `verify-helm-image-tag.sh` and its classifier now require a bare default and fail a v-prefix helper
- Install examples drop the pin for 0.1.24+. Chart 0.1.23 still needs `--set image.tag=v0.1.23`

Dual-tag publishing is unchanged. Git tags stay `v*`.

## Validation

- `bash scripts/test_verify_helm_image_tag.sh` passed (live `:0.1.24`, v-prefix fixture fails, v-appVersion renders `0.1.23`)
- `make helm-unittest` 116/116
- `make verify-helm-image-tag` default `ghcr.io/attune-io/attune:0.1.24`
- `make helm-docs-gen`

Ref #546
