### PR TITLE
test: pin canary isolation on create, hpa, boost, and e2e

### DIFF
--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -918,7 +918,10 @@ func (r *AttunePolicyReconciler) processWorkloads(
 	for _, workload := range workloads {
 		g.Go(func() error {
 			workloadName := workload.GetName()
-			workloadKind := workload.GetObjectKind().GroupVersionKind().Kind
+			// Typed fake clients clear TypeMeta. Use the same helper as
+			// template persistence so rec.Kind is Deployment/STS/DS and
+			// HPA ScaleTargetRef matching works in tests and in cache misses.
+			workloadKind := workloadKindName(workload)
 
 			workloadMeta := metav1.ObjectMeta{Annotations: workload.GetAnnotations()}
 			if conflictDetector.CheckAnnotationOptOut(workloadMeta) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -9701,6 +9701,70 @@ func TestApplyStartupBoosts_PromotedSiblingStillBoosts(t *testing.T) {
 	assert.True(t, boosted["app-b-new"], "promoted app-b must still get startup boost")
 }
 
+func TestApplyStartupBoosts_UnpromotedCanarySliceStillBoosts(t *testing.T) {
+	scheme := testScheme()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{Type: attunev1alpha1.UpdateTypeCanary},
+			CPU: attunev1alpha1.ResourceConfig{
+				StartupBoost: &attunev1alpha1.StartupBoost{
+					Multiplier: "3.0",
+					Duration:   metav1.Duration{Duration: 2 * time.Minute},
+				},
+			},
+		},
+		Status: attunev1alpha1.AttunePolicyStatus{
+			Canary: &attunev1alpha1.CanaryStatus{
+				Phase: attunev1alpha1.CanaryPhaseInProgress,
+				Workloads: []attunev1alpha1.CanaryWorkloadStatus{
+					{Workload: "app-a", Phase: attunev1alpha1.CanaryPhaseInProgress, Pods: []string{"app-a-canary"}},
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "app-a-canary",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Second)),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+					},
+				},
+			},
+		},
+	}
+	clientset := kubefake.NewSimpleClientset(pod)
+	r := NewAttunePolicyReconciler()
+	r.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	r.Scheme = scheme
+	r.Clientset = clientset
+	r.SetNowFunc(func() time.Time { return now })
+	resizer := resize.NewPodResizer(clientset, logr.Discard())
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{Workload: "app-a", Kind: "Deployment", Containers: []attunev1alpha1.ContainerRecommendation{
+			{Name: "main", Recommended: attunev1alpha1.ResourceValues{CPURequest: resource.MustParse("200m")}},
+		}},
+	}
+	r.applyStartupBoosts(context.Background(), policy, map[string][]corev1.Pod{"app-a": {*pod}}, recs, resizer, nil)
+
+	found := false
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			found = true
+		}
+	}
+	assert.True(t, found, "unpromoted canary-slice pod must still get startup boost")
+}
+
 func TestApplyStartupBoosts_NaNMultiplierSkipped(t *testing.T) {
 	// NaN multiplier must be treated as invalid and skip the boost entirely.
 	// Before the fix, NaN <= 1 evaluated to false, so NaN passed the guard.
@@ -11923,78 +11987,97 @@ func TestReconcile_AllCoolingRequeuesAtRemaining(t *testing.T) {
 }
 
 func TestReconcile_CanaryDoesNotRetuneHPAUntilPromoted(t *testing.T) {
-	policy := newTestPolicy("test-policy", "default")
-	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeCanary
-	policy.Spec.UpdateStrategy.Canary = &attunev1alpha1.CanaryConfig{
-		Percentage:        100,
-		ObservationPeriod: metav1.Duration{Duration: 10 * time.Minute},
-	}
-	policy.Spec.CPU.MaxChangePercent = int32Ptr(100)
-	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
-		Phase: attunev1alpha1.CanaryPhaseInProgress,
-		Workloads: []attunev1alpha1.CanaryWorkloadStatus{
-			{Workload: "api-server", Phase: attunev1alpha1.CanaryPhaseInProgress, Pods: []string{"api-server-abc-1"}},
-		},
-	}
+	run := func(t *testing.T, promoted bool) int32 {
+		t.Helper()
+		policy := newTestPolicy("test-policy", "default")
+		policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeCanary
+		policy.Spec.UpdateStrategy.Canary = &attunev1alpha1.CanaryConfig{
+			Percentage:        100,
+			ObservationPeriod: metav1.Duration{Duration: 10 * time.Minute},
+		}
+		policy.Spec.CPU.MaxChangePercent = int32Ptr(100)
+		phase := attunev1alpha1.CanaryPhaseInProgress
+		if promoted {
+			phase = attunev1alpha1.CanaryPhaseFullRollout
+		}
+		policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+			Phase: phase,
+			Workloads: []attunev1alpha1.CanaryWorkloadStatus{
+				{Workload: "api-server", Phase: phase, Pods: []string{"api-server-abc-1"}},
+			},
+		}
 
-	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
-	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
-	oldTarget := int32(80)
-	hpa := &autoscalingv2.HorizontalPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "api-server-hpa",
-			Namespace: "default",
-			Annotations: map[string]string{
-				annotationHPAAutoTune: "true",
+		deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+		pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+		oldTarget := int32(80)
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "api-server-hpa",
+				Namespace: "default",
+				Annotations: map[string]string{
+					annotationHPAAutoTune: "true",
+				},
 			},
-		},
-		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
-				Kind: "Deployment",
-				Name: "api-server",
-			},
-			Metrics: []autoscalingv2.MetricSpec{
-				{
-					Type: autoscalingv2.ResourceMetricSourceType,
-					Resource: &autoscalingv2.ResourceMetricSource{
-						Name: corev1.ResourceCPU,
-						Target: autoscalingv2.MetricTarget{
-							Type:               autoscalingv2.UtilizationMetricType,
-							AverageUtilization: &oldTarget,
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					Kind: "Deployment",
+					Name: "api-server",
+				},
+				Metrics: []autoscalingv2.MetricSpec{
+					{
+						Type: autoscalingv2.ResourceMetricSourceType,
+						Resource: &autoscalingv2.ResourceMetricSource{
+							Name: corev1.ResourceCPU,
+							Target: autoscalingv2.MetricTarget{
+								Type:               autoscalingv2.UtilizationMetricType,
+								AverageUtilization: &oldTarget,
+							},
 						},
 					},
 				},
 			},
-		},
+		}
+
+		mc := &mockCollector{
+			queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+				return generateSamples(200, 0.1), nil
+			},
+		}
+		reconciler, fakeClient := newReconcilerForReconcile(mc, policy, deploy, pod, hpa)
+		reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
+
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+		})
+		require.NoError(t, err)
+
+		var updatedPolicy attunev1alpha1.AttunePolicy
+		require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+			Name: "test-policy", Namespace: "default",
+		}, &updatedPolicy))
+		require.Greater(t, updatedPolicy.Status.Workloads.Resized, int32(0),
+			"canary must actually resize so HPA skip is on the live path")
+		require.NotEmpty(t, updatedPolicy.Status.Recommendations)
+		assert.Equal(t, "Deployment", updatedPolicy.Status.Recommendations[0].Kind,
+			"rec.Kind must match HPA ScaleTargetRef so adjustHPATargets is reachable")
+
+		var updatedHPA autoscalingv2.HorizontalPodAutoscaler
+		require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+			Name: "api-server-hpa", Namespace: "default",
+		}, &updatedHPA))
+		require.NotNil(t, updatedHPA.Spec.Metrics[0].Resource.Target.AverageUtilization)
+		return *updatedHPA.Spec.Metrics[0].Resource.Target.AverageUtilization
 	}
 
