### PR TITLE
fix: skip extra gitops PRs after upgrade without blocking first live open

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -159,7 +159,7 @@ make test-e2e-smoke
 | `test/e2e/startup-boost/` | (cross-cutting) | CPU startup boost is applied to new pods |
 | `test/e2e/configmap-export/` | (cross-cutting) | Recommendations are exported to a ConfigMap (`schema-version` + export-schema label) |
 | `test/e2e/fleet-report/` | (infra) | Fleet report ConfigMap is written when `fleetReport` is enabled in E2E Helm |
-| `test/e2e/gitops-pr-dry-run/` | (cross-cutting) | GitOps PR dry-run sets `PullRequestDryRun`/`PullRequestUnchanged`/`PullRequestCooldown` without forge credentials |
+| `test/e2e/gitops-pr-dry-run/` | (cross-cutting) | GitOps PR dry-run sets `PullRequestDryRun` or `PullRequestUnchanged` without forge credentials |
 
 GitOps PR unit tests must cover the **second cycle** after merge, not only
 the first open. `TestReconcileGitOpsPullRequest_LivePathDoesNotRecreateAfterMerge`

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -220,7 +220,8 @@ Use this ordered path when turning on PR automation for the first time.
    live PRs (see [Status](#status)).
 6. **Turn off dry-run** (`dryRun: false` or omit). On the first live run
    with drift, Attune **bootstraps the head branch** if missing, then
-   opens the PR:
+   opens the PR. A prior dry-run of the same table records the fingerprint
+   only; it does not set a PR URL, so it does not block that first live PR:
    - **GitHub:** empty bootstrap commit on
      `attune/recommendations-<ns>-<policy>` (same tree as `baseBranch`).
    - **GitLab:** branch from `baseBranch` plus

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -241,7 +241,10 @@ Cooldown (default 24h) prevents PR thrash. After a merge, if the head branch
 is deleted, the next cycle may bootstrap again **only when the drift table
 changed**. If template vs recommendation is the same set as the last PR,
 the condition is `PullRequestUnchanged` and Attune does not open another
-empty PR. Apply real template patches (`kubectl attune diff`) so drift
+empty PR. A prior successful PR (`attune.io/gitops-pr-url`) with no stored
+fingerprint (upgrades from 0.1.22/0.1.23) is treated the same way: Attune
+records the live table and skips instead of opening one more empty PR.
+Apply real template patches (`kubectl attune diff`) so drift
 clears (`NoDrift`).
 
 ### Branch bootstrap

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1016,6 +1016,20 @@ branch) leaves the live template unchanged, so drift stays true.
    or `dryRun: true`.
 4. On Attune versions that include the unchanged-drift skip, the
    condition is `PullRequestUnchanged` instead of another empty PR.
+5. v0.1.24 wrote `attune.io/gitops-pr-drift` only after opening a PR.
+   Upgrading from 0.1.22/0.1.23 therefore still opened one more empty
+   set when `cooldown` expired (last-attempt and URL were present, the
+   fingerprint was not). Later versions adopt that fingerprint from the
+   last PR URL and skip. Confirm the annotation is present:
+
+   ```bash
+   kubectl get attunepolicy -A -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.metadata.name}{" drift="}{.metadata.annotations.attune\.io/gitops-pr-drift}{" url="}{.metadata.annotations.attune\.io/gitops-pr-url}{"\n"}{end}'
+   ```
+
+   If `url` is set and `drift` is empty after upgrade, Flux/Argo may be
+   replacing operator annotations. Leave the last PR open or set
+   `dryRun: true` until the chart/operator that adopts the fingerprint
+   is running.
 
 ### GitOps PR failing
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1016,6 +1016,8 @@ branch) leaves the live template unchanged, so drift stays true.
    or `dryRun: true`.
 4. On Attune versions that include the unchanged-drift skip, the
    condition is `PullRequestUnchanged` instead of another empty PR.
+   A dry-run of the same table does not block the first live PR (no
+   `gitops-pr-url` yet).
 5. v0.1.24 wrote `attune.io/gitops-pr-drift` only after opening a PR.
    Upgrading from 0.1.22/0.1.23 therefore still opened one more empty
    PR when `cooldown` expired (last-attempt and URL were present, the

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1017,7 +1017,9 @@ branch) leaves the live template unchanged, so drift stays true.
 4. On Attune versions that include the unchanged-drift skip, the
    condition is `PullRequestUnchanged` instead of another empty PR.
    A dry-run of the same table does not block the first live PR (no
-   `gitops-pr-url` yet).
+   `gitops-pr-url` yet). If a 0.1.24 dry-run already wrote
+   `attune.io/gitops-pr-last-attempt`, delete that annotation or wait
+   out `cooldown` before the first live open.
 5. v0.1.24 wrote `attune.io/gitops-pr-drift` only after opening a PR.
    Upgrading from 0.1.22/0.1.23 therefore still opened one more empty
    PR when `cooldown` expired (last-attempt and URL were present, the

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1018,9 +1018,10 @@ branch) leaves the live template unchanged, so drift stays true.
    condition is `PullRequestUnchanged` instead of another empty PR.
 5. v0.1.24 wrote `attune.io/gitops-pr-drift` only after opening a PR.
    Upgrading from 0.1.22/0.1.23 therefore still opened one more empty
