### PR TITLE
test: fail-closed canary CREATE when pod name is empty

### DIFF
--- a/api/v1alpha1/canary_test.go
+++ b/api/v1alpha1/canary_test.go
@@ -37,6 +37,8 @@ func TestCanaryStatus_AllowsCreateSizing(t *testing.T) {
 	}
 	assert.True(t, inProgress.AllowsCreateSizing("app-a", "a-canary"))
 	assert.False(t, inProgress.AllowsCreateSizing("app-a", "a-new"))
+	assert.False(t, inProgress.AllowsCreateSizing("app-a", ""),
+		"ReplicaSet CREATE often has an empty Name; do not treat it as the canary slice")
 	assert.True(t, inProgress.AllowsCreateSizing("app-b", "b-new"), "promoted app may CREATE-size")
 	assert.False(t, inProgress.AllowsHPARetune("app-a"))
 	assert.True(t, inProgress.AllowsHPARetune("app-b"))
@@ -44,6 +46,8 @@ func TestCanaryStatus_AllowsCreateSizing(t *testing.T) {
 	legacy := &CanaryStatus{Phase: CanaryPhaseInProgress, Pods: []string{"only-this"}}
 	assert.True(t, legacy.AllowsCreateSizing("any", "only-this"))
 	assert.False(t, legacy.AllowsCreateSizing("any", "other"))
+	assert.False(t, legacy.AllowsCreateSizing("any", ""),
+		"empty Name is not a canary-slice identity")
 	assert.False(t, legacy.AllowsHPARetune("any"))
 
 	done := &CanaryStatus{Phase: CanaryPhaseFullRollout}

--- a/cmd/kubectl-attune/doctor.go
+++ b/cmd/kubectl-attune/doctor.go
@@ -177,15 +177,6 @@ func collectPrometheusTargets(objects ...unstructured.Unstructured) []prometheus
 	return out
 }
 
-func collectPrometheusAddresses(objects ...unstructured.Unstructured) []string {
-	targets := collectPrometheusTargets(objects...)
-	out := make([]string, len(targets))
-	for i, t := range targets {
-		out[i] = t.address
-	}
-	return out
-}
-
 type httpStatusError struct {
 	status int
 	url    string

--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -421,8 +421,8 @@ func TestRunDoctor_ExitCodes(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runDoctor(context.Background(), &stdout, &stderr, resizeDiscovery("1", "32", true), dyn, "default", nil)
 	assert.Equal(t, 0, code)
-	assert.Contains(t, stdout.String(), "pods/resize")
-	assert.Contains(t, stdout.String(), "ok")
+	assert.Contains(t, stdout.String(), "pods/resize            ok   [required] discovered")
+	assert.Contains(t, stdout.String(), "Kubernetes version     ok   [required]")
 	assert.Empty(t, stderr.String())
 
 	stdout.Reset()

--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -80,7 +80,7 @@ func TestHasPodsResizeSubresource(t *testing.T) {
 	}))
 }
 
-func TestCollectPrometheusAddresses(t *testing.T) {
+func TestCollectPrometheusTargets(t *testing.T) {
 	t.Parallel()
 	policy := unstructured.Unstructured{Object: map[string]interface{}{
 		"spec": map[string]interface{}{
@@ -103,8 +103,12 @@ func TestCollectPrometheusAddresses(t *testing.T) {
 			},
 		},
 	}}
-	got := collectPrometheusAddresses(policy, defaults, other, unstructured.Unstructured{})
-	assert.Equal(t, []string{"http://prom.ns.svc:9090", "https://thanos.example:9090"}, got)
+	got := collectPrometheusTargets(policy, defaults, other, unstructured.Unstructured{})
+	require.Len(t, got, 2)
+	assert.Equal(t, "http://prom.ns.svc:9090", got[0].address)
+	assert.False(t, got[0].hasAuth)
+	assert.Equal(t, "https://thanos.example:9090", got[1].address)
+	assert.False(t, got[1].hasAuth)
 }
 
 func resizeDiscovery(major, minor string, withResize bool) *fakediscovery.FakeDiscovery {

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -490,6 +490,29 @@ func TestPodMutatingHandler_CanaryMode_SkipsUntilPromoted(t *testing.T) {
 	assert.Nil(t, resp.Patches, "canary CREATE must not apply the full recommendation until that app is promoted")
 }
 
+func TestPodMutatingHandler_CanaryMode_EmptyNameSkips(t *testing.T) {
+	// ReplicaSet CREATE often has Name="" and only GenerateName. Canary
+	// matching uses the real name. An empty name must not match the
+	// slice and must not be treated as generateName.
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeCanary)
+	policy.Status.Canary = &attunev1alpha1.CanaryStatus{
+		Phase: attunev1alpha1.CanaryPhaseInProgress,
+		Pods:  []string{"my-app-abc-xyz"},
+		Workloads: []attunev1alpha1.CanaryWorkloadStatus{
+			{Workload: "my-app", Phase: attunev1alpha1.CanaryPhaseInProgress, Pods: []string{"my-app-abc-xyz"}},
+		},
+	}
+	pod := testPod("", "ReplicaSet", "my-app-abc")
+	pod.GenerateName = "my-app-abc-"
+
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
+	require.True(t, resp.Allowed)
+	assert.Nil(t, resp.Patches, "empty CREATE Name is not in the canary slice")
+}
+
 func TestPodMutatingHandler_CanaryMode_MutatesCanarySlice(t *testing.T) {
 	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeCanary)
 	policy.Status.Canary = &attunev1alpha1.CanaryStatus{


### PR DESCRIPTION
## What This PR Does

ReplicaSet CREATE often has an empty pod `Name`. Canary matching uses the real name. These tests lock that empty name (and `GenerateName`) is not treated as the canary slice.

Doctor success output is asserted as the formatted status column, not a two-letter `ok` substring.

Removes `collectPrometheusAddresses`, which was only used by tests after doctor started tracking auth on each target.

## Why

A later change that treated empty `Name` as "in the canary slice" would size every ReplicaSet CREATE during canary. The existing canary tests all used assigned names.

## Related Issues

Ref #576

Companion to the generateName CREATE log (PR #587). That change is log-only; this PR guards the canary identity rule.

## How to Test

```text
go test ./api/v1alpha1/ -race -count=1 -run TestCanaryStatus_AllowsCreateSizing
go test ./internal/webhook/ -race -count=1 -run TestPodMutatingHandler_CanaryMode_
go test ./cmd/kubectl-attune/ -race -count=1 -run 'TestCollectPrometheus|TestRunDoctor_ExitCodes'
make lint
```

Local: all green (lint 0 issues).

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] CRD changes regenerated (`make manifests`)
- [ ] Documentation updated (if user-facing)
- [ ] Helm chart updated (if applicable)
- [x] No breaking API changes (or documented in CHANGELOG)
