### PR TITLE
fix: keep kubectl attune doctor honest for in-cluster prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ In-place apply is the shared primitive (Kubernetes `/resize`). Attune is the
 | Production path | <1% run in production | Manual apply | **Observe → Recommend → Canary → Auto** |
 
 > **Migrating from VPA?** See the step-by-step [migration guide](docs/guides/migrating-from-vpa.md) for field-by-field mapping, mode matrix, side-by-side YAML, and zero-downtime cutover.
+>
+> Other 2026 in-place appliers (k8s-sustain, CruiseKube, Kedify PRA) are compared in [Why Attune](docs/why-attune.md#other-2026-in-place-appliers).
 
 ## Quick Start
 

--- a/cmd/kubectl-attune/doctor.go
+++ b/cmd/kubectl-attune/doctor.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -204,27 +205,29 @@ func pingPrometheusHealthy(ctx context.Context, address string) error {
 	return nil
 }
 
+func appendListedResources(ctx context.Context, dynClient dynamic.Interface, resource schema.GroupVersionResource, namespace, kind string, out []unstructured.Unstructured, errs []error) ([]unstructured.Unstructured, []error) {
+	var list *unstructured.UnstructuredList
+	var err error
+	if namespace == "" {
+		list, err = dynClient.Resource(resource).List(ctx, metav1.ListOptions{})
+	} else {
+		list, err = dynClient.Resource(resource).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	}
+	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
+		return out, append(errs, fmt.Errorf("list %s: %w", kind, err))
+	}
+	if list != nil {
+		out = append(out, list.Items...)
+	}
+	return out, errs
+}
+
 func listDoctorObjects(ctx context.Context, dynClient dynamic.Interface, namespace string) ([]unstructured.Unstructured, error) {
 	var out []unstructured.Unstructured
 	var errs []error
-	policies, err := dynClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
-		errs = append(errs, fmt.Errorf("list AttunePolicies: %w", err))
-	} else if policies != nil {
-		out = append(out, policies.Items...)
-	}
-	defaults, err := dynClient.Resource(defaultsGVR).List(ctx, metav1.ListOptions{})
-	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
-		errs = append(errs, fmt.Errorf("list AttuneDefaults: %w", err))
-	} else if defaults != nil {
-		out = append(out, defaults.Items...)
-	}
-	nsDefaults, err := dynClient.Resource(namespaceDefaultsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
-		errs = append(errs, fmt.Errorf("list AttuneNamespaceDefaults: %w", err))
-	} else if nsDefaults != nil {
-		out = append(out, nsDefaults.Items...)
-	}
+	out, errs = appendListedResources(ctx, dynClient, gvr, namespace, "AttunePolicies", out, errs)
+	out, errs = appendListedResources(ctx, dynClient, defaultsGVR, "", "AttuneDefaults", out, errs)
+	out, errs = appendListedResources(ctx, dynClient, namespaceDefaultsGVR, namespace, "AttuneNamespaceDefaults", out, errs)
 	return out, errors.Join(errs...)
 }
 

