### PR TITLE
ci: retry cert-manager apply after k3s apiserver bounce

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -210,26 +210,13 @@ runs:
 
     - name: Install cert-manager
       shell: bash -Eeuo pipefail -x {0}
-      run: |
-        for attempt in 1 2 3; do
-          if kubectl apply -f /tmp/cert-manager.yaml; then
-            break
-          fi
-          echo "::warning::cert-manager install attempt $attempt failed, retrying in 15s..."
-          sleep 15
-          if (( attempt == 3 )); then
-            echo "::error::cert-manager install failed after 3 attempts"
-            exit 1
-          fi
-        done
-        kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
-        kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
-        kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
+      run: bash hack/e2e-install-cert-manager.sh /tmp/cert-manager.yaml
 
     - name: Load Prometheus and test images into cluster
       shell: bash -Eeuo pipefail -x {0}
       run: |
         k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar -c "${{ inputs.cluster-name }}"
+        bash hack/e2e-install-cert-manager.sh --wait-only
 
     - name: Install Prometheus
       shell: bash -Eeuo pipefail -x {0}
@@ -293,6 +280,7 @@ runs:
           --bare --tags=e2e --platform=linux/$(go env GOARCH) \
           --tarball=/tmp/attune-e2e.tar --push=false
         k3d image import /tmp/attune-e2e.tar -c "${{ inputs.cluster-name }}"
+        bash hack/e2e-install-cert-manager.sh --wait-only
 
     - name: Install operator via Helm
       shell: bash -Eeuo pipefail -x {0}

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -408,15 +408,13 @@ jobs:
 
       - name: Install cert-manager
         shell: bash -Eeuo pipefail -x {0}
-        run: |
-          kubectl apply -f /tmp/cert-manager.yaml
-          kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
-          kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
-          kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
+        run: bash hack/e2e-install-cert-manager.sh /tmp/cert-manager.yaml
 
       - name: Load Prometheus and test images into cluster
         shell: bash -Eeuo pipefail -x {0}
-        run: k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar /tmp/busybox.tar -c "$CLUSTER_NAME"
+        run: |
+          k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar /tmp/busybox.tar -c "$CLUSTER_NAME"
+          bash hack/e2e-install-cert-manager.sh --wait-only
 
       - name: Install Prometheus
         shell: bash -Eeuo pipefail -x {0}
@@ -505,6 +503,7 @@ jobs:
               exit 1
             fi
           done
+          bash hack/e2e-install-cert-manager.sh --wait-only
 
       - name: Install operator via Helm
         shell: bash -Eeuo pipefail -x {0}

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,7 @@ python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-v
 	bash scripts/test_verify_go_version_sync.sh
 	bash scripts/test_verify_helm_image_tag.sh
 	bash scripts/test_release_image_tags.sh
+	bash scripts/test_e2e_install_cert_manager.sh
 
 .PHONY: test-bench
 test-bench: ## Run benchmark tests

