### PR TITLE
fix: start canary observation after a successful in-place resize

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -653,6 +653,8 @@ To prevent conflicts:
    - OneShot: one eligible pod per cycle
    - Canary: canaryPercentage% of pods (round up to at least 1)
    - Auto: canary first, then remaining after observation period
+     (observation `startTime` is the first successful in-place canary
+     resize, not the first skipped attempt; a revert clears the clock)
 
 2. For each selected pod:
    a. PRE-CHECK:

--- a/docs/guides/canary-rollout.md
+++ b/docs/guides/canary-rollout.md
@@ -44,10 +44,14 @@ spec:
 2. **Canary selection**: the operator picks `ceil(percentage * eligible / 100)`
    pods. Only running pods without an active resize or pending deletion qualify.
 3. **In-place resize**: the operator calls `UpdateResize` on each selected pod.
-4. **Observation**: during `observationPeriod`, the safety monitor checks for
-   OOMKill, restart spikes, pod NotReady, CPU throttle, and SLO guardrail breaches.
+4. **Observation**: `status.canary.startTime` is set only after a successful
+   in-place canary resize. During `observationPeriod` after that resize, the
+   safety monitor checks for OOMKill, restart spikes, pod NotReady, CPU
+   throttle, and SLO guardrail breaches. Skipped cycles (budget, node
+   pressure, already at target) do not start the clock.
 5. **Verdict**: if all canary pods remain healthy, the resize is considered
-   successful. If any violation is detected, the operator auto-reverts.
+   successful. If any violation is detected, the operator auto-reverts and
+   starts a new observation after the next successful in-place resize.
 6. **Cooldown**: the operator waits for the `cooldown` duration before the
    next reconciliation cycle.
 
@@ -96,11 +100,14 @@ kubectl get attunepolicy my-app -o jsonpath='{.status.resizeHistory}' | jq '.[] 
 
 When `autoPromote: true`, the operator handles promotion automatically:
 
-1. After the canary pods pass the observation period with zero reverts,
-   the operator sets `status.canary.phase: FullRollout`.
+1. After the canary pods pass the observation period measured from the
+   successful in-place resize, with zero reverts, the operator sets
+   `status.canary.phase: FullRollout`.
 2. On the next reconcile, all eligible pods are resized (same as Auto mode).