-	mc := &mockCollector{
-		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
-			return generateSamples(200, 0.1), nil
-		},
-	}
-	reconciler, fakeClient := newReconcilerForReconcile(mc, policy, deploy, pod, hpa)
-	reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
-
-	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+	t.Run("unpromoted keeps 80", func(t *testing.T) {
+		assert.Equal(t, int32(80), run(t, false),
+			"unpromoted canary resize must not rewrite the HPA target")
 	})
-	require.NoError(t, err)
-
-	var updatedPolicy attunev1alpha1.AttunePolicy
-	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
-		Name: "test-policy", Namespace: "default",
-	}, &updatedPolicy))
-	require.Greater(t, updatedPolicy.Status.Workloads.Resized, int32(0),
-		"canary must actually resize so HPA skip is on the live path")
-
-	var updatedHPA autoscalingv2.HorizontalPodAutoscaler
-	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
-		Name: "api-server-hpa", Namespace: "default",
-	}, &updatedHPA))
-	require.NotNil(t, updatedHPA.Spec.Metrics[0].Resource.Target.AverageUtilization)
-	assert.Equal(t, int32(80), *updatedHPA.Spec.Metrics[0].Resource.Target.AverageUtilization,
-		"unpromoted canary resize must not rewrite the HPA target")
+	t.Run("promoted retunes away from 80", func(t *testing.T) {
+		got := run(t, true)
+		assert.NotEqual(t, int32(80), got,
+			"promoted canary must retune HPA so the skip is proven reachable (got %d)", got)
+	})
 }
 
 // --- Issue #437: persistResizeAnnotations exhausted-retries path ---

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -9622,6 +9622,85 @@ func TestApplyStartupBoosts_SkipsDuringCanaryInProgress(t *testing.T) {
 	}
 }
 
