### PR TITLE
fix: bound stale reuse, fix cloudwatch search, and allow private gitops

### DIFF
--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -681,6 +681,12 @@ type GitOpsPullRequestConfig struct {
 	// +optional
 	APIURL string `json:"apiUrl,omitempty"`
 
+	// AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+	// GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+	// metadata), and unspecified addresses stay blocked. Default false.
+	// +optional
+	AllowPrivateEndpoints bool `json:"allowPrivateEndpoints,omitempty"`
+
 	// Cooldown is the minimum time between PR create/update attempts for this
 	// policy. Defaults to 24h.
 	// +optional

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -53,13 +53,14 @@ const (
 	ReasonPodsInfeasible            = "PodsInfeasible"
 	ReasonPodsDeferredAndInfeasible = "PodsDeferredAndInfeasible"
 	// GitOps PR automation reasons.
-	ReasonGitOpsPROpen      = "PullRequestOpen"
-	ReasonGitOpsPRFailed    = "PullRequestFailed"
-	ReasonGitOpsPRNoDrift   = "NoDrift"
-	ReasonGitOpsPRCooldown  = "PullRequestCooldown"
-	ReasonGitOpsPRDryRun    = "PullRequestDryRun"
-	ReasonGitOpsPRDisabled  = "PullRequestDisabled"
-	ReasonGitOpsPRUnchanged = "PullRequestUnchanged"
+	ReasonGitOpsPROpen          = "PullRequestOpen"
+	ReasonGitOpsPRFailed        = "PullRequestFailed"
+	ReasonGitOpsPRNoDrift       = "NoDrift"
+	ReasonGitOpsPRCooldown      = "PullRequestCooldown"
+	ReasonGitOpsPRDryRun        = "PullRequestDryRun"
+	ReasonGitOpsPRDisabled      = "PullRequestDisabled"
+	ReasonGitOpsPRUnchanged     = "PullRequestUnchanged"
+	ReasonGitOpsEndpointBlocked = "GitOpsEndpointBlocked"
 )
 
 // CanaryPhaseInProgress and CanaryPhaseFullRollout are now typed constants

--- a/charts/attune/crds/attune.io_attunedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunedefaults.yaml
@@ -597,6 +597,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).

--- a/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
@@ -598,6 +598,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -690,6 +690,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).

--- a/config/crd/bases/attune.io_attunedefaults.yaml
+++ b/config/crd/bases/attune.io_attunedefaults.yaml
@@ -597,6 +597,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).

--- a/config/crd/bases/attune.io_attunenamespacedefaults.yaml
+++ b/config/crd/bases/attune.io_attunenamespacedefaults.yaml
@@ -598,6 +598,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -690,6 +690,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -597,6 +597,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
@@ -1483,6 +1489,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
@@ -2461,6 +2473,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -596,6 +596,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
@@ -1482,6 +1488,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).
@@ -2460,6 +2472,12 @@ spec:
                           PullRequest enables opt-in GitOps PR automation (default off).
                           Requires a token Secret and repository identity. Never logs the token.
                         properties:
+                          allowPrivateEndpoints:
+                            description: |-
+                              AllowPrivateEndpoints permits RFC1918/ULA API hosts (self-hosted
+                              GitLab/Gitea/Bitbucket). Loopback, link-local (including cloud
+                              metadata), and unspecified addresses stay blocked. Default false.
+                            type: boolean
                           apiUrl:
                             description: |-
                               APIURL overrides the API base URL (Enterprise GitHub or self-hosted GitLab).

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -144,10 +144,13 @@ default 24h).
   Prefer short-lived or fine-grained tokens.
 - Optional `apiUrl` (Enterprise GitHub / self-hosted GitLab) must be
   `https`, must not include userinfo, and is rejected when it targets
-  loopback, link-local, private RFC1918, or cloud metadata hosts
-  (`169.254.169.254` and similar). This is stricter than Prometheus
-  addresses so a policy cannot aim the operator token at in-cluster
-  endpoints.
+  loopback, link-local, or cloud metadata hosts (`169.254.169.254` and
+  similar). Private RFC1918/ULA hosts are rejected unless
+  `allowPrivateEndpoints: true` (self-hosted GitLab/Gitea/Bitbucket).
+  This is stricter than Prometheus addresses so a policy cannot aim the
+  operator token at in-cluster endpoints. Corporate `HTTPS_PROXY` is
+  not treated as the SSRF target. A blocked endpoint sets
+  `GitOpsEndpointBlocked` on the `GitOpsPullRequest` condition.
 
 ### Example
 
@@ -186,6 +189,7 @@ Condition type `GitOpsPullRequest`:
 | `PullRequestDryRun` | Would open/update PR |
 | `PullRequestOpen` | PR URL in message |
 | `PullRequestFailed` | API or config error (message is safe) |
+| `GitOpsEndpointBlocked` | `apiUrl` resolved to a disallowed address (set `allowPrivateEndpoints` for RFC1918 self-hosted forges) |
 
 Metric: `attune_gitops_pr_total{result=created|updated|dry_run|failed}`.
 

--- a/docs/guides/recommend-mode.md
+++ b/docs/guides/recommend-mode.md
@@ -59,7 +59,7 @@ Each entry in the array contains:
 | `containers[].explanation` | Estimator chain (percentile → margin → burst → confidence → bounds → change filter) |
 | `containers[].confidence` | Score between 0 and 1 |
 | `containers[].dataPoints` | Number of Prometheus samples used |
-| `stale` | When true, Prometheus returned no fresh data; last-known values stay in status. Resize, boost, initial sizing webhook, template persistence, ConfigMap rewrite, kubectl diff/preview/wizard, and GitOps drift are skipped until fresh Prometheus data |
+| `stale` | When true, the newest finite sample is older than `3 * queryStep` (default 15m), or the last rec was reused after an empty query. Apply paths skip until fresh data. Stale recs do not count toward Ready or savings |
 
 ### Why is CPU recommended at Xm?
 
