### PR TITLE
fix: create-size after in-place success and add isolation e2e

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -303,6 +303,7 @@ runs:
           --set image.tag=e2e \
           --set image.pullPolicy=Never \
           --set webhooks.enabled=true \
+          --set initialSizing.enabled=true \
           --set metrics.enabled=true \
           --set leaderElection.enabled=false \
           --set maxConcurrentReconciles=4 \

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -515,6 +515,7 @@ jobs:
             --set image.tag=e2e \
             --set image.pullPolicy=Never \
             --set webhooks.enabled=true \
+            --set initialSizing.enabled=true \
             --set metrics.enabled=true \
             --set leaderElection.enabled=false \
             --set maxConcurrentReconciles=4 \

--- a/Makefile
+++ b/Makefile
@@ -380,6 +380,7 @@ _deploy-stack:
 		--set image.tag=$(lastword $(subst :, ,$(IMG))) \
 		--set image.pullPolicy=Never \
 		--set webhooks.enabled=true \
+		--set initialSizing.enabled=true \
 		--set metrics.enabled=true \
 		--set leaderElection.enabled=false \
 		--set maxConcurrentReconciles=4 \

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -255,7 +255,10 @@ pod (the CREATE is still allowed).
    labels match. An empty selector matches nothing.
 4. On Canary, CREATE sizing waits until that app is promoted, or the pod
    name is already in `status.canary.workloads[].pods`.
-5. Check operator logs for `fetching workload for initial-sizing selector`
+5. The webhook applies a rec when every container has confidence at least
+   0.5, or this workload already has a successful in-place resize. A 1h
+   `historyWindow` never reaches 0.5 on its own.
+6. Check operator logs for `fetching workload for initial-sizing selector`
    or `initial sizing applied`.
 
 ### Paused

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -561,7 +561,7 @@ on a policy or on `AttuneDefaults` / `AttuneNamespaceDefaults`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `updateStrategy.initialSizing` | bool | `false` | When true and the initial sizing webhook is enabled, new pods matching this policy (by `targetRef.name` or `targetRef.selector`) receive recommended resources at creation time via a mutating admission webhook. Requires the namespace label `attune.io/initial-sizing=enabled`. Canary still skips CREATE for an app until that app is promoted (or the pod is already in the canary slice). |
+| `updateStrategy.initialSizing` | bool | `false` | When true and the initial sizing webhook is enabled, new pods matching this policy (by `targetRef.name` or `targetRef.selector`) receive recommended resources at creation time via a mutating admission webhook. Requires the namespace label `attune.io/initial-sizing=enabled`. A rec is used when every container has confidence at least 0.5, or this workload already has a successful in-place resize. Canary still skips CREATE for an app until that app is promoted (or the pod is already in the canary slice). |
 
 ## Status Conditions
 

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -174,7 +174,7 @@ func (h *PodMutatingHandler) findMatchingPolicy(
 				continue
 			}
 			if rec.Workload == ownerName && rec.Kind == ownerKind {
-				if hasMinConfidence(rec.Containers, minConfidenceForInitialSizing) {
+				if recEligibleForCreateSizing(rec, policy.Status.ResizeHistory, ownerName) {
 					return policy, rec
 				}
 			}
@@ -321,6 +321,37 @@ func extractDeploymentName(rsName string) string {
 		}
 	}
 	return ""
