### PR TITLE
fix: skip stale rec display and bound k3d e2e cleanup

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -88,7 +88,7 @@ runs:
           age=$(( $(date +%s) - started_epoch ))
           if (( age > 3600 )); then
             echo "Deleting stale k3d cluster '$cluster' (age: ${age}s)"
-            k3d cluster delete "$cluster" || true
+            bash hack/k3d-delete.sh "$cluster"
           fi
         done
         docker builder prune -f || true
@@ -157,7 +157,7 @@ runs:
             break
           fi
           echo "::warning::k3d cluster create attempt $attempt failed, retrying in 10s..."
-          k3d cluster delete "${{ inputs.cluster-name }}" 2>/dev/null || true
+          bash hack/k3d-delete.sh "${{ inputs.cluster-name }}"
           sleep 10
           if (( attempt == 3 )); then
             echo "::error::k3d cluster creation failed after 3 attempts"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,12 +104,14 @@ jobs:
               - 'dist/**'
               - 'Makefile'
             # Helper scripts + their unit tests (FOSSA filter, fuzz classifier,
-            # fleet reports, nightly issue body, cert-manager installer).
+            # fleet reports, nightly issue body, cert-manager installer,
+            # bounded k3d delete).
             # Lint runs make python-test, which also covers the helper used
             # by setup-e2e-cluster and e2e-nightly.yaml.
             scripts:
               - 'scripts/**'
               - 'hack/e2e-install-cert-manager.sh'
+              - 'hack/k3d-delete.sh'
               - '.github/actions/setup-e2e-cluster/**'
               - '.github/workflows/e2e-nightly.yaml'
 
@@ -640,9 +642,7 @@ jobs:
       - name: Cleanup k3d cluster
         if: always()
         shell: bash -Eeuo pipefail {0}
-        run: |
-          k3d cluster delete "$K3D_CLUSTER_NAME" 2>/dev/null || true
-          rm -f "$KUBECONFIG"
+        run: bash hack/k3d-delete.sh "$K3D_CLUSTER_NAME" "$KUBECONFIG"
 
   govulncheck:
     name: Govulncheck

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -158,7 +158,7 @@ jobs:
             age=$(( $(date +%s) - started_epoch ))
             if (( age > 3600 )); then
               echo "Deleting stale k3d cluster '$cluster' (age: ${age}s)"
-              k3d cluster delete "$cluster" || true
+              bash hack/k3d-delete.sh "$cluster"
             fi
           done
           docker builder prune -f || true
@@ -265,7 +265,7 @@ jobs:
               --kubeconfig-update-default=false \
               --kubeconfig-switch-context=false; then
               echo "::warning::k3d cluster create attempt $attempt failed, retrying in 10s..."
-              k3d cluster delete "$CLUSTER_NAME" 2>/dev/null || true
+              bash hack/k3d-delete.sh "$CLUSTER_NAME"
               sleep 10
               if (( attempt == 3 )); then
                 echo "::error::k3d cluster creation failed after 3 attempts"
@@ -317,7 +317,7 @@ jobs:
 
           recreate_v132_cluster() {
             echo "Recreating k3d cluster ${CLUSTER_NAME} for feature-gate race recovery..."
-            k3d cluster delete "$CLUSTER_NAME" 2>/dev/null || true
+            bash hack/k3d-delete.sh "$CLUSTER_NAME"
             K3S_CONFIG="/tmp/k3s-v132-config.yaml"
             cat > "$K3S_CONFIG" <<'K3SEOF'
           kube-apiserver-arg:
@@ -605,9 +605,7 @@ jobs:
       - name: Cleanup k3d cluster
         if: always()
         shell: bash -Eeuo pipefail {0}
-        run: |
-          k3d cluster delete "$CLUSTER_NAME" 2>/dev/null || true
-          rm -f "$KUBECONFIG"
+        run: bash hack/k3d-delete.sh "$CLUSTER_NAME" "$KUBECONFIG"
 
   fuzz:
     name: Fuzz Tests

--- a/Makefile
+++ b/Makefile
@@ -234,13 +234,14 @@ test-fuzz: ## Run fuzz tests (coverage-guided; FUZZTIME=30s default, deadline-fl
 	./scripts/run-fuzz.sh
 
 .PHONY: python-test
-python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync, helm image tag, fleet reports, nightly issue body)
+python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync, helm image tag, fleet reports, nightly issue body, k3d-delete)
 	python3 scripts/test_fossa_filter.py -v
 	bash scripts/test_run_fuzz.sh
 	bash scripts/test_verify_go_version_sync.sh
 	bash scripts/test_verify_helm_image_tag.sh
 	bash scripts/test_release_image_tags.sh
 	bash scripts/test_e2e_install_cert_manager.sh
+	bash scripts/test_k3d_delete.sh
 	bash scripts/test_collect_fleet_reports.sh
 	bash scripts/test_nightly_failure_issue_body.sh
 

--- a/cmd/kubectl-attune/diff.go
+++ b/cmd/kubectl-attune/diff.go
@@ -42,6 +42,7 @@ func printDiffItems(items []unstructured.Unstructured, output string) {
 	}
 
 	hasOutput := false