+func TestApplyStartupBoosts_PromotedSiblingStillBoosts(t *testing.T) {
+	scheme := testScheme()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{Type: attunev1alpha1.UpdateTypeCanary},
+			CPU: attunev1alpha1.ResourceConfig{
+				StartupBoost: &attunev1alpha1.StartupBoost{
+					Multiplier: "3.0",
+					Duration:   metav1.Duration{Duration: 2 * time.Minute},
+				},
+			},
+		},
+		Status: attunev1alpha1.AttunePolicyStatus{
+			Canary: &attunev1alpha1.CanaryStatus{
+				Phase: attunev1alpha1.CanaryPhaseInProgress,
+				Workloads: []attunev1alpha1.CanaryWorkloadStatus{
+					{Workload: "app-a", Phase: attunev1alpha1.CanaryPhaseInProgress, Pods: []string{"app-a-canary"}},
+					{Workload: "app-b", Phase: attunev1alpha1.CanaryPhaseFullRollout},
+				},
+			},
+		},
+	}
+	newPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         "default",
+				CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Second)),
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "main",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+						},
+					},
+				},
+			},
+		}
+	}
+	podA := newPod("app-a-new")
+	podB := newPod("app-b-new")
+	clientset := kubefake.NewSimpleClientset(podA, podB)
+	r := NewAttunePolicyReconciler()
+	r.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(podA, podB).Build()
+	r.Scheme = scheme
+	r.Clientset = clientset
+	r.SetNowFunc(func() time.Time { return now })
+
+	resizer := resize.NewPodResizer(clientset, logr.Discard())
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{Workload: "app-a", Kind: "Deployment", Containers: []attunev1alpha1.ContainerRecommendation{
+			{Name: "main", Recommended: attunev1alpha1.ResourceValues{CPURequest: resource.MustParse("200m")}},
+		}},
+		{Workload: "app-b", Kind: "Deployment", Containers: []attunev1alpha1.ContainerRecommendation{
+			{Name: "main", Recommended: attunev1alpha1.ResourceValues{CPURequest: resource.MustParse("200m")}},
+		}},
+	}
+	r.applyStartupBoosts(context.Background(), policy, map[string][]corev1.Pod{
+		"app-a": {*podA},
+		"app-b": {*podB},
+	}, recs, resizer, nil)
+
+	boosted := map[string]bool{}
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() != "update" || a.GetSubresource() != "resize" {
+			continue
+		}
+		updated := a.(k8stesting.UpdateAction).GetObject().(*corev1.Pod)
+		boosted[updated.Name] = true
+	}
+	assert.False(t, boosted["app-a-new"], "unpromoted app-a must not boost a new pod")
+	assert.True(t, boosted["app-b-new"], "promoted app-b must still get startup boost")
+}
+
 func TestApplyStartupBoosts_NaNMultiplierSkipped(t *testing.T) {
 	// NaN multiplier must be treated as invalid and skip the boost entirely.
 	// Before the fix, NaN <= 1 evaluated to false, so NaN passed the guard.
@@ -11841,6 +11920,81 @@ func TestReconcile_AllCoolingRequeuesAtRemaining(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 10*time.Minute, result.RequeueAfter,
 		"all matched apps cooling must requeue at remaining cooldown, not a fresh 1h")
+}
+
+func TestReconcile_CanaryDoesNotRetuneHPAUntilPromoted(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeCanary
+	policy.Spec.UpdateStrategy.Canary = &attunev1alpha1.CanaryConfig{
+		Percentage:        100,
+		ObservationPeriod: metav1.Duration{Duration: 10 * time.Minute},
+	}
+	policy.Spec.CPU.MaxChangePercent = int32Ptr(100)
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase: attunev1alpha1.CanaryPhaseInProgress,
+		Workloads: []attunev1alpha1.CanaryWorkloadStatus{
+			{Workload: "api-server", Phase: attunev1alpha1.CanaryPhaseInProgress, Pods: []string{"api-server-abc-1"}},
+		},
+	}
+
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+	oldTarget := int32(80)
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api-server-hpa",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationHPAAutoTune: "true",
+			},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: "Deployment",
+				Name: "api-server",
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: &oldTarget,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return generateSamples(200, 0.1), nil
+		},
+	}
+	reconciler, fakeClient := newReconcilerForReconcile(mc, policy, deploy, pod, hpa)
+	reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var updatedPolicy attunev1alpha1.AttunePolicy
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "test-policy", Namespace: "default",
+	}, &updatedPolicy))
+	require.Greater(t, updatedPolicy.Status.Workloads.Resized, int32(0),
+		"canary must actually resize so HPA skip is on the live path")
+
+	var updatedHPA autoscalingv2.HorizontalPodAutoscaler
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server-hpa", Namespace: "default",
+	}, &updatedHPA))
+	require.NotNil(t, updatedHPA.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	assert.Equal(t, int32(80), *updatedHPA.Spec.Metrics[0].Resource.Target.AverageUtilization,
+		"unpromoted canary resize must not rewrite the HPA target")
 }
 
 // --- Issue #437: persistResizeAnnotations exhausted-retries path ---

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -410,6 +410,52 @@ func TestPodMutatingHandler_CanaryMode_MutatesCanarySlice(t *testing.T) {
 	require.NotNil(t, resp.Patches, "pod already in the canary slice may be sized")
 }
 