--- a/cmd/kubectl-attune/doctor.go
+++ b/cmd/kubectl-attune/doctor.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -54,7 +55,6 @@ type doctorDiscovery interface {
 type prometheusPinger func(ctx context.Context, address string) error
 
 // buildDoctorDiscovery loads a typed clientset Discovery from kubeconfig.
-// Tests replace this to inject a fake discovery client.
 var buildDoctorDiscovery = defaultBuildDoctorDiscovery
 
 func defaultBuildDoctorDiscovery(kubeconfigPath, contextOverride string) (doctorDiscovery, error) {
@@ -121,7 +121,6 @@ func classifyKubernetesVersion(info *k8sversion.Info) error {
 	return fmt.Errorf("cluster version %d.%d is below Attune's minimum 1.32 (in-place pod resize)", major, minor)
 }
 
-// hasPodsResizeSubresource reports whether discovery lists pods/resize.
 func hasPodsResizeSubresource(lists []*metav1.APIResourceList) bool {
 	for _, list := range lists {
 		if list == nil {
@@ -154,6 +153,18 @@ func collectPrometheusAddresses(objects ...unstructured.Unstructured) []string {
 		out = append(out, addr)
 	}
 	return out
+}
+
+// clusterLocalPrometheusHost is true for Service DNS names that resolve
+// only inside the cluster. Doctor runs on the kubectl host, so those
+// addresses cannot be pinged the way the operator would.
+func clusterLocalPrometheusHost(address string) bool {
+	u, err := url.Parse(address)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return strings.HasSuffix(host, ".svc") || strings.HasSuffix(host, ".cluster.local")
 }
 
 func pingPrometheusHealthy(ctx context.Context, address string) error {
@@ -195,28 +206,26 @@ func pingPrometheusHealthy(ctx context.Context, address string) error {
 
 func listDoctorObjects(ctx context.Context, dynClient dynamic.Interface, namespace string) ([]unstructured.Unstructured, error) {
 	var out []unstructured.Unstructured
+	var errs []error
 	policies, err := dynClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
-		return nil, fmt.Errorf("list AttunePolicies: %w", err)
-	}
-	if policies != nil {
+		errs = append(errs, fmt.Errorf("list AttunePolicies: %w", err))
+	} else if policies != nil {
 		out = append(out, policies.Items...)
 	}
 	defaults, err := dynClient.Resource(defaultsGVR).List(ctx, metav1.ListOptions{})
 	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
-		return nil, fmt.Errorf("list AttuneDefaults: %w", err)
-	}
-	if defaults != nil {
+		errs = append(errs, fmt.Errorf("list AttuneDefaults: %w", err))
+	} else if defaults != nil {
 		out = append(out, defaults.Items...)
 	}
 	nsDefaults, err := dynClient.Resource(namespaceDefaultsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil && !apierrors.IsNotFound(err) && !isNoResourceMatch(err) {
-		return nil, fmt.Errorf("list AttuneNamespaceDefaults: %w", err)
-	}
-	if nsDefaults != nil {
+		errs = append(errs, fmt.Errorf("list AttuneNamespaceDefaults: %w", err))
+	} else if nsDefaults != nil {
 		out = append(out, nsDefaults.Items...)
 	}
-	return out, nil
+	return out, errors.Join(errs...)
 }
 
 type doctorResult struct {
@@ -226,7 +235,7 @@ type doctorResult struct {
 	detail   string
 }
 
-func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstructured.Unstructured, ping prometheusPinger) []doctorResult {
+func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstructured.Unstructured, listErr error, ping prometheusPinger) []doctorResult {
 	if ping == nil {
 		ping = pingPrometheusHealthy
 	}
@@ -272,21 +281,33 @@ func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstru
 
 	addrs := collectPrometheusAddresses(objects...)
 	if len(addrs) == 0 {
+		detail := "skipped (no address on policies or defaults)"
+		if listErr != nil {
+			detail = "skipped (could not list policies or defaults)"
+		}
 		results = append(results, doctorResult{
 			name: "Prometheus", required: false, ok: true,
-			detail: "skipped (no address on policies or defaults)",
+			detail: detail,
 		})
 		return results
 	}
 	var failed []string
+	var reachable []string
+	var skippedLocal []string
 	for _, addr := range addrs {
 		if err := validation.PrometheusAddress(addr); err != nil {
 			failed = append(failed, addr+": "+err.Error())
 			continue
 		}
+		if clusterLocalPrometheusHost(addr) {
+			skippedLocal = append(skippedLocal, addr)
+			continue
+		}
 		if err := ping(ctx, addr); err != nil {
 			failed = append(failed, addr+": "+err.Error())
+			continue
 		}
+		reachable = append(reachable, addr)
 	}
 	if len(failed) > 0 {
 		results = append(results, doctorResult{
@@ -294,9 +315,15 @@ func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstru
 		})
 		return results
 	}
+	detail := strings.Join(reachable, ", ") + " " + prometheusHealthyPath
+	if len(reachable) == 0 && len(skippedLocal) > 0 {
+		detail = "skipped (in-cluster address; ping is from this host, not the operator pod)"
+	} else if len(skippedLocal) > 0 {
+		detail += "; skipped in-cluster " + strings.Join(skippedLocal, ", ")
+	}
 	results = append(results, doctorResult{
 		name: "Prometheus", required: false, ok: true,
-		detail: strings.Join(addrs, ", ") + " " + prometheusHealthyPath,
+		detail: detail,
 	})
 	return results
 }
@@ -315,6 +342,8 @@ func printDoctorResults(w io.Writer, results []doctorResult) {
 		status := "FAIL"
 		if r.ok {
 			status = "ok"
+		} else if !r.required {
+			status = "WARN"
 		}
 		kind := "required"
 		if !r.required {
@@ -329,7 +358,7 @@ func runDoctor(ctx context.Context, stdout, stderr io.Writer, disc doctorDiscove
 	if err != nil {
 		fmt.Fprintf(stderr, "Warning: %v\n", err)
 	}
-	results := runDoctorChecks(ctx, disc, objects, ping)
+	results := runDoctorChecks(ctx, disc, objects, err, ping)
 	printDoctorResults(stdout, results)
 	if doctorFailed(results) {
 		fmt.Fprintln(stderr, "doctor: one or more checks failed")

--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -129,7 +129,7 @@ func TestRunDoctorChecks_VersionAndDiscovery(t *testing.T) {
 
 	t.Run("pass 1.32 with resize", func(t *testing.T) {
 		t.Parallel()
-		results := runDoctorChecks(ctx, resizeDiscovery("1", "32", true), nil, nil)
+		results := runDoctorChecks(ctx, resizeDiscovery("1", "32", true), nil, nil, nil)
 		require.Len(t, results, 3)
 		assert.True(t, results[0].ok, results[0].detail)
 		assert.True(t, results[1].ok, results[1].detail)
@@ -140,7 +140,7 @@ func TestRunDoctorChecks_VersionAndDiscovery(t *testing.T) {
 
 	t.Run("fail 1.31", func(t *testing.T) {
 		t.Parallel()
-		results := runDoctorChecks(ctx, resizeDiscovery("1", "31", true), nil, nil)
+		results := runDoctorChecks(ctx, resizeDiscovery("1", "31", true), nil, nil, nil)
 		require.False(t, results[0].ok)
 		assert.Contains(t, results[0].detail, "1.32")
 		assert.True(t, doctorFailed(results))
@@ -148,7 +148,7 @@ func TestRunDoctorChecks_VersionAndDiscovery(t *testing.T) {
 
 	t.Run("fail missing resize", func(t *testing.T) {
 		t.Parallel()
-		results := runDoctorChecks(ctx, resizeDiscovery("1", "32", false), nil, nil)
+		results := runDoctorChecks(ctx, resizeDiscovery("1", "32", false), nil, nil, nil)
 		require.False(t, results[1].ok)
 		assert.Contains(t, results[1].detail, "InPlacePodVerticalScaling")
 		assert.True(t, doctorFailed(results))
@@ -162,29 +162,57 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 	obj := unstructured.Unstructured{Object: map[string]interface{}{
 		"spec": map[string]interface{}{
 			"metricsSource": map[string]interface{}{
-				"prometheus": map[string]interface{}{"address": "http://prom.monitoring.svc:9090"},
+				"prometheus": map[string]interface{}{"address": "http://prometheus.example:9090"},
 			},
 		},
 	}}
 
 	t.Run("reachable", func(t *testing.T) {
 		t.Parallel()
-		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{obj}, func(context.Context, string) error {
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{obj}, nil, func(context.Context, string) error {
 			return nil
 		})
 		require.True(t, results[2].ok, results[2].detail)
-		assert.Contains(t, results[2].detail, "http://prom.monitoring.svc:9090")
+		assert.Contains(t, results[2].detail, "http://prometheus.example:9090")
 		assert.False(t, doctorFailed(results))
 	})
 
 	t.Run("unreachable does not fail required exit", func(t *testing.T) {
 		t.Parallel()
-		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{obj}, func(context.Context, string) error {
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{obj}, nil, func(context.Context, string) error {
 			return fmt.Errorf("connection refused")
 		})
 		require.False(t, results[2].ok)
 		assert.Contains(t, results[2].detail, "connection refused")
 		assert.False(t, doctorFailed(results), "Prometheus is optional")
+	})
+
+	t.Run("in-cluster address is not pinged from kubectl host", func(t *testing.T) {
+		t.Parallel()
+		local := unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"metricsSource": map[string]interface{}{
+					"prometheus": map[string]interface{}{"address": "http://prom.monitoring.svc:9090"},
+				},
+			},
+		}}
+		pinged := false
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{local}, nil, func(context.Context, string) error {
+			pinged = true
+			return fmt.Errorf("should not ping")
+		})
+		assert.False(t, pinged)
+		require.True(t, results[2].ok, results[2].detail)
+		assert.Contains(t, results[2].detail, "in-cluster")
+		assert.False(t, doctorFailed(results))
+	})
+
+	t.Run("list error without address is not claimed as no address", func(t *testing.T) {
+		t.Parallel()
+		results := runDoctorChecks(ctx, disc, nil, fmt.Errorf("list AttuneDefaults: forbidden"), nil)
+		require.True(t, results[2].ok)
+		assert.Contains(t, results[2].detail, "could not list")
+		assert.NotContains(t, results[2].detail, "no address")
 	})
 
 	t.Run("ssrf rejected without ping", func(t *testing.T) {
@@ -197,7 +225,7 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 			},
 		}}
 		pinged := false
-		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{bad}, func(context.Context, string) error {
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{bad}, nil, func(context.Context, string) error {
 			pinged = true
 			return nil
 		})
@@ -205,6 +233,57 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 		assert.False(t, results[2].ok)
 		assert.Contains(t, results[2].detail, "loopback")
 	})
+}
+
+func TestPrintDoctorResults_OptionalWarn(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	printDoctorResults(&buf, []doctorResult{
+		{name: "Kubernetes version", required: true, ok: true, detail: "v1.32.0"},
+		{name: "Prometheus", required: false, detail: "connection refused"},
+	})
+	out := buf.String()
+	assert.Contains(t, out, "WARN")
+	assert.NotContains(t, out, "FAIL")
+}
+
+func TestClusterLocalPrometheusHost(t *testing.T) {
+	t.Parallel()
+	assert.True(t, clusterLocalPrometheusHost("http://prom.ns.svc:9090"))
+	assert.True(t, clusterLocalPrometheusHost("http://prom.ns.svc.cluster.local:9090"))
+	assert.False(t, clusterLocalPrometheusHost("http://prometheus.example:9090"))
+	assert.False(t, clusterLocalPrometheusHost("not a url"))
+}
+
+func TestListDoctorObjects_KeepsPartialOnError(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			gvr:                  "AttunePolicyList",
+			defaultsGVR:          "AttuneDefaultsList",
+			namespaceDefaultsGVR: "AttuneNamespaceDefaultsList",
+		})
+	policy := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "attune.io/v1alpha1",
+		"kind":       "AttunePolicy",
+		"metadata":   map[string]interface{}{"name": "p", "namespace": "default"},
+		"spec": map[string]interface{}{
+			"metricsSource": map[string]interface{}{
+				"prometheus": map[string]interface{}{"address": "http://prometheus.example:9090"},
+			},
+		},
+	}}
+	_, err := dyn.Resource(gvr).Namespace("default").Create(context.Background(), policy, metav1.CreateOptions{})
+	require.NoError(t, err)
+	dyn.PrependReactor("list", "attunedefaults", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("forbidden")
+	})
+	got, err := listDoctorObjects(context.Background(), dyn, "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AttuneDefaults")
+	require.Len(t, got, 1)
+	assert.Equal(t, "p", got[0].GetName())
 }
 
 func TestRunDoctor_ExitCodes(t *testing.T) {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1252,6 +1252,7 @@ Distributed via Krew:
 ```bash
 kubectl krew install attune
 
+kubectl attune doctor
 kubectl attune status -n production
 kubectl attune savings
 kubectl attune recommendations -n production

--- a/docs/getting-started/first-30-days.md
+++ b/docs/getting-started/first-30-days.md
@@ -188,7 +188,8 @@ minimal.
 
 | When | Command | What you're checking |
 |------|---------|---------------------|
-| Just installed | `kubectl attune status -w` | Operator picked up your policy |
+| Just installed | `kubectl attune doctor` | Cluster is 1.32+ and lists `pods/resize` |
+| Policy created | `kubectl attune status -w` | Operator picked up your policy |
 | Waiting for data | `kubectl attune status -w` | Progress percentage climbing |
 | First recommendations | `kubectl attune recommendations` | Values look reasonable |
 | Understanding a recommendation | `kubectl attune explain <policy>` | Full pipeline trace |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -205,6 +205,9 @@ kubectl krew install attune
 
 # Or build from source
 make build-plugin && sudo cp bin/kubectl-attune /usr/local/bin/
+
+# Confirm the cluster can run in-place resize
+kubectl attune doctor
 ```
 
 See the [CLI Reference](../reference/cli.md) for available commands.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -19,6 +19,7 @@ recommendations, and promoting to Canary mode, all in about five minutes.
     - **Kubernetes 1.32+** — 1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33–1.34 beta enabled by default; **1.35+ GA**.
     - **A metrics source** — Prometheus (default), Datadog, or CloudWatch Container Insights. This guide uses Prometheus; see [Datadog Setup](../guides/datadog-setup.md) or [CloudWatch Setup](../guides/cloudwatch-setup.md) for alternatives.
     - **Attune installed** — see [Installation](installation.md) for Helm and raw manifest options. Default Helm install needs **cert-manager** (or `--set webhooks.enabled=false`).
+    - **Cluster preflight** — `kubectl attune doctor` checks Kubernetes 1.32+ and `pods/resize` before you wait on recommendations.
     - **Prometheus reachability** — the chart NetworkPolicy allows Prometheus egress on port **9090** by default. If your Service listens on port **80** (common with `prometheus-server.monitoring:80`), set `--set networkPolicy.prometheusPort=80` at install time or you will get no data.
 
 ## What else can Attune do?

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -176,6 +176,10 @@ namespace. This is usually a typo in the workload name or an incorrect
 
 **Symptom**: Ready condition is `False` with reason `InsufficientData`.
 
+**Check first**: `kubectl attune doctor` confirms Kubernetes 1.32+ and
+`pods/resize`. A failed Prometheus ping is optional (printed as `WARN`)
+and does not prove the operator cannot reach an in-cluster address.
+
 **Cause**: Not enough Prometheus data points to generate recommendations.
 The default minimum is 48 Prometheus range-query samples. With the default
 `queryStep: 5m`, that is about 4 hours of data.
@@ -357,6 +361,9 @@ attempting a resize.
 disabled by default. The `/resize` subresource is only available when the
 `InPlacePodVerticalScaling` feature gate is enabled on all control plane
 components and kubelets.
+
+**Check first**: `kubectl attune doctor` reports whether the cluster is
+1.32+ and whether discovery lists `pods/resize`.
 
 **Fix**: Enable the feature gate on all components. For managed clusters,
 check your provider's documentation. For self-managed clusters:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -231,6 +231,8 @@ kubectl attune doctor -n production
 kubectl attune doctor -A
 ```
 
+Doctor is single-context. `--all-contexts` and `--contexts` are rejected.
+
 | Check | Required | Passes when |
 |-------|----------|-------------|
 | Kubernetes version | Yes | Server version is 1.32 or newer |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -235,10 +235,11 @@ kubectl attune doctor -A
 |-------|----------|-------------|
 | Kubernetes version | Yes | Server version is 1.32 or newer |
 | `pods/resize` | Yes | Discovery lists the `pods/resize` subresource |
-| Prometheus | No | Skipped when no address is set. When a policy, `AttuneDefaults`, or `AttuneNamespaceDefaults` has `metricsSource.prometheus.address`, doctor GETs `/-/healthy` (SSRF-checked first) |
+| Prometheus | No | Skipped when no address is set, when listing policies/defaults fails, or when the address is in-cluster DNS (`.svc` / `.cluster.local`). Other addresses are GET `/-/healthy` from this host (SSRF-checked first). Optional failures print `WARN`, not `FAIL`. |
 
 Exit 0 when every required check passes. A failed Prometheus check is
-printed but does not change the exit code.
+printed as `WARN` and does not change the exit code. The ping runs on
+the machine that invoked kubectl, not inside the operator pod.
 
 ### version
 

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -362,7 +362,7 @@ available. They are not in the table above.
 | **License** | ISC | BUSL-1.1 | Commercial | Apache-2.0 |
 | **In-place `/resize`** | Yes (1.33+; eviction fallback) | Yes (requires 1.33+) | Yes (seconds-scale band) | Yes (1.32+) |
 | **Canary + auto-revert** | No | No | No (utilization band, not a recommender) | Yes |
-| **What they add** | KEDA + Argo Rollouts, dashboard simulator | Install preflight, product dashboard | Fast spike reaction from kubelet stats | Safety loop, `kubectl attune explain`, GitOps export |
+| **What they add** | KEDA + Argo Rollouts, dashboard simulator | Install preflight, product dashboard | Fast spike reaction from kubelet stats | Safety loop, `kubectl attune doctor`, `explain`, GitOps export |
 
 k8s-sustain is the closest open-source operator. CruiseKube is
 source-available with a production-use BUSL. Kedify PRA is a


### PR DESCRIPTION
`kubectl attune doctor` no longer treats an in-cluster Prometheus URL or a partial list error as a green "no address" skip.

## Problem

The first doctor landing (#582) printed `FAIL` for optional Prometheus checks, dropped already-listed policies when `AttuneDefaults` list failed, and pinged Service DNS (`*.svc`) from the kubectl host. Those pings false-fail on a healthy cluster.

## Change

- Optional Prometheus failures print `WARN` and still exit 0
- List helpers keep partial objects and say `could not list` when no address was seen
- Skip `/-/healthy` for `.svc` / `.cluster.local` hosts (check is from this machine)
- Point install, quickstart, troubleshooting, and SPEC at `doctor`

## Validation

- `go test ./cmd/kubectl-attune/ -count=1`
- `make verify-quick` (2034 tests, lint 0 issues)

Ref #579