+}
+
+// recEligibleForCreateSizing is true when every container meets the
+// confidence floor, or this workload already has a successful in-place
+// resize. One Success means we trust CREATE for that name even when
+// the current rec is still low-confidence (short history windows).
+func recEligibleForCreateSizing(
+	rec *attunev1alpha1.WorkloadRecommendation,
+	history []attunev1alpha1.ResizeHistoryEntry,
+	workload string,
+) bool {
+	if rec == nil {
+		return false
+	}
+	if hasMinConfidence(rec.Containers, minConfidenceForInitialSizing) {
+		return true
+	}
+	return hasSuccessfulInPlaceHistory(history, workload)
+}
+
+func hasSuccessfulInPlaceHistory(history []attunev1alpha1.ResizeHistoryEntry, workload string) bool {
+	if workload == "" {
+		return false
+	}
+	for i := range history {
+		h := history[i]
+		if h.Workload == workload && h.Method == "InPlace" && h.Result == attunev1alpha1.ResizeResultSuccess {
+			return true
+		}
+	}
+	return false
 }
 
 // hasMinConfidence returns true if all containers meet the minimum confidence.

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -347,7 +347,13 @@ func hasSuccessfulInPlaceHistory(history []attunev1alpha1.ResizeHistoryEntry, wo
 	}
 	for i := range history {
 		h := history[i]
-		if h.Workload == workload && h.Method == "InPlace" && h.Result == attunev1alpha1.ResizeResultSuccess {
+		// Empty Method is InPlace, same as resizeHistoryMethod in the
+		// controller (legacy rows before the field was required).
+		method := h.Method
+		if method == "" {
+			method = "InPlace"
+		}
+		if h.Workload == workload && method == "InPlace" && h.Result == attunev1alpha1.ResizeResultSuccess {
 			return true
 		}
 	}

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -357,6 +357,24 @@ func TestPodMutatingHandler_LowConfidence_RevertedHistorySkips(t *testing.T) {
 	assert.Nil(t, resp.Patches, "Reverted history must not unlock CREATE")
 }
 
+func TestPodMutatingHandler_LowConfidence_EmptyMethodHistoryApplies(t *testing.T) {
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+	policy.Status.Recommendations[0].Containers[0].Confidence = 0.01
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{
+		{
+			Workload: "my-app",
+			Result:   attunev1alpha1.ResizeResultSuccess,
+		},
+	}
+	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patches, "legacy Success with empty Method is InPlace")
+}
+
 func TestPodMutatingHandler_StatefulSet(t *testing.T) {
 	policy := testPolicy("sts-policy", "default", "StatefulSet", "my-sts", true, attunev1alpha1.UpdateTypeAuto)
 	pod := testPod("my-sts-0", "StatefulSet", "my-sts")

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -295,6 +295,68 @@ func TestPodMutatingHandler_LowConfidence(t *testing.T) {
 	assert.Nil(t, resp.Patches, "low confidence should skip initial sizing")
 }
 
+func TestPodMutatingHandler_LowConfidence_SuccessfulHistoryApplies(t *testing.T) {
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+	policy.Status.Recommendations[0].Containers[0].Confidence = 0.01
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{
+		{
+			Workload:  "my-app",
+			Container: "app",
+			Resource:  "memory",
+			From:      "64Mi",
+			To:        "256Mi",
+			Method:    "InPlace",
+			Result:    attunev1alpha1.ResizeResultSuccess,
+		},
+	}
+	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patches, "a rec already applied in-place may CREATE-size")
+}
+
+func TestPodMutatingHandler_LowConfidence_WrongWorkloadHistorySkips(t *testing.T) {
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+	policy.Status.Recommendations[0].Containers[0].Confidence = 0.01
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{
+		{
+			Workload: "other-app",
+			Method:   "InPlace",
+			Result:   attunev1alpha1.ResizeResultSuccess,
+		},
+	}
+	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
+	require.True(t, resp.Allowed)
+	assert.Nil(t, resp.Patches, "Success on a different workload must not unlock CREATE")
+}
+
+func TestPodMutatingHandler_LowConfidence_RevertedHistorySkips(t *testing.T) {
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+	policy.Status.Recommendations[0].Containers[0].Confidence = 0.01
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{
+		{
+			Workload: "my-app",
+			Method:   "InPlace",
+			Result:   attunev1alpha1.ResizeResultReverted,
+		},
+	}
+	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
+	require.True(t, resp.Allowed)
+	assert.Nil(t, resp.Patches, "Reverted history must not unlock CREATE")
+}
+
 func TestPodMutatingHandler_StatefulSet(t *testing.T) {
 	policy := testPolicy("sts-policy", "default", "StatefulSet", "my-sts", true, attunev1alpha1.UpdateTypeAuto)
 	pod := testPod("my-sts-0", "StatefulSet", "my-sts")

--- a/test/e2e/canary-two-app/chainsaw-test.yaml
+++ b/test/e2e/canary-two-app/chainsaw-test.yaml
@@ -1,0 +1,336 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: canary-two-app
+spec:
+  description: >
+    Selector canary live-slices app-a only. app-b sits at minAllowed so
+    it is a no-op rec (no canary watch). After app-a promotes, CREATE
+    sizes a new app-a pod and skips app-b.
+  timeouts:
+    apply: 30s
+    assert: 2m
+    delete: 30s
+  steps:
+    - name: create-apps
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: e2e-canary-two-app
+                labels:
+                  attune.io/initial-sizing: enabled
+        - apply:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: app-a
+                namespace: e2e-canary-two-app
+                labels:
+                  app: app-a
+                  tier: api
+              spec:
+                replicas: 3
+                selector:
+                  matchLabels:
+                    app: app-a
+                template:
+                  metadata:
+                    labels:
+                      app: app-a
+                      tier: api
+                  spec:
+                    containers:
+                      - name: app
+                        image: registry.k8s.io/pause:3.9
+                        resizePolicy:
+                          - resourceName: cpu
+                            restartPolicy: NotRequired
+                          - resourceName: memory
+                            restartPolicy: NotRequired
+                        resources:
+                          requests:
+                            cpu: 100m
+                            memory: 256Mi
+        - apply:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: app-b
+                namespace: e2e-canary-two-app
+                labels:
+                  app: app-b
+                  tier: api
+              spec:
+                replicas: 2
+                selector:
+                  matchLabels:
+                    app: app-b
+                template:
+                  metadata:
+                    labels:
+                      app: app-b
+                      tier: api
+                  spec:
+                    containers:
+                      - name: app
+                        image: registry.k8s.io/pause:3.9
+                        resizePolicy:
+                          - resourceName: cpu
+                            restartPolicy: NotRequired
+                          - resourceName: memory
+                            restartPolicy: NotRequired
+                        resources:
+                          requests:
+                            cpu: 50m
+                            memory: 64Mi
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: app-a
+                namespace: e2e-canary-two-app
+              status:
+                readyReplicas: 3
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: app-b
+                namespace: e2e-canary-two-app
+              status:
+                readyReplicas: 2
+    - name: wait-for-metrics
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              PROM_POD=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server -o name | head -1)
+              NS="e2e-canary-two-app"
+              ENCODED_QUERY="container_cpu_usage_seconds_total%7Bnamespace%3D%22${NS}%22%2Ccontainer%21%3D%22%22%7D"
+              for i in $(seq 1 24); do
+                result=$(kubectl exec -n monitoring "$PROM_POD" -- \
+                  wget -qO- "http://localhost:9090/api/v1/query?query=${ENCODED_QUERY}" 2>/dev/null || true)
+                if echo "$result" | grep -q '"result":\[{'; then
+                  echo "cAdvisor metrics available for namespace $NS after ${i}x5s"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "WARNING: No cAdvisor metrics for $NS after 120s, proceeding"
+    - name: create-policy
+      try:
+        - apply:
+            resource:
+              apiVersion: attune.io/v1alpha1
+              kind: AttunePolicy
+              metadata:
+                name: fleet-canary
+                namespace: e2e-canary-two-app
+              spec:
+                targetRef:
+                  kind: Deployment
+                  selector:
+                    matchLabels:
+                      tier: api
+                metricsSource:
+                  prometheus:
+                    address: http://prometheus-server.monitoring:80
+                  minimumDataPoints: 1
+                  historyWindow: 1h
+                  queryStep: 1m
+                  rateWindow: 5m
+                cpu:
+                  percentile: 95
+                  overhead: "20"
+                  minAllowed: 50m
+                  maxAllowed: "4000m"
+                  maxChangePercent: 100
+                memory:
+                  percentile: 99
+                  overhead: "30"
+                  allowDecrease: true
+                  minAllowed: 64Mi
+                  maxAllowed: 8Gi
+                  maxChangePercent: 100
+                updateStrategy:
+                  type: Canary
+                  cooldown: 1m
+                  initialSizing: true
+                  canary:
+                    percentage: 33
+                    observationPeriod: 1m
+                    autoPromote: true
+    - name: verify-discovered-two
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              for i in $(seq 1 24); do
+                D=$(kubectl get attunepolicy fleet-canary -n e2e-canary-two-app \
+                  -o jsonpath='{.status.workloads.discovered}' 2>/dev/null)
+                if [ "$D" = "2" ]; then
+                  echo "discovered 2 workloads"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "Timed out waiting for discovered=2"
+              kubectl get attunepolicy fleet-canary -n e2e-canary-two-app -o yaml
+              exit 1
+    - name: verify-resize-occurred
+      try:
+        - script:
+            timeout: 5m
+            content: |
+              for i in $(seq 1 60); do
+                R=$(kubectl get attunepolicy fleet-canary -n e2e-canary-two-app \
+                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null)
+                if [ "$R" -ge 1 ] 2>/dev/null; then
+                  echo "Resize confirmed: $R"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "No resize occurred"
+              kubectl get attunepolicy fleet-canary -n e2e-canary-two-app -o yaml
+              exit 1
+    - name: verify-app-a-slice-app-b-untouched
+      try:
+        - script:
+            timeout: 5m
+            content: |
+              NS=e2e-canary-two-app
+              count_frac() {
+                app=$1
+                cpu=$2
+                mem=$3
+                kubectl get pods -n "$NS" -l "app=$app" \
+                  --field-selector=status.phase=Running \
+                  -o jsonpath='{range .items[*]}{.spec.containers[0].resources.requests.cpu}{"\t"}{.spec.containers[0].resources.requests.memory}{"\n"}{end}' \
+                | awk -F'\t' -v cpu="$cpu" -v mem="$mem" '
+                    $1=="" {next}
+                    $1==cpu && $2==mem {u++}
+                    $1!=cpu || $2!=mem {c++}
+                    END {printf "%d %d", c+0, u+0}
+                  '
+              }
+              for i in $(seq 1 48); do
+                set -- $(count_frac app-a 100m 256Mi)
+                ac=$1
+                au=$2
+                set -- $(count_frac app-b 50m 64Mi)
+                bc=$1
+                bu=$2
+                # app-b is already at minAllowed; a live canary would
+                # still change it. Stay at template.
+                if [ "$bc" -gt 0 ]; then
+                  echo "FAIL: app-b changed=$bc (want 0, minAllowed no-op)"
+                  kubectl get pods -n "$NS" -o wide
+                  kubectl get attunepolicy fleet-canary -n "$NS" -o yaml
+                  exit 1
+                fi
+                if [ "$ac" -gt 1 ]; then
+                  echo "FAIL: app-a changed=$ac (want 1 of 3)"
+                  kubectl get pods -n "$NS" -o wide
+                  kubectl get attunepolicy fleet-canary -n "$NS" -o yaml
+                  exit 1
+                fi
+                if [ "$ac" -eq 1 ] && [ "$au" -eq 2 ] && [ "$bc" -eq 0 ] && [ "$bu" -eq 2 ]; then
+                  echo "OK: app-a 1/3 slice, app-b still template"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "FAIL: isolation not held"
+              kubectl get pods -n "$NS" -o wide
+              kubectl get attunepolicy fleet-canary -n "$NS" -o yaml
+              exit 1
+    - name: wait-app-a-promoted
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              for i in $(seq 1 36); do
+                kubectl get attunepolicy fleet-canary -n e2e-canary-two-app -o json \
+                  > /tmp/fleet-canary.json 2>/dev/null || true
+                PHASE=$(python3 <<'PY'
+              import json
+              try:
+                  p = json.load(open("/tmp/fleet-canary.json"))
+              except Exception:
+                  raise SystemExit
+              for w in ((p.get("status") or {}).get("canary") or {}).get("workloads") or []:
+                  if w.get("workload") == "app-a":
+                      print(w.get("phase") or "")
+                      break
+              PY
+                )
+                if [ "$PHASE" = "FullRollout" ]; then
+                  echo "app-a promoted"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "Timed out waiting for app-a FullRollout"
+              kubectl get attunepolicy fleet-canary -n e2e-canary-two-app -o yaml
+              exit 1
+    - name: scale-new-pods
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              kubectl scale deploy/app-a -n e2e-canary-two-app --replicas=4
+              kubectl scale deploy/app-b -n e2e-canary-two-app --replicas=3
+              kubectl wait deploy/app-a -n e2e-canary-two-app \
+                --for=condition=Available --timeout=90s
+              kubectl wait deploy/app-b -n e2e-canary-two-app \
+                --for=condition=Available --timeout=90s
+              echo "scaled app-a=4 app-b=3"
+    - name: verify-create-sizing
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              NS=e2e-canary-two-app
+              # New pods only: CREATE annotation is not set by in-place resize.
+              for i in $(seq 1 24); do
+                A=$(kubectl get pods -n "$NS" -l app=app-a \
+                  -o jsonpath='{range .items[*]}{.metadata.annotations.attune\.io/initial-sizing}{"\n"}{end}' \
+                  | grep -c '^applied$' || true)
+                B=$(kubectl get pods -n "$NS" -l app=app-b \
+                  -o jsonpath='{range .items[*]}{.metadata.annotations.attune\.io/initial-sizing}{"\n"}{end}' \
+                  | grep -c '^applied$' || true)
+                if [ "$B" -gt 0 ]; then
+                  echo "FAIL: app-b CREATE-sized ($B pods)"
+                  kubectl get pods -n "$NS" -o yaml
+                  exit 1
+                fi
+                if [ "$A" -ge 1 ]; then
+                  echo "OK: app-a CREATE-sized ($A), app-b none"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "FAIL: no CREATE sizing on promoted app-a"
+              kubectl get pods -n "$NS" -o yaml
+              kubectl get attunepolicy fleet-canary -n "$NS" -o yaml
+              exit 1
+  catch:
+    - describe:
+        apiVersion: attune.io/v1alpha1
+        kind: AttunePolicy
+        namespace: e2e-canary-two-app
+    - describe:
+        apiVersion: apps/v1
+        kind: Deployment
+        namespace: e2e-canary-two-app
+    - podLogs:
+        namespace: attune-system
+        selector: app.kubernetes.io/name=attune

