### PR TITLE
feat: add a-f waste grade to kubectl attune recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ kubectl get attunepolicies -n production
 # api-services    Recommend   3           3      0         True    2d
 
 kubectl attune recommendations -n production
-# NAMESPACE   POLICY        WORKLOAD    CONTAINER  CPU REQ  CPU REC  MEM REQ  MEM REC  CONFIDENCE
-# production  api-services  api-server  app        500m     320m     512Mi    384Mi    92.0%
-# production  api-services  worker      main       1000m    480m     2Gi      1.2Gi    88.5%
-# production  api-services  frontend    nginx      250m     120m     256Mi    180Mi    95.1%
+# NAMESPACE   POLICY        WORKLOAD    CONTAINER  CPU REQ  CPU REC  MEM REQ  MEM REC  GRADE  CONFIDENCE
+# production  api-services  api-server  app        500m     320m     512Mi    384Mi    D      92.0%
+# production  api-services  worker      main       1000m    480m     2Gi      1.2Gi    F      88.5%
+# production  api-services  frontend    nginx      250m     120m     256Mi    180Mi    F      95.1%
 
 kubectl attune savings -n production
 # NAMESPACE   NAME          CPU SAVED  MEMORY SAVED  % SAVED  EST. MONTHLY
@@ -237,8 +237,8 @@ production   api-services   Canary  3          0        1        Monitoring   Id
 Example output (`kubectl attune recommendations`):
 
 ```
-NAMESPACE   POLICY        WORKLOAD    CONTAINER  CPU REQ  CPU REC  MEM REQ  MEM REC  CONFIDENCE
-production  api-services  api-server  app        500m     320m     512Mi    384Mi    92.0%
+NAMESPACE   POLICY        WORKLOAD    CONTAINER  CPU REQ  CPU REC  MEM REQ  MEM REC  GRADE  CONFIDENCE
+production  api-services  api-server  app        500m     320m     512Mi    384Mi    D      92.0%
 ```
 
 ## Grafana Dashboard

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -708,9 +708,9 @@ func printRecommendationsItems(items []unstructured.Unstructured) {
 	showCluster := hasClusterAnnotation(items)
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 3, ' ', 0)
 	if showCluster {
-		fmt.Fprintln(w, "CLUSTER\tNAMESPACE\tPOLICY\tWORKLOAD\tCONTAINER\tCPU REQ\tCPU REC\tMEM REQ\tMEM REC\tCONFIDENCE / STATUS")
+		fmt.Fprintln(w, "CLUSTER\tNAMESPACE\tPOLICY\tWORKLOAD\tCONTAINER\tCPU REQ\tCPU REC\tMEM REQ\tMEM REC\tGRADE\tCONFIDENCE / STATUS")
 	} else {
-		fmt.Fprintln(w, "NAMESPACE\tPOLICY\tWORKLOAD\tCONTAINER\tCPU REQ\tCPU REC\tMEM REQ\tMEM REC\tCONFIDENCE / STATUS")
+		fmt.Fprintln(w, "NAMESPACE\tPOLICY\tWORKLOAD\tCONTAINER\tCPU REQ\tCPU REC\tMEM REQ\tMEM REC\tGRADE\tCONFIDENCE / STATUS")
 	}
 
 	var collecting int
@@ -722,10 +722,10 @@ func printRecommendationsItems(items []unstructured.Unstructured) {
 		if !found || len(recs) == 0 {
 			collecting++
 			if showCluster {
-				fmt.Fprintf(w, "%s\t%s\t%s\t-\t-\t-\t-\t-\t-\t%s\n",
+				fmt.Fprintf(w, "%s\t%s\t%s\t-\t-\t-\t-\t-\t-\t-\t%s\n",
 					cluster, ns, policyName, policyReadyReason(item))
 			} else {
-				fmt.Fprintf(w, "%s\t%s\t-\t-\t-\t-\t-\t-\t%s\n",
+				fmt.Fprintf(w, "%s\t%s\t-\t-\t-\t-\t-\t-\t-\t%s\n",
 					ns, policyName, policyReadyReason(item))
 			}
 			continue
@@ -754,13 +754,14 @@ func printRecommendationsItems(items []unstructured.Unstructured) {
 				recCPU, _ := recommended["cpuRequest"].(string)
 				curMem, _ := current["memoryRequest"].(string)
 				recMem, _ := recommended["memoryRequest"].(string)
+				grade := wasteGrade(curCPU, recCPU, curMem, recMem)
 
 				if showCluster {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.1f%%\n",
-						cluster, ns, policyName, workload, name, curCPU, recCPU, curMem, recMem, confidence*100)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.1f%%\n",
+						cluster, ns, policyName, workload, name, curCPU, recCPU, curMem, recMem, grade, confidence*100)
 				} else {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.1f%%\n",
-						ns, policyName, workload, name, curCPU, recCPU, curMem, recMem, confidence*100)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.1f%%\n",
+						ns, policyName, workload, name, curCPU, recCPU, curMem, recMem, grade, confidence*100)
 				}
 			}
 		}