-   set when `cooldown` expired (last-attempt and URL were present, the
-   fingerprint was not). Later versions adopt that fingerprint from the
-   last PR URL and skip. Confirm the annotation is present:
+   PR when `cooldown` expired (last-attempt and URL were present, the
+   fingerprint was not). Later versions record the live table when a
+   prior PR URL exists and the fingerprint annotation is missing, then
+   skip. Confirm the annotation is present:
 
    ```bash
    kubectl get attunepolicy -A -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.metadata.name}{" drift="}{.metadata.annotations.attune\.io/gitops-pr-drift}{" url="}{.metadata.annotations.attune\.io/gitops-pr-url}{"\n"}{end}'

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -81,8 +81,14 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 		return
 	}
 	fp := gitops.DriftFingerprint(drifts)
-	if fp != "" && policy.Annotations[annotationGitOpsPRDrift] == fp {
-		logger.V(1).Info("GitOps PR skipped: drift table unchanged since last PR")
+	if skip, adopted := gitOpsPRUnchangedSkip(policy, fp); skip {
+		if adopted {
+			logger.V(1).Info("GitOps PR skipped: adopting drift fingerprint from last PR")
+			setGitOpsPRDriftAnnotation(policy, fp)
+			r.persistGitOpsPRAnnotations(ctx, policy)
+		} else {
+			logger.V(1).Info("GitOps PR skipped: drift table unchanged since last PR")
+		}
 		setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRUnchanged,
 			"Drift table unchanged since last pull request; not opening a new empty PR")
 		return
@@ -221,6 +227,25 @@ func (r *AttunePolicyReconciler) touchGitOpsPRAnnotation(policy *attunev1alpha1.
 	if url != "" {
 		policy.Annotations[annotationGitOpsPRURL] = url
 	}
+}
+
+// gitOpsPRUnchangedSkip reports whether the current drift table should
+// not open a new PR. adopted is true when 0.1.22 (or a persist miss)
+// left last-attempt+URL but no fingerprint: treat the live table as the
+// last notification and persist the hash instead of opening another
+// empty PR. Do not adopt when URL is empty; that last-attempt may be a
+// failed API call that should retry after cooldown.
+func gitOpsPRUnchangedSkip(policy *attunev1alpha1.AttunePolicy, fp string) (skip, adopted bool) {
+	if fp == "" {
+		return false, false
+	}
+	if policy.Annotations[annotationGitOpsPRDrift] == fp {
+		return true, false
+	}
+	if policy.Annotations[annotationGitOpsPRDrift] == "" && policy.Annotations[annotationGitOpsPRURL] != "" {
+		return true, true
+	}
+	return false, false
 }
 
 func setGitOpsPRDriftAnnotation(policy *attunev1alpha1.AttunePolicy, fingerprint string) {

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -80,18 +80,25 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 			"No recommendation drift above minChangePercent vs templates")
 		return
 	}
+	dryRun := cfg.DryRun != nil && *cfg.DryRun
 	fp := gitops.DriftFingerprint(drifts)
 	if skip, adopted := gitOpsPRUnchangedSkip(policy, fp); skip {
-		if adopted {
-			logger.V(1).Info("GitOps PR skipped: adopting drift fingerprint from last PR")
-			setGitOpsPRDriftAnnotation(policy, fp)
-			r.persistGitOpsPRAnnotations(ctx, policy)
+		// Dry-run writes the fingerprint without a PR URL. A later live
+		// cycle of the same table must still open the first real PR.
+		if !adopted && !dryRun && policy.Annotations[annotationGitOpsPRURL] == "" {
+			logger.V(1).Info("GitOps PR: first live cycle after dry-run, opening PR")
 		} else {
-			logger.V(1).Info("GitOps PR skipped: drift table unchanged since last PR")
+			if adopted {
+				logger.V(1).Info("GitOps PR skipped: adopting drift fingerprint from last PR")
+				setGitOpsPRDriftAnnotation(policy, fp)
+				r.persistGitOpsPRAnnotations(ctx, policy)
+			} else {
+				logger.V(1).Info("GitOps PR skipped: drift table unchanged since last PR")
+			}
+			setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRUnchanged,
+				"Drift table unchanged since last pull request; not opening a new empty PR")
+			return
 		}
-		setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRUnchanged,
-			"Drift table unchanged since last pull request; not opening a new empty PR")
-		return
 	}
 
 	cooldown := defaultGitOpsPRCooldown
@@ -121,13 +128,13 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 	body := gitops.FormatPRBody(policy.Namespace, policy.Name, drifts)
 	head := gitops.BranchName(policy.Namespace, policy.Name)
 
-	dryRun := cfg.DryRun != nil && *cfg.DryRun
 	if dryRun {
 		logger.Info("GitOps PR dry-run", "provider", provider, "repository", cfg.Repository,
 			"head", head, "base", base, "driftCount", len(drifts))
 		setGitOpsPRCondition(policy, metav1.ConditionTrue, attunev1alpha1.ReasonGitOpsPRDryRun,
 			fmt.Sprintf("Dry-run: would open/update PR on %s (%d drifted resources)", cfg.Repository, len(drifts)))
-		r.touchGitOpsPRAnnotation(policy, "")
+		// Fingerprint only. last-attempt would block the first live PR
+		// for the default 24h cooldown (docs: turn off dry-run, then open).
 		setGitOpsPRDriftAnnotation(policy, fp)
 		r.persistGitOpsPRAnnotations(ctx, policy)
 		operatormetrics.GitOpsPRTotal.WithLabelValues(policy.Namespace, policy.Name, "dry_run").Inc()
@@ -265,27 +272,35 @@ func (r *AttunePolicyReconciler) persistGitOpsPRAnnotations(ctx context.Context,
 		return
 	}
 	logger := log.FromContext(ctx)
-	latest := &attunev1alpha1.AttunePolicy{}
-	if err := r.Get(ctx, client.ObjectKeyFromObject(policy), latest); err != nil {
-		logger.V(1).Info("GitOps PR: failed to re-get policy for annotation persist",
-			"error", err.Error(), "policy", policy.Name, "namespace", policy.Namespace)
+	const attempts = 3
+	var lastErr error
+	for range attempts {
+		latest := &attunev1alpha1.AttunePolicy{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(policy), latest); err != nil {
+			lastErr = err
+			continue
+		}
+		base := latest.DeepCopy()
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{}
+		}
+		if v, ok := policy.Annotations[annotationGitOpsPRLastAttempt]; ok {
+			latest.Annotations[annotationGitOpsPRLastAttempt] = v
+		}
+		if v, ok := policy.Annotations[annotationGitOpsPRURL]; ok {
+			latest.Annotations[annotationGitOpsPRURL] = v
+		}
+		if v, ok := policy.Annotations[annotationGitOpsPRDrift]; ok {
+			latest.Annotations[annotationGitOpsPRDrift] = v
+		}
+		if err := r.Patch(ctx, latest, client.MergeFrom(base)); err != nil {
+			lastErr = err
+			continue
+		}
 		return
 	}
-	base := latest.DeepCopy()
-	if latest.Annotations == nil {
-		latest.Annotations = map[string]string{}
-	}
-	if v, ok := policy.Annotations[annotationGitOpsPRLastAttempt]; ok {
-		latest.Annotations[annotationGitOpsPRLastAttempt] = v
-	}
-	if v, ok := policy.Annotations[annotationGitOpsPRURL]; ok {
-		latest.Annotations[annotationGitOpsPRURL] = v
-	}
-	if v, ok := policy.Annotations[annotationGitOpsPRDrift]; ok {
-		latest.Annotations[annotationGitOpsPRDrift] = v
-	}
-	if err := r.Patch(ctx, latest, client.MergeFrom(base)); err != nil {
-		logger.V(1).Info("GitOps PR: failed to patch cooldown annotations",
-			"error", err.Error(), "policy", policy.Name, "namespace", policy.Namespace)
+	if lastErr != nil {
+		logger.V(1).Info("GitOps PR: failed to persist cooldown annotations",
+			"error", lastErr.Error(), "policy", policy.Name, "namespace", policy.Namespace)
 	}
 }

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -25,6 +25,51 @@ import (
 	"github.com/attune-io/attune/internal/operatormetrics"
 )
 
+func TestGitOpsPRUnchangedSkip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		fp          string
+		annotations map[string]string
+		wantSkip    bool
+		wantAdopted bool
+	}{
+		{name: "empty fingerprint", fp: ""},
+		{
+			name:        "matching fingerprint",
+			fp:          "abc",
+			annotations: map[string]string{annotationGitOpsPRDrift: "abc"},
+			wantSkip:    true,
+		},
+		{
+			name:        "prior URL without fingerprint",
+			fp:          "abc",
+			annotations: map[string]string{annotationGitOpsPRURL: "https://github.com/org/repo/pull/1"},
+			wantSkip:    true,
+			wantAdopted: true,
+		},
+		{
+			name:        "failed attempt has no URL",
+			fp:          "abc",
+			annotations: map[string]string{annotationGitOpsPRLastAttempt: "2026-08-23T00:00:00Z"},
+		},
+		{
+			name:        "different stored fingerprint",
+			fp:          "new",
+			annotations: map[string]string{annotationGitOpsPRDrift: "old", annotationGitOpsPRURL: "https://github.com/org/repo/pull/1"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			policy := &attunev1alpha1.AttunePolicy{ObjectMeta: metav1.ObjectMeta{Annotations: tc.annotations}}
+			skip, adopted := gitOpsPRUnchangedSkip(policy, tc.fp)
+			assert.Equal(t, tc.wantSkip, skip)
+			assert.Equal(t, tc.wantAdopted, adopted)
+		})
+	}
+}
+
 func TestGitopsPREnabled(t *testing.T) {
 	t.Parallel()
 	assert.False(t, gitopsPREnabled(nil))
@@ -594,6 +639,198 @@ func TestReconcileGitOpsPullRequest_LivePathDoesNotRecreateAfterMerge(t *testing
 	assert.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy))
 	assert.Equal(t, 1, fakeForge.createsAfter, "changed drift may open a new PR")
 	assert.Equal(t, 2, len(fakeForge.calls))
+}
+
+// 0.1.22 wrote last-attempt + URL but not attune.io/gitops-pr-drift.
+// After upgrade, cooldown expiry used to open another empty PR for the
+// same table (#537 comment after 0.1.24).
+func TestReconcileGitOpsPullRequest_PreFingerprintUpgradeDoesNotRecreate(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	dry := false
+	start := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "authentik",
+			Namespace: "authentik",
+			Annotations: map[string]string{
+				annotationGitOpsPRLastAttempt: start.Add(-25 * time.Hour).Format(time.RFC3339),
+				annotationGitOpsPRURL:         "https://github.com/org/repo/pull/41",
+			},
+		},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &dry,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "tok", Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+	dep := gitOpsDriftDeployment("api", "authentik", "1")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).Build()
+	fakeForge := &recordingPRClient{}
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	r.gitopsPRClient = fakeForge
+	r.SetNowFunc(func() time.Time { return start })
+	recs := gitOpsCPURec("api", "100m")
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
+	assert.Empty(t, fakeForge.calls, "upgrade with prior PR URL must not open another empty PR")
+	require.NotEmpty(t, policy.Annotations[annotationGitOpsPRDrift])
+
+	// Fingerprint now persists; later cycles stay quiet.
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
+	assert.Empty(t, fakeForge.calls)
+}
+
+func TestReconcileGitOpsPullRequest_PreFingerprintBackfillDuringCooldown(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	dry := false
+	start := time.Date(2026, 8, 24, 18, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "authentik",
+			Namespace: "authentik",
+			Annotations: map[string]string{
+				annotationGitOpsPRLastAttempt: start.Add(-1 * time.Hour).Format(time.RFC3339),
+				annotationGitOpsPRURL:         "https://github.com/org/repo/pull/41",
+			},
+		},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &dry,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "tok", Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+	dep := gitOpsDriftDeployment("api", "authentik", "1")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).Build()
+	fakeForge := &recordingPRClient{}
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	r.gitopsPRClient = fakeForge
+	now := start
+	r.SetNowFunc(func() time.Time { return now })
+	recs := gitOpsCPURec("api", "100m")
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy),
+		"missing fingerprint with a prior PR URL should adopt, not wait out cooldown")
+	assert.Empty(t, fakeForge.calls)
+	require.NotEmpty(t, policy.Annotations[annotationGitOpsPRDrift])
+
+	now = start.Add(24 * time.Hour)
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
+	assert.Empty(t, fakeForge.calls, "backfill during cooldown must prevent the next-morning empty PR")
+}
+
+func TestReconcileGitOpsPullRequest_FailedAttemptWithoutURLStillRetries(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	dry := false
+	start := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "authentik",
+			Namespace: "authentik",
+			Annotations: map[string]string{
+				// Failed API writes last-attempt but not URL.
+				annotationGitOpsPRLastAttempt: start.Add(-25 * time.Hour).Format(time.RFC3339),
+			},
+		},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &dry,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "tok", Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+	dep := gitOpsDriftDeployment("api", "authentik", "1")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).Build()
+	fakeForge := &recordingPRClient{}
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	r.gitopsPRClient = fakeForge
+	r.SetNowFunc(func() time.Time { return start })
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "100m"))
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy))
+	assert.Equal(t, 1, fakeForge.createsBefore, "failed prior attempt with no URL must retry")
+}
+
+func gitOpsDriftDeployment(name, ns, cpu string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse(cpu),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func gitOpsCPURec(workload, cpu string) []attunev1alpha1.WorkloadRecommendation {
+	return []attunev1alpha1.WorkloadRecommendation{{
+		Workload: workload, Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse(cpu),
+			},
+		}},
+	}}
 }
 
 func TestReconcileGitOpsPullRequest_IncompleteConfig(t *testing.T) {

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -691,6 +691,10 @@ func TestReconcileGitOpsPullRequest_PreFingerprintUpgradeDoesNotRecreate(t *test
 	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
 	assert.Empty(t, fakeForge.calls, "upgrade with prior PR URL must not open another empty PR")
 	require.NotEmpty(t, policy.Annotations[annotationGitOpsPRDrift])
+	stored := &attunev1alpha1.AttunePolicy{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(policy), stored))
+	require.Equal(t, policy.Annotations[annotationGitOpsPRDrift], stored.Annotations[annotationGitOpsPRDrift],
+		"adopt must persist attune.io/gitops-pr-drift on the API object")
 
 	// Fingerprint now persists; later cycles stay quiet.
 	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
@@ -747,6 +751,9 @@ func TestReconcileGitOpsPullRequest_PreFingerprintBackfillDuringCooldown(t *test
 		"missing fingerprint with a prior PR URL should adopt, not wait out cooldown")
 	assert.Empty(t, fakeForge.calls)
 	require.NotEmpty(t, policy.Annotations[annotationGitOpsPRDrift])
+	stored := &attunev1alpha1.AttunePolicy{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(policy), stored))
+	require.Equal(t, policy.Annotations[annotationGitOpsPRDrift], stored.Annotations[annotationGitOpsPRDrift])
 
 	now = start.Add(24 * time.Hour)
 	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -539,6 +539,7 @@ func TestReconcileGitOpsPullRequest_UnchangedDriftSkipsAfterCooldown(t *testing.
 
 	// Cooldown expired; same recommendation vs same template must not open again.
 	now = start.Add(25 * time.Hour)
+	gitOpsReload(t, c, policy)
 	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
 	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
 	assert.Equal(t, firstFP, policy.Annotations[annotationGitOpsPRDrift])
@@ -626,8 +627,10 @@ func TestReconcileGitOpsPullRequest_LivePathDoesNotRecreateAfterMerge(t *testing
 	require.Equal(t, 0, fakeForge.createsAfter)
 
 	// User merged the empty PR; GitHub deleted the head branch.
+	// Next reconcile loads the policy from the API, not this pointer.
 	fakeForge.SimulateMerge()
 	now = start.Add(25 * time.Hour)
+	gitOpsReload(t, c, policy)
 	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
 	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
 	assert.Equal(t, 0, fakeForge.createsAfter, "same drift after merge must not CreateOrUpdate")
@@ -808,6 +811,50 @@ func TestReconcileGitOpsPullRequest_FailedAttemptWithoutURLStillRetries(t *testi
 	assert.Equal(t, 1, fakeForge.createsBefore, "failed prior attempt with no URL must retry")
 }
 
+func gitOpsEnabledPolicy(name, ns string, dry bool, anns map[string]string) *attunev1alpha1.AttunePolicy {
+	en := true
+	d := dry
+	return &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Annotations: anns},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Export: &attunev1alpha1.ExportConfig{
+					PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+						Enabled:    &en,
+						DryRun:     &d,
+						Repository: "org/repo",
+						TokenSecretRef: &attunev1alpha1.SecretKeyRef{
+							Name: "tok", Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func gitOpsReload(t *testing.T, c client.Client, policy *attunev1alpha1.AttunePolicy) {
+	t.Helper()
+	fresh := &attunev1alpha1.AttunePolicy{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(policy), fresh))
+	*policy = *fresh
+}
+
+func gitOpsLiveReconciler(t *testing.T, policy *attunev1alpha1.AttunePolicy, objs ...client.Object) (*AttunePolicyReconciler, client.Client, *recordingPRClient) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	all := append([]client.Object{policy}, objs...)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(all...).Build()
+	forge := &recordingPRClient{}
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	r.gitopsPRClient = forge
+	return r, c, forge
+}
+
 func gitOpsDriftDeployment(name, ns, cpu string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
@@ -829,15 +876,49 @@ func gitOpsDriftDeployment(name, ns, cpu string) *appsv1.Deployment {
 }
 
 func gitOpsCPURec(workload, cpu string) []attunev1alpha1.WorkloadRecommendation {
-	return []attunev1alpha1.WorkloadRecommendation{{
+	return []attunev1alpha1.WorkloadRecommendation{gitOpsCPUWorkloadRec(workload, cpu)}
+}
+
+func gitOpsCPUWorkloadRec(workload, cpu string) attunev1alpha1.WorkloadRecommendation {
+	return gitOpsWorkloadRec(workload, cpu, "")
+}
+
+func gitOpsWorkloadRec(workload, cpu, mem string) attunev1alpha1.WorkloadRecommendation {
+	rec := attunev1alpha1.ResourceValues{}
+	if cpu != "" {
+		rec.CPURequest = resource.MustParse(cpu)
+	}
+	if mem != "" {
+		rec.MemoryRequest = resource.MustParse(mem)
+	}
+	return attunev1alpha1.WorkloadRecommendation{
 		Workload: workload, Kind: "Deployment",
 		Containers: []attunev1alpha1.ContainerRecommendation{{
-			Name: "app",
-			Recommended: attunev1alpha1.ResourceValues{
-				CPURequest: resource.MustParse(cpu),
-			},
+			Name: "app", Recommended: rec,
 		}},
-	}}
+	}
+}
+
+func gitOpsDeploymentResources(name, ns, cpu, mem string) *appsv1.Deployment {
+	req := corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse(cpu),
+	}
+	if mem != "" {
+		req[corev1.ResourceMemory] = resource.MustParse(mem)
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:      "app",
+						Resources: corev1.ResourceRequirements{Requests: req},
+					}},
+				},
+			},
+		},
+	}
 }
 
 func TestReconcileGitOpsPullRequest_IncompleteConfig(t *testing.T) {

--- a/internal/controller/gitops_pr_userstate_test.go
+++ b/internal/controller/gitops_pr_userstate_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2026.
+*/
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+)
+
+func TestReconcileGitOpsPullRequest_DryRunThenLiveOpensPR(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	policy := gitOpsEnabledPolicy("authentik", "ns-dry-live", true, nil)
+	dep := gitOpsDriftDeployment("api", "ns-dry-live", "1")
+	r, c, forge := gitOpsLiveReconciler(t, policy, dep)
+	r.SetNowFunc(func() time.Time { return start })
+	recs := gitOpsCPURec("api", "100m")
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	require.Equal(t, attunev1alpha1.ReasonGitOpsPRDryRun, gitOpsPRReason(policy))
+	assert.Empty(t, forge.calls, "dry-run must not call the forge")
+
+	gitOpsReload(t, c, policy)
+	*policy.Spec.UpdateStrategy.Export.PullRequest.DryRun = false
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy),
+		"first live cycle after dry-run must open a PR for the same table")
+	assert.Equal(t, 1, forge.createsBefore)
+}
+
+func TestReconcileGitOpsPullRequest_PersistRetriesFirstPatchFail(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	var patches atomic.Int32
+	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	policy := gitOpsEnabledPolicy("persist-retry", "ns-persist", false, nil)
+	dep := gitOpsDriftDeployment("api", "ns-persist", "1")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cw client.WithWatch, obj client.Object, p client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*attunev1alpha1.AttunePolicy); ok && patches.Add(1) == 1 {
+					return fmt.Errorf("simulated conflict")
+				}
+				return cw.Patch(ctx, obj, p, opts...)
+			},
+		}).Build()
+	forge := &recordingPRClient{}
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	r.gitopsPRClient = forge
+	r.SetNowFunc(func() time.Time { return start })
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "100m"))
+	require.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy))
+	require.Equal(t, 1, forge.createsBefore)
+
+	gitOpsReload(t, c, policy)
+	require.NotEmpty(t, policy.Annotations[annotationGitOpsPRDrift],
+		"first Patch conflict must be retried so the fingerprint lands")
+	require.NotEmpty(t, policy.Annotations[annotationGitOpsPRURL])
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "100m"))
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
+	assert.Equal(t, 1, len(forge.calls))
+}
+
+func TestReconcileGitOpsPullRequest_AdoptThenRecsChangeOpens(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	policy := gitOpsEnabledPolicy("authentik", "ns-adopt-chg", false, map[string]string{
+		annotationGitOpsPRLastAttempt: start.Add(-25 * time.Hour).Format(time.RFC3339),
+		annotationGitOpsPRURL:         "https://github.com/org/repo/pull/41",
+	})
+	dep := gitOpsDriftDeployment("api", "ns-adopt-chg", "1")
+	r, c, forge := gitOpsLiveReconciler(t, policy, dep)
+	r.SetNowFunc(func() time.Time { return start })
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "100m"))
+	require.Equal(t, attunev1alpha1.ReasonGitOpsPRUnchanged, gitOpsPRReason(policy))
+	assert.Empty(t, forge.calls)
+
+	gitOpsReload(t, c, policy)
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "200m"))
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy))
+	assert.Equal(t, 1, forge.createsBefore)
+}
+
+func TestReconcileGitOpsPullRequest_OpenPRRecsChangeDuringCooldown(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	now := start
+	policy := gitOpsEnabledPolicy("authentik", "ns-cool-upd", false, nil)
+	dep := gitOpsDriftDeployment("api", "ns-cool-upd", "1")
+	r, _, forge := gitOpsLiveReconciler(t, policy, dep)
+	r.SetNowFunc(func() time.Time { return now })
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "100m"))
+	require.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy))
+	require.Equal(t, 1, forge.createsBefore)
+
+	now = start.Add(time.Hour)
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "200m"))
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRCooldown, gitOpsPRReason(policy))
+	assert.Equal(t, 1, len(forge.calls), "open PR body stays stale during cooldown")
+}
+
+func TestReconcileGitOpsPullRequest_OpenPRRecsChangeAfterCooldownUpdates(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	now := start
+	policy := gitOpsEnabledPolicy("authentik", "ns-upd", false, nil)
+	dep := gitOpsDriftDeployment("api", "ns-upd", "1")
+	r, c, forge := gitOpsLiveReconciler(t, policy, dep)
+	r.SetNowFunc(func() time.Time { return now })
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "100m"))
+	require.Equal(t, 1, forge.createsBefore)
+
+	now = start.Add(25 * time.Hour)
+	gitOpsReload(t, c, policy)
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "200m"))
+	require.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy))
+	require.Len(t, forge.calls, 2)
+	assert.Equal(t, 2, forge.createsBefore, "head still exists: CreateOrUpdate updates the open PR")
+	assert.Equal(t, 0, forge.createsAfter)
+}
+
+func TestReconcileGitOpsPullRequest_TemplatesPatchedNoDrift(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	now := start
+	policy := gitOpsEnabledPolicy("authentik", "ns-applied", false, nil)
+	dep := gitOpsDriftDeployment("api", "ns-applied", "1")
+	r, c, forge := gitOpsLiveReconciler(t, policy, dep)
+	r.SetNowFunc(func() time.Time { return now })
+	recs := gitOpsCPURec("api", "100m")
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	require.Equal(t, 1, forge.createsBefore)
+
+	now = start.Add(25 * time.Hour)
+	gitOpsReload(t, c, policy)
+	applied := gitOpsDriftDeployment("api", "ns-applied", "100m")
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{applied}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRNoDrift, gitOpsPRReason(policy))
+	assert.Equal(t, 1, len(forge.calls))
+}
+
+func TestReconcileGitOpsPullRequest_TwoWorkloadsOneApplied(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	now := start
+	policy := gitOpsEnabledPolicy("authentik", "ns-two", false, nil)
+	server := gitOpsDriftDeployment("server", "ns-two", "1")
+	worker := gitOpsDriftDeployment("worker", "ns-two", "1")
+	r, c, forge := gitOpsLiveReconciler(t, policy, server, worker)
+	r.SetNowFunc(func() time.Time { return now })
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		gitOpsCPUWorkloadRec("server", "100m"),
+		gitOpsCPUWorkloadRec("worker", "100m"),
+	}
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{server, worker}, recs)
+	require.Equal(t, 1, forge.createsBefore)
+
+	now = start.Add(25 * time.Hour)
+	gitOpsReload(t, c, policy)
+	serverApplied := gitOpsDriftDeployment("server", "ns-two", "100m")
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{serverApplied, worker}, recs)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy),
+		"one remaining drifted workload is a new table")
+	assert.Equal(t, 2, len(forge.calls))
+}
+
+func TestReconcileGitOpsPullRequest_OneRowDropsBelowMinChange(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	now := start
+	policy := gitOpsEnabledPolicy("authentik", "ns-row", false, nil)
+	dep := gitOpsDeploymentResources("api", "ns-row", "1", "1Gi")
+	r, c, forge := gitOpsLiveReconciler(t, policy, dep)
+	r.SetNowFunc(func() time.Time { return now })
+	recs := []attunev1alpha1.WorkloadRecommendation{gitOpsWorkloadRec("api", "100m", "512Mi")}
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, recs)
+	require.Equal(t, 1, forge.createsBefore)
+
+	now = start.Add(25 * time.Hour)
+	gitOpsReload(t, c, policy)
+	// Memory now matches template; only CPU remains above 10%.
+	cpuOnly := []attunev1alpha1.WorkloadRecommendation{gitOpsWorkloadRec("api", "100m", "1Gi")}
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, cpuOnly)
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPROpen, gitOpsPRReason(policy))
+	assert.Equal(t, 2, len(forge.calls))
+}

--- a/internal/gitops/drift_test.go
+++ b/internal/gitops/drift_test.go
@@ -58,6 +58,44 @@ func TestComputeDrift_AboveThreshold(t *testing.T) {
 	assert.NotContains(t, body, "token")
 }
 
+func TestComputeDrift_LimitsOnlyMismatchIsNotDrift(t *testing.T) {
+	t.Parallel()
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("2"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api", Kind: "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("1Gi"),
+			},
+		}},
+	}}
+	assert.Empty(t, ComputeDrift([]client.Object{dep}, recs, 10),
+		"GitOps drift compares requests only; limits-only mismatch is not a PR")
+}
+
 func TestComputeDrift_BelowThreshold(t *testing.T) {
 	t.Parallel()
 	dep := &appsv1.Deployment{

--- a/test/e2e/gitops-pr-dry-run/chainsaw-test.yaml
+++ b/test/e2e/gitops-pr-dry-run/chainsaw-test.yaml
@@ -127,28 +127,26 @@ spec:
                   -o jsonpath='{range .status.conditions[?(@.type=="GitOpsPullRequest")]}{.message}{end}' 2>/dev/null || true)
                 status=$(kubectl -n "$NS" get attunepolicy "$POL" \
                   -o jsonpath='{range .status.conditions[?(@.type=="GitOpsPullRequest")]}{.status}{end}' 2>/dev/null || true)
-                ann=$(kubectl -n "$NS" get attunepolicy "$POL" \
-                  -o jsonpath='{.metadata.annotations.attune\.io/gitops-pr-last-attempt}' 2>/dev/null || true)
+                drift=$(kubectl -n "$NS" get attunepolicy "$POL" \
+                  -o jsonpath='{.metadata.annotations.attune\.io/gitops-pr-drift}' 2>/dev/null || true)
                 recs=$(kubectl -n "$NS" get attunepolicy "$POL" \
                   -o jsonpath='{.status.recommendations[*].workload}' 2>/dev/null || true)
-                # Dry-run sets PullRequestDryRun + last-attempt annotation. The next
-                # reconcile is PullRequestUnchanged (same drift table) or
-                # PullRequestCooldown. All prove the path ran without forge HTTP.
-                if [ -n "$ann" ]; then
-                  if [ "$reason" = "PullRequestDryRun" ] || [ "$reason" = "PullRequestCooldown" ] || [ "$reason" = "PullRequestUnchanged" ]; then
-                    echo "OK: GitOpsPullRequest reason=$reason status=$status (post dry-run)"
-                    echo "message=$msg"
-                    echo "annotation last-attempt=$ann"
-                    case "$msg" in
-                      *dry-run-not-used*|*Bearer*|*ghp_*)
-                        echo "FAIL: token material leaked into condition message"
-                        exit 1
-                        ;;
-                    esac
-                    exit 0
-                  fi
+                # Dry-run sets PullRequestDryRun and persists gitops-pr-drift
+                # only (no last-attempt, so the first live PR is not blocked).
+                # The next reconcile is PullRequestUnchanged (same table).
+                if [ "$reason" = "PullRequestDryRun" ] || [ "$reason" = "PullRequestUnchanged" ]; then
+                  echo "OK: GitOpsPullRequest reason=$reason status=$status (post dry-run)"
+                  echo "message=$msg"
+                  echo "annotation drift=$drift"
+                  case "$msg" in
+                    *dry-run-not-used*|*Bearer*|*ghp_*)
+                      echo "FAIL: token material leaked into condition message"
+                      exit 1
+                      ;;
+                  esac
+                  exit 0
                 fi
-                echo "waiting i=$i reason='$reason' status='$status' ann='$ann' recs='$recs'"
+                echo "waiting i=$i reason='$reason' status='$status' drift='$drift' recs='$recs'"
                 sleep 5
               done
               echo "FAIL: PullRequestDryRun not observed"


### PR DESCRIPTION
## Summary

Stop extra empty GitOps PRs after an upgrade from 0.1.22, and still open the first **live** PR after the documented dry-run enablement path.

## The problem

v0.1.24 (`#538`) skips when `attune.io/gitops-pr-drift` matches. That annotation is only written after a successful open or dry-run.

