### PR TITLE
ci: fix dependabot go.mod sync and rebase behind prs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -2,12 +2,20 @@ name: Dependabot Auto-Merge
 
 on:
   pull_request_target:
+  # After a merge to main, remaining Dependabot PRs are behind and cannot
+  # satisfy strict_required_status_checks_policy. Comment @dependabot rebase
+  # (App token) instead of pushing with GITHUB_TOKEN.
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 concurrency:
-  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  # push events have no pull_request.number; use run_id so they do not
+  # share one empty group.
+  group: dependabot-auto-merge-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -88,7 +96,9 @@ jobs:
           cp hack/verify-go-version-sync.sh /tmp/verify-go-version-sync.sh
           git fetch origin "$PR_BRANCH"
           git checkout -B "sync-go-version" "origin/${PR_BRANCH}"
-          bash /tmp/verify-go-version-sync.sh --write
+          # --root is required: the script lives in /tmp, so its
+          # dirname/.. would otherwise be / and look for //go.mod.
+          bash /tmp/verify-go-version-sync.sh --write --root "${GITHUB_WORKSPACE}"
           if git diff --quiet -- go.mod; then
             echo "OK: go.mod already matches Dockerfile"
             exit 0
@@ -102,17 +112,45 @@ jobs:
             "HEAD:refs/heads/${PR_BRANCH}"
           echo "OK: pushed go.mod sync to ${PR_BRANCH}"
 
