### PR TITLE
fix: name recommendations csv last column honestly

### DIFF
--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -795,7 +795,7 @@ func printRecommendationsItems(items []unstructured.Unstructured) {
 
 func printRecommendationsCSV(items []unstructured.Unstructured) {
 	showCluster := hasClusterAnnotation(items)
-	header := []string{"namespace", "policy", "workload", "container", "cpu_req", "cpu_rec", "mem_req", "mem_rec", "confidence"}
+	header := []string{"namespace", "policy", "workload", "container", "cpu_req", "cpu_rec", "mem_req", "mem_rec", "confidence_or_status"}
 	if showCluster {
 		header = append([]string{"cluster"}, header...)
 	}

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -2403,8 +2403,34 @@ func TestPrintRecommendationsCSV_HeaderAndRow(t *testing.T) {
 	out, err := io.ReadAll(r)
 	require.NoError(t, err)
 	s := string(out)
-	assert.Contains(t, s, "namespace,policy,workload,container,cpu_req,cpu_rec,mem_req,mem_rec,confidence")
+	assert.Contains(t, s, "namespace,policy,workload,container,cpu_req,cpu_rec,mem_req,mem_rec,confidence_or_status")
 	assert.Contains(t, s, "ns,p,api,app,500m,250m,256Mi,128Mi,95.0%")
+}
+
+func TestPrintRecommendationsCSV_EmptyRecsUseReadyReason(t *testing.T) {
+	items := []unstructured.Unstructured{
+		{Object: map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "p", "namespace": "ns"},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{"type": "Ready", "status": "False", "reason": "InsufficientData"},
+				},
+			},
+		}},
+	}
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	printRecommendationsCSV(items)
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "confidence_or_status")
+	assert.Contains(t, s, "ns,p,,,,,,,InsufficientData")
+	assert.NotContains(t, s, ",confidence\n")
 }
 
 func TestPrintEffectivePolicySummary_GitOpsPR(t *testing.T) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -258,7 +258,10 @@ kubectl attune version
 - `status`: JSON or YAML of raw `AttunePolicy` objects
 - `diff`: YAML patch manifests
 - `savings` and `recommendations`: CSV (header plus one data row per
-  policy or container; no totals row)
+  policy or container; no totals row). Recommendations CSV uses
+  `confidence_or_status` for the last column: a confidence percent
+  when recommendations exist, otherwise the policy Ready reason
+  (same as the table's CONFIDENCE / STATUS column).
 
 ```bash
 kubectl attune status -o json


### PR DESCRIPTION
The human recommendations table labels the last column CONFIDENCE / STATUS because policies with no recommendations put the Ready reason there. CSV used the header `confidence` for the same values, so a bootstrap policy looked like a numeric score.

Rename the CSV header to `confidence_or_status` and lock an empty-recommendation row.

## Tests
- Existing row still emits `95.0%`
- Empty recs emit `ns,p,,,,,,,InsufficientData` under `confidence_or_status`