--- a/hack/e2e-install-cert-manager.sh
+++ b/hack/e2e-install-cert-manager.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Apply cert-manager after k3s may still be bouncing (kubelet restart
+# after k3d image import). Poll /readyz, retry kubectl apply, then wait
+# for the three cert-manager Deployments.
+#
+# Used by e2e-nightly.yaml and setup-e2e-cluster so the two paths cannot
+# drift. Override KUBECTL / READYZ_* / APPLY_* in unit tests.
+
+set -euo pipefail
+
+KUBECTL="${KUBECTL:-kubectl}"
+READYZ_ATTEMPTS="${READYZ_ATTEMPTS:-60}"
+READYZ_SLEEP="${READYZ_SLEEP:-2}"
+APPLY_ATTEMPTS="${APPLY_ATTEMPTS:-3}"
+APPLY_RETRY_SLEEP="${APPLY_RETRY_SLEEP:-15}"
+MODE="apply"
+MANIFEST=""
+
+if [[ "${1:-}" == "--wait-only" ]]; then
+  MODE="wait"
+elif [[ -n "${1:-}" ]]; then
+  MANIFEST="$1"
+else
+  echo "usage: e2e-install-cert-manager.sh MANIFEST | --wait-only" >&2
+  exit 2
+fi
+
+wait_readyz() {
+  local attempt
+  for attempt in $(seq 1 "${READYZ_ATTEMPTS}"); do
+    if "${KUBECTL}" get --raw='/readyz' >/dev/null 2>&1; then
+      echo "API server ready after ${attempt} attempt(s)"
+      return 0
+    fi
+    if (( attempt == READYZ_ATTEMPTS )); then
+      echo "::error::API server never became ready (readyz)"
+      return 1
+    fi
+    sleep "${READYZ_SLEEP}"
+  done
+}
+
+wait_readyz
+if [[ "${MODE}" == "wait" ]]; then
+  exit 0
+fi
+
+attempt=1
+while (( attempt <= APPLY_ATTEMPTS )); do
+  if "${KUBECTL}" apply -f "${MANIFEST}"; then
+    break
+  fi
+  if (( attempt == APPLY_ATTEMPTS )); then
+    echo "::error::cert-manager install failed after ${APPLY_ATTEMPTS} attempts"
+    exit 1
+  fi
+  echo "::warning::cert-manager install attempt ${attempt} failed, retrying in ${APPLY_RETRY_SLEEP}s..."
+  sleep "${APPLY_RETRY_SLEEP}"
+  wait_readyz
+  attempt=$((attempt + 1))
+done
+
+"${KUBECTL}" wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
+"${KUBECTL}" wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
+"${KUBECTL}" wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s

--- a/scripts/test_e2e_install_cert_manager.sh
+++ b/scripts/test_e2e_install_cert_manager.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Classifier for hack/e2e-install-cert-manager.sh: first-apply OpenAPI
+# failures must retry; a permanently down apiserver must fail closed.
+# Also assert nightly and the PR-CI composite both call the helper.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT}/hack/e2e-install-cert-manager.sh"
+NIGHTLY="${ROOT}/.github/workflows/e2e-nightly.yaml"
+COMPOSITE="${ROOT}/.github/actions/setup-e2e-cluster/action.yaml"
+
+echo "PLAN: classify e2e-install-cert-manager.sh"
+
+fail() {
+  echo "FAIL: $*"
+  echo "DONE: ok=false"
+  exit 1
+}
+
+[[ -f "${SCRIPT}" ]] || fail "missing ${SCRIPT}"
+
+echo "DO: nightly and setup-e2e-cluster must call the helper"
+grep -F -q 'hack/e2e-install-cert-manager.sh' "${NIGHTLY}" \
+  || fail "e2e-nightly.yaml does not invoke hack/e2e-install-cert-manager.sh"
+grep -F -q 'hack/e2e-install-cert-manager.sh' "${COMPOSITE}" \
+  || fail "setup-e2e-cluster/action.yaml does not invoke hack/e2e-install-cert-manager.sh"
+if grep -n 'kubectl apply -f /tmp/cert-manager.yaml' "${NIGHTLY}" "${COMPOSITE}"; then
+  fail "bare kubectl apply of cert-manager.yaml still present; use the helper"
+fi
+echo "OK: both install paths call the helper"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+MANIFEST="${TMP}/cert-manager.yaml"
+printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' >"${MANIFEST}"
+
+write_kubectl() {
+  local apply_fails="$1" readyz_fails="$2"
+  cat >"${TMP}/kubectl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+STATE="${TMP}/state"
+mkdir -p "\${STATE}"
+cmd="\${1:-}"
+shift || true
+case "\${cmd}" in
+  get)
+    if [[ "\${*}" == *readyz* ]]; then
+      n=\$(cat "\${STATE}/readyz" 2>/dev/null || echo 0)
+      n=\$((n + 1))
+      echo "\${n}" >"\${STATE}/readyz"
+      if (( n <= ${readyz_fails} )); then
+        echo "Error from server (ServiceUnavailable): apiserver not ready" >&2
+        exit 1
+      fi
+      echo ok
+      exit 0
+    fi
+    echo "unexpected kubectl get \$*" >&2
+    exit 2
+    ;;
+  apply)
+    n=\$(cat "\${STATE}/apply" 2>/dev/null || echo 0)
+    n=\$((n + 1))
+    echo "\${n}" >"\${STATE}/apply"
+    if (( n <= ${apply_fails} )); then
+      echo 'error: error validating "${MANIFEST}": error validating data: failed to download openapi: the server is currently unable to handle the request' >&2
+      exit 1
+    fi
+    echo "configmap/ok created"
+    exit 0
+    ;;
+  wait)
+    echo "deployment.apps/cert-manager condition met"
+    exit 0
+    ;;
+  *)
+    echo "unexpected kubectl \${cmd} \$*" >&2
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "${TMP}/kubectl"
+}
+
+run_helper() {
+  KUBECTL="${TMP}/kubectl" \
+    READYZ_ATTEMPTS=5 \
+    READYZ_SLEEP=0 \
+    APPLY_ATTEMPTS=3 \
+    APPLY_RETRY_SLEEP=0 \
+    bash "${SCRIPT}" "${MANIFEST}"
+}
+
+echo "DO: first apply OpenAPI failure then success must pass"
+rm -rf "${TMP}/state"
+write_kubectl 1 0
+if ! run_helper; then
+  fail "retry after one apply failure should succeed"
+fi
+apply_n="$(cat "${TMP}/state/apply")"
+[[ "${apply_n}" == "2" ]] || fail "expected 2 apply calls, got ${apply_n}"
+echo "OK: retried apply after OpenAPI failure"
+
+echo "DO: first readyz miss then apply success must pass"
+rm -rf "${TMP}/state"
+write_kubectl 0 1
+if ! run_helper; then
+  fail "readyz miss then success should succeed"
+fi
+readyz_n="$(cat "${TMP}/state/readyz")"
+[[ "${readyz_n}" == "2" ]] || fail "expected 2 readyz calls, got ${readyz_n}"
+echo "OK: waited for readyz before apply"
+
+echo "DO: three apply failures must fail closed"
+rm -rf "${TMP}/state"
+write_kubectl 99 0
+if run_helper; then
+  fail "permanent apply failure should exit non-zero"
+fi
+apply_n="$(cat "${TMP}/state/apply")"
+[[ "${apply_n}" == "3" ]] || fail "expected 3 apply calls, got ${apply_n}"
+echo "OK: exhausted apply retries"
+
+echo "DO: never-ready apiserver must fail closed"
+rm -rf "${TMP}/state"
+write_kubectl 0 99
+if run_helper; then
+  fail "never-ready readyz should exit non-zero"
+fi
+if [[ -f "${TMP}/state/apply" ]]; then
+  fail "apply must not run when readyz never succeeds"
+fi
+echo "OK: fail-closed when apiserver never becomes ready"
+
+echo "DO: --wait-only must poll readyz and skip apply"
+rm -rf "${TMP}/state"
+write_kubectl 0 1
+if ! KUBECTL="${TMP}/kubectl" READYZ_ATTEMPTS=5 READYZ_SLEEP=0 \
+    bash "${SCRIPT}" --wait-only; then
+  fail "--wait-only should succeed after one readyz miss"
+fi
+if [[ -f "${TMP}/state/apply" ]]; then
+  fail "--wait-only must not call kubectl apply"
+fi
+readyz_n="$(cat "${TMP}/state/readyz")"
+[[ "${readyz_n}" == "2" ]] || fail "--wait-only expected 2 readyz calls, got ${readyz_n}"
+echo "OK: --wait-only"
+
+echo "DO: both paths must re-wait after Prometheus image import"
+grep -F -A6 'Load Prometheus and test images into cluster' "${NIGHTLY}" \
+  | grep -F -q 'hack/e2e-install-cert-manager.sh --wait-only' \
+  || fail "e2e-nightly.yaml missing --wait-only after Prometheus image import"
+grep -F -A6 'Load Prometheus and test images into cluster' "${COMPOSITE}" \
+  | grep -F -q 'hack/e2e-install-cert-manager.sh --wait-only' \
+  || fail "setup-e2e-cluster missing --wait-only after Prometheus image import"
+echo "OK: Prometheus import waits for readyz"
+
+echo "DONE: ok=true"
+echo "NEXT: none"
+exit 0