-  # NOTE: A rebase-dependabot job was removed here. It updated open
-  # Dependabot PR branches on every push to main, but caused more harm
-  # than good: GITHUB_TOKEN pushes do not trigger other workflows (GitHub
-  # infinite-loop prevention), so the rebase invalidated existing CI
-  # results without starting new ones, leaving PRs stuck in "no required
-  # checks reported" limbo. With strict_required_status_checks_policy
-  # disabled in the branch ruleset, PRs can merge when behind main, so
-  # auto-rebase is unnecessary. Dependabot handles its own rebases when
-  # conflicts arise.
-  #
-  # See AGENTS.md "Handling Dependabot PRs" for the supported process
-  # (always rebase cleanly when helping a PR; the DCO workflow skips merge
-  # commits to avoid blocking legitimate updates). This design protects
-  # our high Scorecard scores (CI-Tests=10, Branch-Protection, etc.).
+  rebase-outdated:
+    name: Rebase outdated Dependabot PRs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Ask Dependabot to rebase behind PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        shell: bash -Eeuo pipefail {0}
+        run: |
+          # REST mergeable_state is the source of truth. GraphQL often
+          # stays UNKNOWN. Do not git-push with GITHUB_TOKEN (that
+          # invalidates checks without starting new runs).
+          mapfile -t nums < <(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
+            --jq '.[] | select(.user.login=="dependabot[bot]" and .mergeable_state=="behind") | .number')
+          if [[ ${#nums[@]} -eq 0 ]]; then
+            echo "OK: no behind Dependabot PRs"
+            exit 0
+          fi
+          for n in "${nums[@]}"; do
+            last="$(gh api "repos/${REPO}/issues/${n}/comments" \
+              --jq '.[-1].body // empty')"
+            if [[ "${last}" == *"@dependabot rebase"* ]]; then
+              echo "OK: #${n} already asked to rebase"
+              continue
+            fi
+            gh pr comment "${n}" --repo "${REPO}" --body "@dependabot rebase"
+            echo "OK: asked Dependabot to rebase #${n}"
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,7 +365,13 @@ Dependabot PRs (#348, #349 etc.) are important for **Dependency-Update-Tool (10)
    merge to main is not a `GITHUB_TOKEN` push (those do not re-trigger
    CI/Security/Docs on main). `auto-approve.yaml` (`pull_request`)
    excludes `dependabot[bot]` because secrets are unavailable in that context.
-6. If the PR is behind and you want it to move faster, the rebase above + `gh pr comment` or just wait is preferred over broad CI skips.
+6. After a merge to main, `dependabot-auto-merge.yaml` comments
+   `@dependabot rebase` on open Dependabot PRs that REST reports as
+   `behind` (App token, not a GITHUB_TOKEN git push). That is required
+   because the ruleset has `strict_required_status_checks_policy: true`.
+   Dependabot `rebase-strategy: auto` can lag for hours. To hurry one
+   PR, `gh pr comment N --body "@dependabot rebase"` or run
+   `scripts/rebase-dependabot.sh N`.
 7. After a Dependabot merge, if main has no CI/Security runs for the merge
    SHA, dispatch them: `gh workflow run CI --ref main` (and Security/Docs).
 
@@ -383,7 +389,7 @@ on `update-type`; CI is the real safety gate.
 - Token-Permissions warnings are minimized by scoping writes only where gh commands truly need them (see the dependabot-auto-merge and auto-approve jobs).
 
 See also:
-- `.github/workflows/dependabot-auto-merge.yaml` (the NOTE about the removed rebase job)
+- `.github/workflows/dependabot-auto-merge.yaml` (`@dependabot rebase` on behind PRs after main push; docker PRs sync `go.mod` with `--root`)
 - `.github/workflows/dco.yaml` (bot + merge-commit skips)
 - `pr-title.yaml` (Dependabot is exempted from semantic title)
 
@@ -393,8 +399,10 @@ When in doubt, prefer letting Dependabot open a fresh PR on conflict rather than
 (`golang:X.Y.Z@sha256:...`) must stay on the same patch. `setup-go` and
 govulncheck read `go.mod`; Dependabot docker PRs only bump the image.
 `hack/verify-go-version-sync.sh` enforces the match. The Dependabot
-auto-merge workflow copies the Dockerfile tag into `go.mod` on docker
-PRs so those updates can go green without a human follow-up.
+auto-merge workflow copies the script to `/tmp` (do not run PR-controlled
+files) then must call `--write --root "$GITHUB_WORKSPACE"`. Without
+`--root`, the script treats `/tmp/..` as the repo and fails with
+`go.mod not found at //go.mod`.
 
 ### Issue closure in PR descriptions
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1132,11 +1132,12 @@ Jobs:
 
 ```
 Jobs:
-  auto-merge:
-    - Triggers from successful `CI` workflow runs on Dependabot PRs
-    - Finds the PR by head SHA
-    - Approves and squash-merges all semver types (patch, minor, major)
-    - CI is the safety gate; no semver-type filter
+  auto-merge (pull_request_target, Dependabot only):
+    - Approves with GITHUB_TOKEN; enables squash auto-merge with the App token
+    - All semver types; CI is the safety gate
+    - Docker PRs: copy verify-go-version-sync.sh to /tmp, --write --root workspace
+  rebase-outdated (push to main):
+    - Comments @dependabot rebase on open Dependabot PRs with mergeable_state=behind
 ```
 
 ### 10.2 CI Configuration Files

--- a/hack/verify-go-version-sync.sh
+++ b/hack/verify-go-version-sync.sh
@@ -44,7 +44,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$ROOT" ]]; then
-  ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  # Prefer the script location (hack/../). When CI copies this file to
+  # /tmp so it is not executed from a Dependabot branch, fall back to cwd.
+  SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  if [[ -f "${SCRIPT_ROOT}/go.mod" ]]; then
+    ROOT="${SCRIPT_ROOT}"
+  elif [[ -f "${PWD}/go.mod" ]]; then
+    ROOT="${PWD}"
+    echo "OK: script is outside the repo; using cwd ${ROOT}"
+  else
+    ROOT="${SCRIPT_ROOT}"
+  fi
 fi
 
 echo "PLAN: compare go.mod go directive with Dockerfile golang tag (mode=${MODE})"

--- a/scripts/test_verify_go_version_sync.sh
+++ b/scripts/test_verify_go_version_sync.sh
@@ -69,6 +69,20 @@ set -e
 assert_eq "1" "$rc" "missing Dockerfile exit 1"
 assert_contains "missing-dockerfile" "$out" "missing Dockerfile reason"
 
+# Script copied to /tmp (Dependabot auto-merge path): use cwd, not /tmp/...
+pair="${tmpdir}/copied"
+write_pair "$pair" "1.26.5" "1.26.6"
+copied="${tmpdir}/verify-go-version-sync.sh"
+cp "$SCRIPT" "$copied"
+(
+  cd "$pair"
+  "$copied" --write >/dev/null
+)
+got="$(grep -E '^go ' "${pair}/go.mod")"
+assert_eq "go 1.26.6" "$got" "copied script uses cwd when not next to go.mod"
+"$SCRIPT" --check --root "$pair" >/dev/null
+echo "ok: /tmp copy --write then check exits 0"
+
 # Unparseable Dockerfile.
 pair="${tmpdir}/badimage"
 mkdir -p "$pair"


### PR DESCRIPTION
## Summary

Dependabot docker PRs never synced `go.mod`, and remaining Dependabot PRs stayed `behind` after one merge.

## Problem

1. `#556` (`golang` 1.26.6 to 1.27.0) is red because Lint runs `verify-go-version-sync.sh`. The auto-merge job is supposed to copy the Dockerfile tag into `go.mod` first. It copies the script to `/tmp` (so it does not run PR-controlled files), then invokes it without `--root`. The script treats `/tmp/..` as the repo and fails with `go.mod not found at //go.mod`.
2. `#558` and `#559` did not merge because `#557` (distroless) landed first. The ruleset has `strict_required_status_checks_policy: true`, so auto-merge waits until the branch is up to date. Dependabot `rebase-strategy: auto` can lag for hours. The old workflow comment claiming the strict policy was disabled was wrong.

## Change

- Pass `--write --root "$GITHUB_WORKSPACE"` and fall back to cwd when the script is not next to `go.mod`.
- Classifier covers the `/tmp` copy path.
- On push to `main`, comment `@dependabot rebase` on open Dependabot PRs whose REST `mergeable_state` is `behind` (App token, not a `GITHUB_TOKEN` git push).

## Validation

- `bash scripts/test_verify_go_version_sync.sh` (includes the copied-script case)
- `python3` YAML load of `dependabot-auto-merge.yaml`

## Issue reference

Refers to the open Dependabot queue (`#556`, `#558`, `#559`, `#560`). No issue close.