+func TestPodMutatingHandler_CanaryMode_PromotedAppOnly(t *testing.T) {
+	// One policy, two apps. CREATE must size only the promoted app (or a
+	// pod already in the unpromoted app's canary slice).
+	policy := testPolicy("my-policy", "default", "Deployment", "app-a", true, attunev1alpha1.UpdateTypeCanary)
+	policy.Spec.TargetRef.Name = nil
+	policy.Status.Recommendations = append(policy.Status.Recommendations, attunev1alpha1.WorkloadRecommendation{
+		Workload: "app-b",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{
+			{
+				Name:       "app",
+				Confidence: 0.8,
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest:    resource.MustParse("500m"),
+					MemoryRequest: resource.MustParse("256Mi"),
+				},
+			},
+		},
+	})
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase: attunev1alpha1.CanaryPhaseInProgress,
+		Workloads: []attunev1alpha1.CanaryWorkloadStatus{
+			{Workload: "app-a", Phase: attunev1alpha1.CanaryPhaseFullRollout},
+			{Workload: "app-b", Phase: attunev1alpha1.CanaryPhaseInProgress, Pods: []string{"app-b-canary"}},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	aNew := testPod("app-a-new", "ReplicaSet", "app-a-abc")
+	respA := handler.Handle(context.Background(), makeAdmissionRequest(t, aNew, "default"))
+	require.True(t, respA.Allowed)
+	require.NotNil(t, respA.Patches, "promoted app-a must CREATE-size a new pod")
+
+	bNew := testPod("app-b-new", "ReplicaSet", "app-b-abc")
+	respB := handler.Handle(context.Background(), makeAdmissionRequest(t, bNew, "default"))
+	require.True(t, respB.Allowed)
+	assert.Nil(t, respB.Patches, "unpromoted app-b must not CREATE-size a new pod")
+
+	bCanary := testPod("app-b-canary", "ReplicaSet", "app-b-abc")
+	respSlice := handler.Handle(context.Background(), makeAdmissionRequest(t, bCanary, "default"))
+	require.True(t, respSlice.Allowed)
+	require.NotNil(t, respSlice.Patches, "unpromoted app-b canary-slice pod may be sized")
+}
+
 func TestPodMutatingHandler_CanaryMode_MutatesAfterPromote(t *testing.T) {
 	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeCanary)
 	policy.Status.Canary = &attunev1alpha1.CanaryStatus{

--- a/test/e2e/canary-rollout/chainsaw-test.yaml
+++ b/test/e2e/canary-rollout/chainsaw-test.yaml
@@ -174,7 +174,12 @@ spec:
                   -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'); do
                   cpu=$(kubectl get pod "$pod" -n "$NS" \
                     -o jsonpath='{.spec.containers[0].resources.requests.cpu}')
-                  if [ "$cpu" = "500m" ]; then
+                  if [ -z "$cpu" ]; then
+                    echo "empty cpu request on $pod"
+                    continue
+                  fi
+                  # 500m and 0.5 are the same Quantity.
+                  if [ "$cpu" = "500m" ] || [ "$cpu" = "0.5" ]; then
                     unchanged=$((unchanged + 1))
                   else
                     changed=$((changed + 1))

--- a/test/e2e/canary-rollout/chainsaw-test.yaml
+++ b/test/e2e/canary-rollout/chainsaw-test.yaml
@@ -157,6 +157,51 @@ spec:
               echo "No resize occurred within timeout"
               kubectl get attunepolicy canary-test -n e2e-canary-rollout -o yaml
               exit 1
+    - name: verify-canary-fraction
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              # 33% of 3 pods is 1. Fail if every replica was resized.
+              NS=e2e-canary-rollout
+              seen=0
+              stable=0
+              for i in $(seq 1 36); do
+                changed=0
+                unchanged=0
+                for pod in $(kubectl get pods -n "$NS" -l app=canary-app \
+                  --field-selector=status.phase=Running \
+                  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'); do
+                  cpu=$(kubectl get pod "$pod" -n "$NS" \
+                    -o jsonpath='{.spec.containers[0].resources.requests.cpu}')
+                  if [ "$cpu" = "500m" ]; then
+                    unchanged=$((unchanged + 1))
+                  else
+                    changed=$((changed + 1))
+                  fi
+                done
+                if [ "$changed" -gt 1 ]; then
+                  echo "FAIL: $changed pods left 500m (want 1 of 3)"
+                  kubectl get pods -n "$NS" -o wide
+                  kubectl get attunepolicy canary-test -n "$NS" -o yaml
+                  exit 1
+                fi
+                if [ "$changed" -eq 1 ] && [ "$unchanged" -eq 2 ]; then
+                  seen=1
+                  stable=$((stable + 1))
+                  if [ "$stable" -ge 4 ]; then
+                    echo "OK: canary fraction held at 1/3 for ${stable}x5s"
+                    exit 0
+                  fi
+                else
+                  stable=0
+                fi
+                sleep 5
+              done
+              echo "FAIL: changed=$changed unchanged=$unchanged seen=$seen"
+              kubectl get pods -n "$NS" -o wide
+              kubectl get attunepolicy canary-test -n "$NS" -o yaml
+              exit 1
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1


### PR DESCRIPTION
Pin the remaining canary isolation surfaces that unit helpers already cover but call sites and E2E did not.

## Problem

After #571/#572, `AllowsCreateSizing` / `AllowsHPARetune` / `AllowsStartupBoost` are tested as helpers. Deleting the webhook, Reconcile HPA, or startup-boost `if` would still leave those helper tests green. The existing canary Chainsaw only checks `status.workloads.resized >= 1`, which also passes if every replica was resized.

## Change

- CREATE: one policy, two apps. New `app-a` (promoted) is sized. New `app-b` is not. The `app-b` canary-slice pod is sized.
- Reconcile: canary resize of an unpromoted app must leave the auto-tune HPA utilization at 80. A promoted run must move the target (so an empty `rec.Kind` cannot hide a missing skip). `processWorkloads` now uses `workloadKindName` because typed fake clients clear GVK.
- Startup boost: `app-a` still watching does not boost a new pod; promoted `app-b` still does.
- Chainsaw `canary-rollout`: after the first resize, require exactly 1 of 3 Running pods to leave `500m`, and hold that for 20s.

## Validation

- `go test ./internal/webhook/ ./internal/controller/ -race -count=1 -run 'TestPodMutatingHandler_CanaryMode_|TestApplyStartupBoosts_PromotedSiblingStillBoosts|TestReconcile_CanaryDoesNotRetuneHPAUntilPromoted|TestApplyStartupBoosts_SkipsDuringCanaryInProgress'`
- golangci-lint on the touched packages

Ref #572