--- a/test/e2e/per-app-cooldown/chainsaw-test.yaml
+++ b/test/e2e/per-app-cooldown/chainsaw-test.yaml
@@ -1,0 +1,268 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: per-app-cooldown
+spec:
+  description: >
+    Create app-b only after app-a's first Success. Per-app cooldown
+    must still resize app-b in under 60s. A policy-wide stamp would
+    wait the full 1m.
+  timeouts:
+    apply: 30s
+    assert: 2m
+    delete: 30s
+  steps:
+    - name: create-apps
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: e2e-per-app-cooldown
+        - apply:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: app-a
+                namespace: e2e-per-app-cooldown
+                labels:
+                  app: app-a
+                  tier: api
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    app: app-a
+                template:
+                  metadata:
+                    labels:
+                      app: app-a
+                      tier: api
+                  spec:
+                    containers:
+                      - name: app
+                        image: registry.k8s.io/pause:3.9
+                        resizePolicy:
+                          - resourceName: cpu
+                            restartPolicy: NotRequired
+                          - resourceName: memory
+                            restartPolicy: NotRequired
+                        resources:
+                          requests:
+                            cpu: 100m
+                            memory: 256Mi
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: app-a
+                namespace: e2e-per-app-cooldown
+              status:
+                readyReplicas: 1
+    - name: wait-for-metrics
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              PROM_POD=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server -o name | head -1)
+              NS="e2e-per-app-cooldown"
+              ENCODED_QUERY="container_cpu_usage_seconds_total%7Bnamespace%3D%22${NS}%22%2Ccontainer%21%3D%22%22%7D"
+              for i in $(seq 1 24); do
+                result=$(kubectl exec -n monitoring "$PROM_POD" -- \
+                  wget -qO- "http://localhost:9090/api/v1/query?query=${ENCODED_QUERY}" 2>/dev/null || true)
+                if echo "$result" | grep -q '"result":\[{'; then
+                  echo "cAdvisor metrics available for namespace $NS after ${i}x5s"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "WARNING: No cAdvisor metrics for $NS after 120s, proceeding"
+    - name: create-policy
+      try:
+        - apply:
+            resource:
+              apiVersion: attune.io/v1alpha1
+              kind: AttunePolicy
+              metadata:
+                name: fleet-auto
+                namespace: e2e-per-app-cooldown
+              spec:
+                targetRef:
+                  kind: Deployment
+                  selector:
+                    matchLabels:
+                      tier: api
+                metricsSource:
+                  prometheus:
+                    address: http://prometheus-server.monitoring:80
+                  minimumDataPoints: 1
+                  historyWindow: 1h
+                  queryStep: 1m
+                  rateWindow: 5m
+                cpu:
+                  percentile: 95
+                  overhead: "20"
+                  minAllowed: 50m
+                  maxAllowed: "4000m"
+                  maxChangePercent: 100
+                memory:
+                  percentile: 99
+                  overhead: "30"
+                  allowDecrease: true
+                  minAllowed: 64Mi
+                  maxAllowed: 8Gi
+                  maxChangePercent: 100
+                updateStrategy:
+                  type: Auto
+                  cooldown: 1m
+                  maxConcurrentResizes: 1
+    - name: wait-app-a-success
+      try:
+        - script:
+            timeout: 5m
+            content: |
+              NS=e2e-per-app-cooldown
+              for i in $(seq 1 60); do
+                kubectl get attunepolicy fleet-auto -n "$NS" -o json \
+                  > /tmp/fleet-auto.json 2>/dev/null || true
+                python3 <<'PY'
+              import json
+              import sys
+              try:
+                  p = json.load(open("/tmp/fleet-auto.json"))
+              except Exception:
+                  sys.exit(1)
+              for h in (p.get("status") or {}).get("resizeHistory") or []:
+                  if h.get("result") == "Success" and h.get("workload") == "app-a":
+                      print(h.get("timestamp"))
+                      sys.exit(0)
+              sys.exit(1)
+              PY
+                if [ $? -eq 0 ]; then
+                  echo "app-a Success recorded"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "FAIL: no Success history for app-a"
+              kubectl get attunepolicy fleet-auto -n "$NS" -o yaml
+              exit 1
+    - name: apply-app-b
+      try:
+        - apply:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: app-b
+                namespace: e2e-per-app-cooldown
+                labels:
+                  app: app-b
+                  tier: api
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    app: app-b
+                template:
+                  metadata:
+                    labels:
+                      app: app-b
+                      tier: api
+                  spec:
+                    containers:
+                      - name: app
+                        image: registry.k8s.io/pause:3.9
+                        resizePolicy:
+                          - resourceName: cpu
+                            restartPolicy: NotRequired
+                          - resourceName: memory
+                            restartPolicy: NotRequired
+                        resources:
+                          requests:
+                            cpu: 100m
+                            memory: 256Mi
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: app-b
+                namespace: e2e-per-app-cooldown
+              status:
+                readyReplicas: 1
+    - name: verify-app-b-resized-inside-cooldown
+      try:
+        - script:
+            timeout: 90s
+            content: |
+              NS=e2e-per-app-cooldown
+              for i in $(seq 1 18); do
+                kubectl get attunepolicy fleet-auto -n "$NS" -o json \
+                  > /tmp/fleet-auto.json 2>/dev/null || true
+                python3 <<'PY'
+              import json
+              import sys
+              from datetime import datetime
+              try:
+                  p = json.load(open("/tmp/fleet-auto.json"))
+              except Exception:
+                  sys.exit(3)
+              first = {}
+              for h in (p.get("status") or {}).get("resizeHistory") or []:
+                  if h.get("result") != "Success":
+                      continue
+                  w = h.get("workload")
+                  ts = h.get("timestamp")
+                  if w and ts and w not in first:
+                      first[w] = ts
+              if "app-a" not in first or "app-b" not in first:
+                  sys.exit(3)
+              def parse(s):
+                  return datetime.fromisoformat(s.replace("Z", "+00:00"))
+              ta = parse(first["app-a"])
+              tb = parse(first["app-b"])
+              delta = (tb - ta).total_seconds()
+              print("first Success app-a=%s app-b=%s delta=%.1fs" % (
+                  first["app-a"], first["app-b"], delta))
+              if delta < 0:
+                  sys.exit(4)
+              if delta >= 60:
+                  sys.exit(2)
+              sys.exit(0)
+              PY
+                rc=$?
+                if [ "$rc" -eq 0 ]; then
+                  echo "OK: app-b resized after app-a and inside 60s"
+                  exit 0
+                fi
+                if [ "$rc" -eq 2 ]; then
+                  echo "FAIL: app-b first Success is >= 60s after app-a"
+                  kubectl get attunepolicy fleet-auto -n "$NS" -o yaml
+                  exit 1
+                fi
+                if [ "$rc" -eq 4 ]; then
+                  echo "FAIL: app-b Success is before app-a"
+                  kubectl get attunepolicy fleet-auto -n "$NS" -o yaml
+                  exit 1
+                fi
+                sleep 5
+              done
+              echo "FAIL: no Success history for app-b inside 90s"
+              kubectl get attunepolicy fleet-auto -n "$NS" -o yaml
+              exit 1
+  catch:
+    - describe:
+        apiVersion: attune.io/v1alpha1
+        kind: AttunePolicy
+        namespace: e2e-per-app-cooldown
+    - describe:
+        apiVersion: apps/v1
+        kind: Deployment
+        namespace: e2e-per-app-cooldown
+    - podLogs:
+        namespace: attune-system
+        selector: app.kubernetes.io/name=attune