@@ -795,7 +796,7 @@ func printRecommendationsItems(items []unstructured.Unstructured) {
 
 func printRecommendationsCSV(items []unstructured.Unstructured) {
 	showCluster := hasClusterAnnotation(items)
-	header := []string{"namespace", "policy", "workload", "container", "cpu_req", "cpu_rec", "mem_req", "mem_rec", "confidence_or_status"}
+	header := []string{"namespace", "policy", "workload", "container", "cpu_req", "cpu_rec", "mem_req", "mem_rec", "grade", "confidence_or_status"}
 	if showCluster {
 		header = append([]string{"cluster"}, header...)
 	}
@@ -804,7 +805,7 @@ func printRecommendationsCSV(items []unstructured.Unstructured) {
 	for _, item := range items {
 		recs, found, _ := unstructured.NestedSlice(item.Object, "status", "recommendations")
 		if !found || len(recs) == 0 {
-			row := []string{item.GetNamespace(), item.GetName(), "", "", "", "", "", "", policyReadyReason(item)}
+			row := []string{item.GetNamespace(), item.GetName(), "", "", "", "", "", "", "-", policyReadyReason(item)}
 			if showCluster {
 				row = append([]string{itemCluster(item)}, row...)
 			}
@@ -833,7 +834,8 @@ func printRecommendationsCSV(items []unstructured.Unstructured) {
 				recMem, _ := recommended["memoryRequest"].(string)
 				row := []string{
 					item.GetNamespace(), item.GetName(), workload, name,
-					curCPU, recCPU, curMem, recMem, fmt.Sprintf("%.1f%%", confidence*100),
+					curCPU, recCPU, curMem, recMem, wasteGrade(curCPU, recCPU, curMem, recMem),
+					fmt.Sprintf("%.1f%%", confidence*100),
 				}
 				if showCluster {
 					row = append([]string{itemCluster(item)}, row...)
@@ -1611,6 +1613,60 @@ func parseDollarCents(s string) int64 {
 		return 0
 	}
 	return int64(f * 100)
+}
+
+// wasteGrade maps request waste to A-F. Waste is (current-rec)/rec for each
+// resource; the worse of CPU or memory wins. Under-request (current <= rec)
+// is A. "-" is used when no pair can be compared (collecting, missing rec,
+// unparseable, or non-positive rec).
+func wasteGrade(curCPU, recCPU, curMem, recMem string) string {
+	cpuWaste, cpuOK := requestWaste(curCPU, recCPU)
+	memWaste, memOK := requestWaste(curMem, recMem)
+	if !cpuOK && !memOK {
+		return "-"
+	}
+	waste := 0.0
+	if cpuOK {
+		waste = cpuWaste
+	}
+	if memOK && memWaste > waste {
+		waste = memWaste
+	}
+	switch {
+	case waste < 0.10:
+		return "A"
+	case waste < 0.25:
+		return "B"
+	case waste < 0.50:
+		return "C"
+	case waste < 0.75:
+		return "D"
+	default:
+		return "F"
+	}
+}
+
+func requestWaste(current, recommended string) (float64, bool) {
+	if current == "" || recommended == "" {
+		return 0, false
+	}
+	cur, err := resource.ParseQuantity(current)
+	if err != nil {
+		return 0, false
+	}
+	rec, err := resource.ParseQuantity(recommended)
+	if err != nil {
+		return 0, false
+	}
+	recMilli := rec.MilliValue()
+	if recMilli <= 0 {
+		return 0, false
+	}
+	curMilli := cur.MilliValue()
+	if curMilli <= recMilli {
+		return 0, true
+	}
+	return float64(curMilli-recMilli) / float64(recMilli), true
 }
 
 // savingsPercent computes the CPU savings percentage from reduction and total strings.

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -1279,7 +1279,42 @@ func TestPrintSavings_NoSavings(t *testing.T) {
 	assert.Regexp(t, `fresh-policy\s+-\s+-\s+-\s+-`, output)
 }
 
-// ---------- printRecommendations ----------
+// ---------- wasteGrade ----------
+
+func TestWasteGrade(t *testing.T) {
+	tests := []struct {
+		name           string
+		curCPU, recCPU string
+		curMem, recMem string
+		want           string
+	}{
+		{name: "A under 10 percent cpu", curCPU: "105m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "A"},
+		{name: "A exact match", curCPU: "100m", recCPU: "100m", curMem: "256Mi", recMem: "256Mi", want: "A"},
+		{name: "A under-provisioned", curCPU: "80m", recCPU: "100m", curMem: "128Mi", recMem: "256Mi", want: "A"},
+		{name: "B at 10 percent", curCPU: "110m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "B"},
+		{name: "B just under 25 percent", curCPU: "124m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "B"},
+		{name: "C at 25 percent", curCPU: "125m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "C"},
+		{name: "C just under 50 percent", curCPU: "149m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "C"},
+		{name: "D at 50 percent", curCPU: "150m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "D"},
+		{name: "D just under 75 percent", curCPU: "174m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "D"},
+		{name: "F at 75 percent", curCPU: "175m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "F"},
+		{name: "F double request", curCPU: "500m", recCPU: "250m", curMem: "256Mi", recMem: "128Mi", want: "F"},
+		{name: "worse of cpu and memory", curCPU: "105m", recCPU: "100m", curMem: "200Mi", recMem: "100Mi", want: "F"},
+		{name: "memory only when cpu missing", curCPU: "", recCPU: "", curMem: "125Mi", recMem: "100Mi", want: "C"},
+		{name: "cpu only when memory missing", curCPU: "110m", recCPU: "100m", curMem: "", recMem: "", want: "B"},
+		{name: "mixed units 1Gi vs 512Mi", curCPU: "100m", recCPU: "100m", curMem: "1Gi", recMem: "512Mi", want: "F"},
+		{name: "cores vs millicores", curCPU: "1", recCPU: "500m", curMem: "100Mi", recMem: "100Mi", want: "F"},
+		{name: "collecting empty", curCPU: "", recCPU: "", curMem: "", recMem: "", want: "-"},
+		{name: "missing recommended", curCPU: "500m", recCPU: "", curMem: "256Mi", recMem: "", want: "-"},
+		{name: "unparseable", curCPU: "not-a-qty", recCPU: "100m", curMem: "nope", recMem: "128Mi", want: "-"},
+		{name: "zero recommended", curCPU: "100m", recCPU: "0", curMem: "", recMem: "", want: "-"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, wasteGrade(tt.curCPU, tt.recCPU, tt.curMem, tt.recMem))
+		})
+	}
+}
 
 func TestPrintRecommendations(t *testing.T) {
 	policy := &unstructured.Unstructured{
@@ -1334,11 +1369,13 @@ func TestPrintRecommendations(t *testing.T) {
 	output := buf.String()
 
 	assert.Contains(t, output, "CONFIDENCE / STATUS")
+	assert.Contains(t, output, "GRADE")
 	assert.Contains(t, output, "web-deploy")
 	assert.Contains(t, output, "app")
 	assert.Contains(t, output, "500m")
 	assert.Contains(t, output, "250m")
 	assert.Contains(t, output, "85.0%")
+	assert.Regexp(t, `(?m)\bF\b`, output)
 }
 
 func TestPrintRecommendations_CollectingData(t *testing.T) {
@@ -1383,8 +1420,10 @@ func TestPrintRecommendations_CollectingData(t *testing.T) {
 	output := buf.String()
 
 	assert.Contains(t, output, "CONFIDENCE / STATUS")
+	assert.Contains(t, output, "GRADE")
 	assert.Contains(t, output, "new-policy")
 	assert.Contains(t, output, "Not enough data")
+	assert.Regexp(t, `(?m)new-policy\s+-\s+-\s+-\s+-\s+-\s+-\s+-\s+Not enough data`, output)
 }
 
 func captureRun(t *testing.T, args []string, buildClient dynamicClientFactory) (int, string, string) {
@@ -2465,8 +2504,8 @@ func TestPrintRecommendationsCSV_HeaderAndRow(t *testing.T) {
 	out, err := io.ReadAll(r)
 	require.NoError(t, err)
 	s := string(out)
-	assert.Contains(t, s, "namespace,policy,workload,container,cpu_req,cpu_rec,mem_req,mem_rec,confidence_or_status")
-	assert.Contains(t, s, "ns,p,api,app,500m,250m,256Mi,128Mi,95.0%")
+	assert.Contains(t, s, "namespace,policy,workload,container,cpu_req,cpu_rec,mem_req,mem_rec,grade,confidence_or_status")
+	assert.Contains(t, s, "ns,p,api,app,500m,250m,256Mi,128Mi,F,95.0%")
 }
 
 func TestPrintRecommendationsCSV_EmptyRecsUseReadyReason(t *testing.T) {
@@ -2490,8 +2529,8 @@ func TestPrintRecommendationsCSV_EmptyRecsUseReadyReason(t *testing.T) {
 	out, err := io.ReadAll(r)
 	require.NoError(t, err)
 	s := string(out)
-	assert.Contains(t, s, "confidence_or_status")
-	assert.Contains(t, s, "ns,p,,,,,,,InsufficientData")
+	assert.Contains(t, s, "namespace,policy,workload,container,cpu_req,cpu_rec,mem_req,mem_rec,grade,confidence_or_status")
+	assert.Contains(t, s, "ns,p,,,,,,,-,InsufficientData")
 	assert.NotContains(t, s, ",confidence\n")
 }
 

--- a/cmd/kubectl-attune/multicluster_test.go
+++ b/cmd/kubectl-attune/multicluster_test.go
@@ -373,10 +373,12 @@ func TestPrintRecommendationsItems_ShowsClusterColumn(t *testing.T) {
 	output := buf.String()
 
 	assert.Contains(t, output, "CLUSTER")
+	assert.Contains(t, output, "GRADE")
 	assert.Contains(t, output, "prod-east")
 	assert.Contains(t, output, "api-deploy")
 	assert.Contains(t, output, "250m")
 	assert.Contains(t, output, "95.0%")
+	assert.Regexp(t, `(?m)\bF\b`, output)
 }
 
 // ---------- run() multi-cluster validation ----------

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,10 +91,11 @@ kubectl attune preview -n production api-services
 
 ### recommendations
 
-Shows per-container current vs recommended values with confidence scores.
-When a policy is still collecting data, the last column shows the current
-status message instead. When any policy uses export mode, a footer note points
-to `kubectl attune export list` for the GitOps ConfigMap view and last-export timestamps.
+Shows per-container current vs recommended values with a waste grade and
+confidence scores. When a policy is still collecting data, GRADE is `-` and
+the last column shows the current status message instead. When any policy
+uses export mode, a footer note points to `kubectl attune export list` for
+the GitOps ConfigMap view and last-export timestamps.
 
 ```bash
 kubectl attune recommendations
@@ -111,6 +112,7 @@ kubectl attune recommendations -n production
 | CPU REC | Recommended CPU request |
 | MEM REQ | Current memory request |
 | MEM REC | Recommended memory request |
+| GRADE | Request waste vs recommendation (worse of CPU or memory): A under 10% over, B 10-25%, C 25-50%, D 50-75%, F 75% or more. Current at or below the recommendation is A. `-` while collecting or when quantities cannot be compared. |
 | CONFIDENCE / STATUS | Confidence percentage when recommendations exist, otherwise the current `Ready` message or reason |
 
 ### export
@@ -259,10 +261,11 @@ kubectl attune version
 - `status`: JSON or YAML of raw `AttunePolicy` objects
 - `diff`: YAML patch manifests
 - `savings` and `recommendations`: CSV (header plus one data row per
-  policy or container; no totals row). Recommendations CSV uses
-  `confidence_or_status` for the last column: a confidence percent
-  when recommendations exist, otherwise the policy Ready reason
-  (same as the table's CONFIDENCE / STATUS column).
+  policy or container; no totals row). Recommendations CSV includes
+  `grade` after `mem_rec` (same A-F bands as the table GRADE column,
+  or `-` while collecting). `confidence_or_status` is the last column:
+  a confidence percent when recommendations exist, otherwise the
+  policy Ready reason (same as the table's CONFIDENCE / STATUS column).
 
 ```bash
 kubectl attune status -o json


### PR DESCRIPTION
## Summary

Add an A-F waste grade column to `kubectl attune recommendations` (table and `-o csv`) so current vs recommended requests are scannable the way KRR grades waste.

## Problem

The plugin already prints current and recommended CPU/memory requests, but there is no single letter that answers "how over-requested is this container?" Collecting rows look like data rows with empty recs.

## Change

- Compute waste as `(current - recommended) / recommended` per resource.
- Use the worse of CPU or memory.
- Bands: A under 10% over, B 10-25%, C 25-50%, D 50-75%, F 75% or more.
- Current at or below the recommendation is A.
- Still collecting, missing recs, unparseable quantities, or a non-positive recommendation print `-`.
- Surfaces: table `GRADE` after `MEM REC`, CSV `grade` after `mem_rec`, CLI reference, README samples.

Plugin-only. No CRD, no status field, no new flag.

## Validation

- `go test ./cmd/kubectl-attune/... -count=1` (includes `TestWasteGrade` band table, collecting `-`, CSV header/row, table GRADE, multi-cluster GRADE).
- Boundary cases use integer `MilliValue` so 10%/25%/50%/75% land on the documented band.

Closes #602
