### PR TITLE
fix: grant status patch rbac and add csv output

### DIFF
--- a/charts/attune/templates/clusterrole.yaml
+++ b/charts/attune/templates/clusterrole.yaml
@@ -21,6 +21,7 @@ rules:
       - attunepolicies/status
     verbs:
       - get
+      - patch
       - update
   # Finalizers: allow the controller to manage the cleanup finalizer
   - apiGroups:

--- a/charts/attune/tests/rbac_test.yaml
+++ b/charts/attune/tests/rbac_test.yaml
@@ -7,6 +7,20 @@ tests:
       - isKind:
           of: ClusterRole
 
+  - it: should include attunepolicies status patch for gitopsPR
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - attune.io
+            resources:
+              - attunepolicies/status
+            verbs:
+              - get
+              - patch
+              - update
+
   - it: should include attunepolicies permissions
     asserts:
       - contains:

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -47,7 +48,7 @@ import (
 var version = "dev"
 
 const (
-	structuredOutputUsage = "Output raw AttunePolicy objects as json or yaml (status and diff)"
+	structuredOutputUsage = "Output format: json|yaml (status), yaml (diff), csv (savings and recommendations)"
 	sourcePolicy          = "policy"
 	sourceNamespace       = "namespace default"
 	sourceCluster         = "cluster default"
@@ -129,6 +130,7 @@ func run(args []string, buildClient dynamicClientFactory) int {
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Structured output note:")
 		fmt.Fprintln(os.Stderr, "  -o json|yaml is supported with status. -o yaml is supported with diff.")
+		fmt.Fprintln(os.Stderr, "  -o csv is supported with savings and recommendations.")
 		fmt.Fprintln(os.Stderr, "  For raw AttunePolicy objects with other commands, use kubectl get attunepolicy -o json|yaml.")
 	}
 
@@ -223,9 +225,17 @@ func run(args []string, buildClient dynamicClientFactory) int {
 		case "status":
 			printStatusItems(items, *sortBy, *filter)
 		case "savings":
-			printSavingsItems(items, *sortBy)
+			if *output == "csv" {
+				printSavingsCSV(items, *sortBy)
+			} else {
+				printSavingsItems(items, *sortBy)
+			}
 		case "recommendations":
-			printRecommendationsItems(items)
+			if *output == "csv" {
+				printRecommendationsCSV(items)
+			} else {
+				printRecommendationsItems(items)
+			}
 		case "history":
 			printHistoryItems(items)
 		case "diff":
@@ -262,9 +272,17 @@ func run(args []string, buildClient dynamicClientFactory) int {
 			printStatus(ctx, dynClient, *namespace, *sortBy, *filter)
 		}
 	case "savings":
-		printSavings(ctx, dynClient, *namespace, *sortBy)
+		if *output == "csv" {
+			printSavingsCSV(fetchPolicies(ctx, dynClient, *namespace).Items, *sortBy)
+		} else {
+			printSavings(ctx, dynClient, *namespace, *sortBy)
+		}
 	case "recommendations":
-		printRecommendations(ctx, dynClient, *namespace)
+		if *output == "csv" {
+			printRecommendationsCSV(fetchPolicies(ctx, dynClient, *namespace).Items)
+		} else {
+			printRecommendations(ctx, dynClient, *namespace)
+		}
 	case "export":
 		return runExportList(ctx, dynClient, *namespace, *allNamespaces, parsedArgs)
 	case "explain":
@@ -355,6 +373,12 @@ func structuredOutputCommandError(cmd, output string) error {
 			return nil
 		}
 		return fmt.Errorf("-o %s is not supported with diff; use -o yaml for patch manifests", output)
+	}
+	if output == "csv" {
+		if cmd == "savings" || cmd == "recommendations" {
+			return nil
+		}
+		return fmt.Errorf("-o csv is supported only with savings and recommendations")
 	}
 	if output != "json" && output != "yaml" {
 		return fmt.Errorf("unsupported output format %q, use json or yaml", output)
@@ -582,6 +606,35 @@ func printSavingsItems(items []unstructured.Unstructured, sortByFlag string) {
 	}
 }
 
+func writeCSV(rows [][]string) {
+	w := csv.NewWriter(os.Stdout)
+	if err := w.WriteAll(rows); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing csv: %v\n", err)
+	}
+}
+
+func printSavingsCSV(items []unstructured.Unstructured, sortByFlag string) {
+	sortPolicies(items, sortByFlag)
+	showCluster := hasClusterAnnotation(items)
+	header := []string{"namespace", "name", "cpu_saved", "memory_saved", "pct_saved", "est_monthly"}
+	if showCluster {
+		header = append([]string{"cluster"}, header...)
+	}
+	rows := [][]string{header}
+	for _, item := range items {
+		cpuSaved := getNestedString(item, "status", "savings", "cpuRequestReduction")
+		cpuTotal := getNestedString(item, "status", "savings", "cpuRequestTotal")
+		memSaved := formatMemory(getNestedString(item, "status", "savings", "memoryRequestReduction"))
+		estMonthly := getNestedString(item, "status", "savings", "estimatedMonthlySavings")
+		row := []string{item.GetNamespace(), item.GetName(), cpuSaved, memSaved, savingsPercent(cpuSaved, cpuTotal), estMonthly}
+		if showCluster {
+			row = append([]string{itemCluster(item)}, row...)
+		}
+		rows = append(rows, row)
+	}
+	writeCSV(rows)
+}
+
 func getNestedString(obj unstructured.Unstructured, fields ...string) string {
 	val, found, err := unstructured.NestedString(obj.Object, fields...)
 	if err != nil || !found {
@@ -729,6 +782,57 @@ func printRecommendationsItems(items []unstructured.Unstructured) {
 		fmt.Fprintln(os.Stderr, "\nOne or more policies use export mode (ConfigMap). Recommendations are also written to <policy>-<workload>-recommendations ConfigMaps for GitOps.")
 		fmt.Fprintln(os.Stderr, "Run 'kubectl attune export list' to inspect the exported values with last-updated timestamps. In Recommend+export, no direct resizes occur.")
 	}
+}
+
+func printRecommendationsCSV(items []unstructured.Unstructured) {
+	showCluster := hasClusterAnnotation(items)
+	header := []string{"namespace", "policy", "workload", "container", "cpu_req", "cpu_rec", "mem_req", "mem_rec", "confidence"}
+	if showCluster {
+		header = append([]string{"cluster"}, header...)
+	}
+	rows := [][]string{header}
+	for _, item := range items {
+		recs, found, _ := unstructured.NestedSlice(item.Object, "status", "recommendations")
+		if !found || len(recs) == 0 {
+			row := []string{item.GetNamespace(), item.GetName(), "", "", "", "", "", "", policyReadyReason(item)}
+			if showCluster {
+				row = append([]string{itemCluster(item)}, row...)
+			}
+			rows = append(rows, row)
+			continue
+		}
+		for _, r := range recs {
+			rec, ok := r.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			workload, _ := rec["workload"].(string)
+			containers, _ := rec["containers"].([]interface{})
+			for _, c := range containers {
+				cont, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				name, _ := cont["name"].(string)
+				confidence, _ := cont["confidence"].(float64)
+				current, _ := cont["current"].(map[string]interface{})
+				recommended, _ := cont["recommended"].(map[string]interface{})
+				curCPU, _ := current["cpuRequest"].(string)
+				recCPU, _ := recommended["cpuRequest"].(string)
+				curMem, _ := current["memoryRequest"].(string)
+				recMem, _ := recommended["memoryRequest"].(string)
+				row := []string{
+					item.GetNamespace(), item.GetName(), workload, name,
+					curCPU, recCPU, curMem, recMem, fmt.Sprintf("%.1f%%", confidence*100),
+				}
+				if showCluster {
+					row = append([]string{itemCluster(item)}, row...)
+				}
+				rows = append(rows, row)
+			}
+		}
+	}
+	writeCSV(rows)
 }
 
 // runExportList handles the "export" top-level command and its subcommands (currently only "list").

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -620,7 +620,8 @@ func printSavingsCSV(items []unstructured.Unstructured, sortByFlag string) {
 	if showCluster {
 		header = append([]string{"cluster"}, header...)
 	}
-	rows := [][]string{header}
+	rows := make([][]string, 0, 1+len(items))
+	rows = append(rows, header)
 	for _, item := range items {
 		cpuSaved := getNestedString(item, "status", "savings", "cpuRequestReduction")
 		cpuTotal := getNestedString(item, "status", "savings", "cpuRequestTotal")
@@ -790,7 +791,8 @@ func printRecommendationsCSV(items []unstructured.Unstructured) {
 	if showCluster {
 		header = append([]string{"cluster"}, header...)
 	}
-	rows := [][]string{header}
+	rows := make([][]string, 0, 1+len(items))
+	rows = append(rows, header)
 	for _, item := range items {
 		recs, found, _ := unstructured.NestedSlice(item.Object, "status", "recommendations")
 		if !found || len(recs) == 0 {

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -1640,6 +1640,22 @@ func TestStructuredOutputCommandError(t *testing.T) {
 			wantErr: "supported only with the status command",
 		},
 		{
+			name:   "savings supports csv",
+			cmd:    "savings",
+			output: "csv",
+		},
+		{
+			name:   "recommendations supports csv",
+			cmd:    "recommendations",
+			output: "csv",
+		},
+		{
+			name:    "reject status csv",
+			cmd:     "status",
+			output:  "csv",
+			wantErr: "csv is supported only with savings and recommendations",
+		},
+		{
 			name:    "reject explain yaml",
 			cmd:     "explain",
 			output:  "yaml",
@@ -2310,6 +2326,71 @@ func TestPrintEffectivePolicySummary_PodAggregationDefault(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "Pod aggregation")
 	assert.Contains(t, string(out), attunev1alpha1.DefaultPodAggregation)
+}
+
+func TestPrintSavingsCSV_HeaderAndRow(t *testing.T) {
+	items := []unstructured.Unstructured{
+		{Object: map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "api", "namespace": "prod"},
+			"status": map[string]interface{}{
+				"savings": map[string]interface{}{
+					"cpuRequestReduction":     "350m",
+					"cpuRequestTotal":         "1",
+					"memoryRequestReduction":  "134217728",
+					"estimatedMonthlySavings": "$12.78",
+				},
+			},
+		}},
+	}
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	printSavingsCSV(items, "")
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "namespace,name,cpu_saved,memory_saved,pct_saved,est_monthly")
+	assert.Contains(t, s, "prod,api,350m")
+	assert.Contains(t, s, "$12.78")
+	assert.NotContains(t, s, "TOTAL")
+}
+
+func TestPrintRecommendationsCSV_HeaderAndRow(t *testing.T) {
+	items := []unstructured.Unstructured{
+		{Object: map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "p", "namespace": "ns"},
+			"status": map[string]interface{}{
+				"recommendations": []interface{}{
+					map[string]interface{}{
+						"workload": "api",
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":        "app",
+								"current":     map[string]interface{}{"cpuRequest": "500m", "memoryRequest": "256Mi"},
+								"recommended": map[string]interface{}{"cpuRequest": "250m", "memoryRequest": "128Mi"},
+								"confidence":  0.95,
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	printRecommendationsCSV(items)
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "namespace,policy,workload,container,cpu_req,cpu_rec,mem_req,mem_rec,confidence")
+	assert.Contains(t, s, "ns,p,api,app,500m,250m,256Mi,128Mi,95.0%")
 }
 
 func TestPrintEffectivePolicySummary_GitOpsPR(t *testing.T) {

--- a/config/olm/template/manifests/attune.clusterserviceversion.yaml
+++ b/config/olm/template/manifests/attune.clusterserviceversion.yaml
@@ -257,6 +257,7 @@ spec:
                 - attunepolicies/status
               verbs:
                 - get
+                - patch
                 - update
             - apiGroups:
                 - autoscaling

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -106,6 +106,7 @@ rules:
   - attunepolicies/status
   verbs:
   - get
+  - patch
   - update
 - apiGroups:
   - autoscaling

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3675,6 +3675,7 @@ rules:
   - attunepolicies/status
   verbs:
   - get
+  - patch
   - update
 - apiGroups:
   - autoscaling

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -230,13 +230,18 @@ kubectl attune version
 
 ## Structured output
 
-`--output` / `-o` is supported with the `status` command (JSON or YAML) and the
-`diff` command (YAML only). It prints the raw `AttunePolicy` objects returned by
-the cluster.
+`--output` / `-o` is supported with:
+
+- `status`: JSON or YAML of raw `AttunePolicy` objects
+- `diff`: YAML patch manifests
+- `savings` and `recommendations`: CSV (header plus one data row per
+  policy or container; no totals row)
 
 ```bash
 kubectl attune status -o json
 kubectl attune status -A -o yaml
+kubectl attune savings -A -o csv
+kubectl attune recommendations -n prod -o csv
 ```
 
 For other commands, use the human-oriented plugin output, or fetch raw objects

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -116,7 +116,7 @@ const (
 )
 
 //+kubebuilder:rbac:groups=attune.io,resources=attunepolicies,verbs=get;list;watch;patch
-//+kubebuilder:rbac:groups=attune.io,resources=attunepolicies/status,verbs=get;update
+//+kubebuilder:rbac:groups=attune.io,resources=attunepolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=attune.io,resources=attunepolicies/finalizers,verbs=update
 //+kubebuilder:rbac:groups=attune.io,resources=attunedefaults,verbs=get;list;watch
 //+kubebuilder:rbac:groups=attune.io,resources=attunenamespacedefaults,verbs=get;list;watch


### PR DESCRIPTION
## Summary

Two follow-ups after #580:

1. Grant `patch` on `attunepolicies/status`. `Status().Patch` of `status.gitopsPR` was forbidden, so persist failed in cluster (E2E operator logs after #580).
2. Add `-o csv` for `kubectl attune savings` and `kubectl attune recommendations`.

## Test plan

- [x] Helm unittest ClusterRole includes status patch
- [x] CSV unit tests
- [ ] E2E after RBAC (this PR)

Closes #578