--- a/test/e2e/per-app-cooldown/chainsaw-test.yaml
+++ b/test/e2e/per-app-cooldown/chainsaw-test.yaml
@@ -100,7 +100,7 @@ spec:
                     address: http://prometheus-server.monitoring:80
                   minimumDataPoints: 1
                   historyWindow: 1h
-                  queryStep: 1m
+                  queryStep: 15s
                   rateWindow: 5m
                 cpu:
                   percentile: 95
@@ -194,13 +194,64 @@ spec:
                 namespace: e2e-per-app-cooldown
               status:
                 readyReplicas: 1
+    - name: wait-app-b-metrics
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              PROM_POD=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server -o name | head -1)
+              NS="e2e-per-app-cooldown"
+              ENCODED_QUERY="container_cpu_usage_seconds_total%7Bnamespace%3D%22${NS}%22%2Cpod%3D~%22app-b-.*%22%2Ccontainer%21%3D%22%22%7D"
+              for i in $(seq 1 24); do
+                result=$(kubectl exec -n monitoring "$PROM_POD" -- \
+                  wget -qO- "http://localhost:9090/api/v1/query?query=${ENCODED_QUERY}" 2>/dev/null || true)
+                if echo "$result" | grep -q '"result":\[{'; then
+                  echo "cAdvisor metrics for app-b after ${i}x5s"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "WARNING: no app-b series after 120s, proceeding"
+    - name: wait-app-b-recommendation
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              NS=e2e-per-app-cooldown
+              for i in $(seq 1 36); do
+                kubectl get attunepolicy fleet-auto -n "$NS" -o json \
+                  > /tmp/fleet-auto.json 2>/dev/null || true
+                python3 <<'PY'
+              import json
+              import sys
+              try:
+                  p = json.load(open("/tmp/fleet-auto.json"))
+              except Exception:
+                  sys.exit(1)
+              for rec in (p.get("status") or {}).get("recommendations") or []:
+                  if rec.get("workload") == "app-b" and not rec.get("stale"):
+                      sys.exit(0)
+              sys.exit(1)
+              PY
+                if [ $? -eq 0 ]; then
+                  echo "app-b has a recommendation"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "FAIL: no recommendation for app-b"
+              kubectl get attunepolicy fleet-auto -n "$NS" -o yaml
+              exit 1
     - name: verify-app-b-resized-inside-cooldown
       try:
         - script:
             timeout: 90s
             content: |
