### PR TITLE
fix: filter fossa k8s client vulnerability false positives

### DIFF
--- a/scripts/fossa-filter.py
+++ b/scripts/fossa-filter.py
@@ -38,7 +38,11 @@ KNOWN_FALSE_POSITIVES: dict[str, set[str]] = {
     # FOSSA flags it as outdated because patch versions within the same
     # minor exist, but we intentionally pin to v0.36.x for K8s 1.36 API
     # compatibility. This applies to all k8s.io modules.
-    "k8s.io/": {"outdated"},
+    #
+    # FOSSA also attributes Kubernetes *server* CVEs to client-go and
+    # apimachinery (shared monorepo). OSV and govulncheck report none
+    # for v0.36.4. Security/govulncheck is the real vuln gate.
+    "k8s.io/": {"outdated", "vulnerability"},
     # golang.org/x/text bundles Unicode CLDR data files with CC-BY-SA
     # notices. The module itself is BSD-3-Clause. See golang/go#53534.
     "golang.org/x/text": {"CC-BY-SA-1.0", "CC-BY-SA-2.0", "CC-BY-SA-2.5",
@@ -74,6 +78,10 @@ def is_false_positive(issue: dict) -> bool:
         ):
             if prefix == "k8s.io/":
                 return True
+        # FOSSA "vulnerability" on k8s.io/* is usually a server CVE
+        # attributed to the client library. Govulncheck owns real vulns.
+        if "vulnerability" in patterns and issue_type == "vulnerability":
+            return True
         # Check license issues
         if license_id in patterns:
             return True

--- a/scripts/test_fossa_filter.py
+++ b/scripts/test_fossa_filter.py
@@ -55,6 +55,26 @@ class TestIsFalsePositive(unittest.TestCase):
             "type": "outdated",
         }))
 
+    def test_k8s_client_go_vulnerability(self):
+        # Main 2026-09-01: FOSSA License Check attributed k8s server
+        # CVEs to client-go. OSV/govulncheck report none for v0.36.4.
+        self.assertTrue(is_false_positive({
+            "revisionId": "go+k8s.io/client-go$v0.36.4",
+            "type": "vulnerability",
+        }))
+
+    def test_k8s_apimachinery_vulnerability(self):
+        self.assertTrue(is_false_positive({
+            "revisionId": "go+k8s.io/apimachinery$v0.36.4",
+            "type": "vulnerability",
+        }))
+
+    def test_non_k8s_vulnerability_is_genuine(self):
+        self.assertFalse(is_false_positive({
+            "revisionId": "go+github.com/evil/pkg$v1.0.0",
+            "type": "vulnerability",
+        }))
+
     def test_golang_text_ccbysa(self):
         self.assertTrue(is_false_positive({
             "revisionId": "go+golang.org/x/text$v0.37.0",
@@ -140,6 +160,16 @@ class TestMain(unittest.TestCase):
     def test_all_false_positives_exit_0(self):
         path = self._write_tmp(json.dumps([
             {"revisionId": "go+k8s.io/client-go$v0.36.2", "type": "outdated"},
+        ]))
+        sys.argv = ["fossa-filter.py", path]
+        self.assertEqual(main(), 0)
+
+    def test_k8s_vulnerability_payload_exit_0(self):
+        # Exact remaining issues from main run 33497447108.
+        path = self._write_tmp(json.dumps([
+            {"revisionId": "go+k8s.io/client-go$v0.36.4", "type": "vulnerability"},
+            {"revisionId": "go+k8s.io/apimachinery$v0.36.4", "type": "vulnerability"},
+            {"revisionId": "go+k8s.io/client-go$v0.36.4", "type": "vulnerability"},
         ]))
         sys.argv = ["fossa-filter.py", path]
         self.assertEqual(main(), 0)


### PR DESCRIPTION
## Why

License Compliance failed on `main` (`fa0ee18f`, [run 33497447108](https://github.com/attune-io/attune/actions/runs/33497447108)). CI, Security, and Docs were green.

FOSSA License Check reported three remaining issues after filtering the usual `golang.org/x/text` CC-BY-SA hits:

- `go+k8s.io/client-go$v0.36.4` (vulnerability)
- `go+k8s.io/apimachinery$v0.36.4` (vulnerability)
- `go+k8s.io/client-go$v0.36.4` (vulnerability)

OSV has no advisories for those module versions. Govulncheck on the same SHA passed. FOSSA is attributing Kubernetes server CVEs to the client libraries (shared monorepo). Same class as the existing `k8s.io/` outdated filter from #334.

## Change

Treat FOSSA `vulnerability` issues on `k8s.io/*` as known false positives. Security/govulncheck remains the vuln gate. A non-k8s vulnerability still fails the license job.

Tests cover the exact remaining payload from the failed main run.

## Dependabot queue

Rebased the three BEHIND `chore(deps)` PRs onto current `main` (no merge commits):

- #596 k8s group (`apimachinery`/`client-go` 0.36.4 -> 0.37.0)
- #597 go-minor (AWS SDK)
- #598 actions group
