### PR TITLE
fix: skip doctor prometheus warn on authenticated 401

### DIFF
--- a/cmd/kubectl-attune/doctor.go
+++ b/cmd/kubectl-attune/doctor.go
@@ -139,21 +139,68 @@ func hasPodsResizeSubresource(lists []*metav1.APIResourceList) bool {
 	return false
 }
 
-func collectPrometheusAddresses(objects ...unstructured.Unstructured) []string {
-	seen := map[string]struct{}{}
-	var out []string
+type prometheusDoctorTarget struct {
+	address string
+	hasAuth bool
+}
+
+func prometheusObjectHasAuth(obj unstructured.Unstructured) bool {
+	secret, found, err := unstructured.NestedMap(obj.Object, "spec", "metricsSource", "prometheus", "bearerTokenSecret")
+	if err == nil && found && len(secret) > 0 {
+		return true
+	}
+	headers, found, err := unstructured.NestedStringMap(obj.Object, "spec", "metricsSource", "prometheus", "headers")
+	if err == nil && found && len(headers) > 0 {
+		return true
+	}
+	return false
+}
+
+func collectPrometheusTargets(objects ...unstructured.Unstructured) []prometheusDoctorTarget {
+	seen := map[string]int{}
+	var out []prometheusDoctorTarget
 	for _, obj := range objects {
 		addr := strings.TrimSpace(getNestedString(obj, "spec", "metricsSource", "prometheus", "address"))
 		if addr == "" {
 			continue
 		}
-		if _, ok := seen[addr]; ok {
+		hasAuth := prometheusObjectHasAuth(obj)
+		if i, ok := seen[addr]; ok {
+			if hasAuth {
+				out[i].hasAuth = true
+			}
 			continue
 		}
-		seen[addr] = struct{}{}
-		out = append(out, addr)
+		seen[addr] = len(out)
+		out = append(out, prometheusDoctorTarget{address: addr, hasAuth: hasAuth})
 	}
 	return out
+}
+
+func collectPrometheusAddresses(objects ...unstructured.Unstructured) []string {
+	targets := collectPrometheusTargets(objects...)
+	out := make([]string, len(targets))
+	for i, t := range targets {
+		out[i] = t.address
+	}
+	return out
+}
+
+type httpStatusError struct {
+	status int
+	url    string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("GET %s: HTTP %d", e.url, e.status)
+}
+
+func pingAuthFailure(err error) bool {
+	var he *httpStatusError
+	if errors.As(err, &he) {
+		return he.status == http.StatusUnauthorized || he.status == http.StatusForbidden
+	}
+	return false
 }
 
 // clusterLocalPrometheusHost is true for Service DNS names that resolve
@@ -200,7 +247,7 @@ func pingPrometheusHealthy(ctx context.Context, address string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("GET %s: HTTP %d", u.Redacted(), resp.StatusCode)
+		return &httpStatusError{status: resp.StatusCode, url: u.Redacted()}
 	}
 	return nil
 }
@@ -282,8 +329,8 @@ func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstru
 		})
 	}
 
