### PR TITLE
feat: add kubectl attune doctor preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ kubectl attune export -n production                 # GitOps ConfigMap exports +
 kubectl attune history -n production
 kubectl attune explain -n production api-services
 kubectl attune wizard                               # interactive policy scaffolding
+kubectl attune doctor                               # cluster version, pods/resize, Prometheus
 kubectl attune version
 
 # All namespaces

--- a/cmd/kubectl-attune/doctor.go
+++ b/cmd/kubectl-attune/doctor.go
@@ -170,7 +170,18 @@ func pingPrometheusHealthy(ctx context.Context, address string) error {
 	if err != nil {
 		return err
 	}
-	client := &http.Client{Timeout: prometheusPingTimeout}
+	client := &http.Client{
+		Timeout: prometheusPingTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("too many redirects")
+			}
+			if err := validation.PrometheusAddress(req.URL.String()); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -246,10 +257,12 @@ func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstru
 			name: "pods/resize", required: true, detail: err.Error(),
 		})
 	} else if !hasPodsResizeSubresource(lists) {
+		detail := "subresource not found; enable InPlacePodVerticalScaling (1.32 alpha) or use Kubernetes 1.33+"
+		if err != nil {
+			detail = err.Error() + "; " + detail
+		}
 		results = append(results, doctorResult{
-			name:     "pods/resize",
-			required: true,
-			detail:   "subresource not found; enable InPlacePodVerticalScaling (1.32 alpha) or use Kubernetes 1.33+",
+			name: "pods/resize", required: true, detail: detail,
 		})
 	} else {
 		results = append(results, doctorResult{
@@ -314,8 +327,7 @@ func printDoctorResults(w io.Writer, results []doctorResult) {
 func runDoctor(ctx context.Context, stdout, stderr io.Writer, disc doctorDiscovery, dynClient dynamic.Interface, namespace string, ping prometheusPinger) int {
 	objects, err := listDoctorObjects(ctx, dynClient, namespace)
 	if err != nil {
-		fmt.Fprintf(stderr, "Error: %v\n", err)
-		return 1
+		fmt.Fprintf(stderr, "Warning: %v\n", err)
 	}
 	results := runDoctorChecks(ctx, disc, objects, ping)
 	printDoctorResults(stdout, results)

--- a/cmd/kubectl-attune/doctor.go
+++ b/cmd/kubectl-attune/doctor.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/attune-io/attune/internal/validation"
+)
+
+const (
+	minKubernetesMajor     = 1
+	minKubernetesMinor     = 32
+	prometheusHealthyPath  = "/-/healthy"
+	prometheusPingTimeout  = 3 * time.Second
+	podsResizeResourceName = "pods/resize"
+)
+
+// doctorDiscovery is the discovery subset used by kubectl attune doctor.
+type doctorDiscovery interface {
+	ServerVersion() (*k8sversion.Info, error)
+	ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error)
+}
+
+type prometheusPinger func(ctx context.Context, address string) error
+
+// buildDoctorDiscovery loads a typed clientset Discovery from kubeconfig.
+// Tests replace this to inject a fake discovery client.
+var buildDoctorDiscovery = defaultBuildDoctorDiscovery
+
+func defaultBuildDoctorDiscovery(kubeconfigPath, contextOverride string) (doctorDiscovery, error) {
+	cfg, err := loadRESTConfig(kubeconfigPath, contextOverride)
+	if err != nil {
+		return nil, err
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cs.Discovery(), nil
+}
+
+func loadRESTConfig(kubeconfigPath, contextOverride string) (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfigPath != "" {
+		loadingRules.ExplicitPath = kubeconfigPath
+	}
+	overrides := &clientcmd.ConfigOverrides{}
+	if contextOverride != "" {
+		overrides.CurrentContext = contextOverride
+	}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+	return kubeConfig.ClientConfig()
+}
+
+func parseVersionPart(s string) (int, error) {
+	n := 0
+	found := false
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			found = true
+			n = n*10 + int(r-'0')
+			continue
+		}
+		if found {
+			break
+		}
+	}
+	if !found {
+		return 0, fmt.Errorf("not a number: %q", s)
+	}
+	return n, nil
+}
+
+// classifyKubernetesVersion reports whether the cluster is Attune's minimum
+// (Kubernetes 1.32+). Minor may look like "32", "32+", or "32.4".
+func classifyKubernetesVersion(info *k8sversion.Info) error {
+	if info == nil {
+		return fmt.Errorf("server version is empty")
+	}
+	major, err := parseVersionPart(info.Major)
+	if err != nil {
+		return fmt.Errorf("parse major %q: %w", info.Major, err)
+	}
+	minor, err := parseVersionPart(info.Minor)
+	if err != nil {
+		return fmt.Errorf("parse minor %q: %w", info.Minor, err)
+	}
+	if major > minKubernetesMajor || (major == minKubernetesMajor && minor >= minKubernetesMinor) {
+		return nil
+	}
+	return fmt.Errorf("cluster version %d.%d is below Attune's minimum 1.32 (in-place pod resize)", major, minor)
+}
+
+// hasPodsResizeSubresource reports whether discovery lists pods/resize.
+func hasPodsResizeSubresource(lists []*metav1.APIResourceList) bool {
+	for _, list := range lists {
+		if list == nil {
+			continue
+		}
+		if list.GroupVersion != "v1" {
+			continue
+		}
+		for _, res := range list.APIResources {
+			if res.Name == podsResizeResourceName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func collectPrometheusAddresses(objects ...unstructured.Unstructured) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, obj := range objects {
+		addr := strings.TrimSpace(getNestedString(obj, "spec", "metricsSource", "prometheus", "address"))
+		if addr == "" {
+			continue
+		}
+		if _, ok := seen[addr]; ok {
+			continue
+		}
+		seen[addr] = struct{}{}
+		out = append(out, addr)
+	}
+	return out
+}
+
+func pingPrometheusHealthy(ctx context.Context, address string) error {
+	if err := validation.PrometheusAddress(address); err != nil {
+		return err
+	}
+	u, err := url.Parse(address)
+	if err != nil {
+		return err
+	}
+	u.Path = strings.TrimSuffix(u.Path, "/") + prometheusHealthyPath
+	u.RawQuery = ""
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: prometheusPingTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: HTTP %d", u.Redacted(), resp.StatusCode)
+	}
+	return nil
+}
+
+func listDoctorObjects(ctx context.Context, dynClient dynamic.Interface, namespace string) ([]unstructured.Unstructured, error) {
+	var out []unstructured.Unstructured
+	policies, err := dynClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
+		return nil, fmt.Errorf("list AttunePolicies: %w", err)
+	}
+	if policies != nil {
+		out = append(out, policies.Items...)
+	}
+	defaults, err := dynClient.Resource(defaultsGVR).List(ctx, metav1.ListOptions{})
+	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
+		return nil, fmt.Errorf("list AttuneDefaults: %w", err)
+	}
+	if defaults != nil {
+		out = append(out, defaults.Items...)
+	}
+	nsDefaults, err := dynClient.Resource(namespaceDefaultsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
+		return nil, fmt.Errorf("list AttuneNamespaceDefaults: %w", err)
+	}
+	if nsDefaults != nil {
+		out = append(out, nsDefaults.Items...)
+	}
+	return out, nil
+}
+
+type doctorResult struct {
+	name     string
+	required bool
+	ok       bool
+	detail   string
+}
+
+func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstructured.Unstructured, ping prometheusPinger) []doctorResult {
+	if ping == nil {
+		ping = pingPrometheusHealthy
+	}
+	results := make([]doctorResult, 0, 3)
+
+	ver, err := disc.ServerVersion()
+	if err != nil {
+		results = append(results, doctorResult{
+			name: "Kubernetes version", required: true, detail: err.Error(),
+		})
+	} else if err := classifyKubernetesVersion(ver); err != nil {
+		results = append(results, doctorResult{
+			name: "Kubernetes version", required: true, detail: err.Error(),
+		})
+	} else {
+		git := ver.GitVersion
+		if git == "" {
+			git = ver.Major + "." + ver.Minor
+		}
+		results = append(results, doctorResult{
+			name: "Kubernetes version", required: true, ok: true, detail: git,
+		})
+	}
+
+	_, lists, err := disc.ServerGroupsAndResources()
+	if err != nil && len(lists) == 0 {
+		results = append(results, doctorResult{
+			name: "pods/resize", required: true, detail: err.Error(),
+		})
+	} else if !hasPodsResizeSubresource(lists) {
+		results = append(results, doctorResult{
+			name:     "pods/resize",
+			required: true,
+			detail:   "subresource not found; enable InPlacePodVerticalScaling (1.32 alpha) or use Kubernetes 1.33+",
+		})
+	} else {
+		results = append(results, doctorResult{
+			name: "pods/resize", required: true, ok: true, detail: "discovered",
+		})
+	}
+
+	addrs := collectPrometheusAddresses(objects...)
+	if len(addrs) == 0 {
+		results = append(results, doctorResult{
+			name: "Prometheus", required: false, ok: true,
+			detail: "skipped (no address on policies or defaults)",
+		})
+		return results
+	}
+	var failed []string
+	for _, addr := range addrs {
+		if err := validation.PrometheusAddress(addr); err != nil {
+			failed = append(failed, addr+": "+err.Error())
+			continue
+		}
+		if err := ping(ctx, addr); err != nil {
+			failed = append(failed, addr+": "+err.Error())
+		}
+	}
+	if len(failed) > 0 {
+		results = append(results, doctorResult{
+			name: "Prometheus", required: false, detail: strings.Join(failed, "; "),
+		})
+		return results
+	}
+	results = append(results, doctorResult{
+		name: "Prometheus", required: false, ok: true,
+		detail: strings.Join(addrs, ", ") + " " + prometheusHealthyPath,
+	})
+	return results
+}
+
+func doctorFailed(results []doctorResult) bool {
+	for _, r := range results {
+		if r.required && !r.ok {
+			return true
+		}
+	}
+	return false
+}
+
+func printDoctorResults(w io.Writer, results []doctorResult) {
+	for _, r := range results {
+		status := "FAIL"
+		if r.ok {
+			status = "ok"
+		}
+		kind := "required"
+		if !r.required {
+			kind = "optional"
+		}
+		fmt.Fprintf(w, "%-22s %-4s [%s] %s\n", r.name, status, kind, r.detail)
+	}
+}
+
+func runDoctor(ctx context.Context, stdout, stderr io.Writer, disc doctorDiscovery, dynClient dynamic.Interface, namespace string, ping prometheusPinger) int {
+	objects, err := listDoctorObjects(ctx, dynClient, namespace)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 1
+	}
+	results := runDoctorChecks(ctx, disc, objects, ping)
+	printDoctorResults(stdout, results)
+	if doctorFailed(results) {
+		fmt.Fprintln(stderr, "doctor: one or more checks failed")
+		return 1
+	}
+	return 0
+}

