### PR TITLE
fix: log generateName when create sizing has no pod name

### DIFF
--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -120,7 +120,7 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 	pod.Annotations[AnnotationInitialSizingPolicy] = fmt.Sprintf("%s/%s", req.Namespace, policy.Name)
 
 	h.Logger.Info("initial sizing applied",
-		"pod", pod.Name, "namespace", req.Namespace,
+		"pod", podAdmissionName(pod, req.Name), "namespace", req.Namespace,
 		"policy", policy.Name, "owner", ownerKind+"/"+ownerName)
 
 	marshaledPod, err := json.Marshal(pod)
@@ -358,6 +358,22 @@ func hasSuccessfulInPlaceHistory(history []attunev1alpha1.ResizeHistoryEntry, wo
 		}
 	}
 	return false
+}
+
+// podAdmissionName is the best identifier at CREATE. ReplicaSet pods
+// often have an empty Name and only GenerateName until the API assigns
+// one. Do not use this for canary slice matching.
+func podAdmissionName(pod *corev1.Pod, reqName string) string {
+	if pod != nil && pod.Name != "" {
+		return pod.Name
+	}
+	if reqName != "" {
+		return reqName
+	}
+	if pod != nil && pod.GenerateName != "" {
+		return pod.GenerateName
+	}
+	return ""
 }
 
 // hasMinConfidence returns true if all containers meet the minimum confidence.

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -157,6 +157,17 @@ func testPod(name string, ownerKind, ownerName string) *corev1.Pod {
 	return pod
 }
 
+func TestPodAdmissionName(t *testing.T) {
+	t.Parallel()
+	named := testPod("app-abc-xyz", "ReplicaSet", "app-abc")
+	generated := testPod("", "ReplicaSet", "app-abc")
+	generated.GenerateName = "app-abc-"
+	assert.Equal(t, "app-abc-xyz", podAdmissionName(named, "ignored"))
+	assert.Equal(t, "from-req", podAdmissionName(generated, "from-req"))
+	assert.Equal(t, "app-abc-", podAdmissionName(generated, ""))
+	assert.Equal(t, "", podAdmissionName(nil, ""))
+}
+
 func TestPodMutatingHandler_HappyPath(t *testing.T) {
 	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")


### PR DESCRIPTION
## Summary

Log `generateName` (or the admission request name) when CREATE sizing applies to a pod that does not have `metadata.name` yet.

## Problem

The #575 E2E log showed `initial sizing applied` with `pod:""`. ReplicaSet CREATE often has only `generateName` at admission.

## Change

`podAdmissionName` prefers `pod.Name`, then `req.Name`, then `GenerateName`. Canary slice matching still uses the real name (empty stays a non-match).

## Validation

`go test ./internal/webhook/ -race -count=1 -run TestPodAdmissionName`

## Issue reference

None.