+	staleSkipped := 0
 	for _, item := range items {
 		recs, found, _ := unstructured.NestedSlice(item.Object, "status", "recommendations")
 		if !found || len(recs) == 0 {
@@ -54,6 +55,10 @@ func printDiffItems(items []unstructured.Unstructured, output string) {
 		for _, r := range recs {
 			rec, ok := r.(map[string]interface{})
 			if !ok {
+				continue
+			}
+			if recStale(rec) {
+				staleSkipped++
 				continue
 			}
 			workload, _ := rec["workload"].(string)
@@ -76,6 +81,10 @@ func printDiffItems(items []unstructured.Unstructured, output string) {
 	}
 
 	if !hasOutput {
+		if staleSkipped > 0 {
+			fmt.Println("No fresh recommendations available (stale recs skipped). Run 'kubectl attune status' to check policy status.")
+			return
+		}
 		fmt.Println("No recommendations available. Run 'kubectl attune status' to check policy status.")
 	}
 }

--- a/cmd/kubectl-attune/diff_test.go
+++ b/cmd/kubectl-attune/diff_test.go
@@ -88,6 +88,58 @@ func TestPrintDiff_UnifiedOutput(t *testing.T) {
 	assert.Contains(t, output, "+      memory: \"384Mi\"")
 }
 
+func TestPrintDiff_StaleSkipped(t *testing.T) {
+	policy := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "attune.io/v1alpha1",
+			"kind":       "AttunePolicy",
+			"metadata": map[string]interface{}{
+				"name":      "api-server-attune",
+				"namespace": "default",
+			},
+			"status": map[string]interface{}{
+				"recommendations": []interface{}{
+					map[string]interface{}{
+						"workload": "api-server",
+						"kind":     "Deployment",
+						"stale":    true,
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":        "app",
+								"current":     map[string]interface{}{"cpuRequest": "500m", "memoryRequest": "512Mi"},
+								"recommended": map[string]interface{}{"cpuRequest": "280m", "memoryRequest": "384Mi"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{gvr: "AttunePolicyList"}, policy)
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	printDiff(context.Background(), dynClient, "default", "")
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+	output := buf.String()
+
+	assert.Contains(t, output, "stale recs skipped")
+	assert.NotContains(t, output, "--- a/")
+	assert.NotContains(t, output, "cpu: \"280m\"")
+}
+
 func TestPrintDiff_NoChanges(t *testing.T) {
 	policy := &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -755,13 +755,14 @@ func printRecommendationsItems(items []unstructured.Unstructured) {
 				curMem, _ := current["memoryRequest"].(string)
 				recMem, _ := recommended["memoryRequest"].(string)
 				grade := recommendationGrade(rec, curCPU, recCPU, curMem, recMem)
+				confOrStatus := recConfidenceOrStatus(rec, confidence)
 
 				if showCluster {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.1f%%\n",
-						cluster, ns, policyName, workload, name, curCPU, recCPU, curMem, recMem, grade, confidence*100)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+						cluster, ns, policyName, workload, name, curCPU, recCPU, curMem, recMem, grade, confOrStatus)
 				} else {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.1f%%\n",
-						ns, policyName, workload, name, curCPU, recCPU, curMem, recMem, grade, confidence*100)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+						ns, policyName, workload, name, curCPU, recCPU, curMem, recMem, grade, confOrStatus)
 				}
 			}
 		}
@@ -835,7 +836,7 @@ func printRecommendationsCSV(items []unstructured.Unstructured) {
 				row := []string{
 					item.GetNamespace(), item.GetName(), workload, name,
 					curCPU, recCPU, curMem, recMem, recommendationGrade(rec, curCPU, recCPU, curMem, recMem),
-					fmt.Sprintf("%.1f%%", confidence*100),
+					recConfidenceOrStatus(rec, confidence),
 				}
 				if showCluster {
 					row = append([]string{itemCluster(item)}, row...)
@@ -1061,6 +1062,9 @@ func printExplain(ctx context.Context, dynClient dynamic.Interface, namespace, p
 		}
 		workload, _ := rec["workload"].(string)
 		fmt.Printf("\nWorkload: %s\n", workload)
+		if recStale(rec) {
+			fmt.Printf("  stale (no fresh Prometheus data; resize is blocked)\n")
+		}
 		containers, _ := rec["containers"].([]interface{})
 		for _, c := range containers {
 			cont, ok := c.(map[string]interface{})
@@ -1631,6 +1635,13 @@ func recStale(rec map[string]interface{}) bool {
 	}
 	b, ok := v.(bool)
 	return ok && b
+}
+
+func recConfidenceOrStatus(rec map[string]interface{}, confidence float64) string {
+	if recStale(rec) {
+		return "stale"
+	}
+	return fmt.Sprintf("%.1f%%", confidence*100)
 }
 
 // wasteGrade maps request waste to A-F, or U when under-provisioned.

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -754,7 +754,7 @@ func printRecommendationsItems(items []unstructured.Unstructured) {
 				recCPU, _ := recommended["cpuRequest"].(string)
 				curMem, _ := current["memoryRequest"].(string)
 				recMem, _ := recommended["memoryRequest"].(string)
-				grade := wasteGrade(curCPU, recCPU, curMem, recMem)
+				grade := recommendationGrade(rec, curCPU, recCPU, curMem, recMem)
 
 				if showCluster {
 					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%.1f%%\n",
@@ -834,7 +834,7 @@ func printRecommendationsCSV(items []unstructured.Unstructured) {
 				recMem, _ := recommended["memoryRequest"].(string)
 				row := []string{
 					item.GetNamespace(), item.GetName(), workload, name,
-					curCPU, recCPU, curMem, recMem, wasteGrade(curCPU, recCPU, curMem, recMem),
+					curCPU, recCPU, curMem, recMem, recommendationGrade(rec, curCPU, recCPU, curMem, recMem),
 					fmt.Sprintf("%.1f%%", confidence*100),
 				}
 				if showCluster {
@@ -1613,6 +1613,24 @@ func parseDollarCents(s string) int64 {
 		return 0
 	}
 	return int64(f * 100)
+}
+
+// recommendationGrade is wasteGrade unless the workload rec is stale.
+// The operator does not resize from stale recs; GRADE must not look live.
+func recommendationGrade(rec map[string]interface{}, curCPU, recCPU, curMem, recMem string) string {
+	if recStale(rec) {
+		return "-"
+	}
+	return wasteGrade(curCPU, recCPU, curMem, recMem)
+}
+
+func recStale(rec map[string]interface{}) bool {
+	v, ok := rec["stale"]
+	if !ok {
+		return false
+	}
+	b, ok := v.(bool)
+	return ok && b
 }
 
 // wasteGrade maps request waste to A-F, or U when under-provisioned.

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -2053,6 +2053,10 @@ func printPreview(ctx context.Context, dynClient dynamic.Interface, namespace, p
 			continue
 		}
 		workload, _ := rec["workload"].(string)
+		if recStale(rec) {
+			fmt.Fprintf(os.Stderr, "Skipping stale recommendation for %s (no fresh Prometheus data).\n", workload)
+			continue
+		}
 		containers, _ := rec["containers"].([]interface{})
 
 		for _, c := range containers {

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -1323,6 +1323,15 @@ func TestWasteGrade(t *testing.T) {
 	}
 }
 
+func TestRecommendationGrade_StaleOverridesWaste(t *testing.T) {
+	rec := map[string]interface{}{"stale": true}
+	assert.Equal(t, "-", recommendationGrade(rec, "0", "250m", "0", "512Mi"))
+	assert.Equal(t, "-", recommendationGrade(rec, "500m", "250m", "256Mi", "128Mi"))
+	fresh := map[string]interface{}{"stale": false}
+	assert.Equal(t, "U", recommendationGrade(fresh, "0", "250m", "0", "512Mi"))
+	assert.Equal(t, "F", recommendationGrade(map[string]interface{}{}, "500m", "250m", "256Mi", "128Mi"))
+}
+
 func TestPrintRecommendations(t *testing.T) {
 	policy := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -1441,6 +1450,64 @@ func TestPrintRecommendations_UnderProvisionedGradeU(t *testing.T) {
 	assert.Contains(t, output, "250m")
 	assert.Regexp(t, `(?m)\bU\b`, output)
 	assert.NotRegexp(t, `(?m)\bA\b`, output)
+}
+
+func TestPrintRecommendations_StaleGradeDash(t *testing.T) {
+	policy := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "attune.io/v1alpha1",
+			"kind":       "AttunePolicy",
+			"metadata": map[string]interface{}{
+				"name":      "web",
+				"namespace": "prod",
+			},
+			"status": map[string]interface{}{
+				"recommendations": []interface{}{
+					map[string]interface{}{
+						"workload": "api",
+						"stale":    true,
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":       "app",
+								"confidence": 0.92,
+								"current": map[string]interface{}{
+									"cpuRequest":    "0",
+									"memoryRequest": "0",
+								},
+								"recommended": map[string]interface{}{
+									"cpuRequest":    "250m",
+									"memoryRequest": "512Mi",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{gvr: "AttunePolicyList"}, policy)
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	printRecommendations(context.Background(), dynClient, "prod")
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+	output := buf.String()
+
+	assert.Contains(t, output, "250m")
+	assert.Regexp(t, `(?m)\s-\s+92.0%`, output)
+	assert.NotRegexp(t, `(?m)\bU\b`, output)
 }
 
 func TestPrintRecommendations_CollectingData(t *testing.T) {
@@ -2606,6 +2673,42 @@ func TestPrintRecommendationsCSV_UnderProvisionedGradeU(t *testing.T) {
 	s := string(out)
 	assert.Contains(t, s, "ns,p,api,app,0,250m,0,512Mi,U,92.0%")
 	assert.NotContains(t, s, ",A,")
+}
+
+func TestPrintRecommendationsCSV_StaleGradeDash(t *testing.T) {
+	items := []unstructured.Unstructured{
+		{Object: map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "p", "namespace": "ns"},
+			"status": map[string]interface{}{
+				"recommendations": []interface{}{
+					map[string]interface{}{
+						"workload": "api",
+						"stale":    true,
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":        "app",
+								"current":     map[string]interface{}{"cpuRequest": "0", "memoryRequest": "0"},
+								"recommended": map[string]interface{}{"cpuRequest": "250m", "memoryRequest": "512Mi"},
+								"confidence":  0.92,
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	printRecommendationsCSV(items)
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "ns,p,api,app,0,250m,0,512Mi,-,92.0%")
+	assert.NotContains(t, s, ",U,")
 }
 
 func TestPrintRecommendationsCSV_EmptyRecsUseReadyReason(t *testing.T) {

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -355,6 +355,65 @@ func TestPrintPreview(t *testing.T) {
 	assert.Contains(t, output, "Memory")
 }
 
+func TestPrintPreview_StaleSkipped(t *testing.T) {
+	policy := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "attune.io/v1alpha1",
+			"kind":       "AttunePolicy",
+			"metadata": map[string]interface{}{
+				"name":      "web-app",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"updateStrategy": map[string]interface{}{"type": "Recommend"},
+			},
+			"status": map[string]interface{}{
+				"recommendations": []interface{}{
+					map[string]interface{}{
+						"workload": "web-deploy",
+						"stale":    true,
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":        "app",
+								"current":     map[string]interface{}{"cpuRequest": "500m", "memoryRequest": "256Mi"},
+								"recommended": map[string]interface{}{"cpuRequest": "250m", "memoryRequest": "256Mi"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{gvr: "AttunePolicyList"}, policy)
+
+	oldOut, oldErr := os.Stdout, os.Stderr
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	errR, errW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout, os.Stderr = outW, errW
+
+	printPreview(context.Background(), dynClient, "default", "web-app")
+
+	require.NoError(t, outW.Close())
+	require.NoError(t, errW.Close())
+	os.Stdout, os.Stderr = oldOut, oldErr
+
+	var outBuf, errBuf bytes.Buffer
+	_, err = outBuf.ReadFrom(outR)
+	require.NoError(t, err)
+	_, err = errBuf.ReadFrom(errR)
+	require.NoError(t, err)
+
+	assert.NotContains(t, outBuf.String(), "500m")
+	assert.NotContains(t, outBuf.String(), "250m")
+	assert.Contains(t, errBuf.String(), "stale")
+	assert.Contains(t, errBuf.String(), "web-deploy")
+}
+
 func TestPrintHistory(t *testing.T) {
 	policy := &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -1565,8 +1565,9 @@ func TestPrintRecommendations_StaleGradeDash(t *testing.T) {
 	output := buf.String()
 
 	assert.Contains(t, output, "250m")
-	assert.Regexp(t, `(?m)\s-\s+92.0%`, output)
+	assert.Regexp(t, `(?m)\s-\s+stale\b`, output)
 	assert.NotRegexp(t, `(?m)\bU\b`, output)
+	assert.NotContains(t, output, "92.0%")
 }
 
 func TestPrintRecommendations_CollectingData(t *testing.T) {
@@ -2063,6 +2064,53 @@ func TestPrintExplain(t *testing.T) {
 	assert.Contains(t, output, "Raw percentile:              200m")
 	assert.Contains(t, output, "Change filter [10.00%, 50.00%]: 250m (max_change_capped)")
 	assert.Contains(t, output, "Final adjustment:           memory decrease blocked by allowDecrease=false")
+}
+
+func TestPrintExplain_StaleNote(t *testing.T) {
+	policy := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "attune.io/v1alpha1",
+			"kind":       "AttunePolicy",
+			"metadata": map[string]interface{}{
+				"name":      "my-policy",
+				"namespace": "default",
+			},
+			"status": map[string]interface{}{
+				"recommendations": []interface{}{
+					map[string]interface{}{
+						"workload": "web-deploy",
+						"stale":    true,
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":        "app",
+								"confidence":  0.85,
+								"current":     map[string]interface{}{"cpuRequest": "500m"},
+								"recommended": map[string]interface{}{"cpuRequest": "250m"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			gvr:                  "AttunePolicyList",
+			namespaceDefaultsGVR: "AttuneNamespaceDefaultsList",
+			defaultsGVR:          "AttuneDefaultsList",
+		}, policy)
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	printExplain(context.Background(), dynClient, "default", "my-policy")
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "stale (no fresh Prometheus data")
 }
 
 func TestPrintExplain_NoRecommendations(t *testing.T) {
@@ -2766,8 +2814,9 @@ func TestPrintRecommendationsCSV_StaleGradeDash(t *testing.T) {
 	out, err := io.ReadAll(r)
 	require.NoError(t, err)
 	s := string(out)
-	assert.Contains(t, s, "ns,p,api,app,0,250m,0,512Mi,-,92.0%")
+	assert.Contains(t, s, "ns,p,api,app,0,250m,0,512Mi,-,stale")
 	assert.NotContains(t, s, ",U,")
+	assert.NotContains(t, s, "92.0%")
 }
 
 func TestPrintRecommendationsCSV_EmptyRecsUseReadyReason(t *testing.T) {

--- a/cmd/kubectl-attune/wizard.go
+++ b/cmd/kubectl-attune/wizard.go
@@ -300,6 +300,10 @@ func wizardPromote(ctx context.Context, dynClient dynamic.Interface, namespace s
 				continue
 			}
 			workload, _ := rec["workload"].(string)
+			if recStale(rec) {
+				fmt.Printf("  %s: stale (skipped; no fresh Prometheus data)\n", workload)
+				continue
+			}
 			containers, _ := rec["containers"].([]interface{})
 			for _, c := range containers {
 				cont, ok := c.(map[string]interface{})

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -113,7 +113,7 @@ kubectl attune recommendations -n production
 | MEM REQ | Current memory request |
 | MEM REC | Recommended memory request |
 | GRADE | Request waste vs recommendation (worse of CPU or memory): A under 10% over (or up to 10% under), B 10-25%, C 25-50%, D 50-75%, F 75% or more. `U` when current is more than 10% below the recommendation, including a zero request. `U` wins if one resource is under-provisioned and the other is waste. `-` while collecting, when the workload rec is stale, or when quantities cannot be compared. |
-| CONFIDENCE / STATUS | Confidence percentage when recommendations exist, otherwise the current `Ready` message or reason |
+| CONFIDENCE / STATUS | Confidence percentage when recommendations exist, `stale` when the workload rec is based on cached Prometheus data, otherwise the current `Ready` message or reason |
 
 ### export
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -112,7 +112,7 @@ kubectl attune recommendations -n production
 | CPU REC | Recommended CPU request |
 | MEM REQ | Current memory request |
 | MEM REC | Recommended memory request |
-| GRADE | Request waste vs recommendation (worse of CPU or memory): A under 10% over (or up to 10% under), B 10-25%, C 25-50%, D 50-75%, F 75% or more. `U` when current is more than 10% below the recommendation, including a zero request. `U` wins if one resource is under-provisioned and the other is waste. `-` while collecting or when quantities cannot be compared. |
+| GRADE | Request waste vs recommendation (worse of CPU or memory): A under 10% over (or up to 10% under), B 10-25%, C 25-50%, D 50-75%, F 75% or more. `U` when current is more than 10% below the recommendation, including a zero request. `U` wins if one resource is under-provisioned and the other is waste. `-` while collecting, when the workload rec is stale, or when quantities cannot be compared. |
 | CONFIDENCE / STATUS | Confidence percentage when recommendations exist, otherwise the current `Ready` message or reason |
 
 ### export
@@ -263,7 +263,7 @@ kubectl attune version
 - `savings` and `recommendations`: CSV (header plus one data row per
   policy or container; no totals row). Recommendations CSV includes
   `grade` after `mem_rec` (same A-F bands as the table GRADE column,
-  plus `U` when under-provisioned, or `-` while collecting).
+  plus `U` when under-provisioned, or `-` while collecting or stale).
   `confidence_or_status` is the last column:
   a confidence percent when recommendations exist, otherwise the
   policy Ready reason (same as the table's CONFIDENCE / STATUS column).

--- a/hack/k3d-delete.sh
+++ b/hack/k3d-delete.sh
@@ -24,8 +24,11 @@ TIMEOUT_BIN="${TIMEOUT_BIN:-timeout}"
 
 echo "PLAN: delete k3d cluster ${NAME} (timeout ${TIMEOUT_SEC}s)"
 
+KILL_AFTER="${K3D_DELETE_KILL_AFTER_SEC:-5}"
 if command -v "${TIMEOUT_BIN}" >/dev/null 2>&1; then
-  "${TIMEOUT_BIN}" "${TIMEOUT_SEC}" "${K3D}" cluster delete "${NAME}" || true
+  # SIGTERM at TIMEOUT_SEC, then SIGKILL so a wedged docker/k3d cannot
+  # ignore TERM and hold the E2E job until the 30m cap.
+  "${TIMEOUT_BIN}" -k "${KILL_AFTER}" "${TIMEOUT_SEC}" "${K3D}" cluster delete "${NAME}" || true
 else
   echo "::warning::timeout not found; deleting ${NAME} without a bound"
   "${K3D}" cluster delete "${NAME}" || true

--- a/hack/k3d-delete.sh
+++ b/hack/k3d-delete.sh
@@ -28,7 +28,12 @@ KILL_AFTER="${K3D_DELETE_KILL_AFTER_SEC:-5}"
 if command -v "${TIMEOUT_BIN}" >/dev/null 2>&1; then
   # SIGTERM at TIMEOUT_SEC, then SIGKILL so a wedged docker/k3d cannot
   # ignore TERM and hold the E2E job until the 30m cap.
-  "${TIMEOUT_BIN}" -k "${KILL_AFTER}" "${TIMEOUT_SEC}" "${K3D}" cluster delete "${NAME}" || true
+  del_status=0
+  "${TIMEOUT_BIN}" -k "${KILL_AFTER}" "${TIMEOUT_SEC}" "${K3D}" cluster delete "${NAME}" || del_status=$?
+  # GNU timeout uses 124; a SIGKILL'd child is 137 (128+9).
+  if [[ "${del_status}" -eq 124 || "${del_status}" -eq 137 ]]; then
+    echo "::warning::k3d delete timed out for ${NAME}; cluster may still exist"
+  fi
 else
   echo "::warning::timeout not found; deleting ${NAME} without a bound"
   "${K3D}" cluster delete "${NAME}" || true

--- a/hack/k3d-delete.sh
+++ b/hack/k3d-delete.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bounded k3d cluster delete. A hung docker/k3d must not consume the
+# remaining E2E job timeout (seen after setup-e2e-cluster failed on
+# main: k3d cluster delete ran until the 30m job cap). Always exits 0.
+#
+# Usage: k3d-delete.sh CLUSTER_NAME [KUBECONFIG]
+# Overrides for tests: K3D, TIMEOUT_BIN, K3D_DELETE_TIMEOUT_SEC.
+
+set -euo pipefail
+
+if [[ $# -lt 1 || -z "${1}" ]]; then
+  echo "usage: k3d-delete.sh CLUSTER_NAME [KUBECONFIG]" >&2
+  exit 2
+fi
+
+NAME="$1"
+KUBECONFIG_PATH="${2:-}"
+TIMEOUT_SEC="${K3D_DELETE_TIMEOUT_SEC:-60}"
+K3D="${K3D:-k3d}"
+TIMEOUT_BIN="${TIMEOUT_BIN:-timeout}"
+
+echo "PLAN: delete k3d cluster ${NAME} (timeout ${TIMEOUT_SEC}s)"
+
+if command -v "${TIMEOUT_BIN}" >/dev/null 2>&1; then
+  "${TIMEOUT_BIN}" "${TIMEOUT_SEC}" "${K3D}" cluster delete "${NAME}" || true
+else
+  echo "::warning::timeout not found; deleting ${NAME} without a bound"
+  "${K3D}" cluster delete "${NAME}" || true
+fi
+
+if [[ -n "${KUBECONFIG_PATH}" ]]; then
+  rm -f "${KUBECONFIG_PATH}"
+fi
+
+echo "DONE: ok=true cluster=${NAME}"
+echo "NEXT: none"

--- a/scripts/test_k3d_delete.sh
+++ b/scripts/test_k3d_delete.sh
@@ -88,6 +88,10 @@ fi
 status=$?
 kill "${waiter}" 2>/dev/null || true
 wait "${waiter}" 2>/dev/null || true
+# GNU timeout exits 124 when it kills the child (TERM=143, KILL=137).
+if [[ "${status}" -eq 137 || "${status}" -eq 143 ]]; then
+  exit 124
+fi
 exit "${status}"
 EOF
 chmod +x "${TMP}/timeout"
@@ -109,7 +113,7 @@ echo "DO: hung delete ignores TERM and is still bounded by SIGKILL"
 : >"${K3D_LOG}"
 export K3D_DELETE_KILL_AFTER_SEC=1
 start=$(date +%s)
-K3D_HANG=1 bash "${SCRIPT}" hung-cluster
+K3D_HANG=1 bash "${SCRIPT}" hung-cluster >"${TMP}/hung.out" 2>&1 || true
 elapsed=$(( $(date +%s) - start ))
 if (( elapsed > 8 )); then
   fail "hung delete took ${elapsed}s; expected TERM at 1s then KILL at +1s"

--- a/scripts/test_k3d_delete.sh
+++ b/scripts/test_k3d_delete.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Classifier for hack/k3d-delete.sh: cleanup must bound k3d cluster
+# delete so a hung docker/k3d cannot eat the E2E job timeout.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT}/hack/k3d-delete.sh"
+CI="${ROOT}/.github/workflows/ci.yaml"
+NIGHTLY="${ROOT}/.github/workflows/e2e-nightly.yaml"
+COMPOSITE="${ROOT}/.github/actions/setup-e2e-cluster/action.yaml"
+
+echo "PLAN: classify k3d-delete.sh"
+
+fail() {
+  echo "FAIL: $*"
+  echo "DONE: ok=false"
+  exit 1
+}
+
+[[ -f "${SCRIPT}" ]] || fail "missing ${SCRIPT}"
+[[ -x "${SCRIPT}" ]] || fail "${SCRIPT} is not executable"
+
+echo "DO: CI, nightly, and setup-e2e-cluster must call the helper"
+grep -F -q 'hack/k3d-delete.sh' "${CI}" \
+  || fail "ci.yaml does not invoke hack/k3d-delete.sh"
+grep -F -q 'hack/k3d-delete.sh' "${NIGHTLY}" \
+  || fail "e2e-nightly.yaml does not invoke hack/k3d-delete.sh"
+grep -F -q 'hack/k3d-delete.sh' "${COMPOSITE}" \
+  || fail "setup-e2e-cluster/action.yaml does not invoke hack/k3d-delete.sh"
+echo "OK: all three paths call the helper"
+
+echo "DO: no unbounded k3d cluster delete remains in those paths"
+if grep -nE 'k3d cluster delete' "${CI}" "${NIGHTLY}" "${COMPOSITE}" \
+  | grep -v 'k3d-delete.sh' | grep -v '#'; then
+  fail "bare k3d cluster delete still present; use hack/k3d-delete.sh"
+fi
+echo "OK: no bare k3d cluster delete in CI paths"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+cat >"${TMP}/k3d" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "k3d $*" >>"${K3D_LOG}"
+if [[ "${K3D_HANG:-0}" == "1" ]]; then
+  sleep 30
+fi
+if [[ "${K3D_FAIL:-0}" == "1" ]]; then
+  echo "k3d failed" >&2
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "${TMP}/k3d"
+
+cat >"${TMP}/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# usage: timeout SEC CMD...
+secs="$1"
+shift
+"$@" &
+pid=$!
+(
+  sleep "${secs}"
+  kill "${pid}" 2>/dev/null || true
+) &
+waiter=$!
+if wait "${pid}"; then
+  kill "${waiter}" 2>/dev/null || true
+  wait "${waiter}" 2>/dev/null || true
+  exit 0
+fi
+status=$?
+kill "${waiter}" 2>/dev/null || true
+wait "${waiter}" 2>/dev/null || true
+exit "${status}"
+EOF
+chmod +x "${TMP}/timeout"
+
+export PATH="${TMP}:${PATH}"
+export K3D="${TMP}/k3d"
+export TIMEOUT_BIN="${TMP}/timeout"
+export K3D_DELETE_TIMEOUT_SEC=1
+export K3D_LOG="${TMP}/k3d.log"
+
+echo "DO: successful delete exits 0 and invokes k3d"
+: >"${K3D_LOG}"
+K3D_HANG=0 K3D_FAIL=0 bash "${SCRIPT}" e2e-test
+grep -Fq 'cluster delete e2e-test' "${K3D_LOG}" \
+  || fail "successful delete did not call k3d cluster delete"
+echo "OK: successful delete"
+
+echo "DO: hung delete is bounded and still exits 0"
+: >"${K3D_LOG}"
+start=$(date +%s)
+K3D_HANG=1 bash "${SCRIPT}" hung-cluster
+elapsed=$(( $(date +%s) - start ))
+if (( elapsed > 8 )); then
+  fail "hung delete took ${elapsed}s; expected timeout around 1s"
+fi
+echo "OK: hung delete bounded (${elapsed}s)"
+
+echo "DO: k3d failure still exits 0"
+: >"${K3D_LOG}"
+K3D_FAIL=1 bash "${SCRIPT}" fail-cluster
+echo "OK: failed delete exits 0"
+
+echo "DO: kubeconfig path is removed"
+kc="${TMP}/kubeconfig"
+echo leftover >"${kc}"
+K3D_HANG=0 K3D_FAIL=0 bash "${SCRIPT}" e2e-test "${kc}"
+[[ ! -e "${kc}" ]] || fail "kubeconfig ${kc} was not removed"
+echo "OK: kubeconfig removed"
+
+echo "DONE: ok=true"
+echo "NEXT: none"

--- a/scripts/test_k3d_delete.sh
+++ b/scripts/test_k3d_delete.sh
@@ -24,18 +24,17 @@ fail() {
 [[ -f "${SCRIPT}" ]] || fail "missing ${SCRIPT}"
 [[ -x "${SCRIPT}" ]] || fail "${SCRIPT} is not executable"
 
-echo "DO: CI, nightly, and setup-e2e-cluster must call the helper"
-grep -F -q 'hack/k3d-delete.sh' "${CI}" \
-  || fail "ci.yaml does not invoke hack/k3d-delete.sh"
-grep -F -q 'hack/k3d-delete.sh' "${NIGHTLY}" \
-  || fail "e2e-nightly.yaml does not invoke hack/k3d-delete.sh"
-grep -F -q 'hack/k3d-delete.sh' "${COMPOSITE}" \
-  || fail "setup-e2e-cluster/action.yaml does not invoke hack/k3d-delete.sh"
-echo "OK: all three paths call the helper"
+echo "DO: CI, nightly, and setup-e2e-cluster must invoke the helper"
+ci_calls=$(grep -cE 'bash hack/k3d-delete\.sh' "${CI}" || true)
+nightly_calls=$(grep -cE 'bash hack/k3d-delete\.sh' "${NIGHTLY}" || true)
+composite_calls=$(grep -cE 'bash hack/k3d-delete\.sh' "${COMPOSITE}" || true)
+(( ci_calls >= 1 )) || fail "ci.yaml run-line calls=${ci_calls} want >=1"
+(( nightly_calls >= 3 )) || fail "e2e-nightly.yaml run-line calls=${nightly_calls} want >=3"
+(( composite_calls >= 2 )) || fail "setup-e2e-cluster run-line calls=${composite_calls} want >=2"
+echo "OK: invoke counts ci=${ci_calls} nightly=${nightly_calls} composite=${composite_calls}"
 
 echo "DO: no unbounded k3d cluster delete remains in those paths"
-if grep -nE 'k3d cluster delete' "${CI}" "${NIGHTLY}" "${COMPOSITE}" \
-  | grep -v 'k3d-delete.sh' | grep -v '#'; then
+if grep -nE 'k3d[[:space:]]+cluster[[:space:]]+delete' "${CI}" "${NIGHTLY}" "${COMPOSITE}"; then
   fail "bare k3d cluster delete still present; use hack/k3d-delete.sh"
 fi
 echo "OK: no bare k3d cluster delete in CI paths"
@@ -48,6 +47,7 @@ cat >"${TMP}/k3d" <<'EOF'
 set -euo pipefail
 echo "k3d $*" >>"${K3D_LOG}"
 if [[ "${K3D_HANG:-0}" == "1" ]]; then
+  trap '' TERM
   sleep 30
 fi
 if [[ "${K3D_FAIL:-0}" == "1" ]]; then
@@ -61,14 +61,23 @@ chmod +x "${TMP}/k3d"
 cat >"${TMP}/timeout" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-# usage: timeout SEC CMD...
+# usage: timeout [-k KILL_AFTER] SEC CMD...
+kill_after=""
+if [[ "${1:-}" == "-k" ]]; then
+  kill_after="$2"
+  shift 2
+fi
 secs="$1"
 shift
 "$@" &
 pid=$!
 (
   sleep "${secs}"
-  kill "${pid}" 2>/dev/null || true
+  kill -TERM "${pid}" 2>/dev/null || true
+  if [[ -n "${kill_after}" ]]; then
+    sleep "${kill_after}"
+    kill -KILL "${pid}" 2>/dev/null || true
+  fi
 ) &
 waiter=$!
 if wait "${pid}"; then
@@ -96,20 +105,37 @@ grep -Fq 'cluster delete e2e-test' "${K3D_LOG}" \
   || fail "successful delete did not call k3d cluster delete"
 echo "OK: successful delete"
 
-echo "DO: hung delete is bounded and still exits 0"
+echo "DO: hung delete ignores TERM and is still bounded by SIGKILL"
 : >"${K3D_LOG}"
+export K3D_DELETE_KILL_AFTER_SEC=1
 start=$(date +%s)
 K3D_HANG=1 bash "${SCRIPT}" hung-cluster
 elapsed=$(( $(date +%s) - start ))
 if (( elapsed > 8 )); then
-  fail "hung delete took ${elapsed}s; expected timeout around 1s"
+  fail "hung delete took ${elapsed}s; expected TERM at 1s then KILL at +1s"
 fi
 echo "OK: hung delete bounded (${elapsed}s)"
+unset K3D_DELETE_KILL_AFTER_SEC
 
 echo "DO: k3d failure still exits 0"
 : >"${K3D_LOG}"
 K3D_FAIL=1 bash "${SCRIPT}" fail-cluster
 echo "OK: failed delete exits 0"
+
+echo "DO: empty name exits 2 and does not call k3d"
+: >"${K3D_LOG}"
+if bash "${SCRIPT}" ""; then
+  fail "empty name should exit 2"
+fi
+[[ ! -s "${K3D_LOG}" ]] || fail "empty name still invoked k3d"
+echo "OK: empty name rejected"
+
+echo "DO: missing TIMEOUT_BIN still calls k3d"
+: >"${K3D_LOG}"
+TIMEOUT_BIN=/nonexistent/timeout K3D_HANG=0 K3D_FAIL=0 bash "${SCRIPT}" fallback-cluster
+grep -Fq 'cluster delete fallback-cluster' "${K3D_LOG}" \
+  || fail "fallback path did not call k3d"
+echo "OK: missing timeout falls back"
 
 echo "DO: kubeconfig path is removed"
 kc="${TMP}/kubeconfig"


### PR DESCRIPTION
## Summary

Bound E2E `k3d cluster delete` so a hung cleanup cannot eat the 30m job timeout, and stop presenting stale workload recs as live in `kubectl attune`.

## Problem

After #606, main CI cancelled when `setup-e2e-cluster` failed and `k3d cluster delete` ran until the job cap. Separately, GRADE `U`/`A-F` and preview/diff treated `status.recommendations[].stale` like live data even though the operator will not resize those recs.

## Change

- `hack/k3d-delete.sh`: 60s timeout, SIGKILL 5s later, always exit 0
- Shared by CI E2E cleanup, nightly, and `setup-e2e-cluster`
- Classifier in `scripts/test_k3d_delete.sh` (invoke counts, hang bound, empty name)
- GRADE `-` and CONFIDENCE / STATUS `stale` for stale recs (table and CSV)
- preview, diff, wizard, and explain skip or label stale recs

## Validation

- Red: `scripts/test_k3d_delete.sh` failed without the helper
- Green: classifier + `go test ./cmd/kubectl-attune/ -race -count=1`
- `make verify-quick` (exit 0)

Local reviewer on the earlier #606 U-grade work was 0 issues. This cycle is the follow-on MPI batch.

Closes #607

Ref #608