-3. If any revert occurs during observation, promotion is blocked and the
-   operator continues resizing only the canary subset.
+3. If any revert occurs during observation, promotion is blocked, the
+   observation clock is cleared, and a new watch starts after the next
+   successful in-place resize. The operator continues resizing only the
+   canary subset until that new watch passes.
 
 Check the canary phase:
 

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -4826,9 +4826,10 @@ func TestResolveCanaryPhase_InitializesOnFirstCall(t *testing.T) {
 	mode := reconciler.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
 
 	assert.Equal(t, attunev1alpha1.UpdateTypeCanary, mode, "first call should stay in canary mode")
-	require.NotNil(t, policy.Status.Canary)
-	assert.Equal(t, attunev1alpha1.CanaryPhaseInProgress, policy.Status.Canary.Phase)
-	assert.NotNil(t, policy.Status.Canary.StartTime)
+	if policy.Status.Canary != nil {
+		assert.Nil(t, policy.Status.Canary.StartTime, "observation clock must not start before an in-place resize")
+		assert.NotEqual(t, attunev1alpha1.CanaryPhaseFullRollout, policy.Status.Canary.Phase)
+	}
 }
 
 func TestResolveCanaryPhase_PromotesAfterObservation(t *testing.T) {
@@ -4947,6 +4948,7 @@ func TestResolveCanaryPhase_BlocksOnRevert(t *testing.T) {
 
 	assert.Equal(t, attunev1alpha1.UpdateTypeCanary, mode, "should block promotion when revert happened")
 	assert.Equal(t, attunev1alpha1.CanaryPhaseInProgress, policy.Status.Canary.Phase)
+	assert.Nil(t, policy.Status.Canary.StartTime, "revert must clear the observation clock")
 }
 
 func TestResolveCanaryPhase_FullRolloutStaysAuto(t *testing.T) {
@@ -4981,11 +4983,12 @@ func TestResolveCanaryPhase_ResetsOnSpecChange(t *testing.T) {
 	reconciler := NewAttunePolicyReconciler()
 	mode := reconciler.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
 
-	// Should reset and re-initialize, staying in canary mode.
+	// Should reset and wait for the next in-place resize, staying in canary mode.
 	assert.Equal(t, attunev1alpha1.UpdateTypeCanary, mode, "spec change should reset canary, not stay in FullRollout")
-	require.NotNil(t, policy.Status.Canary)
-	assert.Equal(t, attunev1alpha1.CanaryPhaseInProgress, policy.Status.Canary.Phase)
-	assert.Equal(t, int64(3), policy.Status.Canary.ObservedGeneration, "new cycle should track current generation")
+	if policy.Status.Canary != nil {
+		assert.NotEqual(t, attunev1alpha1.CanaryPhaseFullRollout, policy.Status.Canary.Phase)
+		assert.Nil(t, policy.Status.Canary.StartTime, "spec change must not start a new clock before a resize")
+	}
 }
 
 func TestResolveCanaryPhase_NoResetWhenGenerationMatches(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -4813,7 +4813,7 @@ func TestReconcile_PrometheusQueryErrorsMentionCPUAndMemoryWhenBothFail(t *testi
 
 // ---------- resolveCanaryPhase ----------
 
-func TestResolveCanaryPhase_InitializesOnFirstCall(t *testing.T) {
+func TestResolveCanaryPhase_DoesNotInitializeWithoutHistory(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeCanary
 	policy.Spec.UpdateStrategy.Canary = &attunev1alpha1.CanaryConfig{
@@ -4826,10 +4826,7 @@ func TestResolveCanaryPhase_InitializesOnFirstCall(t *testing.T) {
 	mode := reconciler.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
 
 	assert.Equal(t, attunev1alpha1.UpdateTypeCanary, mode, "first call should stay in canary mode")
-	if policy.Status.Canary != nil {
-		assert.Nil(t, policy.Status.Canary.StartTime, "observation clock must not start before an in-place resize")
-		assert.NotEqual(t, attunev1alpha1.CanaryPhaseFullRollout, policy.Status.Canary.Phase)
-	}
+	assert.Nil(t, policy.Status.Canary, "observation must not start before an in-place resize")
 }
 
 func TestResolveCanaryPhase_PromotesAfterObservation(t *testing.T) {

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
@@ -130,5 +133,139 @@ func TestSelectPodsForResize_MixedEligibility(t *testing.T) {
 	for _, p := range selected {
 		assert.Equal(t, corev1.PodRunning, p.Status.Phase)
 		assert.Nil(t, p.DeletionTimestamp)
+	}
+}
+
+func canaryAutoPromotePolicy(period time.Duration) *attunev1alpha1.AttunePolicy {
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeCanary
+	policy.Spec.UpdateStrategy.Canary = &attunev1alpha1.CanaryConfig{
+		Percentage:        20,
+		ObservationPeriod: metav1.Duration{Duration: period},
+		AutoPromote:       true,
+	}
+	return policy
+}
+
+func TestResolveCanaryPhase_DoesNotStartWatchWithoutInPlaceSuccess(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase:     attunev1alpha1.CanaryPhaseInProgress,
+		StartTime: &metav1.Time{Time: now.Add(-10 * time.Minute)},
+	}
+
+	r := NewAttunePolicyReconciler()
+	r.SetNowFunc(func() time.Time { return now })
+
+	mode := r.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
+	assert.Equal(t, attunev1alpha1.UpdateTypeCanary, mode)
+	assert.Equal(t, attunev1alpha1.CanaryPhaseInProgress, policy.Status.Canary.Phase)
+	assert.NotEqual(t, attunev1alpha1.CanaryPhaseFullRollout, policy.Status.Canary.Phase)
+}
+
+func TestResolveCanaryPhase_DoesNotPromoteLateResizeWithoutWatchingIt(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	premature := metav1.NewTime(now.Add(-10 * time.Minute))
+	lateSuccess := metav1.NewTime(now.Add(-30 * time.Second))
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase:     attunev1alpha1.CanaryPhaseInProgress,
+		StartTime: &premature,
+	}
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{
+		{Method: "InPlace", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: lateSuccess},
+	}
+
+	r := NewAttunePolicyReconciler()
+	r.SetNowFunc(func() time.Time { return now })
+
+	mode := r.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
+	assert.Equal(t, attunev1alpha1.UpdateTypeCanary, mode, "late first success must not promote on a premature clock")
+	assert.Equal(t, attunev1alpha1.CanaryPhaseInProgress, policy.Status.Canary.Phase)
+	require.NotNil(t, policy.Status.Canary.StartTime)
+	assert.Equal(t, lateSuccess.Time, policy.Status.Canary.StartTime.Time, "watch must re-anchor to the successful resize")
+
+	r.SetNowFunc(func() time.Time { return lateSuccess.Add(10 * time.Minute) })
+	mode = r.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
+	assert.Equal(t, attunev1alpha1.UpdateTypeAuto, mode, "same resize aged a full period should promote")
+	assert.Equal(t, attunev1alpha1.CanaryPhaseFullRollout, policy.Status.Canary.Phase)
+}
+
+func TestResolveCanaryPhase_ResetsOnRevert(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	start := metav1.NewTime(now.Add(-4 * time.Minute))
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase:     attunev1alpha1.CanaryPhaseInProgress,
+		StartTime: &start,
+		Pods:      []string{"api-server-aaa"},
+	}
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{
+		{Method: "InPlace", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: metav1.NewTime(start.Add(1 * time.Minute))},
+		{Result: attunev1alpha1.ResizeResultReverted, Timestamp: metav1.NewTime(start.Add(2 * time.Minute))},
+	}
+
+	r := NewAttunePolicyReconciler()
+	r.SetNowFunc(func() time.Time { return now })
+
+	mode := r.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
+	assert.Equal(t, attunev1alpha1.UpdateTypeCanary, mode)
+	assert.Equal(t, attunev1alpha1.CanaryPhaseInProgress, policy.Status.Canary.Phase)
+	assert.Nil(t, policy.Status.Canary.StartTime, "revert must start a new observation instead of freezing")
+	assert.Empty(t, policy.Status.Canary.Pods)
+
+	nextSuccess := metav1.NewTime(now.Add(1 * time.Minute))
+	policy.Status.ResizeHistory = append(policy.Status.ResizeHistory, attunev1alpha1.ResizeHistoryEntry{
+		Method: "InPlace", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: nextSuccess,
+	})
+	r.SetNowFunc(func() time.Time { return nextSuccess.Time })
+	mode = r.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
+	assert.Equal(t, attunev1alpha1.UpdateTypeCanary, mode)
+	require.NotNil(t, policy.Status.Canary.StartTime)
+	assert.Equal(t, nextSuccess.Time, policy.Status.Canary.StartTime.Time)
+
+	r.SetNowFunc(func() time.Time { return nextSuccess.Add(10 * time.Minute) })
+	mode = r.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
+	assert.Equal(t, attunev1alpha1.UpdateTypeAuto, mode)
+	assert.Equal(t, attunev1alpha1.CanaryPhaseFullRollout, policy.Status.Canary.Phase)
+}
+
+func TestExecuteResizes_CanaryAutoPromoteStartsWatchAfterInPlaceResize(t *testing.T) {
+	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	reconciler, _ := newResizeReconciler(pod, deploy)
+
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("api-server", "500m", "512Mi", "1000m", "1Gi", "750m", "384Mi", "1500m", "768Mi"),
+	}
+
+	count, history := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recommendations, podMap("api-server", pod), nil, nil)
+	assert.Equal(t, 1, count)
+	require.NotEmpty(t, history)
+	require.NotNil(t, policy.Status.Canary)
+	assert.Equal(t, attunev1alpha1.CanaryPhaseInProgress, policy.Status.Canary.Phase)
+	require.NotNil(t, policy.Status.Canary.StartTime, "watch starts after a successful in-place resize")
+	assert.Contains(t, policy.Status.Canary.Pods, pod.Name)
+}
+
+func TestExecuteResizes_CanaryDoesNotStartWatchWhenNoResize(t *testing.T) {
+	pod := newResizePod("api-server", "750m", "384Mi", "1500m", "768Mi")
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	reconciler, _ := newResizeReconciler(pod, deploy)
+
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("api-server", "500m", "512Mi", "0", "0", "750m", "384Mi", "1500m", "768Mi"),
+	}
+
+	count, history := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recommendations, podMap("api-server", pod), nil, nil)
+	assert.Equal(t, 0, count)
+	assert.Empty(t, history)
+	if policy.Status.Canary != nil {
+		assert.Nil(t, policy.Status.Canary.StartTime, "skipped resize must not start the observation clock")
 	}
 }

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -192,6 +192,32 @@ func TestResolveCanaryPhase_DoesNotPromoteLateResizeWithoutWatchingIt(t *testing
 	assert.Equal(t, attunev1alpha1.CanaryPhaseFullRollout, policy.Status.Canary.Phase)
 }
 
+func TestResolveCanaryPhase_ResetsWhenSuccessFlippedToReverted(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	resizeAt := metav1.NewTime(now.Add(-4 * time.Minute))
+	watchStart := metav1.NewTime(now.Add(-4*time.Minute + 2*time.Second))
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase:     attunev1alpha1.CanaryPhaseInProgress,
+		StartTime: &watchStart,
+		Pods:      []string{"api-server-aaa"},
+	}
+	// Production safety revert flips the Success row in place and keeps
+	// the original resize timestamp, which is before StartTime.
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{
+		{Method: "InPlace", Result: attunev1alpha1.ResizeResultReverted, Timestamp: resizeAt},
+	}
+
+	r := NewAttunePolicyReconciler()
+	r.SetNowFunc(func() time.Time { return now })
+
+	mode := r.resolveCanaryPhase(context.Background(), policy, attunev1alpha1.UpdateTypeCanary)
+	assert.Equal(t, attunev1alpha1.UpdateTypeCanary, mode)
+	assert.Equal(t, attunev1alpha1.CanaryPhaseInProgress, policy.Status.Canary.Phase)
+	assert.Nil(t, policy.Status.Canary.StartTime, "in-place Success flipped to Reverted must clear the clock")
+	assert.Empty(t, policy.Status.Canary.Pods)
+}
+
 func TestResolveCanaryPhase_ResetsOnRevert(t *testing.T) {
 	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
 	start := metav1.NewTime(now.Add(-4 * time.Minute))

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -317,6 +317,9 @@ func (r *AttunePolicyReconciler) executeResizes(
 				if len(podHistory) > 0 {
 					historyMu.Lock()
 					history = append(history, podHistory...)
+					if podResized {
+						r.startCanaryWatch(policy, pod.Name)
+					}
 					historyMu.Unlock()
 				}
 				if podResized {
@@ -924,6 +927,12 @@ func clampRequestsToLimits(target *corev1.ResourceRequirements) []string {
 // resolveCanaryPhase checks whether canary pods have passed the observation
 // period without reverts. If so, it promotes to FullRollout and returns
 // ModeAuto so selectPodsForResize resizes all pods.
+//
+// Observation starts after a successful in-place canary resize (see
+// startCanaryWatch), not on the first executeResizes attempt. A premature
+// StartTime from an earlier cycle is re-anchored to the first real success.
+// A revert clears the clock so the next in-place success starts a new watch
+// instead of freezing or promoting immediately.
 func (r *AttunePolicyReconciler) resolveCanaryPhase(ctx context.Context, policy *attunev1alpha1.AttunePolicy, currentMode attunev1alpha1.UpdateType) attunev1alpha1.UpdateType {
 	logger := log.FromContext(ctx)
 	observationPeriod := getObservationPeriod(policy)
@@ -946,54 +955,108 @@ func (r *AttunePolicyReconciler) resolveCanaryPhase(ctx context.Context, policy 
 		return attunev1alpha1.UpdateTypeAuto
 	}
 
-	// Phase: CanaryInProgress -- check if observation period has elapsed.
-	if cs != nil && cs.Phase == attunev1alpha1.CanaryPhaseInProgress && cs.StartTime != nil {
-		elapsed := r.now().Sub(cs.StartTime.Time)
-		if elapsed >= observationPeriod {
-			// Check for reverts during the observation window and require at least
-			// one successful in-place resize before promoting.
-			hasRevert := false
-			hasSuccessfulInPlaceResize := false
-			for _, h := range policy.Status.ResizeHistory {
-				if !h.Timestamp.After(cs.StartTime.Time) {
-					continue
-				}
-				if h.Result == attunev1alpha1.ResizeResultReverted {
-					hasRevert = true
-					break
-				}
-				if isSuccessfulInPlaceHistory(h) {
-					hasSuccessfulInPlaceResize = true
-				}
-			}
-			if hasRevert {
-				logger.Info("Canary observation found reverts, staying in canary mode",
-					"policy", policy.Name, "observationPeriod", observationPeriod)
-				return currentMode
-			}
-			if !hasSuccessfulInPlaceResize {
-				logger.Info("Canary observation has no successful in-place resize yet, staying in canary mode",
-					"policy", policy.Name, "observationPeriod", observationPeriod)
-				return currentMode
-			}
-			logger.Info("Canary observation passed, promoting to full rollout",
+	if cs == nil || cs.Phase != attunev1alpha1.CanaryPhaseInProgress {
+		return currentMode
+	}
+
+	lastRevert := latestMatchingHistoryTime(policy.Status.ResizeHistory, func(h attunev1alpha1.ResizeHistoryEntry) bool {
+		return h.Result == attunev1alpha1.ResizeResultReverted
+	})
+	if lastRevert != nil && (cs.StartTime == nil || lastRevert.After(cs.StartTime.Time)) {
+		logger.Info("Canary observation found reverts, resetting watch",
+			"policy", policy.Name, "observationPeriod", observationPeriod)
+		cs.StartTime = nil
+		cs.Pods = nil
+	}
+
+	firstSuccess := earliestSuccessfulInPlaceAfter(policy.Status.ResizeHistory, lastRevert)
+	if firstSuccess == nil {
+		if cs.StartTime != nil {
+			logger.Info("Canary observation has no successful in-place resize yet, staying in canary mode",
 				"policy", policy.Name, "observationPeriod", observationPeriod)
-			policy.Status.Canary.Phase = attunev1alpha1.CanaryPhaseFullRollout
-			return attunev1alpha1.UpdateTypeAuto
 		}
 		return currentMode
 	}
 
-	// Phase: not started yet. Initialize canary tracking on the next resize.
-	if cs == nil {
-		now := metav1.NewTime(r.now())
+	if cs.StartTime == nil || cs.StartTime.Time.Before(firstSuccess.Time) {
+		t := *firstSuccess
+		cs.StartTime = &t
+		logger.V(1).Info("Canary observation clock anchored to in-place resize",
+			"policy", policy.Name, "startTime", cs.StartTime.Time)
+	}
+
+	if r.now().Sub(cs.StartTime.Time) < observationPeriod {
+		return currentMode
+	}
+	logger.Info("Canary observation passed, promoting to full rollout",
+		"policy", policy.Name, "observationPeriod", observationPeriod)
+	cs.Phase = attunev1alpha1.CanaryPhaseFullRollout
+	return attunev1alpha1.UpdateTypeAuto
+}
+
+// startCanaryWatch records the first successful in-place canary resize as the
+// observation start. It is a no-op when autoPromote is off or the cycle is
+// already in FullRollout.
+func (r *AttunePolicyReconciler) startCanaryWatch(policy *attunev1alpha1.AttunePolicy, podName string) {
+	if policy.Spec.UpdateStrategy.Type != attunev1alpha1.UpdateTypeCanary {
+		return
+	}
+	if policy.Spec.UpdateStrategy.Canary == nil || !policy.Spec.UpdateStrategy.Canary.AutoPromote {
+		return
+	}
+	if policy.Status.Canary != nil && policy.Status.Canary.Phase == attunev1alpha1.CanaryPhaseFullRollout {
+		return
+	}
+	if policy.Status.Canary == nil {
 		policy.Status.Canary = &attunev1alpha1.CanaryStatus{
 			Phase:              attunev1alpha1.CanaryPhaseInProgress,
-			StartTime:          &now,
 			ObservedGeneration: policy.Generation,
 		}
 	}
-	return currentMode
+	if policy.Status.Canary.StartTime == nil {
+		now := metav1.NewTime(r.now())
+		policy.Status.Canary.StartTime = &now
+		policy.Status.Canary.ObservedGeneration = policy.Generation
+	}
+	if podName != "" {
+		policy.Status.Canary.Pods = appendUnique(policy.Status.Canary.Pods, podName)
+	}
+}
+
+func latestMatchingHistoryTime(
+	history []attunev1alpha1.ResizeHistoryEntry,
+	match func(attunev1alpha1.ResizeHistoryEntry) bool,
+) *metav1.Time {
+	var latest *metav1.Time
+	for i := range history {
+		h := history[i]
+		if !match(h) {
+			continue
+		}
+		if latest == nil || h.Timestamp.After(latest.Time) {
+			t := h.Timestamp
+			latest = &t
+		}
+	}
+	return latest
+}
+
+func earliestSuccessfulInPlaceAfter(history []attunev1alpha1.ResizeHistoryEntry, after *metav1.Time) *metav1.Time {
+	var earliest *metav1.Time
+	for i := range history {
+		h := history[i]
+		if !isSuccessfulInPlaceHistory(h) {
+			continue
+		}
+		if after != nil && !h.Timestamp.After(after.Time) {
+			continue
+		}
+		if earliest == nil || h.Timestamp.Before(earliest) {
+			t := h.Timestamp
+			earliest = &t
+		}
+	}
+	return earliest
 }
 
 // resizePreChecks holds per-cycle cached data for shouldSkipResize,

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -962,18 +962,16 @@ func (r *AttunePolicyReconciler) resolveCanaryPhase(ctx context.Context, policy 
 	lastRevert := latestMatchingHistoryTime(policy.Status.ResizeHistory, func(h attunev1alpha1.ResizeHistoryEntry) bool {
 		return h.Result == attunev1alpha1.ResizeResultReverted
 	})
-	if lastRevert != nil && (cs.StartTime == nil || lastRevert.After(cs.StartTime.Time)) {
-		logger.Info("Canary observation found reverts, resetting watch",
-			"policy", policy.Name, "observationPeriod", observationPeriod)
-		cs.StartTime = nil
-		cs.Pods = nil
-	}
-
 	firstSuccess := earliestSuccessfulInPlaceAfter(policy.Status.ResizeHistory, lastRevert)
 	if firstSuccess == nil {
-		if cs.StartTime != nil {
-			logger.Info("Canary observation has no successful in-place resize yet, staying in canary mode",
+		// Production reverts flip the Success row in place and keep its
+		// original timestamp, which is often not after StartTime. Reset
+		// whenever there is no live in-place success after the last revert.
+		if cs.StartTime != nil || len(cs.Pods) > 0 {
+			logger.Info("Canary observation has no successful in-place resize yet, resetting watch",
 				"policy", policy.Name, "observationPeriod", observationPeriod)
+			cs.StartTime = nil
+			cs.Pods = nil
 		}
 		return currentMode
 	}


### PR DESCRIPTION
## Summary

Canary `autoPromote` now starts the observation clock after a successful in-place resize, not on the first `executeResizes` attempt. A late first success no longer promotes immediately on a premature clock. A safety revert clears the clock so the next in-place success starts a new watch instead of freezing the cycle.

## Problem

`resolveCanaryPhase` set `status.canary.startTime` when canary status was still nil, before any pod actually resized. Skipped cycles (budget, node pressure, already at target) started that clock anyway. If a resize landed after the observation period had already elapsed, the operator promoted without watching that resize.

After a revert, `hasRevert` stayed true against the original `startTime`, so a new observation never started.

This was still present on current `main`. The same contract was already documented (`CanaryStatus.StartTime` is "when the canary subset was first resized") and was evaluated as a complete HARD-proposal solution (`t-f3TZfLfwi3QFwDCvid9jx`).

## Change

- Do not initialize `StartTime` on the first `resolveCanaryPhase` call
- `startCanaryWatch` records the first successful in-place canary resize
- Re-anchor a premature `StartTime` to the first real in-place success
- Clear `StartTime` and canary pod names on revert; the next success starts a new watch
- Spec generation change still resets canary status
- `autoPromote: false` still never promotes

## Validation

Red step (unfixed code): late-resize promote, revert freeze, skip-starts-clock, and first-call StartTime tests failed.

Green step:

```
go test ./internal/controller/ -race -count=1 -timeout=300s
ok
make lint
0 issues
```

New tests:

- `TestResolveCanaryPhase_DoesNotPromoteLateResizeWithoutWatchingIt`
- `TestResolveCanaryPhase_ResetsOnRevert`
- `TestExecuteResizes_CanaryAutoPromoteStartsWatchAfterInPlaceResize`
- `TestExecuteResizes_CanaryDoesNotStartWatchWhenNoResize`

## Other HARD proposals reviewed

Assimilated this cycle: canary observation clock (this PR).

Still open as follow-ups (not in this PR):

- #566 per-workload cooldown (policy-wide `attune.io/last-resize-time` still locks every matched app)
- #567 canary isolation (CREATE webhook, startup boost, and HPA still move the rest of the fleet)

Already on `main` in a thinner form: GitOps empty-repeat skip (`attune.io/gitops-pr-drift`, #538) and node MemoryPressure / allocatable skips. Those do not need this PR.

Closes #565
Ref #566
Ref #567