-	addrs := collectPrometheusAddresses(objects...)
-	if len(addrs) == 0 {
+	targets := collectPrometheusTargets(objects...)
+	if len(targets) == 0 {
 		detail := "skipped (no address on policies or defaults)"
 		if listErr != nil {
 			detail = "skipped (could not list policies or defaults)"
@@ -297,7 +344,9 @@ func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstru
 	var failed []string
 	var reachable []string
 	var skippedLocal []string
-	for _, addr := range addrs {
+	var skippedAuth []string
+	for _, tgt := range targets {
+		addr := tgt.address
 		if err := validation.PrometheusAddress(addr); err != nil {
 			failed = append(failed, addr+": "+err.Error())
 			continue
@@ -307,6 +356,10 @@ func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstru
 			continue
 		}
 		if err := ping(ctx, addr); err != nil {
+			if tgt.hasAuth && pingAuthFailure(err) {
+				skippedAuth = append(skippedAuth, addr)
+				continue
+			}
 			failed = append(failed, addr+": "+err.Error())
 			continue
 		}
@@ -319,10 +372,20 @@ func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstru
 		return results
 	}
 	detail := strings.Join(reachable, ", ") + " " + prometheusHealthyPath
-	if len(reachable) == 0 && len(skippedLocal) > 0 {
+	switch {
+	case len(reachable) == 0 && len(skippedLocal) > 0 && len(skippedAuth) > 0:
+		detail = "skipped (in-cluster address; ping is from this host, not the operator pod; HTTP 401/403 on address that uses bearer token or headers)"
+	case len(reachable) == 0 && len(skippedLocal) > 0:
 		detail = "skipped (in-cluster address; ping is from this host, not the operator pod)"
-	} else if len(skippedLocal) > 0 {
-		detail += "; skipped in-cluster " + strings.Join(skippedLocal, ", ")
+	case len(reachable) == 0 && len(skippedAuth) > 0:
+		detail = "skipped (HTTP 401/403; address uses bearer token or headers the operator would send)"
+	default:
+		if len(skippedLocal) > 0 {
+			detail += "; skipped in-cluster " + strings.Join(skippedLocal, ", ")
+		}
+		if len(skippedAuth) > 0 {
+			detail += "; skipped authenticated " + strings.Join(skippedAuth, ", ")
+		}
 	}
 	results = append(results, doctorResult{
 		name: "Prometheus", required: false, ok: true,

--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -245,6 +245,105 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 		assert.False(t, results[2].ok)
 		assert.Contains(t, results[2].detail, "loopback")
 	})
+
+	t.Run("bearer token 401 is skip not warn", func(t *testing.T) {
+		t.Parallel()
+		authed := unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"metricsSource": map[string]interface{}{
+					"prometheus": map[string]interface{}{
+						"address":           "http://prometheus.example:9090",
+						"bearerTokenSecret": map[string]interface{}{"name": "prom-token", "key": "token"},
+					},
+				},
+			},
+		}}
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{authed}, nil, func(context.Context, string) error {
+			return &httpStatusError{status: 401, url: "http://prometheus.example:9090/-/healthy"}
+		})
+		require.True(t, results[2].ok, results[2].detail)
+		assert.Contains(t, results[2].detail, "401")
+		assert.Contains(t, results[2].detail, "bearer")
+		assert.False(t, doctorFailed(results))
+	})
+
+	t.Run("headers 403 is skip not warn", func(t *testing.T) {
+		t.Parallel()
+		authed := unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"metricsSource": map[string]interface{}{
+					"prometheus": map[string]interface{}{
+						"address": "http://mimir.example:8080",
+						"headers": map[string]interface{}{"X-Scope-OrgID": "team-a"},
+					},
+				},
+			},
+		}}
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{authed}, nil, func(context.Context, string) error {
+			return &httpStatusError{status: 403, url: "http://mimir.example:8080/-/healthy"}
+		})
+		require.True(t, results[2].ok, results[2].detail)
+		assert.Contains(t, results[2].detail, "403")
+		assert.False(t, doctorFailed(results))
+	})
+
+	t.Run("bearer token connection error is still warn", func(t *testing.T) {
+		t.Parallel()
+		authed := unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"metricsSource": map[string]interface{}{
+					"prometheus": map[string]interface{}{
+						"address":           "http://prometheus.example:9090",
+						"bearerTokenSecret": map[string]interface{}{"name": "prom-token", "key": "token"},
+					},
+				},
+			},
+		}}
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{authed}, nil, func(context.Context, string) error {
+			return fmt.Errorf("connection refused")
+		})
+		require.False(t, results[2].ok, results[2].detail)
+		assert.Contains(t, results[2].detail, "connection refused")
+		assert.False(t, doctorFailed(results), "Prometheus is optional")
+	})
+
+	t.Run("401 without auth config is still warn", func(t *testing.T) {
+		t.Parallel()
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{obj}, nil, func(context.Context, string) error {
+			return &httpStatusError{status: 401, url: "http://prometheus.example:9090/-/healthy"}
+		})
+		require.False(t, results[2].ok, results[2].detail)
+		assert.Contains(t, results[2].detail, "HTTP 401")
+	})
+
+	t.Run("same address with and without auth merges auth", func(t *testing.T) {
+		t.Parallel()
+		plain := obj
+		authed := unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"metricsSource": map[string]interface{}{
+					"prometheus": map[string]interface{}{
+						"address":           "http://prometheus.example:9090",
+						"bearerTokenSecret": map[string]interface{}{"name": "prom-token", "key": "token"},
+					},
+				},
+			},
+		}}
+		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{plain, authed}, nil, func(context.Context, string) error {
+			return &httpStatusError{status: 401, url: "http://prometheus.example:9090/-/healthy"}
+		})
+		require.True(t, results[2].ok, results[2].detail)
+		assert.Contains(t, results[2].detail, "401")
+	})
+}
+
+func TestPingAuthFailure(t *testing.T) {
+	t.Parallel()
+	assert.True(t, pingAuthFailure(&httpStatusError{status: 401, url: "http://x"}))
+	assert.True(t, pingAuthFailure(&httpStatusError{status: 403, url: "http://x"}))
+	assert.False(t, pingAuthFailure(&httpStatusError{status: 500, url: "http://x"}))
+	assert.False(t, pingAuthFailure(fmt.Errorf("HTTP 401")))
+	assert.False(t, pingAuthFailure(nil))
 }
 
 func TestPrintDoctorResults_OptionalWarn(t *testing.T) {

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -179,6 +179,8 @@ namespace. This is usually a typo in the workload name or an incorrect
 **Check first**: `kubectl attune doctor` confirms Kubernetes 1.32+ and
 `pods/resize`. A failed Prometheus ping is optional (printed as `WARN`)
 and does not prove the operator cannot reach an in-cluster address.
+A 401 or 403 on an address that sets `bearerTokenSecret` or custom
+`headers` is skipped the same way: doctor does not send those credentials.
 
 **Cause**: Not enough Prometheus data points to generate recommendations.
 The default minimum is 48 Prometheus range-query samples. With the default

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -237,7 +237,7 @@ Doctor is single-context. `--all-contexts` and `--contexts` are rejected.
 |-------|----------|-------------|
 | Kubernetes version | Yes | Server version is 1.32 or newer |
 | `pods/resize` | Yes | Discovery lists the `pods/resize` subresource |
-| Prometheus | No | Skipped when no address was seen (none set, or listing failed with no objects). Also skipped for in-cluster DNS (`.svc` / `.cluster.local`). Other addresses, including `service.namespace` without `.svc`, are GET `/-/healthy` from this host (SSRF-checked first). Optional failures print `WARN`, not `FAIL`. |
+| Prometheus | No | Skipped when no address was seen (none set, or listing failed with no objects). Also skipped for in-cluster DNS (`.svc` / `.cluster.local`). Other addresses, including `service.namespace` without `.svc`, are GET `/-/healthy` from this host (SSRF-checked first). A 401/403 on an address that sets `bearerTokenSecret` or `headers` is skipped (this host does not send the operator's auth). Optional failures print `WARN`, not `FAIL`. |
 
 Exit 0 when every required check passes. A failed Prometheus check is
 printed as `WARN` and does not change the exit code. The ping runs on


### PR DESCRIPTION
Doctor GETs Prometheus `/-/healthy` from the kubectl host without the policy `bearerTokenSecret` or extra `headers`. A 401 or 403 on those addresses printed `WARN` even though the operator would send that auth.

This treats 401/403 as a skip when the listed object has a bearer token or headers. Connection errors and 401 on addresses with no auth still `WARN`. Exit code is unchanged (Prometheus stays optional).

## Tests
- bearer token + 401 -> skip, not WARN
- headers + 403 -> skip
- bearer token + connection refused -> still WARN
- 401 without auth config -> still WARN
- same address listed with and without auth merges hasAuth

## Docs
- `docs/reference/cli.md` check table
- `docs/guides/troubleshooting.md` InsufficientData note

