### PR TITLE
fix: skip stale recs on remaining apply paths

### DIFF
--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -952,8 +952,9 @@ type WorkloadRecommendation struct {
 
 	// Stale indicates the recommendation is based on cached data because
 	// Prometheus did not return fresh data during the most recent query.
-	// Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
-	// executed with stale recommendations.
+	// Resizes, startup boost, initial sizing webhook, template persistence,
+	// ConfigMap rewrite, and GitOps drift are not executed with stale
+	// recommendations.
 	// +optional
 	Stale bool `json:"stale,omitempty"`
 }

--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -952,7 +952,8 @@ type WorkloadRecommendation struct {
 
 	// Stale indicates the recommendation is based on cached data because
 	// Prometheus did not return fresh data during the most recent query.
-	// Resizes are not executed with stale recommendations.
+	// Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
+	// executed with stale recommendations.
 	// +optional
 	Stale bool `json:"stale,omitempty"`
 }

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -1557,8 +1557,9 @@ spec:
                       description: |-
                         Stale indicates the recommendation is based on cached data because
                         Prometheus did not return fresh data during the most recent query.
-                        Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
-                        executed with stale recommendations.
+                        Resizes, startup boost, initial sizing webhook, template persistence,
+                        ConfigMap rewrite, and GitOps drift are not executed with stale
+                        recommendations.
                       type: boolean
                     workload:
                       description: Workload is the name of the workload.

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -1557,7 +1557,8 @@ spec:
                       description: |-
                         Stale indicates the recommendation is based on cached data because
                         Prometheus did not return fresh data during the most recent query.
