### PR TITLE
feat: mark under-provisioned recommendations as u

### DIFF
--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1615,9 +1615,11 @@ func parseDollarCents(s string) int64 {
 	return int64(f * 100)
 }
 
-// wasteGrade maps request waste to A-F. Waste is (current-rec)/rec for each
-// resource; the worse of CPU or memory wins. Under-request (current <= rec)
-// is A. "-" is used when no pair can be compared (collecting, missing rec,
+// wasteGrade maps request waste to A-F, or U when under-provisioned.
+// Waste is (current-rec)/rec for each resource. More than 10% under
+// the recommendation is U and wins over A-F (risk over cost). The
+// worse of CPU or memory waste otherwise selects the letter. "-" is
+// used when no pair can be compared (collecting, missing rec,
 // unparseable, or non-positive rec).
 func wasteGrade(curCPU, recCPU, curMem, recMem string) string {
 	cpuWaste, cpuOK := requestWaste(curCPU, recCPU)
@@ -1625,8 +1627,11 @@ func wasteGrade(curCPU, recCPU, curMem, recMem string) string {
 	if !cpuOK && !memOK {
 		return "-"
 	}
+	if (cpuOK && cpuWaste < -0.10) || (memOK && memWaste < -0.10) {
+		return "U"
+	}
 	waste := 0.0
-	if cpuOK {
+	if cpuOK && cpuWaste > waste {
 		waste = cpuWaste
 	}
 	if memOK && memWaste > waste {
@@ -1663,9 +1668,6 @@ func requestWaste(current, recommended string) (float64, bool) {
 		return 0, false
 	}
 	curMilli := cur.MilliValue()
-	if curMilli <= recMilli {
-		return 0, true
-	}
 	return float64(curMilli-recMilli) / float64(recMilli), true
 }
 

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -1290,7 +1290,14 @@ func TestWasteGrade(t *testing.T) {
 	}{
 		{name: "A under 10 percent cpu", curCPU: "105m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "A"},
 		{name: "A exact match", curCPU: "100m", recCPU: "100m", curMem: "256Mi", recMem: "256Mi", want: "A"},
-		{name: "A under-provisioned", curCPU: "80m", recCPU: "100m", curMem: "128Mi", recMem: "256Mi", want: "A"},
+		{name: "A within 10 percent under", curCPU: "240m", recCPU: "250m", curMem: "100Mi", recMem: "100Mi", want: "A"},
+		{name: "A at 10 percent under", curCPU: "90m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "A"},
+		{name: "U just beyond 10 percent under", curCPU: "89m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "U"},
+		{name: "U under-provisioned", curCPU: "80m", recCPU: "100m", curMem: "128Mi", recMem: "256Mi", want: "U"},
+		{name: "U zero request", curCPU: "0", recCPU: "250m", curMem: "0", recMem: "512Mi", want: "U"},
+		{name: "U scale-up", curCPU: "100m", recCPU: "2000m", curMem: "128Mi", recMem: "128Mi", want: "U"},
+		{name: "U wins cpu over mem under", curCPU: "180m", recCPU: "100m", curMem: "40Mi", recMem: "100Mi", want: "U"},
+		{name: "U wins cpu under mem over", curCPU: "40m", recCPU: "100m", curMem: "180Mi", recMem: "100Mi", want: "U"},
 		{name: "B at 10 percent", curCPU: "110m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "B"},
 		{name: "B just under 25 percent", curCPU: "124m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "B"},
 		{name: "C at 25 percent", curCPU: "125m", recCPU: "100m", curMem: "100Mi", recMem: "100Mi", want: "C"},
@@ -1376,6 +1383,64 @@ func TestPrintRecommendations(t *testing.T) {
 	assert.Contains(t, output, "250m")
 	assert.Contains(t, output, "85.0%")
 	assert.Regexp(t, `(?m)\bF\b`, output)
+}
+
+func TestPrintRecommendations_UnderProvisionedGradeU(t *testing.T) {
+	policy := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "attune.io/v1alpha1",
+			"kind":       "AttunePolicy",
+			"metadata": map[string]interface{}{
+				"name":      "web",
+				"namespace": "prod",
+			},
+			"status": map[string]interface{}{
+				"recommendations": []interface{}{
+					map[string]interface{}{
+						"workload": "api",
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":       "app",
+								"confidence": 0.92,
+								"current": map[string]interface{}{
+									"cpuRequest":    "0",
+									"memoryRequest": "0",
+								},
+								"recommended": map[string]interface{}{
+									"cpuRequest":    "250m",
+									"memoryRequest": "512Mi",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{gvr: "AttunePolicyList"}, policy)
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	printRecommendations(context.Background(), dynClient, "prod")
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+	output := buf.String()
+
+	assert.Contains(t, output, "GRADE")
+	assert.Contains(t, output, "250m")
+	assert.Regexp(t, `(?m)\bU\b`, output)
+	assert.NotRegexp(t, `(?m)\bA\b`, output)
 }
 
 func TestPrintRecommendations_CollectingData(t *testing.T) {
@@ -2506,6 +2571,41 @@ func TestPrintRecommendationsCSV_HeaderAndRow(t *testing.T) {
 	s := string(out)
 	assert.Contains(t, s, "namespace,policy,workload,container,cpu_req,cpu_rec,mem_req,mem_rec,grade,confidence_or_status")
 	assert.Contains(t, s, "ns,p,api,app,500m,250m,256Mi,128Mi,F,95.0%")
+}
+
+func TestPrintRecommendationsCSV_UnderProvisionedGradeU(t *testing.T) {
+	items := []unstructured.Unstructured{
+		{Object: map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "p", "namespace": "ns"},
+			"status": map[string]interface{}{
+				"recommendations": []interface{}{
+					map[string]interface{}{
+						"workload": "api",
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":        "app",
+								"current":     map[string]interface{}{"cpuRequest": "0", "memoryRequest": "0"},
+								"recommended": map[string]interface{}{"cpuRequest": "250m", "memoryRequest": "512Mi"},
+								"confidence":  0.92,
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	printRecommendationsCSV(items)
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "ns,p,api,app,0,250m,0,512Mi,U,92.0%")
+	assert.NotContains(t, s, ",A,")
 }
 
 func TestPrintRecommendationsCSV_EmptyRecsUseReadyReason(t *testing.T) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -112,7 +112,7 @@ kubectl attune recommendations -n production
 | CPU REC | Recommended CPU request |
 | MEM REQ | Current memory request |
 | MEM REC | Recommended memory request |
-| GRADE | Request waste vs recommendation (worse of CPU or memory): A under 10% over, B 10-25%, C 25-50%, D 50-75%, F 75% or more. Current at or below the recommendation is A. `-` while collecting or when quantities cannot be compared. |
+| GRADE | Request waste vs recommendation (worse of CPU or memory): A under 10% over (or up to 10% under), B 10-25%, C 25-50%, D 50-75%, F 75% or more. `U` when current is more than 10% below the recommendation, including a zero request. `U` wins if one resource is under-provisioned and the other is waste. `-` while collecting or when quantities cannot be compared. |
 | CONFIDENCE / STATUS | Confidence percentage when recommendations exist, otherwise the current `Ready` message or reason |
 
 ### export
@@ -263,7 +263,8 @@ kubectl attune version
 - `savings` and `recommendations`: CSV (header plus one data row per
   policy or container; no totals row). Recommendations CSV includes
   `grade` after `mem_rec` (same A-F bands as the table GRADE column,
-  or `-` while collecting). `confidence_or_status` is the last column:
+  plus `U` when under-provisioned, or `-` while collecting).
+  `confidence_or_status` is the last column:
   a confidence percent when recommendations exist, otherwise the
   policy Ready reason (same as the table's CONFIDENCE / STATUS column).
 


### PR DESCRIPTION
## Summary

`kubectl attune recommendations` now grades containers that are more than 10% under their recommendation as `U` instead of `A`.

## Problem

`requestWaste` clamped any current request at or below the recommendation to 0% waste. That made two very different cases look the same:

1. A correctly sized container (current ≈ recommended)
2. An under-provisioned container, including BestEffort `0` requests

An operator scanning GRADE for problems then saw the best letter on the containers most at risk of CPU throttling and OOMKill.

## Change

- `requestWaste` returns a signed `(current-rec)/rec` ratio
- `wasteGrade` returns `U` when either CPU or memory is more than 10% under
- `U` wins if one resource is waste and the other is under
- Existing A-F over-provision bands are unchanged
- `-` is still used for collecting, unparseable, or non-positive recommendations
- Table and CSV both use the same helper
- `docs/reference/cli.md` documents `U`

README sample rows are all over-provisioned and stay accurate.

## Validation

Red-green on `./cmd/kubectl-attune/`:

- Red: zero request, scale-up, 11% under, and mixed CPU-over/mem-under all returned `A` or `F`
- Green after the fix: those cases return `U`; 4% under and exact 10% under stay `A`; existing A-F band tests still pass

Also ran:

- `go test ./cmd/kubectl-attune/ -race -count=1`
- `make lint` (0 issues)
- `make verify-quick` (2160 tests, helm, docs)

Local reviewer on the uncommitted diff: 0 bugs, 0 suggestions, 0 nits.

Closes #605
