### PR TITLE
fix: per-app canary seed and remaining cooldown requeue

### DIFF
--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1683,6 +1683,20 @@ func formatCanaryStatus(item unstructured.Unstructured) string {
 	if phase == "" {
 		return "Pending"
 	}
+	workloads, found, _ := unstructured.NestedSlice(item.Object, "status", "canary", "workloads")
+	if found && len(workloads) > 0 {
+		promoted := 0
+		for _, raw := range workloads {
+			m, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if p, _ := m["phase"].(string); p == "FullRollout" {
+				promoted++
+			}
+		}
+		return fmt.Sprintf("%s (%d/%d apps)", phase, promoted, len(workloads))
+	}
 	pods, _, _ := unstructured.NestedStringSlice(item.Object, "status", "canary", "pods")
 	if len(pods) > 0 {
 		return fmt.Sprintf("%s (%d pods)", phase, len(pods))

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -892,6 +892,22 @@ func TestFormatCanaryStatus(t *testing.T) {
 			},
 			expected: "FullRollout",
 		},
+		{
+			name: "canary mixed per-app promote",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{"updateStrategy": map[string]interface{}{"type": "Canary"}},
+				"status": map[string]interface{}{
+					"canary": map[string]interface{}{
+						"phase": "CanaryInProgress",
+						"workloads": []interface{}{
+							map[string]interface{}{"workload": "a", "phase": "FullRollout"},
+							map[string]interface{}{"workload": "b", "phase": "CanaryInProgress"},
+						},
+					},
+				},
+			},
+			expected: "CanaryInProgress (1/2 apps)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/architecture/resize-api.md
+++ b/docs/architecture/resize-api.md
@@ -47,9 +47,9 @@ Before calling `UpdateResize`, the controller runs several safety checks:
 3. **Memory limit usage floor**: When decreasing a memory limit, raises
    the target if it would fall at or below recent usage plus
    `memory.decreaseUsageMarginPercent` headroom.
-4. **Node capacity / pressure**: Verifies that total pod requests after
-   resize don't exceed the node's allocatable resources; skips request
-   increases under MemoryPressure / DiskPressure / PIDPressure.
+4. **Node capacity / pressure**: Verifies that this pod's requests after
+   resize, plus other pods on the node, do not exceed allocatable; skips
+   request increases under MemoryPressure / DiskPressure / PIDPressure.
 5. **LimitRange/ResourceQuota**: Checks that the target doesn't violate
    namespace constraints.
 6. **QoS preservation**: Ensures the resize won't change the pod's QoS

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -219,15 +219,16 @@ sequenceDiagram
 
 ## Cooldown enforcement
 
-After any resize operation (successful or reverted), the operator records the
-timestamp in the `attune.io/last-resize-time` annotation. On the next
-reconciliation, it checks:
+After any resize operation (successful or reverted), the operator records
+`attune.io/last-resize-time` (policy-wide) and
+`attune.io/last-resize-time.<workload>` (per app). A later resize of app A
+does not lock app B.
 
-```go
-if time.Since(lastResizeTime) < cooldown {
-    // skip resize, requeue after remaining cooldown
-}
-```
+On the next reconciliation, each workload is skipped while
+`now - lastResizeTime.<app> < effectiveCooldown` (base cooldown times
+`2^N` consecutive reverts for that app). When every matched app is still
+cooling, `RequeueAfter` is the soonest remaining window, not a fresh full
+cooldown. A watch event mid-window must not restart the timer.
 
 The default cooldown is 1 hour. This prevents rapid-fire resizes that could
 destabilize workloads.
@@ -245,9 +246,11 @@ if totalCPU > allocCPU || totalMem > allocMem {
 ```
 
 This prevents resizes that would exceed the node's capacity and cause eviction.
-The check is per-pod, not per-node, so it does not account for other pods on the
-same node. If the node lookup fails (e.g., node not found), the resize proceeds
-without the check.
+Request increases also subtract other pods' requests on the same node
+(neighbor free request budget). A failed neighbor list skips the increase.
+If the node lookup fails (for example node not found), request increases are
+skipped (fail-closed). Decreases still proceed. See
+[Node capacity](node-capacity.md).
 
 ## Container exclusion
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -147,9 +147,9 @@ spec:
   excludeKnownSidecars: false
 ```
 
-Before executing a resize, the operator also checks that the total resource
-requests across all containers (with the new target applied) do not exceed the
-node's allocatable resources.
+Before executing a resize, the operator also checks that this pod's requests
+(with the new target applied) plus other pods on the same node do not exceed
+the node's allocatable resources.
 
 ## Prometheus auto-discovery
 

--- a/docs/guides/bin-packing.md
+++ b/docs/guides/bin-packing.md
@@ -7,7 +7,8 @@ Those are complementary jobs.
 ## What Attune does
 
 - Right-sizes running pods via in-place resize
-- Guards increases against node **allocatable** headroom
+- Guards increases against node **allocatable** headroom and other pods'
+  reserved requests on the same node
 - Skips request **increases** when the node is under **MemoryPressure**,
   **DiskPressure**, or **PIDPressure** (decreases still allowed)
 - Exposes savings metrics and status for capacity planning
@@ -32,7 +33,7 @@ Those are complementary jobs.
 
 See also issue-aligned behavior:
 
-- Skip resizes that would make total pod requests exceed node allocatable
+- Skip resizes that would make this pod plus neighbors exceed node allocatable
 - Skip request increases under node pressure conditions
 
 Tune `maxAllowed` and change caps so recommendations stay within typical

--- a/docs/guides/canary-rollout.md
+++ b/docs/guides/canary-rollout.md
@@ -64,9 +64,10 @@ spec:
 ## Monitoring canary pods
 
 The operator tracks which pods were selected for the canary subset in
-`status.canary.pods` and per app in `status.canary.workloads`. You can
-see the count in `kubectl attune status` (the CANARY column), or list
-the exact pod names:
+`status.canary.pods` and per app in `status.canary.workloads`. The
+`kubectl attune status` CANARY column shows `CanaryInProgress (1/2 apps)`
+when some apps are promoted and others are still watching. List the
+per-app rows:
 
 ```bash
 kubectl get attunepolicy my-app -o jsonpath='{.status.canary.workloads}' | jq .

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -192,10 +192,14 @@ spec:
 | `resizeHistory[].reason` | `string` | Why a resize was reverted or failed (e.g. `oomkill`, `restart`, `notready`, `slo:<name>`, `infeasible`). Empty for successful resizes. |
 | `workloadErrors[].workload` | `string` | Workload name that encountered an error during reconciliation |
 | `workloadErrors[].error` | `string` | Human-readable error description |
-| `canary.phase` | `string` | `CanaryInProgress` or `FullRollout` |
-| `canary.startTime` | `Time` | When the canary subset was first resized |
+| `canary.phase` | `string` | `CanaryInProgress` or `FullRollout`. FullRollout only when every listed app is promoted |
+| `canary.startTime` | `Time` | Earliest live per-app watch start (or first canary resize) |
 | `canary.observedGeneration` | `int64` | Policy generation when this canary cycle started |
-| `canary.pods` | `[]string` | Names of pods selected for the canary subset |
+| `canary.pods` | `[]string` | Union of per-app canary pod names |
+| `canary.workloads[].workload` | `string` | Deployment or StatefulSet name |
+| `canary.workloads[].phase` | `string` | `CanaryInProgress` or `FullRollout` for that app |
+| `canary.workloads[].startTime` | `Time` | When that app's canary subset was first resized |
+| `canary.workloads[].pods` | `[]string` | That app's canary pod names |
 
 `ResourceRecommendationExplanation` contains the intermediate fields emitted by
 the estimator chain: `rawPercentile`, `overhead`, `afterOverhead`,
@@ -209,7 +213,7 @@ the estimator chain: `rawPercentile`, `overhead`, `afterOverhead`,
 | Type | Reasons | Description |
 |------|---------|-------------|
 | `Ready` | `Monitoring`, `InsufficientData`, `NoWorkloadsFound`, `PrometheusUnavailable`, `InvalidConfig`, `WorkloadDiscoveryFailed`, `Paused` | Overall health |
-| `Resizing` | `InProgress`, `Idle`, `CooldownActive` | Active resize operation state |
+| `Resizing` | `InProgress`, `Idle`, `CooldownActive` | Active resize operation state. `CooldownActive` only when every matched app is still cooling |
 | `Degraded` | `HighRevertRate` | High revert rate detected (3+ of last 5 reverted) |
 | `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Whether the current time is within the configured resize schedule window |
 | `ResizeBlocked` | `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | One or more target pods stuck Deferred (kubelet pending) or Infeasible; message includes sample pod names and next actions |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,7 +38,7 @@ kubectl attune status --watch          # live-refresh every 10s
 | READY | Current `Ready` reason (`Monitoring`, `InsufficientData`, `NoWorkloadsFound`, `PrometheusUnavailable`, `InvalidConfig`, `WorkloadDiscoveryFailed`, or `Paused`), or the current `Ready` condition message when `Ready=False` includes actionable details |
 | RESIZING | `InProgress`, `Idle`, `CooldownActive`, or `-` (non-resize modes) |
 | DEGRADED | `HighRevertRate` or `-` |
-| CANARY | Canary phase and pod count (e.g., `CanaryInProgress (2 pods)`) when mode is Canary, `-` otherwise |
+| CANARY | Canary phase. With per-app rows: `CanaryInProgress (1/2 apps)`. Legacy: `CanaryInProgress (2 pods)`. `-` when mode is not Canary |
 | EXPORT | `CM` when `export.configMap: true` (recommendations written to ConfigMaps for GitOps), `-` otherwise |
 
 When any policy has per-workload errors, they are printed below the table

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -261,7 +261,7 @@ that do not set them explicitly. Policy-level values always take precedence.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `type` | string | `Recommend` | `Observe`, `Recommend`, `OneShot`, `Canary`, `Auto` |
-| `cooldown` | duration | `1h` | Minimum time between resizes of the same workload. Other apps on the same policy are not locked. Request increases also skip when this pod plus other pods on the node would exceed allocatable (always-on neighbor budget; see [Node capacity](../architecture/node-capacity.md)). |
+| `cooldown` | duration | `1h` | Minimum time between resizes of the same workload. Other apps on the same policy are not locked. When every matched app is still cooling, the next reconcile waits only until the soonest per-app window expires (a watch event does not restart a full cooldown). Request increases also skip when this pod plus other pods on the node would exceed allocatable (always-on neighbor budget; see [Node capacity](../architecture/node-capacity.md)). |
 | `autoRevert` | bool | `true` | Revert unsafe resizes automatically |
 | `resizeMethod` | string | `InPlaceOnly` | `InPlaceOnly` or `InPlaceOrRecreate` |
 | `maxConcurrentResizes` | int32 | `1` | Max pods to resize simultaneously |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -261,7 +261,7 @@ that do not set them explicitly. Policy-level values always take precedence.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `type` | string | `Recommend` | `Observe`, `Recommend`, `OneShot`, `Canary`, `Auto` |
-| `cooldown` | duration | `1h` | Minimum time between resizes of the same workload. Other apps on the same policy are not locked. When every matched app is still cooling, the next reconcile waits only until the soonest per-app window expires (a watch event does not restart a full cooldown). Request increases also skip when this pod plus other pods on the node would exceed allocatable (always-on neighbor budget; see [Node capacity](../architecture/node-capacity.md)). |
+| `cooldown` | duration | `1h` | Minimum time between resizes of the same workload. Other apps on the same policy are not locked. When every matched app is still cooling, the next reconcile waits only until the soonest per-app window expires (a watch event does not restart a full cooldown). |
 | `autoRevert` | bool | `true` | Revert unsafe resizes automatically |
 | `resizeMethod` | string | `InPlaceOnly` | `InPlaceOnly` or `InPlaceOrRecreate` |
 | `maxConcurrentResizes` | int32 | `1` | Max pods to resize simultaneously |
@@ -275,6 +275,10 @@ that do not set them explicitly. Policy-level values always take precedence.
 | `sloGuardrails` | list | `[]` | Application-level SLO PromQL checks after resize |
 | `canary` | object | (none) | Canary rollout (percentage, observationPeriod). CREATE sizing, startup boost, and HPA stay off for an app until that app is promoted. |
 | `initialSizing` | bool | `false` | Enable mutating webhook for pod creation |
+
+Request increases also skip when this pod plus other pods on the same
+node would exceed allocatable. That gate is always on and is not a
+policy field. See [Node capacity](../architecture/node-capacity.md).
 
 Example: set a cluster-wide maintenance window and budget cap via
 `AttuneDefaults`, then individual policies inherit them unless overridden:

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -235,8 +235,9 @@ Every resize is guarded by a multi-layer safety system:
   policy is flagged as `Degraded` so you know the parameters need tuning.
 - **LimitRange/ResourceQuota guard**: Resizes that would violate namespace
   constraints are skipped entirely.
-- **Node capacity guard**: The operator checks that total pod resource
-  requests after resize won't exceed node allocatable.
+- **Node capacity guard**: The operator checks that this pod's requests
+  after resize, plus other pods on the same node, will not exceed
+  allocatable.
 
 ### HPA coexistence, for real
 

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -693,9 +693,16 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Step 10: Requeue after cooldown, or sooner if safety observations are pending
-	// or data collection is still in progress.
+	// or data collection is still in progress. When every matched app is still
+	// cooling, wait only until the first per-app stamp expires. A mid-cooldown
+	// watch event must not restart a full cooldown from now.
 	cooldown := r.parseCooldown(&policy)
 	requeueAfter := cooldown
+	if allCooling {
+		if rem := r.minCooldownRemaining(&policy, recWorkloads); rem > 0 && rem < requeueAfter {
+			requeueAfter = rem
+		}
+	}
 	if autoRevertEnabled(policy.Spec.UpdateStrategy) && (policy.Status.Workloads.Resized > 0 || safetyObservationsPending) {
 		obs := getObservationPeriod(&policy)
 		if obs < requeueAfter {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -11815,6 +11815,34 @@ func TestReconcile_SufficientDataRequeuesAtCooldown(t *testing.T) {
 		"sufficient data should requeue at cooldown interval")
 }
 
+func TestReconcile_AllCoolingRequeuesAtRemaining(t *testing.T) {
+	now := time.Date(2026, 8, 24, 16, 0, 0, 0, time.UTC)
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Cooldown = &metav1.Duration{Duration: 1 * time.Hour}
+	policy.Annotations = map[string]string{
+		lastResizeAnnotation:                     now.Add(-50 * time.Minute).UTC().Format(time.RFC3339),
+		lastResizeAnnotationKey("api-server"):    now.Add(-50 * time.Minute).UTC().Format(time.RFC3339),
+		lastResizeAnnotationKey("other-service"): now.Add(-5 * time.Minute).UTC().Format(time.RFC3339),
+	}
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	pod := newTestPod("api-server-abc-1", "default", map[string]string{"app": "api-server"})
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return generateSamples(200, 0.1), nil
+		},
+	}
+	reconciler, _ := newReconcilerForReconcile(mc, policy, deploy, pod)
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 10*time.Minute, result.RequeueAfter,
+		"all matched apps cooling must requeue at remaining cooldown, not a fresh 1h")
+}
+
 // --- Issue #437: persistResizeAnnotations exhausted-retries path ---
 
 func TestExecuteResizes_AnnotationConflictExhaustedRetries(t *testing.T) {

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
@@ -372,4 +374,78 @@ func TestExecuteResizes_CanaryDoesNotStartWatchWhenNoResize(t *testing.T) {
 	if policy.Status.Canary != nil {
 		assert.Nil(t, policy.Status.Canary.StartTime, "skipped resize must not start the observation clock")
 	}
+}
+
+func TestExecuteResizes_PromotedAppResizesAll_UnpromotedStaysCanary(t *testing.T) {
+	makePods := func(app string, n int) []*corev1.Pod {
+		out := make([]*corev1.Pod, n)
+		for i := range n {
+			p := newResizePod(app, "500m", "512Mi", "2000m", "2Gi")
+			p.Name = fmt.Sprintf("%s-%d", app, i)
+			out[i] = p
+		}
+		return out
+	}
+	aPods := makePods("app-a", 3)
+	bPods := makePods("app-b", 3)
+	deployA := newTestDeployment("app-a", "default", map[string]string{"app": "app-a"})
+	deployB := newTestDeployment("app-b", "default", map[string]string{"app": "app-b"})
+
+	extras := []client.Object{deployA, deployB}
+	csObjs := []runtime.Object{deployA.DeepCopy(), deployB.DeepCopy()}
+	for _, p := range append(aPods, bPods...) {
+		csObjs = append(csObjs, p.DeepCopy())
+	}
+	for _, p := range append(aPods[1:], bPods...) {
+		extras = append(extras, p)
+	}
+	reconciler, _ := newResizeReconciler(aPods[0], extras...)
+	reconciler.Clientset = kubefake.NewSimpleClientset(csObjs...)
+
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	policy.Spec.UpdateStrategy.Canary.Percentage = 10
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase: attunev1alpha1.CanaryPhaseInProgress,
+		Workloads: []attunev1alpha1.CanaryWorkloadStatus{
+			{Workload: "app-a", Phase: attunev1alpha1.CanaryPhaseFullRollout},
+			{Workload: "app-b", Phase: attunev1alpha1.CanaryPhaseInProgress, Pods: []string{"app-b-0"}},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("app-a", "500m", "512Mi", "2000m", "2Gi", "750m", "512Mi", "2000m", "2Gi"),
+		newResizeRecommendation("app-b", "500m", "512Mi", "2000m", "2Gi", "750m", "512Mi", "2000m", "2Gi"),
+	}
+	podsBy := map[string][]corev1.Pod{
+		"app-a": derefPods(aPods),
+		"app-b": derefPods(bPods),
+	}
+
+	count, history := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deployA, deployB}, recs, podsBy, nil, nil)
+	assert.Equal(t, 2, count, "both apps have at least one resize")
+
+	aOK, bOK := 0, 0
+	for _, h := range history {
+		if !isSuccessfulInPlaceHistory(h) {
+			continue
+		}
+		switch h.Workload {
+		case "app-a":
+			aOK++
+		case "app-b":
+			bOK++
+		}
+	}
+	// History writes one Success row per resource. 3 pods × cpu+memory = 6;
+	// canary 10% of 3 pods is 1 pod × cpu+memory = 2.
+	assert.Equal(t, 6, aOK, "promoted app must resize every eligible pod")
+	assert.Equal(t, 2, bOK, "unpromoted app must stay on the canary percentage (min 1)")
+}
+
+func derefPods(pods []*corev1.Pod) []corev1.Pod {
+	out := make([]corev1.Pod, len(pods))
+	for i, p := range pods {
+		out[i] = *p
+	}
+	return out
 }

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -440,6 +441,31 @@ func TestExecuteResizes_PromotedAppResizesAll_UnpromotedStaysCanary(t *testing.T
 	// canary 10% of 3 pods is 1 pod × cpu+memory = 2.
 	assert.Equal(t, 6, aOK, "promoted app must resize every eligible pod")
 	assert.Equal(t, 2, bOK, "unpromoted app must stay on the canary percentage (min 1)")
+}
+
+func TestExecuteResizes_CanarySeedSkipsBatchAndStale(t *testing.T) {
+	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "default"}}
+	reconciler, _ := newResizeReconciler(pod, deploy, cj)
+
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("api-server", "500m", "512Mi", "1000m", "1Gi", "750m", "384Mi", "1500m", "768Mi"),
+		newResizeRecommendation("nightly", "500m", "512Mi", "1000m", "1Gi", "750m", "384Mi", "1500m", "768Mi"),
+		func() attunev1alpha1.WorkloadRecommendation {
+			r := newResizeRecommendation("stale-app", "500m", "512Mi", "1000m", "1Gi", "750m", "384Mi", "1500m", "768Mi")
+			r.Stale = true
+			return r
+		}(),
+	}
+
+	_, _ = reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy, cj}, recs, podMap("api-server", pod), nil, nil)
+	require.NotNil(t, policy.Status.Canary)
+	assert.NotNil(t, policy.Status.Canary.WorkloadStatus("api-server"))
+	assert.Nil(t, policy.Status.Canary.WorkloadStatus("nightly"), "batch workloads must not block FullRollout")
+	assert.Nil(t, policy.Status.Canary.WorkloadStatus("stale-app"), "stale recs must not block FullRollout")
 }
 
 func derefPods(pods []*corev1.Pod) []corev1.Pod {

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -470,6 +470,44 @@ func TestExecuteResizes_CanarySeedSkipsBatchAndStale(t *testing.T) {
 	assert.Nil(t, policy.Status.Canary.WorkloadStatus("stale-app"), "stale recs must not block FullRollout")
 }
 
+func TestExecuteResizes_CanaryPrunesLeftoverBatchRow(t *testing.T) {
+	now := time.Date(2026, 8, 24, 16, 0, 0, 0, time.UTC)
+	start := metav1.NewTime(now.Add(-15 * time.Minute))
+	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "default"}}
+	reconciler, _ := newResizeReconciler(pod, deploy, cj)
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase:     attunev1alpha1.CanaryPhaseInProgress,
+		StartTime: &start,
+		Workloads: []attunev1alpha1.CanaryWorkloadStatus{
+			{Workload: "api-server", Phase: attunev1alpha1.CanaryPhaseInProgress, StartTime: &start, Pods: []string{pod.Name}},
+			{Workload: "nightly", Phase: attunev1alpha1.CanaryPhaseInProgress},
+			{Workload: "gone-app", Phase: attunev1alpha1.CanaryPhaseInProgress},
+		},
+	}
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{
+		{Workload: "api-server", Method: "InPlace", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: start},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("api-server", "500m", "512Mi", "1000m", "1Gi", "750m", "384Mi", "1500m", "768Mi"),
+		newResizeRecommendation("nightly", "500m", "512Mi", "1000m", "1Gi", "750m", "384Mi", "1500m", "768Mi"),
+	}
+
+	_, _ = reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy, cj}, recs, podMap("api-server", pod), nil, nil)
+	require.NotNil(t, policy.Status.Canary)
+	assert.Nil(t, policy.Status.Canary.WorkloadStatus("nightly"), "pre-fix Job/CronJob row must be dropped")
+	assert.Nil(t, policy.Status.Canary.WorkloadStatus("gone-app"), "unmatched leftover row must be dropped")
+	require.NotNil(t, policy.Status.Canary.WorkloadStatus("api-server"))
+	assert.Equal(t, attunev1alpha1.CanaryPhaseFullRollout, policy.Status.Canary.WorkloadStatus("api-server").Phase)
+	assert.Equal(t, attunev1alpha1.CanaryPhaseFullRollout, policy.Status.Canary.Phase,
+		"leftover batch row must not keep the policy in CanaryInProgress")
+}
+
 func derefPods(pods []*corev1.Pod) []corev1.Pod {
 	out := make([]corev1.Pod, len(pods))
 	for i, p := range pods {

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -508,6 +508,37 @@ func TestExecuteResizes_CanaryPrunesLeftoverBatchRow(t *testing.T) {
 		"leftover batch row must not keep the policy in CanaryInProgress")
 }
 
+func TestExecuteResizes_CanaryPruneToEmptyDoesNotLegacyPromote(t *testing.T) {
+	now := time.Date(2026, 8, 24, 16, 0, 0, 0, time.UTC)
+	old := metav1.NewTime(now.Add(-2 * time.Hour))
+	cj := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "default"}}
+	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+	reconciler, _ := newResizeReconciler(pod, cj)
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	policy := canaryAutoPromotePolicy(10 * time.Minute)
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase: attunev1alpha1.CanaryPhaseInProgress,
+		Workloads: []attunev1alpha1.CanaryWorkloadStatus{
+			{Workload: "nightly", Phase: attunev1alpha1.CanaryPhaseInProgress},
+		},
+	}
+	// Leftover Success from a Deployment that is no longer matched.
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{
+		{Workload: "old-app", Method: "InPlace", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: old},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("nightly", "500m", "512Mi", "1000m", "1Gi", "750m", "384Mi", "1500m", "768Mi"),
+	}
+
+	_, _ = reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{cj}, recs, map[string][]corev1.Pod{}, nil, nil)
+	require.NotNil(t, policy.Status.Canary)
+	assert.Empty(t, policy.Status.Canary.Workloads)
+	assert.Equal(t, attunev1alpha1.CanaryPhaseInProgress, policy.Status.Canary.Phase,
+		"empty table after prune must not FullRollout from leftover Success")
+}
+
 func derefPods(pods []*corev1.Pod) []corev1.Pod {
 	out := make([]corev1.Pod, len(pods))
 	for i, p := range pods {

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -392,8 +392,10 @@ func TestExecuteResizes_PromotedAppResizesAll_UnpromotedStaysCanary(t *testing.T
 	deployA := newTestDeployment("app-a", "default", map[string]string{"app": "app-a"})
 	deployB := newTestDeployment("app-b", "default", map[string]string{"app": "app-b"})
 
-	extras := []client.Object{deployA, deployB}
-	csObjs := []runtime.Object{deployA.DeepCopy(), deployB.DeepCopy()}
+	extras := make([]client.Object, 0, 2+(len(aPods)-1)+len(bPods))
+	extras = append(extras, deployA, deployB)
+	csObjs := make([]runtime.Object, 0, 2+len(aPods)+len(bPods))
+	csObjs = append(csObjs, deployA.DeepCopy(), deployB.DeepCopy())
 	for _, p := range append(aPods, bPods...) {
 		csObjs = append(csObjs, p.DeepCopy())
 	}

--- a/internal/controller/cooldown_test.go
+++ b/internal/controller/cooldown_test.go
@@ -197,6 +197,51 @@ func TestIsWorkloadCooldownActive_MalformedPerWorkload(t *testing.T) {
 	assert.False(t, r.isWorkloadCooldownActive(policy, "app-a"))
 }
 
+func TestMinCooldownRemaining_UsesSoonestApp(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	now := time.Date(2026, 8, 24, 16, 0, 0, 0, time.UTC)
+	r.SetNowFunc(func() time.Time { return now })
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				lastResizeAnnotationKey("app-a"): now.Add(-50 * time.Minute).Format(time.RFC3339),
+				lastResizeAnnotationKey("app-b"): now.Add(-5 * time.Minute).Format(time.RFC3339),
+			},
+		},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Cooldown: &metav1.Duration{Duration: 1 * time.Hour},
+			},
+		},
+	}
+	assert.Equal(t, 10*time.Minute, r.minCooldownRemaining(policy, []string{"app-a", "app-b"}),
+		"A expires first (10m left); do not wait B's 55m")
+	assert.Equal(t, 55*time.Minute, r.minCooldownRemaining(policy, []string{"app-b"}))
+}
+
+func TestMinCooldownRemaining_IgnoresExpiredAndUnstamped(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	now := time.Date(2026, 8, 24, 16, 0, 0, 0, time.UTC)
+	r.SetNowFunc(func() time.Time { return now })
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				lastResizeAnnotationKey("app-a"): now.Add(-50 * time.Minute).Format(time.RFC3339),
+				lastResizeAnnotationKey("app-b"): now.Add(-2 * time.Hour).Format(time.RFC3339),
+			},
+		},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Cooldown: &metav1.Duration{Duration: 1 * time.Hour},
+			},
+		},
+	}
+	assert.Equal(t, 10*time.Minute, r.minCooldownRemaining(policy, []string{"app-a", "app-b", "app-c"}),
+		"expired B and unstamped C must not drive remaining to 0")
+	assert.Equal(t, time.Duration(0), r.minCooldownRemaining(policy, []string{"app-b", "app-c"}),
+		"nobody cooling → 0; callers must not RequeueAfter this")
+}
+
 func TestGetEffectiveCooldown_PerWorkloadBackoff(t *testing.T) {
 	r := NewAttunePolicyReconciler()
 	cooldown := 1 * time.Hour

--- a/internal/controller/cooldown_test.go
+++ b/internal/controller/cooldown_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
@@ -213,4 +217,46 @@ func TestGetEffectiveCooldown_PerWorkloadBackoff(t *testing.T) {
 	}
 	assert.Equal(t, 4*cooldown, r.getEffectiveCooldown(policy, "app-a"), "two reverts on A → 4x")
 	assert.Equal(t, cooldown, r.getEffectiveCooldown(policy, "app-b"), "B has no revert streak")
+}
+
+func TestExecuteResizes_CooldownSkipsOnlyCoolingWorkload(t *testing.T) {
+	now := time.Date(2026, 8, 24, 16, 0, 0, 0, time.UTC)
+	podA := newResizePod("app-a", "500m", "512Mi", "2000m", "2Gi")
+	podB := newResizePod("app-b", "500m", "512Mi", "2000m", "2Gi")
+	deployA := newTestDeployment("app-a", "default", map[string]string{"app": "app-a"})
+	deployB := newTestDeployment("app-b", "default", map[string]string{"app": "app-b"})
+
+	reconciler, _ := newResizeReconciler(podA, deployA, deployB, podB)
+	reconciler.Clientset = kubefake.NewSimpleClientset(podA.DeepCopy(), podB.DeepCopy(), deployA.DeepCopy(), deployB.DeepCopy())
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	policy := newTestPolicy("multi", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.Cooldown = &metav1.Duration{Duration: 1 * time.Hour}
+	policy.Annotations = map[string]string{
+		lastResizeAnnotation:             now.Add(-5 * time.Minute).UTC().Format(time.RFC3339),
+		lastResizeAnnotationKey("app-a"): now.Add(-5 * time.Minute).UTC().Format(time.RFC3339),
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("app-a", "500m", "512Mi", "2000m", "2Gi", "750m", "512Mi", "2000m", "2Gi"),
+		newResizeRecommendation("app-b", "500m", "512Mi", "2000m", "2Gi", "750m", "512Mi", "2000m", "2Gi"),
+	}
+	count, history := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deployA, deployB}, recs,
+		map[string][]corev1.Pod{"app-a": {*podA}, "app-b": {*podB}}, nil, nil)
+	assert.Equal(t, 1, count)
+	aOK, bOK := 0, 0
+	for _, h := range history {
+		if !isSuccessfulInPlaceHistory(h) {
+			continue
+		}
+		if h.Workload == "app-a" {
+			aOK++
+		}
+		if h.Workload == "app-b" {
+			bOK++
+		}
+	}
+	assert.Equal(t, 0, aOK, "app-a is cooling and must not resize")
+	assert.Greater(t, bOK, 0, "app-b has no per-app stamp and must still resize")
 }

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -441,6 +441,30 @@ func (r *AttunePolicyReconciler) allWorkloadsCooling(policy *attunev1alpha1.Attu
 	return true
 }
 
+// minCooldownRemaining is the soonest remaining cooldown among the named
+// workloads. Expired or never-resized apps are ignored. Zero means nobody
+// is still cooling (do not use that as RequeueAfter; it busy-loops).
+func (r *AttunePolicyReconciler) minCooldownRemaining(policy *attunev1alpha1.AttunePolicy, workloads []string) time.Duration {
+	var soonest time.Duration
+	found := false
+	now := r.now()
+	for _, w := range workloads {
+		last, ok := lastResizeTimeForWorkload(policy, w)
+		if !ok {
+			continue
+		}
+		rem := r.getEffectiveCooldown(policy, w) - now.Sub(last)
+		if rem <= 0 {
+			continue
+		}
+		if !found || rem < soonest {
+			soonest = rem
+			found = true
+		}
+	}
+	return soonest
+}
+
 // getEffectiveCooldown returns the cooldown with exponential backoff applied
 // based on consecutive reverts for the named workload (empty = whole history).
 func (r *AttunePolicyReconciler) getEffectiveCooldown(policy *attunev1alpha1.AttunePolicy, workload string) time.Duration {

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -132,11 +132,15 @@ func (r *AttunePolicyReconciler) executeResizes(
 			if rec.Stale {
 				continue
 			}
-			if w := workloadMap[rec.Workload]; w != nil && isBatchWorkload(w) {
+			w := workloadMap[rec.Workload]
+			if w == nil || isBatchWorkload(w) {
 				continue
 			}
 			policy.Status.Canary.UpsertWorkload(rec.Workload)
 		}
+		// Drop leftover #571 rows (Job/CronJob, unmatched names) so they
+		// cannot keep RollupPhase in InProgress forever.
+		pruneStaleCanaryWorkloads(policy.Status.Canary, workloadMap)
 		mode = r.resolveCanaryPhase(ctx, policy, mode)
 	}
 
@@ -1036,6 +1040,23 @@ func (r *AttunePolicyReconciler) resolveCanaryPhase(ctx context.Context, policy 
 		"policy", policy.Name, "observationPeriod", observationPeriod)
 	cs.Phase = attunev1alpha1.CanaryPhaseFullRollout
 	return attunev1alpha1.UpdateTypeAuto
+}
+
+// pruneStaleCanaryWorkloads removes per-app rows that can never promote:
+// batch (Job/CronJob) and names that are not in the current workload list.
+func pruneStaleCanaryWorkloads(cs *attunev1alpha1.CanaryStatus, workloadMap map[string]client.Object) {
+	if cs == nil || len(cs.Workloads) == 0 {
+		return
+	}
+	kept := make([]attunev1alpha1.CanaryWorkloadStatus, 0, len(cs.Workloads))
+	for _, row := range cs.Workloads {
+		obj := workloadMap[row.Workload]
+		if obj == nil || isBatchWorkload(obj) {
+			continue
+		}
+		kept = append(kept, row)
+	}
+	cs.Workloads = kept
 }
 
 func canaryWorkloadNames(policy *attunev1alpha1.AttunePolicy) []string {

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -113,6 +113,12 @@ func (r *AttunePolicyReconciler) executeResizes(
 		canaryAutoPromote = policy.Spec.UpdateStrategy.Canary.AutoPromote
 	}
 
+	// Pre-build name→Object map for O(1) workload lookups.
+	workloadMap := make(map[string]client.Object, len(workloads))
+	for _, w := range workloads {
+		workloadMap[w.GetName()] = w
+	}
+
 	// Canary auto-promotion: if all canary pods passed the observation
 	// period without reverts, promote to full rollout.
 	if mode == attunev1alpha1.UpdateTypeCanary && canaryAutoPromote {
@@ -123,6 +129,12 @@ func (r *AttunePolicyReconciler) executeResizes(
 			}
 		}
 		for _, rec := range recommendations {
+			if rec.Stale {
+				continue
+			}
+			if w := workloadMap[rec.Workload]; w != nil && isBatchWorkload(w) {
+				continue
+			}
 			policy.Status.Canary.UpsertWorkload(rec.Workload)
 		}
 		mode = r.resolveCanaryPhase(ctx, policy, mode)
@@ -183,12 +195,6 @@ func (r *AttunePolicyReconciler) executeResizes(
 
 	var historyMu sync.Mutex
 	var wg sync.WaitGroup
-
-	// Pre-build name→Object map for O(1) workload lookups.
-	workloadMap := make(map[string]client.Object, len(workloads))
-	for _, w := range workloads {
-		workloadMap[w.GetName()] = w
-	}
 
 	for _, rec := range recommendations {
 		if ctx.Err() != nil {

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -139,9 +139,13 @@ func (r *AttunePolicyReconciler) executeResizes(
 			policy.Status.Canary.UpsertWorkload(rec.Workload)
 		}
 		// Drop leftover #571 rows (Job/CronJob, unmatched names) so they
-		// cannot keep RollupPhase in InProgress forever.
-		pruneStaleCanaryWorkloads(policy.Status.Canary, workloadMap)
-		mode = r.resolveCanaryPhase(ctx, policy, mode)
+		// cannot keep RollupPhase in InProgress forever. If that empties
+		// the table, skip the legacy policy-wide clock: leftover Success
+		// history would FullRollout and instantly promote the next app.
+		emptied := pruneStaleCanaryWorkloads(policy.Status.Canary, workloadMap)
+		if !emptied {
+			mode = r.resolveCanaryPhase(ctx, policy, mode)
+		}
 	}
 
 	resizer := resize.NewPodResizer(r.Clientset, logger)
@@ -1044,10 +1048,12 @@ func (r *AttunePolicyReconciler) resolveCanaryPhase(ctx context.Context, policy 
 
 // pruneStaleCanaryWorkloads removes per-app rows that can never promote:
 // batch (Job/CronJob) and names that are not in the current workload list.
-func pruneStaleCanaryWorkloads(cs *attunev1alpha1.CanaryStatus, workloadMap map[string]client.Object) {
+// Returns true when the table went from nonempty to empty.
+func pruneStaleCanaryWorkloads(cs *attunev1alpha1.CanaryStatus, workloadMap map[string]client.Object) bool {
 	if cs == nil || len(cs.Workloads) == 0 {
-		return
+		return false
 	}
+	before := len(cs.Workloads)
 	kept := make([]attunev1alpha1.CanaryWorkloadStatus, 0, len(cs.Workloads))
 	for _, row := range cs.Workloads {
 		obj := workloadMap[row.Workload]
@@ -1057,6 +1063,7 @@ func pruneStaleCanaryWorkloads(cs *attunev1alpha1.CanaryStatus, workloadMap map[
 		kept = append(kept, row)
 	}
 	cs.Workloads = kept
+	return before > 0 && len(kept) == 0
 }
 
 func canaryWorkloadNames(policy *attunev1alpha1.AttunePolicy) []string {

--- a/lychee.toml
+++ b/lychee.toml
@@ -18,6 +18,8 @@ exclude = [
   "docs\\.aws\\.amazon\\.com",
   # kind docs intermittently reset connections from GHA runners.
   "kind\\.sigs\\.k8s\\.io",
+  # kubernetes.io blog intermittently fails connect from GHA (PR #572 Link Check).
+  "kubernetes\\.io/blog",
 ]
 exclude_loopback = true
 max_concurrency = 8


### PR DESCRIPTION
Follow-up to #571. Per-app cooldown skip was live, but three product holes remained.

## Problem

1. **Canary seed hang.** `autoPromote` upserted a `status.canary.workloads[]` row for every recommendation, including Jobs/CronJobs (recommend-only) and stale recs. Those rows never get a successful in-place resize, so the policy never reaches `FullRollout`.
2. **CLI progress count.** `kubectl attune get` counted canary pods. After per-app `workloads[]`, the useful number is apps promoted vs apps in the table.
3. **Requeue restarted the cooldown.** Skip is per-app, but `RequeueAfter` was still a fresh `parseCooldown` on every pass. A watch event 50 minutes into a 1h window waited another hour. `docs/architecture/safety.md` already said remaining cooldown; the code did not.
4. **Leftover canary rows.** Policies that already had a Job/CronJob or unmatched name in `status.canary.workloads` from before this fix never reached `FullRollout`. Those rows never get an in-place success.

## Change

- Seed canary rows only for non-stale recommendations that match a non-batch object. Prune leftover batch and unmatched rows each cycle so `RollupPhase` can finish. If that empties the table, do not FullRollout from leftover policy-wide Success history.
- Pin mixed promote: a `FullRollout` app resizes every replica; an `InProgress` sibling stays at the canary fraction. Pin per-app cooldown so B still resizes while A is cooling.
- CLI `CANARY` column prefers `CanaryInProgress (1/2 apps)` when `workloads[]` is set.
- When every matched app is cooling, `RequeueAfter` is `minCooldownRemaining` (soonest stamp expiry). Never `RequeueAfter: 0` when some apps are not cooling (that busy-loops on persistent skips).
- Docs: remaining requeue, neighbor request budget on safety / resize-api / bin-packing / concepts / why-attune / configuration.

## Validation

- `make verify-quick` green (1959 unit tests, 92.2% coverage, lint, helm, CRD freshness).
- New: `TestExecuteResizes_PromotedAppResizesAll_UnpromotedStaysCanary`, `TestExecuteResizes_CooldownSkipsOnlyCoolingWorkload`, `TestExecuteResizes_CanarySeedSkipsBatchAndStale`, `TestExecuteResizes_CanaryPrunesLeftoverBatchRow`, `TestMinCooldownRemaining_*`, `TestReconcile_AllCoolingRequeuesAtRemaining` (10m left, not a fresh 1h).

Ref #571