0.1.22 stored `attune.io/gitops-pr-last-attempt` and `attune.io/gitops-pr-url` only. After upgrade, cooldown skip did not backfill the fingerprint. When cooldown expired, 0.1.24 opened another empty bootstrap PR. That matches [issue comment 5406310688](https://github.com/attune-io/attune/issues/537#issuecomment-5406310688).

`#538` tests started from a 0.1.24 dry-run or live open (hash already set). They never started from Bobcat's object. The dry-run path also wrote the fingerprint (and last-attempt) with no PR URL, so turning `dryRun` off hit `PullRequestUnchanged` or cooldown and never opened GitHub.

## The change

- If a prior PR URL exists and the fingerprint is missing, record the live table and skip (failed attempts with no URL still retry).
- Matching fingerprint without a URL on a **live** cycle is the first open after dry-run, not a skip.
- Dry-run persists the fingerprint only (no last-attempt).
- Persist retries Get+Patch three times so one conflict does not drop the hash.

## Tests (user-state, not implementation snapshots)

- Upgrade: last-attempt + URL, no fingerprint, cooldown expired
- Backfill during cooldown
- Failed attempt without URL still retries
- Dry-run then live opens the first real PR
- Fresh `Get` after persist (next reconcile is not the dirty pointer)
- First persist Patch fails, retry lands, no second create
- Adopt, then recs change, opens
- Open PR, recs change during cooldown: no update
- Open PR, recs change after cooldown: update, not a second create
- Templates patched: `NoDrift`
- Two workloads, one applied: new table, another PR
- One row drops under `minChangePercent`: new table
- Limits-only mismatch is not drift

Not covered: Flux/Argo replacing every operator annotation (needs status storage).

## Test plan

- [x] Red then green on the 0.1.22 upgrade case
- [x] `go test ./internal/controller/ ./internal/gitops/ -count=1`
- [x] golangci-lint on those packages

Closes #537