+              # Recs for app-b already exist. Per-app cooldown resizes
+              # on the next reconcile (seconds). A policy-wide stamp
+              # still holds until app-a's 1m expires.
               NS=e2e-per-app-cooldown
-              for i in $(seq 1 18); do
+              for i in $(seq 1 6); do
                 kubectl get attunepolicy fleet-auto -n "$NS" -o json \
                   > /tmp/fleet-auto.json 2>/dev/null || true
                 python3 <<'PY'
@@ -219,8 +270,10 @@ spec:
                   ts = h.get("timestamp")
                   if w and ts and w not in first:
                       first[w] = ts
-              if "app-a" not in first or "app-b" not in first:
+              if "app-b" not in first:
                   sys.exit(3)
+              if "app-a" not in first:
+                  sys.exit(4)
               def parse(s):
                   return datetime.fromisoformat(s.replace("Z", "+00:00"))
               ta = parse(first["app-a"])
@@ -230,28 +283,21 @@ spec:
                   first["app-a"], first["app-b"], delta))
               if delta < 0:
                   sys.exit(4)
-              if delta >= 60:
-                  sys.exit(2)
               sys.exit(0)
               PY
                 rc=$?
                 if [ "$rc" -eq 0 ]; then
-                  echo "OK: app-b resized after app-a and inside 60s"
+                  echo "OK: app-b resized after it had a rec (A still cooling)"
                   exit 0
                 fi
