### PR TITLE
ci: compute dependabot mergeable_state per PR

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -135,22 +135,31 @@ jobs:
           REPO: ${{ github.repository }}
         shell: bash -Eeuo pipefail {0}
         run: |
-          # REST mergeable_state is the source of truth. GraphQL often
-          # stays UNKNOWN. Do not git-push with GITHUB_TOKEN (that
-          # invalidates checks without starting new runs).
+          # The list endpoint often returns mergeable_state=unknown.
+          # GET /pulls/N computes it. Observed on the first run after #561:
+          # list said unknown, so this job no-op'd while all four
+          # Dependabot PRs were behind. Do not git-push with GITHUB_TOKEN.
           mapfile -t nums < <(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
-            --jq '.[] | select(.user.login=="dependabot[bot]" and .mergeable_state=="behind") | .number')
+            --jq '.[] | select(.user.login=="dependabot[bot]") | .number')
           if [[ ${#nums[@]} -eq 0 ]]; then
-            echo "OK: no behind Dependabot PRs"
+            echo "OK: no open Dependabot PRs"
             exit 0
           fi
+          asked=0
           for n in "${nums[@]}"; do
-            last="$(gh api "repos/${REPO}/issues/${n}/comments" \
-              --jq '.[-1].body // empty')"
-            if [[ "${last}" == *"@dependabot rebase"* ]]; then
-              echo "OK: #${n} already asked to rebase"
+            state="$(gh api "repos/${REPO}/pulls/${n}" --jq .mergeable_state)"
+            if [[ "${state}" == "unknown" ]]; then
+              sleep 2
+              state="$(gh api "repos/${REPO}/pulls/${n}" --jq .mergeable_state)"
+            fi
+            echo "OK: #${n} mergeable_state=${state}"
+            if [[ "${state}" != "behind" ]]; then
               continue
             fi
+            # Ask again even if we already commented. A prior rebase can
+            # land, then another merge to main makes the PR behind again.
             gh pr comment "${n}" --repo "${REPO}" --body "@dependabot rebase"
             echo "OK: asked Dependabot to rebase #${n}"
+            asked=$((asked + 1))
           done
+          echo "DONE: asked=${asked}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,11 +366,13 @@ Dependabot PRs (#348, #349 etc.) are important for **Dependency-Update-Tool (10)
    CI/Security/Docs on main). `auto-approve.yaml` (`pull_request`)
    excludes `dependabot[bot]` because secrets are unavailable in that context.
 6. After a merge to main, `dependabot-auto-merge.yaml` comments
-   `@dependabot rebase` on open Dependabot PRs that REST reports as
-   `behind` (App token, not a GITHUB_TOKEN git push). That is required
-   because the ruleset has `strict_required_status_checks_policy: true`.
-   Dependabot `rebase-strategy: auto` can lag for hours. To hurry one
-   PR, `gh pr comment N --body "@dependabot rebase"` or run
+   `@dependabot rebase` on open Dependabot PRs. It lists Dependabot PRs
+   then `GET /pulls/N` so GitHub computes `mergeable_state` (the list
+   endpoint often returns `unknown` and would skip everyone). App token,
+   not a GITHUB_TOKEN git push. Required because the ruleset has
+   `strict_required_status_checks_policy: true`. Dependabot
+   `rebase-strategy: auto` can lag for hours. To hurry one PR,
+   `gh pr comment N --body "@dependabot rebase"` or run
    `scripts/rebase-dependabot.sh N`.
 7. After a Dependabot merge, if main has no CI/Security runs for the merge
    SHA, dispatch them: `gh workflow run CI --ref main` (and Security/Docs).


### PR DESCRIPTION
## Summary

The post-merge rebase job after #561 did nothing because the pulls list API returned `mergeable_state=unknown`.

## Problem

`GET /repos/.../pulls?state=open` often leaves `mergeable_state` as `unknown`. The job filtered on `behind` in that list, printed `OK: no behind Dependabot PRs`, and skipped #556/#558/#559/#560. A single `GET /pulls/N` computes the real state (`behind` for all four).

## Change

List Dependabot PR numbers, then GET each one (retry once if still unknown). Comment `@dependabot rebase` when the computed state is `behind`, even if we already asked (a rebase can land, then another main merge makes the PR behind again).

## Validation

- `python3` YAML load of `dependabot-auto-merge.yaml`
- First #561 main run log: `OK: no behind Dependabot PRs` while REST `GET /pulls/556` was `behind`

## Issue reference

Follow-up to #561. No issue close.
