### PR TITLE
fix: log generateName when create sizing has no pod name

### DIFF
--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -120,7 +120,7 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 	pod.Annotations[AnnotationInitialSizingPolicy] = fmt.Sprintf("%s/%s", req.Namespace, policy.Name)
 
 	h.Logger.Info("initial sizing applied",
-		"pod", pod.Name, "namespace", req.Namespace,
+		"pod", podAdmissionName(pod, req.Name), "namespace", req.Namespace,
 		"policy", policy.Name, "owner", ownerKind+"/"+ownerName)
 
 	marshaledPod, err := json.Marshal(pod)
@@ -358,6 +358,22 @@ func hasSuccessfulInPlaceHistory(history []attunev1alpha1.ResizeHistoryEntry, wo
 		}
 	}
 	return false
+}
+
+// podAdmissionName is the best identifier at CREATE. ReplicaSet pods
+// often have an empty Name and only GenerateName until the API assigns
+// one. Do not use this for canary slice matching.
+func podAdmissionName(pod *corev1.Pod, reqName string) string {
+	if pod != nil && pod.Name != "" {
+		return pod.Name
+	}
+	if reqName != "" {
+		return reqName
+	}
+	if pod != nil && pod.GenerateName != "" {
+		return pod.GenerateName
+	}
+	return ""
 }
 
 // hasMinConfidence returns true if all containers meet the minimum confidence.

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -157,6 +157,17 @@ func testPod(name string, ownerKind, ownerName string) *corev1.Pod {
 	return pod
 }
 
+func TestPodAdmissionName(t *testing.T) {
+	t.Parallel()
+	named := testPod("app-abc-xyz", "ReplicaSet", "app-abc")
+	generated := testPod("", "ReplicaSet", "app-abc")
+	generated.GenerateName = "app-abc-"
+	assert.Equal(t, "app-abc-xyz", podAdmissionName(named, "ignored"))
+	assert.Equal(t, "from-req", podAdmissionName(generated, "from-req"))
+	assert.Equal(t, "app-abc-", podAdmissionName(generated, ""))
+	assert.Equal(t, "", podAdmissionName(nil, ""))
+}
+
 func TestPodMutatingHandler_HappyPath(t *testing.T) {
 	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")


### PR DESCRIPTION
## What This PR Does

On ReplicaSet CREATE, admission often has an empty pod `Name` and only `GenerateName`. After a successful mutate the operator logged `pod=""`, which made E2E and cluster logs hard to follow.

Log `podAdmissionName` instead: real `Name`, then the admission request name, then `GenerateName`. Canary matching still uses the real name.

## Why

E2E and operator CREATE logs could not tell which ReplicaSet prefix was sized. This is log-only.

## Related Issues

Ref #576

Leftover from closed PR #576. Relanded on a new branch from current main.

## How to Test

```text
go test ./internal/webhook/ -race -count=1 -run TestPodAdmissionName
go test ./internal/webhook/ -race -count=1
make lint
```

Local: all three green (lint 0 issues).

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] CRD changes regenerated (`make manifests`)
- [ ] Documentation updated (if user-facing)
- [ ] Helm chart updated (if applicable)
- [x] No breaking API changes (or documented in CHANGELOG)