-                if [ "$rc" -eq 2 ]; then
-                  echo "FAIL: app-b first Success is >= 60s after app-a"
-                  kubectl get attunepolicy fleet-auto -n "$NS" -o yaml
-                  exit 1
-                fi
                 if [ "$rc" -eq 4 ]; then
-                  echo "FAIL: app-b Success is before app-a"
+                  echo "FAIL: missing app-a Success or app-b before app-a"
                   kubectl get attunepolicy fleet-auto -n "$NS" -o yaml
                   exit 1
                 fi
                 sleep 5
               done
-              echo "FAIL: no Success history for app-b inside 90s"
+              echo "FAIL: app-b had a rec but no Success within 60s"
               kubectl get attunepolicy fleet-auto -n "$NS" -o yaml
               exit 1
   catch:


### PR DESCRIPTION
## Summary

Add cluster tests for two-app selector canary isolation, CREATE sizing after promote, and per-app cooldown. Unlock CREATE in short history windows after a successful in-place resize.

## Problem

Units already covered selector CREATE and per-app cooldown. Nothing on a real API server proved:

1. Live canary requests stay on one app's slice while a sibling at minAllowed is a no-op.
2. After that app promotes, a new pod is CREATE-sized and the sibling is not.
3. A sibling created after the first Success still resizes inside 60s (policy-wide cooldown would wait 1m).

CREATE also never fired in E2E: confidence is `min(timeSpanDays, sqrt(n/24)) / 7`, so a 1h window stays near 0.006 against the 0.5 floor.

## Change

- Treat a rec as CREATE-eligible when confidence is at least 0.5, or this workload already has a successful InPlace history row.
- Enable `initialSizing.enabled` in E2E Helm. The webhook still requires namespace label `attune.io/initial-sizing=enabled`.
- `test/e2e/canary-two-app`: selector canary, app-a 1/3 live slice, app-b at minAllowed, then CREATE only on promoted app-a.
- `test/e2e/per-app-cooldown`: create app-b only after app-a Success; require T_b after T_a and under 60s.

## Validation

- `go test ./internal/webhook/ -race -count=1`
- `make lint-chainsaw`
- Local review after the first pass (canary is per-app min 1 pod). Re-review: 0 bugs.

## Issue reference

No open issue tracks these scenarios.