@@ -88,7 +88,7 @@ Recommendations can look "ready" while pods stay unchanged. Common reasons:
 | Budget cap | events `BudgetExhausted`, metric `attune_budget_exhausted_total` | Raise per-cycle caps or reduce targets |
 | Canary not promoted | `status.canary.phase` | Wait for observation or set `autoPromote` |
 | Deferred / Infeasible | condition `ResizeBlocked`, `workloads.deferred` / `infeasible` | See [troubleshooting](troubleshooting.md#deferred-or-infeasible-resize-stuck-pods) |
-| Stale data | `recommendations[].stale` | Last-known values stay in status. Resize, boost, initial sizing webhook, template persistence, ConfigMap rewrite, kubectl diff/preview/wizard, and GitOps drift skip until fresh Prometheus data. Fix Prometheus reachability |
+| Stale data | `recommendations[].stale` | Last-known values stay in status for up to `3 * queryStep`. Resize and other apply paths skip. Ready and savings ignore stale recs. After the bound expires the rec drops and Ready can become `InsufficientData`. Fix Prometheus reachability |
 | Schedule window | condition `ScheduleBlocked` | Wait for window or adjust schedule |
 | At target after clamp | events / logs for filtering or memory clamp | Expected when already near recommendation |
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -809,9 +809,14 @@ large pod count.
 
 When Prometheus does not return fresh data during a reconcile cycle, the
 operator marks the recommendation as **stale** and skips apply paths that
-would act on outdated metrics. Resize is one example; startup boost, initial
-sizing (CREATE webhook), and template persistence are also skipped, the
-recommendation ConfigMap is not rewritten, and a GitOps apply PR is not
+would act on outdated metrics. A rec is stale when the newest finite
+sample is older than `3 * queryStep` (default 15m), or when the last
+known rec is reused after an empty query. Reuse expires after that same
+bound; then the rec drops and Ready can become `InsufficientData`.
+Stale recs do not increment `workloads.withRecommendations` and do not
+enter savings gauges. Resize is one skipped apply path; startup boost,
+initial sizing (CREATE webhook), and template persistence are also skipped,
+the recommendation ConfigMap is not rewritten, and a GitOps apply PR is not
 opened. You will see this in the operator logs (resize example):
 
 ```

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -8,6 +8,58 @@ Maintainers: before publishing a release after multi-version product changes,
 run the full E2E Nightly matrix on tip of `main` (see
 [Releasing: full E2E matrix](../contributing/releasing.md#1b-full-e2e-matrix-required-before-tagging-a-product-release)).
 
+## v0.1.25 to v0.1.26
+
+v0.1.26 tightens stale-recommendation handling and CloudWatch collection.
+Existing policy YAML keeps working. Read this section if you inherit
+`maxConcurrentResizes` from `AttuneDefaults`, use CloudWatch, or run a
+self-hosted Git forge.
+
+### Inherit maxConcurrentResizes from AttuneDefaults
+
+The built-in default moved from the CRD OpenAPI schema into the
+controller so `AttuneDefaults` can set a cluster-wide value. Policies
+created before that change already have `maxConcurrentResizes: 1` stored
+in etcd. That explicit `1` wins over `AttuneDefaults`.
+
+To inherit a cluster-wide value, remove the field from those policies:
+
+```bash
+kubectl patch attunepolicy POLICY -n NS --type=json \
+  -p='[{"op":"remove","path":"/spec/updateStrategy/maxConcurrentResizes"}]'
+```
+
+Helm does not upgrade CRDs on `helm upgrade`. Apply CRDs before the
+chart upgrade or new policies on a stale CRD still materialize `1`:
+
+```bash
+kubectl apply --server-side --force-conflicts -f \
+  https://github.com/attune-io/attune/releases/latest/download/crds.yaml
+```
+
+### Stale recommendations expire
+
+A recommendation is fresh only when the newest finite sample is newer
+than `3 * queryStep` (default 15m). Older in-window samples are marked
+`stale`. Empty Prometheus results reuse the last rec only inside that
+same window. After it expires, the rec drops and Ready can become
+`InsufficientData`. Stale recs no longer count toward
+`workloads.withRecommendations` or savings gauges.
+
+### CloudWatch pod prefix
+
+CloudWatch `SEARCH` no longer emits `PodName="prefix*"`. Quoted CloudWatch
+tokens are exact matches, so that term matched nothing. Filtering is
+client-side only.
+
+### Self-hosted GitOps forges
+
+`export.pullRequest.apiUrl` still rejects private IP literals by default.
+Set `allowPrivateEndpoints: true` for RFC1918/ULA self-hosted GitLab,
+Gitea, or Bitbucket. Loopback and link-local (including IMDS) stay
+blocked. Corporate `HTTPS_PROXY` on a private address is no longer
+treated as the SSRF target.
+
 ## v0.1.24 to v0.1.25
 
 v0.1.25 is a GitOps reliability patch. Existing policy YAML keeps working.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -168,7 +168,7 @@ spec:
 | `recommendations[].containers[].confidence` | `float64` | Confidence score (0-1) |
 | `recommendations[].containers[].dataPoints` | `int32` | Prometheus samples used |
 | `recommendations[].containers[].lastUpdated` | `Time` | Last recommendation timestamp |
-| `recommendations[].stale` | `bool` | `true` when Prometheus returned no fresh data; last-known values stay in status. Resize, boost, initial sizing webhook, template persistence, ConfigMap rewrite, kubectl preview/diff/wizard, and GitOps drift are skipped until fresh data arrives |
+| `recommendations[].stale` | `bool` | `true` when the newest finite sample is older than `3 * queryStep` (default 15m), or when the last rec was reused after an empty query. Resize, boost, initial sizing webhook, template persistence, ConfigMap rewrite, kubectl preview/diff/wizard, and GitOps drift are skipped until fresh data arrives. Stale recs do not count toward Ready or savings. Reuse expires after the same freshness bound |
 | `recommendations[].lastDataTime` | `Time` | Timestamp of the most recent Prometheus data point |
 
 | `savings.cpuRequestReduction` | `string` | Total CPU request reduction (e.g. "1200m") |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -451,6 +451,7 @@ provider PRs when templates drift. Full cookbook:
 | `updateStrategy.export.pullRequest.repository` | string | (required when enabled) | `owner/repo` (GitHub) or project path/id (GitLab). |
 | `updateStrategy.export.pullRequest.tokenSecretRef` | object | (required when enabled) | Secret `name` + `key` for a fine-scoped API token. Never log the token. |
 | `updateStrategy.export.pullRequest.apiUrl` | string | provider default | Enterprise GitHub or self-hosted GitLab API base (SSRF-validated). |
+| `updateStrategy.export.pullRequest.allowPrivateEndpoints` | bool | `false` | Permit RFC1918/ULA API hosts for self-hosted forges. Loopback, link-local (IMDS), and unspecified stay blocked. |
 | `updateStrategy.export.pullRequest.baseBranch` | string | `main` | Target branch for the PR. |
 | `updateStrategy.export.pullRequest.cooldown` | duration | `24h` | Minimum time between PR create/update attempts for this policy. |
 | `updateStrategy.export.pullRequest.minChangePercent` | int32 | `10` | Minimum absolute percent change (per container resource vs template) to open or update a PR (1-100). |
@@ -574,7 +575,7 @@ The controller sets these conditions on each `AttunePolicy`:
 | `Degraded` | `HighRevertRate` | Set when 3+ of the last 5 resizes were reverted |
 | `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Set when `updateStrategy.schedule` is configured; indicates whether the current time is within an allowed resize window |
 | `ResizeBlocked` | `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Pods stuck Deferred or Infeasible; see troubleshooting "Deferred or Infeasible resize" |
-| `GitOpsPullRequest` | `PullRequestOpen`, `PullRequestFailed`, `NoDrift`, `PullRequestUnchanged`, `PullRequestCooldown`, `PullRequestDryRun`, `PullRequestDisabled` | Opt-in `export.pullRequest` automation status (see [GitOps integration](../guides/gitops-integration.md)) |
+| `GitOpsPullRequest` | `PullRequestOpen`, `PullRequestFailed`, `GitOpsEndpointBlocked`, `NoDrift`, `PullRequestUnchanged`, `PullRequestCooldown`, `PullRequestDryRun`, `PullRequestDisabled` | Opt-in `export.pullRequest` automation status (see [GitOps integration](../guides/gitops-integration.md)) |
 
 ### Status fields (GitOps PR)
 

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -999,7 +999,9 @@ func (r *AttunePolicyReconciler) processWorkloads(
 				rec.Workload = workloadName
 				rec.Kind = workloadKind
 				result.recommendations = append(result.recommendations, *rec)
-				result.workloadsWithRecs++
+				if !rec.Stale {
+					result.workloadsWithRecs++
+				}
 			}
 			if seriesCapped {
 				result.seriesCapped = true

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -1463,7 +1463,7 @@ func generateSamples(count int, baseValue float64) []rsmetrics.Sample {
 	now := time.Now()
 	for i := 0; i < count; i++ {
 		samples[i] = rsmetrics.Sample{
-			Timestamp: now.Add(-time.Duration(count-i) * time.Hour),
+			Timestamp: now.Add(-time.Duration(count-1-i) * time.Hour),
 			Value:     baseValue + float64(i%10)*0.01,
 		}
 	}
@@ -1755,8 +1755,10 @@ func TestComputeRecommendations_EmptyQueryReusesPriorAsStale(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	deploy := newTestDeployment("api-server", "default", nil)
 	reconciler := newReconcilerWithClient()
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	reconciler.SetNowFunc(func() time.Time { return now })
 
-	priorData := metav1.NewTime(time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC))
+	priorData := metav1.NewTime(now.Add(-time.Minute))
 	cpuRec, err := resource.ParseQuantity("250m")
 	require.NoError(t, err)
 	memRec, err := resource.ParseQuantity("256Mi")
@@ -1794,7 +1796,8 @@ func TestComputeRecommendations_EmptyQueryReusesPriorAsStale(t *testing.T) {
 }
 
 func TestComputeRecommendations_QueryGapsReusePriorAsStale(t *testing.T) {
-	priorData := metav1.NewTime(time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC))
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	priorData := metav1.NewTime(now.Add(-time.Minute))
 	cpuRec, err := resource.ParseQuantity("250m")
 	require.NoError(t, err)
 	memRec, err := resource.ParseQuantity("256Mi")
@@ -1842,6 +1845,7 @@ func TestComputeRecommendations_QueryGapsReusePriorAsStale(t *testing.T) {
 			policy := newTestPolicy("test-policy", "default")
 			deploy := newTestDeployment("api-server", "default", nil)
 			reconciler := newReconcilerWithClient()
+			reconciler.SetNowFunc(func() time.Time { return now })
 			policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
 				Workload:     "api-server",
 				Kind:         "Deployment",
@@ -1882,7 +1886,9 @@ func TestComputeRecommendations_LastDataTimeOlderThanHistoryWindowIsStale(t *tes
 	reconciler := newReconcilerWithClient()
 	reconciler.SetNowFunc(func() time.Time { return now })
 
-	old := now.Add(-3 * time.Hour)
+	// 30m is inside the 2h history window (old check never fired) and
+	// outside 3*queryStep (15m). The mock still ignores start/end.
+	old := now.Add(-30 * time.Minute)
 	mc := &mockCollector{
 		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
 			return []rsmetrics.Sample{{Timestamp: old, Value: 0.1}}, nil
@@ -1892,9 +1898,151 @@ func TestComputeRecommendations_LastDataTimeOlderThanHistoryWindowIsStale(t *tes
 	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
-	assert.True(t, rec.Stale, "last sample older than historyWindow must mark the rec stale")
+	assert.True(t, rec.Stale, "last sample older than 3*queryStep must mark the rec stale even when inside historyWindow")
 	require.NotNil(t, rec.LastDataTime)
 	assert.True(t, rec.LastDataTime.Equal(&metav1.Time{Time: old}), "LastDataTime is the last non-empty sample, not now")
+}
+
+func TestComputeRecommendations_InWindowSampleOlderThanFreshnessIsStale(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.MetricsSource.HistoryWindow = &metav1.Duration{Duration: 7 * 24 * time.Hour}
+	policy.Spec.MetricsSource.MinimumDataPoints = int32Ptr(1)
+	deploy := newTestDeployment("api-server", "default", nil)
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	reconciler := newReconcilerWithClient()
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	// Two hours old is inside a 7d history window but outside 3*queryStep (15m).
+	old := now.Add(-2 * time.Hour)
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, start, end time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			if old.Before(start) || old.After(end) {
+				return nil, nil
+			}
+			return []rsmetrics.Sample{{Timestamp: old, Value: 0.1}}, nil
+		},
+	}
+
+	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.True(t, rec.Stale, "in-window sample older than 3*queryStep must be stale")
+	require.NotNil(t, rec.LastDataTime)
+	assert.True(t, rec.LastDataTime.Equal(&metav1.Time{Time: old}))
+}
+
+func TestComputeRecommendations_ExpiredReuseIsDropped(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	deploy := newTestDeployment("api-server", "default", nil)
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	reconciler := newReconcilerWithClient()
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	expired := metav1.NewTime(now.Add(-time.Hour))
+	cpuRec, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+	policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+		Workload:     "api-server",
+		Kind:         "Deployment",
+		LastDataTime: &expired,
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name:        "main",
+			Recommended: attunev1alpha1.ResourceValues{CPURequest: cpuRec},
+		}},
+	}}
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return nil, nil
+		},
+	}
+
+	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, rec, "reuse must expire when LastDataTime is older than 3*queryStep")
+}
+
+func TestComputeRecommendations_ReuseIgnoresDifferentKind(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "default"},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api-server"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api-server"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "main",
+						Image: "nginx:latest",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	reconciler := newReconcilerWithClient()
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	priorData := metav1.NewTime(now.Add(-time.Minute))
+	cpuRec, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+	policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+		Workload:     "api-server",
+		Kind:         "Deployment",
+		LastDataTime: &priorData,
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name:        "main",
+			Recommended: attunev1alpha1.ResourceValues{CPURequest: cpuRec},
+		}},
+	}}
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return nil, nil
+		},
+	}
+
+	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, sts, mc, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, rec, "must not reuse a Deployment rec for a StatefulSet of the same name")
+}
+
+func TestComputeRecommendations_ReuseIgnoresEmptyPriorKind(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	deploy := newTestDeployment("api-server", "default", nil)
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	reconciler := newReconcilerWithClient()
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	priorData := metav1.NewTime(now.Add(-time.Minute))
+	cpuRec, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+	policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+		Workload:     "api-server",
+		Kind:         "",
+		LastDataTime: &priorData,
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name:        "main",
+			Recommended: attunev1alpha1.ResourceValues{CPURequest: cpuRec},
+		}},
+	}}
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return nil, nil
+		},
+	}
+
+	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, rec, "empty prior Kind must not reuse onto a typed workload")
 }
 
 func TestComputeRecommendations_FreshDataClearsStale(t *testing.T) {
@@ -12228,6 +12376,54 @@ func TestSetReadyCondition(t *testing.T) {
 	}
 }
 
+func TestProcessWorkloads_StaleRecNotCountedForReady(t *testing.T) {
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	prior := metav1.NewTime(now.Add(-time.Minute))
+	cpuRec, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+
+	dep := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(dep).Build()
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+		Workload:     "api-server",
+		Kind:         "Deployment",
+		LastDataTime: &prior,
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name:        "main",
+			Recommended: attunev1alpha1.ResourceValues{CPURequest: cpuRec},
+		}},
+	}}
+
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.SetNowFunc(func() time.Time { return now })
+	r.MetricsFactory = mockMetricsFactory(&mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return nil, nil
+		},
+	})
+
+	result := r.processWorkloads(context.Background(), policy, []client.Object{dep}, &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return nil, nil
+		},
+	}, nil, nil)
+
+	require.Len(t, result.recommendations, 1)
+	assert.True(t, result.recommendations[0].Stale)
+	assert.Equal(t, int32(0), result.workloadsWithRecs, "stale reuse must not keep Ready=Monitoring")
+}
+
+func TestRecommendationFreshnessBound(t *testing.T) {
+	assert.Equal(t, 15*time.Minute, recommendationFreshnessBound(5*time.Minute))
+	assert.Equal(t, 15*time.Minute, recommendationFreshnessBound(0))
+	assert.Equal(t, 45*time.Second, recommendationFreshnessBound(15*time.Second))
+}
+
 func TestProcessWorkloads_Parallel(t *testing.T) {
 	// Track peak concurrent queries to prove parallelism.
 	var inflight atomic.Int32
@@ -12382,7 +12578,7 @@ func TestProcessWorkloads_ParallelPartialFailure(t *testing.T) {
 
 func TestProcessWorkloads_MixedStaleAndFresh(t *testing.T) {
 	now := time.Now()
-	priorData := metav1.NewTime(now.Add(-24 * time.Hour))
+	priorData := metav1.NewTime(now.Add(-time.Minute))
 	cpuRec, err := resource.ParseQuantity("250m")
 	require.NoError(t, err)
 	memRec, err := resource.ParseQuantity("256Mi")
@@ -12455,6 +12651,7 @@ func TestProcessWorkloads_MixedStaleAndFresh(t *testing.T) {
 	require.NotNil(t, recA.LastDataTime)
 	assert.True(t, recA.LastDataTime.Equal(&priorData), "stale reuse must preserve LastDataTime")
 	assert.False(t, recB.Stale, "fresh Prometheus data must not mark app-b stale")
+	assert.Equal(t, int32(1), result.workloadsWithRecs, "only the fresh rec counts toward Ready")
 }
 
 func TestReconcile_InsufficientDataRequeuesAtQueryStep(t *testing.T) {

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -132,9 +133,9 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 	head := gitops.BranchName(policy.Namespace, policy.Name)
 
 	if cfg.APIURL != "" {
-		if err := validation.GitOpsAPIURL(cfg.APIURL); err != nil {
+		if err := validation.GitOpsAPIURLAllowingPrivate(cfg.APIURL, cfg.AllowPrivateEndpoints); err != nil {
 			logger.Error(err, "GitOps PR: apiUrl failed SSRF checks")
-			setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRFailed,
+			setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsEndpointBlocked,
 				"apiUrl is not an allowed HTTPS host")
 			operatormetrics.GitOpsPRTotal.WithLabelValues(policy.Namespace, policy.Name, "failed").Inc()
 			return
@@ -170,15 +171,17 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 		switch provider {
 		case "gitlab":
 			prClient = &gitops.GitLabClient{
-				BaseURL: cfg.APIURL,
-				Token:   token,
-				Project: cfg.Repository,
+				BaseURL:      cfg.APIURL,
+				Token:        token,
+				Project:      cfg.Repository,
+				AllowPrivate: cfg.AllowPrivateEndpoints,
 			}
 		default:
 			prClient = &gitops.GitHubClient{
-				BaseURL:    cfg.APIURL,
-				Token:      token,
-				Repository: cfg.Repository,
+				BaseURL:      cfg.APIURL,
+				Token:        token,
+				Repository:   cfg.Repository,
+				AllowPrivate: cfg.AllowPrivateEndpoints,
 			}
 		}
 	}
@@ -190,8 +193,13 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 		// Never include raw API bodies or error strings that might echo
 		// IMDS credentials. Status is a short static message only.
 		logger.Error(err, "GitOps PR create/update failed", "provider", provider, "repository", cfg.Repository)
-		setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRFailed,
-			"PR API request failed")
+		reason := attunev1alpha1.ReasonGitOpsPRFailed
+		msg := "PR API request failed"
+		if errors.Is(err, gitops.ErrSSRFBlocked) {
+			reason = attunev1alpha1.ReasonGitOpsEndpointBlocked
+			msg = "GitOps API URL resolved to a disallowed address"
+		}
+		setGitOpsPRCondition(policy, metav1.ConditionFalse, reason, msg)
 		operatormetrics.GitOpsPRTotal.WithLabelValues(policy.Namespace, policy.Name, "failed").Inc()
 		r.touchGitOpsPRAnnotation(policy, "")
 		r.persistGitOpsPRAnnotations(ctx, policy)

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -450,6 +450,43 @@ func TestReconcileGitOpsPullRequest_APIErrorStatusOmitsBody(t *testing.T) {
 	assert.NotContains(t, message, "status 403")
 }
 
+type ssrfBlockedPRClient struct{}
+
+func (ssrfBlockedPRClient) CreateOrUpdate(_ context.Context, _ gitops.PRRequest) (gitops.PRResult, error) {
+	return gitops.PRResult{}, fmt.Errorf("%w: host %q resolved to a disallowed address", gitops.ErrSSRFBlocked, "gitlab.corp.example")
+}
+
+func TestReconcileGitOpsPullRequest_SSRFBlockedReason(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	dry := false
+	policy := gitOpsEnabledPolicy("p", "default", dry, nil)
+	policy.Spec.UpdateStrategy.Export.PullRequest.Enabled = &en
+	dep := gitOpsDriftDeployment("api", "default", "1")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	r.gitopsPRClient = ssrfBlockedPRClient{}
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "100m"))
+
+	var reason, message string
+	for _, cond := range policy.Status.Conditions {
+		if cond.Type == attunev1alpha1.ConditionGitOpsPullRequest {
+			reason = cond.Reason
+			message = cond.Message
+		}
+	}
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsEndpointBlocked, reason)
+	assert.Equal(t, "GitOps API URL resolved to a disallowed address", message)
+	assert.NotContains(t, message, "gitlab.corp.example")
+}
+
 func TestReconcileGitOpsPullRequest_DryRunIncrementsMetric(t *testing.T) {
 	// Complements DryRun reason assertion: dry-run path increments metric
 	// and never requires a Secret in the fake client.

--- a/internal/controller/gitops_pr_userstate_test.go
+++ b/internal/controller/gitops_pr_userstate_test.go
@@ -203,7 +203,7 @@ func TestReconcileGitOpsPullRequest_InvalidAPIURLDoesNotOpen(t *testing.T) {
 	r, _, forge := gitOpsLiveReconciler(t, policy, dep)
 	r.SetNowFunc(func() time.Time { return time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC) })
 	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "100m"))
-	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRFailed, gitOpsPRReason(policy))
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsEndpointBlocked, gitOpsPRReason(policy))
 	assert.Empty(t, forge.calls)
 }
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -307,6 +307,16 @@ func (r *AttunePolicyReconciler) getMinimumDataPoints(policy *attunev1alpha1.Att
 	return defaultMinimumDataPoints
 }
 
+// recommendationFreshnessBound is how recent the newest finite sample must
+// be for a recommendation to count as fresh. Three query steps covers a
+// couple of missed scrapes without treating the whole historyWindow as current.
+func recommendationFreshnessBound(queryStep time.Duration) time.Duration {
+	if queryStep <= 0 {
+		queryStep = attunev1alpha1.DefaultQueryStep
+	}
+	return 3 * queryStep
+}
+
 // getQueryStep returns the query step interval from the policy or the default (5m).
 // When MinQueryStep is set on the reconciler, enforces that floor (tier-aware).
 func (r *AttunePolicyReconciler) getQueryStep(policy *attunev1alpha1.AttunePolicy) time.Duration {

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -471,9 +471,11 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 		// Only reuse when an eligible container had no usable data.
 		// Exclude-all must still return nil so status drops the rec.
 		if eligibleContainers > 0 {
-			if reused := reuseStaleRecommendation(policy, workload.GetName()); reused != nil {
+			freshness := recommendationFreshnessBound(queryStep)
+			if reused := reuseStaleRecommendation(policy, workloadKindName(workload), workload.GetName(), now, freshness); reused != nil {
 				logger.Info("Reusing prior recommendation as stale; Prometheus returned no fresh data",
-					"workload", workload.GetName())
+					"workload", workload.GetName(),
+					"kind", workloadKindName(workload))
 				return reused, queryErrors, failedMetricTypes, maxDataPoints, seriesCapped, nil
 			}
 		}
@@ -485,12 +487,13 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 		last = now
 	}
 	lastDataTime := metav1.NewTime(last)
-	stale := now.Sub(last) > historyWindow
+	freshness := recommendationFreshnessBound(queryStep)
+	stale := now.Sub(last) > freshness
 	if stale {
-		logger.Info("Recommendation is stale; last Prometheus data is older than history window",
+		logger.Info("Recommendation is stale; last Prometheus data is older than freshness bound",
 			"workload", workload.GetName(),
 			"lastDataTime", lastDataTime,
-			"historyWindow", historyWindow)
+			"freshnessBound", freshness)
 	}
 	return &attunev1alpha1.WorkloadRecommendation{
 		Containers:   containerRecs,
@@ -501,14 +504,22 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 
 // reuseStaleRecommendation copies a prior status rec so an empty Prometheus
 // query does not wipe the last known sizing. LastDataTime stays the last
-// non-empty sample. Callers must treat the copy as stale.
-func reuseStaleRecommendation(policy *attunev1alpha1.AttunePolicy, workload string) *attunev1alpha1.WorkloadRecommendation {
+// non-empty sample. Callers must treat the copy as stale. Reuse is refused
+// when Kind does not match (including an empty prior Kind), LastDataTime
+// is missing, or the last sample is older than freshness.
+func reuseStaleRecommendation(policy *attunev1alpha1.AttunePolicy, kind, workload string, now time.Time, freshness time.Duration) *attunev1alpha1.WorkloadRecommendation {
 	if policy == nil || workload == "" {
 		return nil
 	}
 	for i := range policy.Status.Recommendations {
 		prior := &policy.Status.Recommendations[i]
 		if prior.Workload != workload || len(prior.Containers) == 0 {
+			continue
+		}
+		if kind != "" && prior.Kind != kind {
+			continue
+		}
+		if prior.LastDataTime == nil || now.Sub(prior.LastDataTime.Time) > freshness {
 			continue
 		}
 		rec := prior.DeepCopy()

--- a/internal/controller/savings.go
+++ b/internal/controller/savings.go
@@ -48,6 +48,9 @@ type savingsAccumulator struct {
 func accumulateSavings(recommendations []attunev1alpha1.WorkloadRecommendation) savingsAccumulator {
 	var acc savingsAccumulator
 	for _, rec := range recommendations {
+		if rec.Stale {
+			continue
+		}
 		for _, c := range rec.Containers {
 			acc.totalCPU += c.Current.CPURequest.MilliValue()
 			acc.totalMem += c.Current.MemoryRequest.Value()

--- a/internal/controller/savings_test.go
+++ b/internal/controller/savings_test.go
@@ -229,6 +229,48 @@ func TestComputeSavings_Mixed(t *testing.T) {
 	assert.Equal(t, "$4.53", savings.EstimatedMonthlyCostIncrease)
 }
 
+func TestComputeSavings_SkipsStale(t *testing.T) {
+	r := newSavingsReconciler()
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "fresh",
+			Kind:     "Deployment",
+			Containers: []attunev1alpha1.ContainerRecommendation{{
+				Name: "main",
+				Current: attunev1alpha1.ResourceValues{
+					CPURequest:    resource.MustParse("500m"),
+					MemoryRequest: resource.MustParse("256Mi"),
+				},
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest:    resource.MustParse("100m"),
+					MemoryRequest: resource.MustParse("128Mi"),
+				},
+			}},
+		},
+		{
+			Workload: "stale",
+			Kind:     "Deployment",
+			Stale:    true,
+			Containers: []attunev1alpha1.ContainerRecommendation{{
+				Name: "main",
+				Current: attunev1alpha1.ResourceValues{
+					CPURequest:    resource.MustParse("2000m"),
+					MemoryRequest: resource.MustParse("2Gi"),
+				},
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest:    resource.MustParse("100m"),
+					MemoryRequest: resource.MustParse("128Mi"),
+				},
+			}},
+		},
+	}
+
+	savings, acc := r.computeSavings(recommendations, nil)
+	assert.Equal(t, "400m", savings.CPURequestReduction, "stale rec must not add 1900m")
+	assert.Equal(t, int64(400), acc.totalCPUSaved)
+	assert.Equal(t, int64(500), acc.totalCPU)
+}
+
 // --- Defense-in-depth parsing helpers ---
 
 func TestParseFloat64_ValidValue(t *testing.T) {

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -34,6 +34,9 @@ import (
 
 var errGitOpsRedirect = errors.New("redirects are not allowed")
 
+// ErrSSRFBlocked is returned when the GitOps HTTP dial refuses the resolved address.
+var ErrSSRFBlocked = errors.New("gitops SSRF blocked")
+
 // PRRequest is the input for create-or-update PR.
 type PRRequest struct {
 	Title  string
@@ -63,18 +66,20 @@ type HTTPDoer interface {
 
 // GitHubClient implements PullRequestClient for GitHub REST API.
 type GitHubClient struct {
-	BaseURL    string // default https://api.github.com
-	Token      string
-	Repository string // owner/repo
-	HTTP       HTTPDoer
+	BaseURL      string // default https://api.github.com
+	Token        string
+	Repository   string // owner/repo
+	HTTP         HTTPDoer
+	AllowPrivate bool
 }
 
 // GitLabClient implements PullRequestClient for GitLab REST API.
 type GitLabClient struct {
-	BaseURL string // default https://gitlab.com/api/v4
-	Token   string
-	Project string // URL-encoded path or numeric id path "group/project"
-	HTTP    HTTPDoer
+	BaseURL      string // default https://gitlab.com/api/v4
+	Token        string
+	Project      string // URL-encoded path or numeric id path "group/project"
+	HTTP         HTTPDoer
+	AllowPrivate bool
 }
 
 const bootstrapCommitMessage = "chore(attune): bootstrap recommendation branch"
@@ -89,7 +94,7 @@ func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 	}
 	httpClient := c.HTTP
 	if httpClient == nil {
-		httpClient = newGitOpsHTTPClient()
+		httpClient = newGitOpsHTTPClient(c.AllowPrivate)
 	}
 
 	// Find existing open PR for this head branch. GitHub supports head=owner:ref
@@ -282,7 +287,7 @@ func (c *GitHubClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer
 }
 
 func (c *GitHubClient) doJSON(ctx context.Context, httpClient HTTPDoer, method, rawURL string, payload interface{}) ([]byte, int, error) {
-	if err := validation.GitOpsAPIURL(rawURL); err != nil {
+	if err := validation.GitOpsAPIURLAllowingPrivate(rawURL, c.AllowPrivate); err != nil {
 		return nil, 0, fmt.Errorf("gitops api url rejected")
 	}
 	var rdr io.Reader
@@ -324,7 +329,7 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 	}
 	httpClient := c.HTTP
 	if httpClient == nil {
-		httpClient = newGitOpsHTTPClient()
+		httpClient = newGitOpsHTTPClient(c.AllowPrivate)
 	}
 	project := url.PathEscape(c.Project)
 
@@ -447,7 +452,7 @@ func (c *GitLabClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer
 }
 
 func (c *GitLabClient) doJSON(ctx context.Context, httpClient HTTPDoer, method, rawURL string, payload interface{}) ([]byte, int, error) {
-	if err := validation.GitOpsAPIURL(rawURL); err != nil {
+	if err := validation.GitOpsAPIURLAllowingPrivate(rawURL, c.AllowPrivate); err != nil {
 		return nil, 0, fmt.Errorf("gitops api url rejected")
 	}
 	var rdr io.Reader
@@ -478,10 +483,10 @@ func (c *GitLabClient) doJSON(ctx context.Context, httpClient HTTPDoer, method, 
 	return body, resp.StatusCode, nil
 }
 
-func newGitOpsHTTPClient() *http.Client {
+func newGitOpsHTTPClient(allowPrivate bool) *http.Client {
 	return &http.Client{
 		Timeout:       30 * time.Second,
-		Transport:     gitopsSafeTransport(),
+		Transport:     gitopsSafeTransport(allowPrivate),
 		CheckRedirect: gitopsCheckRedirect,
 	}
 }
@@ -490,33 +495,50 @@ func gitopsCheckRedirect(*http.Request, []*http.Request) error {
 	return errGitOpsRedirect
 }
 
-// gitopsSafeTransport resolves hostnames and refuses private, loopback,
-// link-local, and metadata IPs before dialing. Stricter than the Prometheus
-// transport, which must allow ClusterIP scrapes.
-func gitopsSafeTransport() http.RoundTripper {
-	dialer := &net.Dialer{Timeout: 10 * time.Second}
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			host, port, err := net.SplitHostPort(addr)
-			if err != nil {
-				return nil, fmt.Errorf("gitops dial: invalid address")
-			}
-			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-			if err != nil {
-				return nil, fmt.Errorf("gitops dial: DNS resolution failed")
-			}
-			for _, ip := range ips {
-				if validation.GitOpsBlockedIP(ip.IP) {
-					return nil, fmt.Errorf("gitops SSRF blocked: resolved to a disallowed address")
-				}
-			}
-			return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+// gitopsSafeTransport checks the request URL host (the SSRF target) before
+// the request is sent. The inner transport may use HTTPS_PROXY; the proxy
+// hop itself is not the SSRF target. allowPrivate permits RFC1918/ULA
+// forges. Loopback, link-local, unspecified, and AWS IPv6 IMDS stay blocked.
+func gitopsSafeTransport(allowPrivate bool) http.RoundTripper {
+	return &gitopsSSRFTransport{
+		allowPrivate: allowPrivate,
+		base: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+			ResponseHeaderTimeout: 30 * time.Second,
+			IdleConnTimeout:       90 * time.Second,
+			MaxIdleConnsPerHost:   10,
 		},
-		ResponseHeaderTimeout: 30 * time.Second,
-		IdleConnTimeout:       90 * time.Second,
-		MaxIdleConnsPerHost:   10,
 	}
+}
+
+type gitopsSSRFTransport struct {
+	allowPrivate bool
+	base         http.RoundTripper
+}
+
+func (t *gitopsSSRFTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := req.URL.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("gitops dial: invalid address")
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(req.Context(), host)
+	if err != nil {
+		return nil, fmt.Errorf("gitops dial: DNS resolution failed")
+	}
+	for _, ip := range ips {
+		if gitopsDialBlocked(ip.IP, t.allowPrivate) {
+			return nil, fmt.Errorf("%w: host %q resolved to a disallowed address", ErrSSRFBlocked, host)
+		}
+	}
+	return t.base.RoundTrip(req)
+}
+
+func gitopsDialBlocked(ip net.IP, allowPrivate bool) bool {
+	if allowPrivate {
+		return validation.GitOpsAlwaysBlockedIP(ip)
+	}
+	return validation.GitOpsBlockedIP(ip)
 }
 
 func redactToken(s, token string) string {

--- a/internal/gitops/transport_test.go
+++ b/internal/gitops/transport_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing limitations under
+the License.
+*/
+
+package gitops
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitopsDialBlocked(t *testing.T) {
+	t.Parallel()
+	private := net.ParseIP("10.1.2.3")
+	loopback := net.ParseIP("127.0.0.1")
+	imds := net.ParseIP("169.254.169.254")
+	public := net.ParseIP("1.1.1.1")
+	require.NotNil(t, private)
+	require.NotNil(t, loopback)
+	require.NotNil(t, imds)
+	require.NotNil(t, public)
+
+	assert.True(t, gitopsDialBlocked(private, false))
+	assert.False(t, gitopsDialBlocked(private, true))
+	assert.True(t, gitopsDialBlocked(loopback, true), "loopback stays blocked")
+	assert.True(t, gitopsDialBlocked(imds, true), "IMDS stays blocked")
+	assert.False(t, gitopsDialBlocked(public, false))
+	assert.False(t, gitopsDialBlocked(public, true))
+}
+
+func TestGitopsDialBlocked_AWSIMDSv6(t *testing.T) {
+	t.Parallel()
+	imds := net.ParseIP("fd00:ec2::254")
+	require.NotNil(t, imds)
+	assert.True(t, gitopsDialBlocked(imds, false))
+	assert.True(t, gitopsDialBlocked(imds, true), "IPv6 IMDS stays blocked when allowPrivate is set")
+}

--- a/internal/metrics/cloudwatch.go
+++ b/internal/metrics/cloudwatch.go
@@ -110,15 +110,14 @@ func (c *CloudWatchCollector) QueryRangeGrouped(ctx context.Context, query strin
 	}
 	period32 := int32(min(period, 86400)) //nolint:gosec // period is clamped to [60, 86400]
 
-	// Metric/Stat/ClusterName/Namespace/PodPrefix are pinned or allowlisted
-	// above so they cannot break out of the quoted SEARCH terms.
-	prefixTerm := ""
-	if spec.PodPrefix != "" {
-		prefixTerm = fmt.Sprintf(` PodName="%s*"`, spec.PodPrefix)
-	}
+	// Metric/Stat/ClusterName/Namespace are pinned or allowlisted above so
+	// they cannot break out of the quoted SEARCH terms. PodPrefix is not
+	// interpolated: CloudWatch quoted tokens are exact matches, so
+	// PodName="api-*" would never match real pods. Client-side HasPrefix
+	// below is the real filter.
 	searchExpr := fmt.Sprintf(
-		`SEARCH('{ContainerInsights,ClusterName,Namespace,PodName,ContainerName} MetricName="%s" ClusterName="%s" Namespace="%s"%s', '%s', %d)`,
-		spec.Metric, spec.ClusterName, spec.Namespace, prefixTerm, spec.Stat, period32,
+		`SEARCH('{ContainerInsights,ClusterName,Namespace,PodName,ContainerName} MetricName="%s" ClusterName="%s" Namespace="%s"', '%s', %d)`,
+		spec.Metric, spec.ClusterName, spec.Namespace, spec.Stat, period32,
 	)
 
 	input := &cloudwatch.GetMetricDataInput{

--- a/internal/metrics/cloudwatch_test.go
+++ b/internal/metrics/cloudwatch_test.go
@@ -532,7 +532,8 @@ func TestCloudWatchCollector_PodPrefixInSEARCH(t *testing.T) {
 	_, err = c.QueryRangeGrouped(context.Background(), string(query),
 		time.Now().Add(-time.Hour), time.Now(), time.Minute)
 	require.NoError(t, err)
-	assert.Contains(t, gotExpr, `PodName="api-server-*"`)
+	assert.NotContains(t, gotExpr, `PodName=`, "quoted SEARCH has no prefix wildcard; filter client-side")
+	assert.Contains(t, gotExpr, `MetricName="container_memory_working_set"`)
 }
 
 func TestCloudWatchCollector_HostilePodPrefixNotInSEARCH(t *testing.T) {

--- a/internal/validation/gitops.go
+++ b/internal/validation/gitops.go
@@ -28,6 +28,13 @@ import (
 // ULA / loopback / link-local / metadata targets. GitOps calls carry a
 // bearer token and must not aim at in-cluster or cloud-metadata endpoints.
 func GitOpsAPIURL(address string) error {
+	return GitOpsAPIURLAllowingPrivate(address, false)
+}
+
+// GitOpsAPIURLAllowingPrivate is GitOpsAPIURL with an opt-in for RFC1918/ULA
+// IP literals (self-hosted forges). Loopback, link-local, unspecified, and
+// metadata hostnames stay blocked even when allowPrivate is true.
+func GitOpsAPIURLAllowingPrivate(address string, allowPrivate bool) error {
 	parsed, err := url.Parse(address)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
@@ -52,6 +59,7 @@ func GitOpsAPIURL(address string) error {
 		"metadata.internal",
 		"instance-data.ec2.internal",
 		"169.254.169.254",
+		"fd00:ec2::254",
 		"localhost",
 	}
 	lowerHost := strings.ToLower(hostname)
@@ -62,17 +70,26 @@ func GitOpsAPIURL(address string) error {
 	}
 
 	if ip := net.ParseIP(hostname); ip != nil {
-		if GitOpsBlockedIP(ip) {
+		if allowPrivate {
+			if GitOpsAlwaysBlockedIP(ip) {
+				return fmt.Errorf("address must not target loopback, link-local, or metadata IP %q", hostname)
+			}
+		} else if GitOpsBlockedIP(ip) {
 			return fmt.Errorf("address must not target loopback, link-local, private, or metadata IP %q", hostname)
 		}
 	}
 	return nil
 }
 
-// GitOpsBlockedIP reports whether an IP must not be dialed for GitOps HTTP.
-// Stricter than Prometheus: RFC1918 and ULA are blocked because GitOps is
-// not an in-cluster metrics scrape.
-func GitOpsBlockedIP(ip net.IP) bool {
+// awsIMDSv6 is the AWS EC2 Instance Metadata Service v2 IPv6 endpoint.
+// It is ULA (fd00::/8), not link-local, so IsPrivate is true but
+// IsLinkLocalUnicast is false. Must stay blocked when allowPrivate is set.
+var awsIMDSv6 = net.ParseIP("fd00:ec2::254")
+
+// GitOpsAlwaysBlockedIP reports addresses that stay blocked even when
+// allowPrivateEndpoints is set: loopback, link-local (IMDS), unspecified,
+// and AWS IPv6 IMDS.
+func GitOpsAlwaysBlockedIP(ip net.IP) bool {
 	if ip == nil {
 		return true
 	}
@@ -80,5 +97,15 @@ func GitOpsBlockedIP(ip net.IP) bool {
 		ip = v4
 	}
 	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
-		ip.IsUnspecified() || ip.IsPrivate()
+		ip.IsUnspecified() || ip.Equal(awsIMDSv6)
+}
+
+// GitOpsBlockedIP reports whether an IP must not be dialed for GitOps HTTP.
+// Stricter than Prometheus: RFC1918 and ULA are blocked because GitOps is
+// not an in-cluster metrics scrape.
+func GitOpsBlockedIP(ip net.IP) bool {
+	if GitOpsAlwaysBlockedIP(ip) {
+		return true
+	}
+	return ip.IsPrivate()
 }

--- a/internal/validation/gitops_test.go
+++ b/internal/validation/gitops_test.go
@@ -49,6 +49,7 @@ func TestGitOpsAPIURL_RejectsIMDS(t *testing.T) {
 	blocked := []string{
 		"https://169.254.169.254/",
 		"https://169.254.169.254/latest/meta-data/",
+		"https://[fd00:ec2::254]/",
 		"https://[fd00:ec2::254]/latest/meta-data/",
 		"https://metadata.google.internal/computeMetadata",
 		"https://METADATA.GOOGLE.INTERNAL/foo",
@@ -123,6 +124,28 @@ func TestGitOpsBlockedIP(t *testing.T) {
 			assert.Equal(t, tt.blocked, GitOpsBlockedIP(ip), tt.ip)
 		})
 	}
+}
+
+func TestGitOpsAPIURL_AllowPrivateRFC1918(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, GitOpsAPIURLAllowingPrivate("https://10.96.0.1/", true))
+	assert.NoError(t, GitOpsAPIURLAllowingPrivate("https://192.168.1.10:8443/", true))
+	assert.NoError(t, GitOpsAPIURLAllowingPrivate("https://[fd00::1]/", true))
+	assert.Error(t, GitOpsAPIURLAllowingPrivate("https://127.0.0.1/", true))
+	assert.Error(t, GitOpsAPIURLAllowingPrivate("https://169.254.169.254/", true))
+	assert.Error(t, GitOpsAPIURLAllowingPrivate("https://[fd00:ec2::254]/", true), "IPv6 IMDS stays blocked")
+	assert.Error(t, GitOpsAPIURLAllowingPrivate("https://localhost/", true))
+	assert.Error(t, GitOpsAPIURL("https://10.96.0.1/"), "default still blocks RFC1918")
+}
+
+func TestGitOpsAlwaysBlockedIP(t *testing.T) {
+	t.Parallel()
+	assert.True(t, GitOpsAlwaysBlockedIP(net.ParseIP("127.0.0.1")))
+	assert.True(t, GitOpsAlwaysBlockedIP(net.ParseIP("169.254.169.254")))
+	assert.True(t, GitOpsAlwaysBlockedIP(net.ParseIP("::1")))
+	assert.True(t, GitOpsAlwaysBlockedIP(net.ParseIP("fd00:ec2::254")), "AWS IPv6 IMDS")
+	assert.False(t, GitOpsAlwaysBlockedIP(net.ParseIP("10.0.0.1")))
+	assert.False(t, GitOpsAlwaysBlockedIP(net.ParseIP("8.8.8.8")))
 }
 
 func TestPrometheusAddress_StillAllowsPrivate(t *testing.T) {

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -123,7 +123,7 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 		// policy cannot aim the operator's bearer token at in-cluster or
 		// cloud metadata endpoints. This is stricter than PrometheusAddress.
 		if pr.APIURL != "" {
-			if err := validation.GitOpsAPIURL(pr.APIURL); err != nil {
+			if err := validation.GitOpsAPIURLAllowingPrivate(pr.APIURL, pr.AllowPrivateEndpoints); err != nil {
 				return warnings, fmt.Errorf("updateStrategy.export.pullRequest.apiUrl: %w", err)
 			}
 		}

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -289,6 +289,32 @@ func TestValidate_GitOpsPullRequestAPIURL_PrivateRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "apiUrl")
 }
 
+func TestValidate_GitOpsPullRequestAPIURL_PrivateAllowedWhenOptIn(t *testing.T) {
+	validator := &AttunePolicyValidator{}
+	en := true
+	policy := validPolicy()
+	policy.Spec.UpdateStrategy.Export = &attunev1alpha1.ExportConfig{
+		PullRequest: &attunev1alpha1.GitOpsPullRequestConfig{
+			Enabled:               &en,
+			Repository:            "org/repo",
+			TokenSecretRef:        &attunev1alpha1.SecretKeyRef{Name: "tok", Key: "token"},
+			APIURL:                "https://10.96.0.1/",
+			AllowPrivateEndpoints: true,
+		},
+	}
+
+	_, err := validator.ValidateCreate(context.Background(), policy)
+	assert.NoError(t, err)
+
+	policy.Spec.UpdateStrategy.Export.PullRequest.APIURL = "https://169.254.169.254/"
+	_, err = validator.ValidateCreate(context.Background(), policy)
+	require.Error(t, err, "link-local/IMDS stays blocked when allowPrivateEndpoints is set")
+
+	policy.Spec.UpdateStrategy.Export.PullRequest.APIURL = "https://[fd00:ec2::254]/"
+	_, err = validator.ValidateCreate(context.Background(), policy)
+	require.Error(t, err, "IPv6 IMDS stays blocked when allowPrivateEndpoints is set")
+}
+
 func TestValidate_GitOpsPullRequestAPIURL_EnterpriseOK(t *testing.T) {
 	validator := &AttunePolicyValidator{}
 	en := true


### PR DESCRIPTION
Bound stale recommendation reuse, fix CloudWatch SEARCH, and support self-hosted GitOps forges.

## Problem

A post-v0.1.25 review (#614-#619) found six real issues:

1. Stale reuse had no age limit, so a permanently empty metrics pipeline stayed `Ready=True` and kept publishing savings.
2. The live `stale` check compared last sample age to `historyWindow`, which a window-honoring collector can never fail.
3. Reuse matched workload name only, so a Deployment and StatefulSet with the same name could cross-attribute containers.
4. CloudWatch `SEARCH` emitted `PodName="prefix*"`. Quoted CloudWatch tokens are exact matches, so collection returned nothing.
5. GitOps SSRF dial blocked RFC1918 DNS names and treated `HTTPS_PROXY` as the SSRF target.
6. Existing policies already have `maxConcurrentResizes: 1` in etcd, so `AttuneDefaults` cannot inherit after the CRD default was removed.

## Change

- Freshness is `3 * queryStep` (default 15m) for both live samples and reuse expiry.
- Stale recs stay in status for CLI display while in-window, but do not increment `workloads.withRecommendations` or enter savings.
- Reuse matches `Kind` and `Workload`. Empty prior Kind does not reuse.
- CloudWatch drops the server-side prefix term. Client-side `HasPrefix` remains.
- GitOps checks the request host (not the proxy hop). `allowPrivateEndpoints` permits RFC1918/ULA. Loopback, link-local, unspecified, and AWS IPv6 IMDS (`fd00:ec2::254`) stay blocked. Blocked dials set `GitOpsEndpointBlocked`.
- Upgrade note for removing stored `maxConcurrentResizes: 1` and applying Helm CRDs.

## Validation

- `go test ./internal/controller/ ./internal/metrics/ ./internal/gitops/ ./internal/validation/ ./internal/webhook/ -race -count=1`
- `make lint`
- `make helm-unittest`
- Reviewer pass: IPv6 IMDS hole and scheme-less proxy matching were fixed before commit.

Closes #614
Closes #615
Closes #616
Closes #617
Closes #618
Closes #619
