### PR TITLE
test: lock doctor prometheus skip heuristic

### DIFF
--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -215,6 +215,18 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 		assert.NotContains(t, results[2].detail, "no address")
 	})
 
+	t.Run("list error with a collected address still pings", func(t *testing.T) {
+		t.Parallel()
+		pinged := false
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{obj}, fmt.Errorf("list AttuneDefaults: forbidden"), func(context.Context, string) error {
+			pinged = true
+			return nil
+		})
+		assert.True(t, pinged)
+		require.True(t, results[2].ok, results[2].detail)
+		assert.Contains(t, results[2].detail, "http://prometheus.example:9090")
+	})
+
 	t.Run("ssrf rejected without ping", func(t *testing.T) {
 		t.Parallel()
 		bad := unstructured.Unstructured{Object: map[string]interface{}{
@@ -245,6 +257,15 @@ func TestPrintDoctorResults_OptionalWarn(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "WARN")
 	assert.NotContains(t, out, "FAIL")
+
+	buf.Reset()
+	printDoctorResults(&buf, []doctorResult{
+		{name: "Kubernetes version", required: true, detail: "below 1.32"},
+		{name: "Prometheus", required: false, detail: "connection refused"},
+	})
+	out = buf.String()
+	assert.Contains(t, out, "FAIL")
+	assert.Contains(t, out, "WARN")
 }
 
 func TestClusterLocalPrometheusHost(t *testing.T) {
@@ -253,6 +274,9 @@ func TestClusterLocalPrometheusHost(t *testing.T) {
 	assert.True(t, clusterLocalPrometheusHost("http://prom.ns.svc.cluster.local:9090"))
 	assert.False(t, clusterLocalPrometheusHost("http://prometheus.example:9090"))
 	assert.False(t, clusterLocalPrometheusHost("not a url"))
+	// Chart and docs use service.namespace without .svc. That is still
+	// pinged; do not treat every two-label host as in-cluster.
+	assert.False(t, clusterLocalPrometheusHost("http://prometheus-server.monitoring:80"))
 }
 
 func TestListDoctorObjects_KeepsPartialOnError(t *testing.T) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -237,7 +237,7 @@ Doctor is single-context. `--all-contexts` and `--contexts` are rejected.
 |-------|----------|-------------|
 | Kubernetes version | Yes | Server version is 1.32 or newer |
 | `pods/resize` | Yes | Discovery lists the `pods/resize` subresource |
-| Prometheus | No | Skipped when no address is set, when listing policies/defaults fails, or when the address is in-cluster DNS (`.svc` / `.cluster.local`). Other addresses are GET `/-/healthy` from this host (SSRF-checked first). Optional failures print `WARN`, not `FAIL`. |
+| Prometheus | No | Skipped when no address was seen (none set, or listing failed with no objects). Also skipped for in-cluster DNS (`.svc` / `.cluster.local`). Other addresses, including `service.namespace` without `.svc`, are GET `/-/healthy` from this host (SSRF-checked first). Optional failures print `WARN`, not `FAIL`. |
 
 Exit 0 when every required check passes. A failed Prometheus check is
 printed as `WARN` and does not change the exit code. The ping runs on


### PR DESCRIPTION
Locks the doctor Prometheus skip rules that cycle 1 shipped.

- Two-label `service.namespace` (the chart example) is still pinged
- A list error does not skip ping when an address was already collected
- Required `FAIL` and optional `WARN` can appear in the same printout

Ref #579
Ref #583