--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sversion "k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestClassifyKubernetesVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		info    *k8sversion.Info
+		wantErr string
+	}{
+		{name: "nil", wantErr: "empty"},
+		{name: "1.31", info: &k8sversion.Info{Major: "1", Minor: "31"}, wantErr: "below Attune's minimum 1.32"},
+		{name: "1.32", info: &k8sversion.Info{Major: "1", Minor: "32"}},
+		{name: "1.32 plus suffix", info: &k8sversion.Info{Major: "1", Minor: "32+"}},
+		{name: "1.32.4 patch in minor", info: &k8sversion.Info{Major: "1", Minor: "32.4"}},
+		{name: "1.35", info: &k8sversion.Info{Major: "1", Minor: "35"}},
+		{name: "2.0", info: &k8sversion.Info{Major: "2", Minor: "0"}},
+		{name: "bad major", info: &k8sversion.Info{Major: "x", Minor: "32"}, wantErr: "parse major"},
+		{name: "bad minor", info: &k8sversion.Info{Major: "1", Minor: "x"}, wantErr: "parse minor"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := classifyKubernetesVersion(tt.info)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestHasPodsResizeSubresource(t *testing.T) {
+	t.Parallel()
+	assert.False(t, hasPodsResizeSubresource(nil))
+	assert.False(t, hasPodsResizeSubresource([]*metav1.APIResourceList{
+		{GroupVersion: "v1", APIResources: []metav1.APIResource{{Name: "pods"}}},
+	}))
+	assert.True(t, hasPodsResizeSubresource([]*metav1.APIResourceList{
+		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "pods/resize"}}},
+		{GroupVersion: "v1", APIResources: []metav1.APIResource{{Name: "pods/resize", Namespaced: true}}},
+	}))
+	assert.False(t, hasPodsResizeSubresource([]*metav1.APIResourceList{
+		{GroupVersion: "apps/v1", APIResources: []metav1.APIResource{{Name: "pods/resize"}}},
+	}))
+}
+
+func TestCollectPrometheusAddresses(t *testing.T) {
+	t.Parallel()
+	policy := unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"metricsSource": map[string]interface{}{
+				"prometheus": map[string]interface{}{"address": "http://prom.ns.svc:9090"},
+			},
+		},
+	}}
+	defaults := unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"metricsSource": map[string]interface{}{
+				"prometheus": map[string]interface{}{"address": "http://prom.ns.svc:9090"},
+			},
+		},
+	}}
+	other := unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"metricsSource": map[string]interface{}{
+				"prometheus": map[string]interface{}{"address": "https://thanos.example:9090"},
+			},
+		},
+	}}
+	got := collectPrometheusAddresses(policy, defaults, other, unstructured.Unstructured{})
+	assert.Equal(t, []string{"http://prom.ns.svc:9090", "https://thanos.example:9090"}, got)
+}
+
+func resizeDiscovery(major, minor string, withResize bool) *fakediscovery.FakeDiscovery {
+	fd := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+	fd.FakedServerVersion = &k8sversion.Info{Major: major, Minor: minor, GitVersion: "v" + major + "." + minor + ".0"}
+	core := metav1.APIResourceList{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{{Name: "pods", Kind: "Pod", Namespaced: true}},
+	}
+	if withResize {
+		core.APIResources = append(core.APIResources, metav1.APIResource{
+			Name: podsResizeResourceName, Kind: "Pod", Namespaced: true,
+		})
+	}
+	fd.Resources = []*metav1.APIResourceList{&core}
+	return fd
+}
+
+func TestRunDoctorChecks_VersionAndDiscovery(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("pass 1.32 with resize", func(t *testing.T) {
+		t.Parallel()
+		results := runDoctorChecks(ctx, resizeDiscovery("1", "32", true), nil, nil)
+		require.Len(t, results, 3)
+		assert.True(t, results[0].ok, results[0].detail)
+		assert.True(t, results[1].ok, results[1].detail)
+		assert.True(t, results[2].ok)
+		assert.Contains(t, results[2].detail, "skipped")
+		assert.False(t, doctorFailed(results))
+	})
+
+	t.Run("fail 1.31", func(t *testing.T) {
+		t.Parallel()
+		results := runDoctorChecks(ctx, resizeDiscovery("1", "31", true), nil, nil)
+		require.False(t, results[0].ok)
+		assert.Contains(t, results[0].detail, "1.32")
+		assert.True(t, doctorFailed(results))
+	})
+
+	t.Run("fail missing resize", func(t *testing.T) {
+		t.Parallel()
+		results := runDoctorChecks(ctx, resizeDiscovery("1", "32", false), nil, nil)
+		require.False(t, results[1].ok)
+		assert.Contains(t, results[1].detail, "InPlacePodVerticalScaling")
+		assert.True(t, doctorFailed(results))
+	})
+}
+
+func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	disc := resizeDiscovery("1", "35", true)
+	obj := unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"metricsSource": map[string]interface{}{
+				"prometheus": map[string]interface{}{"address": "http://prom.monitoring.svc:9090"},
+			},
+		},
+	}}
+
+	t.Run("reachable", func(t *testing.T) {
+		t.Parallel()
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{obj}, func(context.Context, string) error {
+			return nil
+		})
+		require.True(t, results[2].ok, results[2].detail)
+		assert.Contains(t, results[2].detail, "http://prom.monitoring.svc:9090")
+		assert.False(t, doctorFailed(results))
+	})
+
+	t.Run("unreachable does not fail required exit", func(t *testing.T) {
+		t.Parallel()
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{obj}, func(context.Context, string) error {
+			return fmt.Errorf("connection refused")
+		})
+		require.False(t, results[2].ok)
+		assert.Contains(t, results[2].detail, "connection refused")
+		assert.False(t, doctorFailed(results), "Prometheus is optional")
+	})
+
+	t.Run("ssrf rejected without ping", func(t *testing.T) {
+		t.Parallel()
+		bad := unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"metricsSource": map[string]interface{}{
+					"prometheus": map[string]interface{}{"address": "http://127.0.0.1:1"},
+				},
+			},
+		}}
+		pinged := false
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{bad}, func(context.Context, string) error {
+			pinged = true
+			return nil
+		})
+		assert.False(t, pinged)
+		assert.False(t, results[2].ok)
+		assert.Contains(t, results[2].detail, "loopback")
+	})
+}
+
+func TestRunDoctor_ExitCodes(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			gvr:                  "AttunePolicyList",
+			defaultsGVR:          "AttuneDefaultsList",
+			namespaceDefaultsGVR: "AttuneNamespaceDefaultsList",
+		})
+	var stdout, stderr bytes.Buffer
+	code := runDoctor(context.Background(), &stdout, &stderr, resizeDiscovery("1", "32", true), dyn, "default", nil)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout.String(), "pods/resize")
+	assert.Contains(t, stdout.String(), "ok")
+	assert.Empty(t, stderr.String())
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runDoctor(context.Background(), &stdout, &stderr, resizeDiscovery("1", "31", true), dyn, "default", nil)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr.String(), "one or more checks failed")
+	assert.Contains(t, stdout.String(), "FAIL")
+}
+
+func TestParseVersionPart(t *testing.T) {
+	t.Parallel()
+	n, err := parseVersionPart("32+")
+	require.NoError(t, err)
+	assert.Equal(t, 32, n)
+	_, err = parseVersionPart("abc")
+	assert.Error(t, err)
+}

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -123,6 +123,7 @@ func run(args []string, buildClient dynamicClientFactory) int {
 		fmt.Fprintln(os.Stderr, "  history           Show resize history (including eviction fallbacks)")
 		fmt.Fprintln(os.Stderr, "  diff              Show resource change diffs from recommendations")
 		fmt.Fprintln(os.Stderr, "  wizard            Interactive policy creation and type promotion")
+		fmt.Fprintln(os.Stderr, "  doctor            Check cluster version, pods/resize, and Prometheus")
 		fmt.Fprintln(os.Stderr, "  version           Print plugin version")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Flags:")
@@ -184,7 +185,7 @@ func run(args []string, buildClient dynamicClientFactory) int {
 
 	isMultiCtx := *allContexts || *contexts != ""
 	if isMultiCtx {
-		if cmd == "explain" || cmd == "preview" || cmd == "wizard" || cmd == "export" {
+		if cmd == "explain" || cmd == "preview" || cmd == "wizard" || cmd == "export" || cmd == "doctor" {
 			fmt.Fprintf(os.Stderr, "Error: %s requires a single cluster context; remove --contexts/--all-contexts\n", cmd)
 			return 1
 		}
@@ -295,6 +296,13 @@ func run(args []string, buildClient dynamicClientFactory) int {
 		printDiff(ctx, dynClient, *namespace, *output)
 	case "wizard":
 		return runWizard(ctx, dynClient, *namespace, parsedArgs, newInteractivePrompter())
+	case "doctor":
+		disc, err := buildDoctorDiscovery(*kubeconfig, "")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		return runDoctor(ctx, os.Stdout, os.Stderr, disc, dynClient, *namespace, pingPrometheusHealthy)
 	}
 	return 0
 }
@@ -326,7 +334,7 @@ func buildDynamicClient(kubeconfigPath, contextOverride string) (dynamic.Interfa
 
 func isKnownCommand(cmd string) bool {
 	switch cmd {
-	case "status", "savings", "recommendations", "explain", "history", "preview", "version", "wizard", "diff", "export":
+	case "status", "savings", "recommendations", "explain", "history", "preview", "version", "wizard", "diff", "export", "doctor":
 		return true
 	default:
 		return false
@@ -335,7 +343,7 @@ func isKnownCommand(cmd string) bool {
 
 func isZeroArgCommand(cmd string) bool {
 	switch cmd {
-	case "status", "savings", "recommendations", "history", "diff":
+	case "status", "savings", "recommendations", "history", "diff", "doctor":
 		return true
 	default:
 		return false

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -1484,6 +1484,13 @@ func TestRun_MainWiring(t *testing.T) {
 			wantStderr:   "status accepts no positional arguments",
 		},
 		{
+			name:         "doctor rejects leftover positional args",
+			args:         []string{"doctor", "extra"},
+			factory:      fakeDynamicClientFactory(t, policy),
+			wantExitCode: 1,
+			wantStderr:   "doctor accepts no positional arguments",
+		},
+		{
 			name:         "explain rejects trailing args after policy name",
 			args:         []string{"explain", "api-svc", "extra"},
 			factory:      fakeDynamicClientFactory(t, policy),
@@ -1546,6 +1553,7 @@ func TestIsZeroArgCommand(t *testing.T) {
 		{cmd: "savings", want: true},
 		{cmd: "recommendations", want: true},
 		{cmd: "history", want: true},
+		{cmd: "doctor", want: true},
 		{cmd: "explain", want: false},
 		{cmd: "version", want: false},
 	}
@@ -1589,6 +1597,12 @@ func TestZeroArgCommandArgs(t *testing.T) {
 			cmd:     "history",
 			args:    []string{"extra"},
 			wantErr: "history accepts no positional arguments",
+		},
+		{
+			name:    "doctor rejects positional arg",
+			cmd:     "doctor",
+			args:    []string{"extra"},
+			wantErr: "doctor accepts no positional arguments",
 		},
 	}
 

--- a/cmd/kubectl-attune/multicluster_test.go
+++ b/cmd/kubectl-attune/multicluster_test.go
@@ -395,6 +395,13 @@ func TestRun_MultiClusterRejectsWizard(t *testing.T) {
 	assert.Contains(t, stderr, "wizard requires a single cluster context")
 }
 
+func TestRun_MultiClusterRejectsDoctor(t *testing.T) {
+	exitCode, _, stderr := captureRun(t, []string{"doctor", "--all-contexts"},
+		fakeDynamicClientFactory(t))
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "doctor requires a single cluster context")
+}
+
 func TestRun_MultiClusterRejectsPreview(t *testing.T) {
 	exitCode, _, stderr := captureRun(t, []string{"preview", "--contexts", "a,b", "my-policy"},
 		fakeDynamicClientFactory(t))

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -220,6 +220,26 @@ confirmation.
 The wizard does not support multi-cluster mode (`--all-contexts` /
 `--contexts`).
 
+### doctor
+
+Preflight for in-place resize. Checks the cluster before you expect
+Attune to collect data or call `/resize`.
+
+```bash
+kubectl attune doctor
+kubectl attune doctor -n production
+kubectl attune doctor -A
+```
+
+| Check | Required | Passes when |
+|-------|----------|-------------|
+| Kubernetes version | Yes | Server version is 1.32 or newer |
+| `pods/resize` | Yes | Discovery lists the `pods/resize` subresource |
+| Prometheus | No | Skipped when no address is set. When a policy, `AttuneDefaults`, or `AttuneNamespaceDefaults` has `metricsSource.prometheus.address`, doctor GETs `/-/healthy` (SSRF-checked first) |
+
+Exit 0 when every required check passes. A failed Prometheus check is
+printed but does not change the exit code.
+
 ### version
 
 Shows the plugin version. Works without cluster access.

--- a/examples/README.md
+++ b/examples/README.md
@@ -79,5 +79,5 @@ kubectl krew install attune
 ```
 
 The plugin adds commands like `kubectl attune status`, `kubectl attune recommendations`,
-and `kubectl attune explain`. Some examples reference these commands, but they always
+`kubectl attune doctor`, and `kubectl attune explain`. Some examples reference these commands, but they always
 show the standard kubectl equivalent first.


### PR DESCRIPTION
## Summary

Add `kubectl attune doctor` so install problems show up before the operator sits in InsufficientData or fails `/resize`.

## Checks

- Kubernetes version 1.32+ (required)
- Discovery of the `pods/resize` subresource (required)
- Prometheus `/-/healthy` when a policy, AttuneDefaults, or AttuneNamespaceDefaults has `metricsSource.prometheus.address` (optional; SSRF-checked first). A failed optional check is printed but does not change the exit code.

## Test plan

- [x] `go test ./cmd/kubectl-attune/` (version classifier, fake discovery, Prometheus skip/fail/SSRF, exit codes, CLI wiring)
- [x] golangci-lint on `./cmd/kubectl-attune/...`

Closes #579