-                        Resizes are not executed with stale recommendations.
+                        Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
+                        executed with stale recommendations.
                       type: boolean
                     workload:
                       description: Workload is the name of the workload.

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1063,7 +1063,7 @@ func printExplain(ctx context.Context, dynClient dynamic.Interface, namespace, p
 		workload, _ := rec["workload"].(string)
 		fmt.Printf("\nWorkload: %s\n", workload)
 		if recStale(rec) {
-			fmt.Printf("  stale (no fresh Prometheus data; last-known status is kept; apply paths skip until fresh data: resize, boost, export rewrite, GitOps, preview/diff/wizard)\n")
+			fmt.Printf("  stale (no fresh Prometheus data; last-known status is kept; apply paths skip until fresh data: resize, boost, initial sizing, template persist, export rewrite, GitOps, preview/diff/wizard)\n")
 		}
 		containers, _ := rec["containers"].([]interface{})
 		for _, c := range containers {

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1063,7 +1063,7 @@ func printExplain(ctx context.Context, dynClient dynamic.Interface, namespace, p
 		workload, _ := rec["workload"].(string)
 		fmt.Printf("\nWorkload: %s\n", workload)
 		if recStale(rec) {
-			fmt.Printf("  stale (no fresh Prometheus data; resize is blocked)\n")
+			fmt.Printf("  stale (no fresh Prometheus data; last-known status is kept; apply paths skip until fresh data: resize, boost, export rewrite, GitOps, preview/diff/wizard)\n")
 		}
 		containers, _ := rec["containers"].([]interface{})
 		for _, c := range containers {

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -1557,8 +1557,9 @@ spec:
                       description: |-
                         Stale indicates the recommendation is based on cached data because
                         Prometheus did not return fresh data during the most recent query.
-                        Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
-                        executed with stale recommendations.
+                        Resizes, startup boost, initial sizing webhook, template persistence,
+                        ConfigMap rewrite, and GitOps drift are not executed with stale
+                        recommendations.
                       type: boolean
                     workload:
                       description: Workload is the name of the workload.

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -1557,7 +1557,8 @@ spec:
                       description: |-
                         Stale indicates the recommendation is based on cached data because
                         Prometheus did not return fresh data during the most recent query.
-                        Resizes are not executed with stale recommendations.
+                        Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
+                        executed with stale recommendations.
                       type: boolean
                     workload:
                       description: Workload is the name of the workload.

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -3328,8 +3328,9 @@ spec:
                       description: |-
                         Stale indicates the recommendation is based on cached data because
                         Prometheus did not return fresh data during the most recent query.
-                        Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
-                        executed with stale recommendations.
+                        Resizes, startup boost, initial sizing webhook, template persistence,
+                        ConfigMap rewrite, and GitOps drift are not executed with stale
+                        recommendations.
                       type: boolean
                     workload:
                       description: Workload is the name of the workload.

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -3328,7 +3328,8 @@ spec:
                       description: |-
                         Stale indicates the recommendation is based on cached data because
                         Prometheus did not return fresh data during the most recent query.
-                        Resizes are not executed with stale recommendations.
+                        Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
+                        executed with stale recommendations.
                       type: boolean
                     workload:
                       description: Workload is the name of the workload.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3327,7 +3327,8 @@ spec:
                       description: |-
                         Stale indicates the recommendation is based on cached data because
                         Prometheus did not return fresh data during the most recent query.
-                        Resizes are not executed with stale recommendations.
+                        Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
+                        executed with stale recommendations.
                       type: boolean
                     workload:
                       description: Workload is the name of the workload.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3327,8 +3327,9 @@ spec:
                       description: |-
                         Stale indicates the recommendation is based on cached data because
                         Prometheus did not return fresh data during the most recent query.
-                        Resizes, startup boost, ConfigMap rewrite, and GitOps drift are not
-                        executed with stale recommendations.
+                        Resizes, startup boost, initial sizing webhook, template persistence,
+                        ConfigMap rewrite, and GitOps drift are not executed with stale
+                        recommendations.
                       type: boolean
                     workload:
                       description: Workload is the name of the workload.

--- a/docs/guides/auto-mode.md
+++ b/docs/guides/auto-mode.md
@@ -211,7 +211,7 @@ key renames require a schema bump and docs update.
 | `<container>.cpu-request` / `memory-request` | Recommended requests |
 | `<container>.cpu-limit` / `memory-limit` | Recommended limits (when non-zero) |
 | `<container>.confidence` | Confidence score string |
-| `last-updated` / `generated-at` | RFC3339 generation time |
+| `last-updated` / `generated-at` | RFC3339 generation time. These keys do not move while `status.recommendations[].stale` is true (the operator does not rewrite the ConfigMap). |
 
 Labels: `attune.io/policy`, `attune.io/workload`, `attune.io/export-schema=v1`.
 

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -100,13 +100,13 @@ reference).
 For environments that want the operator to compute recommendations but require **all** resource changes to flow through Git (ArgoCD, Flux, etc.):
 
 1. Set `updateStrategy.type: Recommend` (or `Auto` with `export` also enabled) plus `export.configMap: true`.
-2. The operator creates one ConfigMap per workload (named `<policy>-<workload>-recommendations`) containing per-container CPU/memory recommendations, confidence, and a RFC3339 `last-updated` timestamp. The ConfigMap carries the `attune.io/policy` label.
+2. The operator creates one ConfigMap per workload (named `<policy>-<workload>-recommendations`) containing per-container CPU/memory recommendations, confidence, and a RFC3339 `last-updated` timestamp. The ConfigMap carries the `attune.io/policy` label. If `status.recommendations[].stale` is true, the operator does not rewrite that ConfigMap or bump `last-updated`. Do not treat a frozen `last-updated` as fresh. GitOps apply PRs are not opened from that recommendation.
 3. Your CI/CD pipeline (or a lightweight sidecar) reads the ConfigMaps and proposes patches to the Deployment/StatefulSet specs stored in Git.
 4. GitOps applies the patches through the normal sync/approval flow.
 
 See the [Auto mode guide](auto-mode.md#exporting-recommendations-to-configmaps) for the exact ConfigMap schema, example output, and owner-reference cleanup behavior.
 
-**Orphan cleanup (stale recommendation removal)**: When a workload leaves the policy selector (selector change, scale-to-zero, or deletion while the policy still exists), the operator automatically deletes the corresponding recommendation ConfigMap on the next reconcile. Only ConfigMaps bearing the matching `attune.io/policy` label are considered. This guarantees GitOps consumers never see stale recommendations for workloads no longer in scope.
+**Orphan cleanup (workload left the policy)**: When a workload leaves the policy selector (selector change, scale-to-zero, or deletion while the policy still exists), the operator automatically deletes the corresponding recommendation ConfigMap on the next reconcile. Only ConfigMaps bearing the matching `attune.io/policy` label are considered. That is different from `recommendations[].stale`: orphan cleanup removes exports for workloads that are no longer in scope; a stale flag keeps last-known status and leaves the existing ConfigMap as-is (no rewrite, no `last-updated` bump).
 
 **Consuming the ConfigMap from CI (example)**:
 

--- a/docs/guides/recommend-mode.md
+++ b/docs/guides/recommend-mode.md
@@ -59,7 +59,7 @@ Each entry in the array contains:
 | `containers[].explanation` | Estimator chain (percentile → margin → burst → confidence → bounds → change filter) |
 | `containers[].confidence` | Score between 0 and 1 |
 | `containers[].dataPoints` | Number of Prometheus samples used |
-| `stale` | When true, Prometheus returned no fresh data; last-known values stay in status. Resize, boost, ConfigMap rewrite, kubectl diff/preview/wizard, and GitOps drift are skipped until fresh Prometheus data |
+| `stale` | When true, Prometheus returned no fresh data; last-known values stay in status. Resize, boost, initial sizing webhook, template persistence, ConfigMap rewrite, kubectl diff/preview/wizard, and GitOps drift are skipped until fresh Prometheus data |
 
 ### Why is CPU recommended at Xm?
 
@@ -88,7 +88,7 @@ Recommendations can look "ready" while pods stay unchanged. Common reasons:
 | Budget cap | events `BudgetExhausted`, metric `attune_budget_exhausted_total` | Raise per-cycle caps or reduce targets |
 | Canary not promoted | `status.canary.phase` | Wait for observation or set `autoPromote` |
 | Deferred / Infeasible | condition `ResizeBlocked`, `workloads.deferred` / `infeasible` | See [troubleshooting](troubleshooting.md#deferred-or-infeasible-resize-stuck-pods) |
-| Stale data | `recommendations[].stale` | Last-known values stay in status. Resize, boost, ConfigMap rewrite, kubectl diff/preview/wizard, and GitOps drift skip until fresh Prometheus data. Fix Prometheus reachability |
+| Stale data | `recommendations[].stale` | Last-known values stay in status. Resize, boost, initial sizing webhook, template persistence, ConfigMap rewrite, kubectl diff/preview/wizard, and GitOps drift skip until fresh Prometheus data. Fix Prometheus reachability |
 | Schedule window | condition `ScheduleBlocked` | Wait for window or adjust schedule |
 | At target after clamp | events / logs for filtering or memory clamp | Expected when already near recommendation |
 

--- a/docs/guides/recommend-mode.md
+++ b/docs/guides/recommend-mode.md
@@ -59,7 +59,7 @@ Each entry in the array contains:
 | `containers[].explanation` | Estimator chain (percentile → margin → burst → confidence → bounds → change filter) |
 | `containers[].confidence` | Score between 0 and 1 |
 | `containers[].dataPoints` | Number of Prometheus samples used |
-| `stale` | When true, Prometheus returned no fresh data; resizes are blocked |
+| `stale` | When true, Prometheus returned no fresh data; last-known values stay in status. Resize, boost, ConfigMap rewrite, kubectl diff/preview/wizard, and GitOps drift are skipped until fresh Prometheus data |
 
 ### Why is CPU recommended at Xm?
 
@@ -88,7 +88,7 @@ Recommendations can look "ready" while pods stay unchanged. Common reasons:
 | Budget cap | events `BudgetExhausted`, metric `attune_budget_exhausted_total` | Raise per-cycle caps or reduce targets |
 | Canary not promoted | `status.canary.phase` | Wait for observation or set `autoPromote` |
 | Deferred / Infeasible | condition `ResizeBlocked`, `workloads.deferred` / `infeasible` | See [troubleshooting](troubleshooting.md#deferred-or-infeasible-resize-stuck-pods) |
-| Stale data | `recommendations[].stale` | Fix Prometheus reachability |
+| Stale data | `recommendations[].stale` | Last-known values stay in status. Resize, boost, ConfigMap rewrite, kubectl diff/preview/wizard, and GitOps drift skip until fresh Prometheus data. Fix Prometheus reachability |
 | Schedule window | condition `ScheduleBlocked` | Wait for window or adjust schedule |
 | At target after clamp | events / logs for filtering or memory clamp | Expected when already near recommendation |
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -804,11 +804,13 @@ to limit the cache to the namespaces where your policies exist. Also raise
 operator memory via a `clusterSize` preset if you intentionally watch a
 large pod count.
 
-## Resizes skipped due to stale recommendations
+## Apply paths skipped due to stale recommendations
 
 When Prometheus does not return fresh data during a reconcile cycle, the
-operator marks the recommendation as **stale** and skips the resize to avoid
-acting on outdated metrics. You will see this in the operator logs:
+operator marks the recommendation as **stale** and skips apply paths that
+would act on outdated metrics. Resize is one example; startup boost is also
+skipped, the recommendation ConfigMap is not rewritten, and a GitOps apply
+PR is not opened. You will see this in the operator logs (resize example):
 
 ```
 Skipping resize for workload with stale recommendation  workload=my-app
@@ -829,7 +831,7 @@ kubectl logs -n attune-system deploy/attune \
   | grep -E "stale|Prometheus query returned no data"
 ```
 
-Resizes resume automatically once fresh data is available.
+Apply paths resume automatically once fresh data is available.
 
 ## Deployment-owned ReplicaSet targeting
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -249,7 +249,8 @@ annotation.
 **Cause**: The mutating webhook only patches CREATE when every gate passes.
 A selector policy also has to fetch the owning Deployment, StatefulSet, or
 DaemonSet and match `targetRef.selector`. Get or parse errors skip the
-pod (the CREATE is still allowed).
+pod (the CREATE is still allowed). A stale recommendation also skips
+initial sizing (last-known values stay in status, but CREATE is not patched).
 
 **Fix**:
 
@@ -808,9 +809,10 @@ large pod count.
 
 When Prometheus does not return fresh data during a reconcile cycle, the
 operator marks the recommendation as **stale** and skips apply paths that
-would act on outdated metrics. Resize is one example; startup boost is also
-skipped, the recommendation ConfigMap is not rewritten, and a GitOps apply
-PR is not opened. You will see this in the operator logs (resize example):
+would act on outdated metrics. Resize is one example; startup boost, initial
+sizing (CREATE webhook), and template persistence are also skipped, the
+recommendation ConfigMap is not rewritten, and a GitOps apply PR is not
+opened. You will see this in the operator logs (resize example):
 
 ```
 Skipping resize for workload with stale recommendation  workload=my-app
@@ -1008,6 +1010,7 @@ spec:
   `when: OnRecommendation` for Recommend.
 - **`OnRecommendation`**: still skipped in **Observe** mode.
 - **Canary**: template patches wait until canary reaches `FullRollout`.
+- **Stale recommendation**: `recommendations[].stale` is true; the template is not patched until fresh Prometheus data.
 
 ### Mid-rollout or no-op
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -168,7 +168,7 @@ spec:
 | `recommendations[].containers[].confidence` | `float64` | Confidence score (0-1) |
 | `recommendations[].containers[].dataPoints` | `int32` | Prometheus samples used |
 | `recommendations[].containers[].lastUpdated` | `Time` | Last recommendation timestamp |
-| `recommendations[].stale` | `bool` | `true` when Prometheus returned no fresh data; last-known values stay in status. Resize, boost, ConfigMap rewrite, kubectl preview/diff/wizard, and GitOps drift are skipped until fresh data arrives |
+| `recommendations[].stale` | `bool` | `true` when Prometheus returned no fresh data; last-known values stay in status. Resize, boost, initial sizing webhook, template persistence, ConfigMap rewrite, kubectl preview/diff/wizard, and GitOps drift are skipped until fresh data arrives |
 | `recommendations[].lastDataTime` | `Time` | Timestamp of the most recent Prometheus data point |
 
 | `savings.cpuRequestReduction` | `string` | Total CPU request reduction (e.g. "1200m") |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -168,7 +168,7 @@ spec:
 | `recommendations[].containers[].confidence` | `float64` | Confidence score (0-1) |
 | `recommendations[].containers[].dataPoints` | `int32` | Prometheus samples used |
 | `recommendations[].containers[].lastUpdated` | `Time` | Last recommendation timestamp |
-| `recommendations[].stale` | `bool` | `true` when Prometheus returned no fresh data; resize is blocked until fresh data arrives |
+| `recommendations[].stale` | `bool` | `true` when Prometheus returned no fresh data; last-known values stay in status. Resize, boost, ConfigMap rewrite, kubectl preview/diff/wizard, and GitOps drift are skipped until fresh data arrives |
 | `recommendations[].lastDataTime` | `Time` | Timestamp of the most recent Prometheus data point |
 
 | `savings.cpuRequestReduction` | `string` | Total CPU request reduction (e.g. "1200m") |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,7 +72,8 @@ The `--sort-by` flag also works with the `savings` command.
 
 Shows a per-container comparison of current vs recommended resources for a
 single policy. Use this before promoting from Recommend to Canary or Auto
-to preview what changes would be applied.
+to preview what changes would be applied. Workloads whose recommendation is
+stale are skipped until Prometheus returns fresh data.
 
 ```bash
 kubectl attune preview -n production api-services
@@ -129,6 +130,8 @@ kubectl attune export list -A
 
 The `LAST UPDATED` column shows the RFC3339 timestamp when the operator last wrote that workload's recommendations
 (the value inside the ConfigMap's `last-updated` key). This is the authoritative handoff for GitOps pipelines.
+A frozen `last-updated` is not fresh when `status.recommendations[].stale` is true: the operator does not rewrite
+the ConfigMap or bump the timestamp until Prometheus returns new data.
 
 | Column     | Description |
 |------------|-------------|
@@ -169,7 +172,7 @@ kubectl attune explain -n production api-services
 
 ### diff
 
-Shows resource change recommendations in diff format for GitOps workflows. Outputs the difference between current and recommended resources for each workload.
+Shows resource change recommendations in diff format for GitOps workflows. Outputs the difference between current and recommended resources for each workload. Workloads whose recommendation is stale are skipped until Prometheus returns fresh data.
 
 ```bash
 kubectl attune diff
@@ -218,7 +221,8 @@ then offers to apply directly or save the YAML to a file.
 
 **Promote flow**: lists existing policies with their current mode and
 status, shows the recommendation summary, and updates the mode after
-confirmation.
+confirmation. Stale recommendations are skipped (same as `preview` and
+`diff`) until Prometheus returns fresh data.
 
 The wizard does not support multi-cluster mode (`--all-contexts` /
 `--contexts`).

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -1793,6 +1793,86 @@ func TestComputeRecommendations_EmptyQueryReusesPriorAsStale(t *testing.T) {
 	assert.False(t, policy.Status.Recommendations[0].Stale, "reuse must DeepCopy, not mutate status in place")
 }
 
+func TestComputeRecommendations_QueryGapsReusePriorAsStale(t *testing.T) {
+	priorData := metav1.NewTime(time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC))
+	cpuRec, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+	memRec, err := resource.ParseQuantity("256Mi")
+	require.NoError(t, err)
+
+	nanSamples := make([]rsmetrics.Sample, 50)
+	nanNow := time.Now()
+	for i := range nanSamples {
+		nanSamples[i] = rsmetrics.Sample{
+			Timestamp: nanNow.Add(-time.Duration(50-i) * time.Hour),
+			Value:     math.NaN(),
+		}
+	}
+
+	tests := []struct {
+		name            string
+		queryRangeFunc  func(context.Context, string, time.Time, time.Time, time.Duration) ([]rsmetrics.Sample, error)
+		wantQueryErrors int
+		wantFailedTypes []string
+	}{
+		{
+			name: "both queries error",
+			queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+				return nil, fmt.Errorf("connection refused")
+			},
+			wantQueryErrors: 2,
+			wantFailedTypes: []string{"CPU", "memory"},
+		},
+		{
+			name: "insufficient data points",
+			queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+				return generateSamples(20, 0.1), nil
+			},
+		},
+		{
+			name: "all NaN samples",
+			queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+				return nanSamples, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := newTestPolicy("test-policy", "default")
+			deploy := newTestDeployment("api-server", "default", nil)
+			reconciler := newReconcilerWithClient()
+			policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+				Workload:     "api-server",
+				Kind:         "Deployment",
+				LastDataTime: &priorData,
+				Stale:        false,
+				Containers: []attunev1alpha1.ContainerRecommendation{{
+					Name: "main",
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest:    cpuRec,
+						MemoryRequest: memRec,
+					},
+				}},
+			}}
+
+			mc := &mockCollector{queryRangeFunc: tt.queryRangeFunc}
+			rec, qErrors, failedMetricTypes, _, _, err := reconciler.computeRecommendations(
+				context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
+			require.NoError(t, err)
+			require.NotNil(t, rec, "Prometheus gap must reuse the prior recommendation")
+			assert.True(t, rec.Stale, "reused rec must be marked stale")
+			require.NotNil(t, rec.LastDataTime)
+			assert.True(t, rec.LastDataTime.Equal(&priorData), "LastDataTime must stay the last non-empty sample")
+			assert.False(t, policy.Status.Recommendations[0].Stale, "reuse must DeepCopy, not mutate status in place")
+			if tt.wantQueryErrors > 0 {
+				assert.Equal(t, tt.wantQueryErrors, qErrors)
+				assert.ElementsMatch(t, tt.wantFailedTypes, failedMetricTypes)
+			}
+		})
+	}
+}
+
 func TestComputeRecommendations_LastDataTimeOlderThanHistoryWindowIsStale(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	policy.Spec.MetricsSource.HistoryWindow = &metav1.Duration{Duration: 2 * time.Hour}
@@ -9694,6 +9774,85 @@ func TestApplyStartupBoosts_AppliesBoostToNewPod(t *testing.T) {
 	assert.True(t, foundResize, "expected a resize action for startup boost")
 }
 
+func TestApplyStartupBoosts_SkipsStaleRecommendation(t *testing.T) {
+	scheme := testScheme()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			CPU: attunev1alpha1.ResourceConfig{
+				StartupBoost: &attunev1alpha1.StartupBoost{
+					Multiplier: "3.0",
+					Duration:   metav1.Duration{Duration: 2 * time.Minute},
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-app-abc",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Second)),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	clientset := kubefake.NewSimpleClientset(pod)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+	r.SetNowFunc(func() time.Time { return now })
+
+	logger := ctrl.Log.WithName("test")
+	resizer := resize.NewPodResizer(clientset, logger)
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "my-app",
+			Kind:     "Deployment",
+			Stale:    true,
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name: "main",
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("200m"),
+					},
+				},
+			},
+		},
+	}
+	podsByWorkload := map[string][]corev1.Pod{"my-app": {*pod}}
+
+	r.applyStartupBoosts(context.Background(), policy, podsByWorkload, recs, resizer, nil)
+
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			t.Fatal("startup boost must not resize from a stale recommendation")
+		}
+	}
+
+	var updated corev1.Pod
+	err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "my-app-abc", Namespace: "default",
+	}, &updated)
+	require.NoError(t, err)
+	assert.Empty(t, updated.Annotations[annotationStartupBoostAt],
+		"stale rec must not persist a startup-boost annotation")
+}
+
 func TestApplyStartupBoosts_SkipsDuringCanaryInProgress(t *testing.T) {
 	scheme := testScheme()
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -12143,6 +12302,83 @@ func TestProcessWorkloads_ParallelPartialFailure(t *testing.T) {
 	// Verify parallelism still occurred despite failures.
 	assert.Greater(t, peakInflight.Load(), int32(1),
 		"expected concurrent queries even with partial failures")
+}
+
+func TestProcessWorkloads_MixedStaleAndFresh(t *testing.T) {
+	now := time.Now()
+	priorData := metav1.NewTime(now.Add(-24 * time.Hour))
+	cpuRec, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+	memRec, err := resource.ParseQuantity("256Mi")
+	require.NoError(t, err)
+
+	samples := make([]rsmetrics.Sample, 60)
+	for i := range samples {
+		samples[i] = rsmetrics.Sample{
+			Timestamp: now.Add(-time.Duration(60-i) * 5 * time.Minute),
+			Value:     0.1,
+		}
+	}
+	grouped := map[string][]rsmetrics.Sample{"main": samples}
+
+	collector := &mockCollector{
+		queryRangeGroupedFunc: func(_ context.Context, query string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
+			if strings.Contains(query, "app-a-") {
+				return nil, fmt.Errorf("connection refused")
+			}
+			return grouped, nil
+		},
+	}
+
+	depA := newTestDeployment("app-a", "default", map[string]string{"app": "app-a"})
+	depB := newTestDeployment("app-b", "default", map[string]string{"app": "app-b"})
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(depA, depB).
+		Build()
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.TargetRef.Name = nil
+	policy.Spec.TargetRef.Selector = &metav1.LabelSelector{}
+	priorContainers := []attunev1alpha1.ContainerRecommendation{{
+		Name: "main",
+		Recommended: attunev1alpha1.ResourceValues{
+			CPURequest:    cpuRec,
+			MemoryRequest: memRec,
+		},
+	}}
+	policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{
+		{Workload: "app-a", Kind: "Deployment", LastDataTime: &priorData, Stale: false, Containers: priorContainers},
+		{Workload: "app-b", Kind: "Deployment", LastDataTime: &priorData, Stale: false, Containers: priorContainers},
+	}
+
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.MetricsFactory = mockMetricsFactory(collector)
+	r.SetNowFunc(func() time.Time { return now })
+
+	result := r.processWorkloads(context.Background(), policy, []client.Object{depA, depB}, collector, nil, nil)
+
+	require.Len(t, result.recommendations, 2)
+	assert.Greater(t, result.totalQueryErrors, 0, "app-a query errors must be counted")
+
+	var recA, recB *attunev1alpha1.WorkloadRecommendation
+	for i := range result.recommendations {
+		switch result.recommendations[i].Workload {
+		case "app-a":
+			recA = &result.recommendations[i]
+		case "app-b":
+			recB = &result.recommendations[i]
+		}
+	}
+	require.NotNil(t, recA, "app-a must reuse the prior rec as stale")
+	require.NotNil(t, recB, "app-b must produce a fresh rec")
+	assert.True(t, recA.Stale)
+	require.NotNil(t, recA.LastDataTime)
+	assert.True(t, recA.LastDataTime.Equal(&priorData), "stale reuse must preserve LastDataTime")
+	assert.False(t, recB.Stale, "fresh Prometheus data must not mark app-b stale")
 }
 
 func TestReconcile_InsufficientDataRequeuesAtQueryStep(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -9575,6 +9575,82 @@ func TestExportRecommendationConfigMaps_SkipsLongName(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "ConfigMap with name >253 chars should not be created")
 }
 
+func TestExportRecommendationConfigMaps_SkipsStale(t *testing.T) {
+	scheme := testScheme()
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "default",
+			UID:       "abc-123",
+		},
+	}
+	const t0 = "2026-01-01T00:00:00Z"
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy-my-app-recommendations",
+			Namespace: "default",
+			Labels: map[string]string{
+				"attune.io/policy":   "test-policy",
+				"attune.io/workload": "my-app",
+			},
+		},
+		Data: map[string]string{
+			"main.cpu-request": "100m",
+			"last-updated":     t0,
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, existingCM).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.SetNowFunc(func() time.Time { return time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC) })
+
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "my-app",
+			Kind:     "Deployment",
+			Stale:    true,
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name:       "main",
+					Confidence: 0.95,
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest:    resource.MustParse("500m"),
+						MemoryRequest: resource.MustParse("512Mi"),
+					},
+				},
+			},
+		},
+	}
+
+	r.exportRecommendationConfigMaps(context.Background(), policy, recs)
+
+	var cm corev1.ConfigMap
+	err := fakeClient.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "test-policy-my-app-recommendations",
+	}, &cm)
+	require.NoError(t, err, "stale rec must remain in currentWorkloads so the CM is not deleted")
+	assert.Equal(t, "100m", cm.Data["main.cpu-request"], "stale rec must not overwrite existing cpu-request")
+	assert.Equal(t, t0, cm.Data["last-updated"], "stale rec must not restamp last-updated")
+
+	// No existing CM: a stale-only rec must not create one.
+	staleOnlyPolicy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale-only",
+			Namespace: "default",
+			UID:       "def-456",
+		},
+	}
+	require.NoError(t, fakeClient.Create(context.Background(), staleOnlyPolicy))
+	r.exportRecommendationConfigMaps(context.Background(), staleOnlyPolicy, recs)
+	err = fakeClient.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      "stale-only-my-app-recommendations",
+	}, &cm)
+	assert.True(t, apierrors.IsNotFound(err), "stale-only rec must not create a ConfigMap")
+}
+
 func TestAdjustHPATargets_ScalesTargetUtilization(t *testing.T) {
 	scheme := testScheme()
 	oldTarget := int32(80)

--- a/internal/controller/export.go
+++ b/internal/controller/export.go
@@ -48,6 +48,10 @@ func (r *AttunePolicyReconciler) exportRecommendationConfigMaps(
 	r.cleanupOrphanedRecommendationConfigMaps(ctx, policy, recommendations)
 
 	for _, rec := range recommendations {
+		// Stale recs stay in currentWorkloads so existing ConfigMaps are not deleted.
+		if rec.Stale {
+			continue
+		}
 		cmName := fmt.Sprintf("%s-%s-recommendations", policy.Name, rec.Workload)
 		// Kubernetes resource names are limited to 253 characters.
 		if len(cmName) > 253 {

--- a/internal/controller/export.go
+++ b/internal/controller/export.go
@@ -50,6 +50,8 @@ func (r *AttunePolicyReconciler) exportRecommendationConfigMaps(
 	for _, rec := range recommendations {
 		// Stale recs stay in currentWorkloads so existing ConfigMaps are not deleted.
 		if rec.Stale {
+			logger.V(1).Info("Skipping ConfigMap rewrite for stale recommendation",
+				"workload", rec.Workload)
 			continue
 		}
 		cmName := fmt.Sprintf("%s-%s-recommendations", policy.Name, rec.Workload)

--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -64,6 +64,13 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 	now := r.now()
 
 	for _, rec := range recommendations {
+		// Stale recs stay in the slice after Prometheus gaps; do not
+		// boost from last-known CPU the way resize already skips.
+		if rec.Stale {
+			logger.V(1).Info("Skipping startup boost for workload with stale recommendation",
+				"workload", rec.Workload)
+			continue
+		}
 		pods := podsByWorkload[rec.Workload]
 		// Build per-container recommendation map for this workload.
 		recMap := make(map[string]resource.Quantity, len(rec.Containers))

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -821,6 +821,75 @@ func TestApplyTemplatePersistence_SkipsMidRollout(t *testing.T) {
 	assert.Empty(t, history, "mid-rollout must not patch")
 }
 
+func TestApplyTemplatePersistence_SkipsStale(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeRecommend
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api",
+		Kind:     "Deployment",
+		Stale:    true,
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("512Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("200m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+			},
+		}},
+	}}
+
+	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
+		attunev1alpha1.TemplatePersistenceOnRecommendation, nil)
+	assert.Empty(t, history, "stale rec must not patch the workload template")
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.Equal(t, int64(500), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(),
+		"stale rec must leave template CPU request unchanged")
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"stale rec must leave template memory request unchanged")
+}
+
 func TestApplyTemplatePersistence_NoOpWhenTemplateMatches(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, appsv1.AddToScheme(scheme))

--- a/internal/gitops/drift.go
+++ b/internal/gitops/drift.go
@@ -55,6 +55,10 @@ func ComputeDrift(
 ) []ContainerDrift {
 	byKey := map[string]attunev1alpha1.WorkloadRecommendation{}
 	for _, r := range recs {
+		// Stale last-known recs must not open GitOps apply PRs.
+		if r.Stale {
+			continue
+		}
 		byKey[r.Kind+"/"+r.Workload] = r
 	}
 	var out []ContainerDrift
@@ -65,6 +69,9 @@ func ComputeDrift(
 		if !ok {
 			// try match on workload name only
 			for _, r := range recs {
+				if r.Stale {
+					continue
+				}
 				if r.Workload == name {
 					rec = r
 					ok = true

--- a/internal/gitops/drift_test.go
+++ b/internal/gitops/drift_test.go
@@ -430,3 +430,58 @@ func TestComputeDrift_SkipsWorkloadWithoutRecommendation(t *testing.T) {
 	}}
 	assert.Empty(t, ComputeDrift([]client.Object{dep}, recs, 10))
 }
+
+func TestComputeDrift_SkipsStaleRecommendation(t *testing.T) {
+	t.Parallel()
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("500m"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	t.Run("kind match", func(t *testing.T) {
+		t.Parallel()
+		recs := []attunev1alpha1.WorkloadRecommendation{{
+			Workload: "api",
+			Kind:     "Deployment",
+			Stale:    true,
+			Containers: []attunev1alpha1.ContainerRecommendation{{
+				Name: "app",
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("200m"),
+				},
+			}},
+		}}
+		assert.Empty(t, ComputeDrift([]client.Object{dep}, recs, 10),
+			"stale rec must not produce GitOps drift")
+	})
+
+	t.Run("name-only match", func(t *testing.T) {
+		t.Parallel()
+		recs := []attunev1alpha1.WorkloadRecommendation{{
+			Workload: "api",
+			Kind:     "ReplicaSet",
+			Stale:    true,
+			Containers: []attunev1alpha1.ContainerRecommendation{{
+				Name: "app",
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("200m"),
+				},
+			}},
+		}}
+		assert.Empty(t, ComputeDrift([]client.Object{dep}, recs, 10),
+			"stale rec must not produce GitOps drift via name-only match")
+	})
+}

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -173,6 +173,10 @@ func (h *PodMutatingHandler) findMatchingPolicy(
 		for j := range policy.Status.Recommendations {
 			rec := &policy.Status.Recommendations[j]
 			if rec.Stale {
+				if rec.Workload == ownerName && rec.Kind == ownerKind {
+					h.Logger.V(1).Info("initial sizing skipped: recommendation is stale",
+						"policy", policy.Name, "owner", ownerName, "pod", podName)
+				}
 				continue
 			}
 			if rec.Workload == ownerName && rec.Kind == ownerKind {


### PR DESCRIPTION
## Why

After #610 the operator keeps last-known recommendations when Prometheus
returns no fresh data and sets `stale: true`. Resize already skipped those
recs. Startup boost, ConfigMap export, and GitOps drift still treated them
as apply-ready.

## What changed

- Startup boost skips stale recs (same fail-closed as resize).
- ConfigMap export does not rewrite or restamp `last-updated` for stale recs.
  Orphan cleanup still sees those workloads so CMs are not deleted.
- GitOps `ComputeDrift` skips stale recs so apply PRs are not opened from
  last-known sizing.
- Initial sizing and template persistence were already skipping; docs and
  a template-persist test now lock that. Webhook stale skip logs at V(1).
- Tests lock query-error, insufficient, and all-NaN reuse plus mixed
  processWorkloads status.

## Tests

- `TestApplyStartupBoosts_SkipsStaleRecommendation`
- `TestExportRecommendationConfigMaps_SkipsStale`
- `TestComputeDrift_SkipsStaleRecommendation`
- `TestApplyTemplatePersistence_SkipsStale`
- `TestComputeRecommendations` reuse table (query error / insufficient / NaN)
- `TestProcessWorkloads` mixed stale + fresh

Do not merge release PR #601 from this change.