### PR DESCRIPTION
## What This PR Does

Shares one cert-manager install helper between nightly E2E and the PR CI cluster action.

The helper polls `/readyz`, retries `kubectl apply` three times, then waits for the three cert-manager Deployments. After Prometheus and operator image imports, both paths also re-poll `/readyz` before the next API call.

## Why

Nightly run [32928172618](https://github.com/attune-io/attune/actions/runs/32928172618) failed only on K8s 1.34 at `Install cert-manager`. The cluster was 44 seconds old. kubelet had restarted three times after `k3d image import`, and `kubectl apply` died on:

```
failed to download openapi: the server is currently unable to handle the request
```

A debug dump one second later still showed `apiserver not ready`. Fuzz plus 1.32/1.33/1.35 were green on the same SHA. The previous nightly was green.

PR CI already retried apply three times. Nightly used a single-shot apply. That drift is what turned a brief apiserver bounce into a red nightly.

## Related Issues

Closes #592

## How to Test

```bash
make python-test
# or just:
bash scripts/test_e2e_install_cert_manager.sh
```

The classifier stubs kubectl and covers: retry after the OpenAPI error, wait for `/readyz` before apply, fail-closed after three apply failures, fail-closed when `/readyz` never succeeds, `--wait-only` skipping apply, and both YAML paths calling the helper.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] CRD changes regenerated (`make manifests`)
- [ ] Documentation updated (if user-facing)
- [ ] Helm chart updated (if applicable)
- [x] No breaking API changes (or documented in CHANGELOG)
