### PR TITLE
fix: honor quota aliases, pin gitops dial, and warn doctor skips

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,15 +40,15 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
-      go: ${{ steps.filter.outputs.go }}
-      go-source: ${{ steps.filter.outputs.go-source }}
-      bench: ${{ steps.filter.outputs.bench }}
-      helm: ${{ steps.filter.outputs.helm }}
-      yaml: ${{ steps.filter.outputs.yaml }}
-      docs: ${{ steps.filter.outputs.docs }}
-      e2e: ${{ steps.filter.outputs.e2e }}
-      manifests: ${{ steps.filter.outputs.manifests }}
-      scripts: ${{ steps.filter.outputs.scripts }}
+      go: ${{ steps.force.outputs.go || steps.filter.outputs.go }}
+      go-source: ${{ steps.force.outputs.go-source || steps.filter.outputs.go-source }}
+      bench: ${{ steps.force.outputs.bench || steps.filter.outputs.bench }}
+      helm: ${{ steps.force.outputs.helm || steps.filter.outputs.helm }}
+      yaml: ${{ steps.force.outputs.yaml || steps.filter.outputs.yaml }}
+      docs: ${{ steps.force.outputs.docs || steps.filter.outputs.docs }}
+      e2e: ${{ steps.force.outputs.e2e || steps.filter.outputs.e2e }}
+      manifests: ${{ steps.force.outputs.manifests || steps.filter.outputs.manifests }}
+      scripts: ${{ steps.force.outputs.scripts || steps.filter.outputs.scripts }}
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
@@ -119,6 +119,20 @@ jobs:
               - 'hack/k3d-delete.sh'
               - '.github/actions/setup-e2e-cluster/**'
               - '.github/workflows/e2e-nightly.yaml'
+
+      - name: Force full matrix on workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: force
+        run: |
+          echo "go=true" >> "$GITHUB_OUTPUT"
+          echo "go-source=true" >> "$GITHUB_OUTPUT"
+          echo "helm=true" >> "$GITHUB_OUTPUT"
+          echo "yaml=true" >> "$GITHUB_OUTPUT"
+          echo "docs=true" >> "$GITHUB_OUTPUT"
+          echo "e2e=true" >> "$GITHUB_OUTPUT"
+          echo "manifests=true" >> "$GITHUB_OUTPUT"
+          echo "scripts=true" >> "$GITHUB_OUTPUT"
+          echo "bench=true" >> "$GITHUB_OUTPUT"
 
   lint:
     name: Lint
@@ -215,7 +229,9 @@ jobs:
 
       - name: Install MkDocs
         shell: bash -Eeuo pipefail {0}
-        run: pip install mkdocs-material==9.7.6
+        run: |
+          python3 -m pip install --user --break-system-packages --require-hashes -r docs/requirements.txt
+          echo "$(python3 -m site --user-base)/bin" >> "$GITHUB_PATH"
 
       - name: Build docs site
         shell: bash -Eeuo pipefail {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ env:
   HELM_UNITTEST_VERSION: "v0.7.2"
   GOCOVER_COBERTURA_VERSION: "v1.5.0"
   BENCHSTAT_VERSION: "v0.0.0-20260512194132-3cf34090a3db"
-  CERT_MANAGER_VERSION: "v1.17.2"
+  CERT_MANAGER_VERSION: "v1.21.1"
   PROMETHEUS_IMAGE: "quay.io/prometheus/prometheus:v3.4.1"
   PROMETHEUS_CHART_VERSION: "27.22.0"
   STRESS_NG_IMAGE: "ghcr.io/alexei-led/stress-ng:0.20.01"
@@ -42,6 +42,7 @@ jobs:
     outputs:
       go: ${{ steps.filter.outputs.go }}
       go-source: ${{ steps.filter.outputs.go-source }}
+      bench: ${{ steps.filter.outputs.bench }}
       helm: ${{ steps.filter.outputs.helm }}
       yaml: ${{ steps.filter.outputs.yaml }}
       docs: ${{ steps.filter.outputs.docs }}
@@ -70,6 +71,10 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - 'Makefile'
+            bench:
+              - 'internal/controller/**'
+              - 'internal/metrics/**'
+              - 'internal/recommendation/**'
             helm:
               - 'charts/**'
               - 'hack/verify-helm-image-tag.sh'
@@ -396,7 +401,9 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 15
     needs: changes
-    if: needs.changes.outputs.go == 'true'
+    if: >
+      needs.changes.outputs.bench == 'true' ||
+      (github.ref == 'refs/heads/main' && needs.changes.outputs.go == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -443,8 +450,10 @@ jobs:
       - name: Run benchmarks
         shell: bash -Eeuo pipefail -x {0}
         run: |
+          COUNT=5
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then COUNT=1; fi
           go test ${{ matrix.path }} -bench='${{ matrix.bench }}' -benchmem -run='^$' \
-            -count=5 -timeout=10m | tee bench-current.txt
+            -count=$COUNT -timeout=10m | tee bench-current.txt
 
       - name: Compare with baseline
         shell: bash -Eeuo pipefail {0}

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -36,7 +36,7 @@ concurrency:
 
 env:
   K3D_VERSION: "v5.8.3"
-  CERT_MANAGER_VERSION: "v1.17.2"
+  CERT_MANAGER_VERSION: "v1.21.1"
   PROMETHEUS_IMAGE: "quay.io/prometheus/prometheus:v3.4.1"
   PROMETHEUS_CHART_VERSION: "27.22.0"
   STRESS_NG_IMAGE: "ghcr.io/alexei-led/stress-ng:0.20.01"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOTESTSUM_VERSION ?= v1.13.0
 GOVULNCHECK_VERSION ?= v1.7.0
 K3D_VERSION ?= v5.8.3
 GITLEAKS_VERSION ?= 8.30.1
-CERT_MANAGER_VERSION ?= v1.17.2
+CERT_MANAGER_VERSION ?= v1.21.1
 KO_VERSION ?= v0.18.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ gotestsum: ## Install gotestsum
 SETUP_ENVTEST = $(LOCALBIN)/setup-envtest
 .PHONY: setup-envtest
 setup-envtest: ## Install setup-envtest
-	@test -s $(SETUP_ENVTEST) || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.24
+	@test -s $(SETUP_ENVTEST) || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.24.1
 
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 .PHONY: golangci-lint

--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -366,12 +366,13 @@ type ResourceConfig struct {
 	// +optional
 	AllowDecrease *bool `json:"allowDecrease,omitempty"`
 
-	// MemoryFromCPURatio derives memory recommendations from CPU recommendations
-	// using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-	// JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-	// and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-	// Go GC targets a fixed percentage of available memory).
-	// Example: "2.0" means memory = 2x the CPU recommendation in bytes
+	// MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+	// per core, instead of the memory signal from the active source
+	// (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+	// workloads where heap scales linearly with CPU allocation and source
+	// memory metrics are unreliable (JVM reserves heap upfront, Go GC
+	// targets a fixed percentage of available memory).
+	// Example: "2.0" means 1 core = 2 GiB memory
 	// (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
 	// minAllowed, maxAllowed, and maxChangePercent bounds.
 	// Only valid on the memory ResourceConfig; ignored on CPU.

--- a/charts/attune/crds/attune.io_attunedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunedefaults.yaml
@@ -152,12 +152,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -304,12 +305,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.

--- a/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
@@ -153,12 +153,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -305,12 +306,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -149,12 +149,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -309,12 +310,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.

--- a/charts/attune/values.schema.json
+++ b/charts/attune/values.schema.json
@@ -672,7 +672,7 @@
             },
             "memoryFromCpuRatio": {
               "type": "string",
-              "description": "Derive memory from CPU using this ratio (e.g. 4.0 = 4 GiB per core)"
+              "description": "Ignored on CPU. Only memory.memoryFromCpuRatio derives memory from CPU (GiB per core)."
             },
             "startupBoost": {
               "type": "object",

--- a/cmd/kubectl-attune/doctor.go
+++ b/cmd/kubectl-attune/doctor.go
@@ -327,7 +327,7 @@ func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstru
 			detail = "skipped (could not list policies or defaults)"
 		}
 		results = append(results, doctorResult{
-			name: "Prometheus", required: false, ok: true,
+			name: "Prometheus", required: false, ok: false,
 			detail: detail,
 		})
 		return results
@@ -379,7 +379,7 @@ func runDoctorChecks(ctx context.Context, disc doctorDiscovery, objects []unstru
 		}
 	}
 	results = append(results, doctorResult{
-		name: "Prometheus", required: false, ok: true,
+		name: "Prometheus", required: false, ok: len(reachable) > 0,
 		detail: detail,
 	})
 	return results

--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -153,8 +153,8 @@ func TestRunDoctorChecks_VersionAndDiscovery(t *testing.T) {
 		require.Len(t, results, 3)
 		assert.True(t, results[0].ok, results[0].detail)
 		assert.True(t, results[1].ok, results[1].detail)
-		assert.True(t, results[2].ok)
-		assert.Contains(t, results[2].detail, "skipped")
+		assert.False(t, results[2].ok, "no Prometheus ping is not ok")
+		assert.Contains(t, results[2].detail, "skipped (no address on policies or defaults)")
 		assert.False(t, doctorFailed(results))
 	})
 
@@ -222,7 +222,7 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 			return fmt.Errorf("should not ping")
 		})
 		assert.False(t, pinged)
-		require.True(t, results[2].ok, results[2].detail)
+		require.False(t, results[2].ok, "skip-only in-cluster is WARN, not ok: %s", results[2].detail)
 		assert.Contains(t, results[2].detail, "in-cluster")
 		assert.False(t, doctorFailed(results))
 	})
@@ -230,7 +230,7 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 	t.Run("list error without address is not claimed as no address", func(t *testing.T) {
 		t.Parallel()
 		results := runDoctorChecks(ctx, disc, nil, fmt.Errorf("list AttuneDefaults: forbidden"), nil)
-		require.True(t, results[2].ok)
+		require.False(t, results[2].ok, "no ping is not ok")
 		assert.Contains(t, results[2].detail, "could not list")
 		assert.NotContains(t, results[2].detail, "no address")
 	})
@@ -281,7 +281,7 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{authed}, nil, func(context.Context, string) error {
 			return &httpStatusError{status: 401, url: "http://prometheus.example:9090/-/healthy"}
 		})
-		require.True(t, results[2].ok, results[2].detail)
+		require.False(t, results[2].ok, "401 with configured auth is skip/WARN, not ok: %s", results[2].detail)
 		assert.Contains(t, results[2].detail, "401")
 		assert.Contains(t, results[2].detail, "bearer")
 		assert.False(t, doctorFailed(results))
@@ -302,7 +302,7 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{authed}, nil, func(context.Context, string) error {
 			return &httpStatusError{status: 403, url: "http://mimir.example:8080/-/healthy"}
 		})
-		require.True(t, results[2].ok, results[2].detail)
+		require.False(t, results[2].ok, "403 with configured auth is skip/WARN, not ok: %s", results[2].detail)
 		assert.Contains(t, results[2].detail, "403")
 		assert.False(t, doctorFailed(results))
 	})
@@ -352,7 +352,7 @@ func TestRunDoctorChecks_PrometheusOptional(t *testing.T) {
 		results := runDoctorChecks(ctx, disc, []unstructured.Unstructured{plain, authed}, nil, func(context.Context, string) error {
 			return &httpStatusError{status: 401, url: "http://prometheus.example:9090/-/healthy"}
 		})
-		require.True(t, results[2].ok, results[2].detail)
+		require.False(t, results[2].ok, "skip-only 401 is WARN, not ok: %s", results[2].detail)
 		assert.Contains(t, results[2].detail, "401")
 	})
 }
@@ -505,6 +505,8 @@ func TestRunDoctor_ExitCodes(t *testing.T) {
 	assert.Equal(t, 0, code)
 	assert.Contains(t, stdout.String(), "pods/resize            ok   [required] discovered")
 	assert.Contains(t, stdout.String(), "Kubernetes version     ok   [required]")
+	assert.Contains(t, stdout.String(), "Prometheus             WARN [optional] skipped (no address on policies or defaults)")
+	assert.NotContains(t, stdout.String(), "Prometheus             ok")
 	assert.Empty(t, stderr.String())
 
 	stdout.Reset()

--- a/config/crd/bases/attune.io_attunedefaults.yaml
+++ b/config/crd/bases/attune.io_attunedefaults.yaml
@@ -152,12 +152,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -304,12 +305,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.

--- a/config/crd/bases/attune.io_attunenamespacedefaults.yaml
+++ b/config/crd/bases/attune.io_attunenamespacedefaults.yaml
@@ -153,12 +153,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -305,12 +306,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -149,12 +149,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -309,12 +310,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -152,12 +152,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -304,12 +305,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -1044,12 +1046,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -1196,12 +1199,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -1932,12 +1936,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -2092,12 +2097,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -151,12 +151,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -303,12 +304,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -1043,12 +1045,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -1195,12 +1198,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -1931,12 +1935,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.
@@ -2091,12 +2096,13 @@ spec:
                     type: integer
                   memoryFromCpuRatio:
                     description: |-
-                      MemoryFromCPURatio derives memory recommendations from CPU recommendations
-                      using a fixed ratio, instead of using Prometheus memory metrics. Useful for
-                      JVM, Go, and .NET workloads where heap scales linearly with CPU allocation
-                      and Prometheus memory metrics are unreliable (JVM reserves heap upfront,
-                      Go GC targets a fixed percentage of available memory).
-                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+                      MemoryFromCPURatio derives memory from the CPU recommendation as GiB
+                      per core, instead of the memory signal from the active source
+                      (Prometheus usage or VPA memory target). Useful for JVM, Go, and .NET
+                      workloads where heap scales linearly with CPU allocation and source
+                      memory metrics are unreliable (JVM reserves heap upfront, Go GC
+                      targets a fixed percentage of available memory).
+                      Example: "2.0" means 1 core = 2 GiB memory
                       (e.g., 500m CPU -> 1Gi memory). The derived value still passes through
                       minAllowed, maxAllowed, and maxChangePercent bounds.
                       Only valid on the memory ResourceConfig; ignored on CPU.

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -162,6 +162,12 @@ Before executing a resize, the controller performs two checks:
 2. **ResourceQuota**: Checks aggregate namespace headroom. If the resize
    would increase CPU or memory requests beyond the remaining headroom
    (`hard - used`) in any ResourceQuota, the resize is skipped.
+   Headroom uses `requests.cpu` / `requests.memory` when those names are
+   set, or the `cpu` / `memory` aliases when a quota uses the short names.
+
+If listing ResourceQuotas or LimitRanges fails (for example missing
+`list`/`watch` RBAC), request increases fail closed and are skipped.
+Decreases still proceed.
 
 Both checks prevent resize failures that would produce confusing API errors.
 Skipped resizes are logged but do not set error conditions.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -481,7 +481,9 @@ together, or switch to `RequestsOnly` if the pod should be Burstable.
 with a message mentioning `exceed ResourceQuota`.
 
 **Cause**: The resize would increase CPU or memory requests beyond the
-remaining headroom in the namespace's ResourceQuota.
+remaining headroom in the namespace's ResourceQuota. Attune uses
+`requests.cpu` / `requests.memory` when those names are present, or the
+`cpu` / `memory` aliases when a quota uses the short names.
 
 **Fix**:
 
@@ -493,6 +495,36 @@ remaining headroom in the namespace's ResourceQuota.
 
 2. Either increase the quota limits, or tighten the policy's resource
    bounds so recommendations stay within quota.
+
+### Resize skipped: quota list unavailable
+
+**Symptom**: Operator logs `quota list unavailable; skipping request increase`
+or `ResourceQuota list unavailable` / `LimitRange list unavailable`.
+Request increases are skipped.
+
+**Cause**: The controller could not list ResourceQuotas or LimitRanges in
+the pod namespace, usually because the operator ServiceAccount is missing
+`list`/`watch` on those resources. Request increases fail closed so a
+quota cannot be exceeded while the check is unavailable. Decreases still
+proceed.
+
+**Fix**:
+
+1. Confirm the operator ServiceAccount can list quotas and limit ranges
+   in the workload namespace:
+
+    ```bash
+    # Helm release "attune" → ServiceAccount "attune" in the operator
+    # namespace (typically attune-system). Raw manifests use
+    # attune-controller-manager instead.
+    kubectl auth can-i list resourcequotas -n <ns> \
+      --as system:serviceaccount:<operator-ns>:attune
+    kubectl auth can-i list limitranges -n <ns> \
+      --as system:serviceaccount:<operator-ns>:attune
+    ```
+
+2. Grant `list` and `watch` on `resourcequotas` and `limitranges` if
+   either command returns `no`.
 
 ## Revert issues
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -326,7 +326,7 @@ ready. This typically means cert-manager is missing or broken.
 2. If cert-manager is not installed, install it:
 
     ```bash
-    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.21.1/cert-manager.yaml
     kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
     ```
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -10,9 +10,11 @@ run the full E2E Nightly matrix on tip of `main` (see
 
 ## v0.1.25 to v0.1.26
 
-v0.1.26 tightens stale-recommendation handling and CloudWatch collection.
-Existing policy YAML keeps working. Read this section if you inherit
-`maxConcurrentResizes` from `AttuneDefaults`, use CloudWatch, or run a
+v0.1.26 tightens stale-recommendation handling, CloudWatch collection,
+ResourceQuota list fail-closed, VPA `memoryFromCpuRatio`, and GitOps
+labels. Existing policy YAML keeps working. Read this section if you
+inherit `maxConcurrentResizes` from `AttuneDefaults`, use CloudWatch,
+ResourceQuota, VPA with a memory ratio, GitOps labels, or run a
 self-hosted Git forge.
 
 ### Inherit maxConcurrentResizes from AttuneDefaults
@@ -59,6 +61,27 @@ Set `allowPrivateEndpoints: true` for RFC1918/ULA self-hosted GitLab,
 Gitea, or Bitbucket. Loopback and link-local (including IMDS) stay
 blocked. Corporate `HTTPS_PROXY` on a private address is no longer
 treated as the SSRF target.
+
+### ResourceQuota List fail-closed
+
+If listing ResourceQuotas or LimitRanges fails (missing `list`/`watch`
+RBAC or an API error), Attune skips request increases. Decreases still
+apply. This is the same class of fail-closed behavior as
+[node-status unavailability](#request-increases-fail-closed-when-node-status-is-unavailable).
+See [troubleshooting: quota list unavailable](troubleshooting.md#resize-skipped-quota-list-unavailable).
+
+### VPA honors memoryFromCpuRatio
+
+When `metricsSource.vpa` is set and `memory.memoryFromCpuRatio` is also
+set, Attune now derives memory from the CPU recommendation instead of
+using the VPA memory target. Unset `memory.memoryFromCpuRatio` to keep
+VPA memory targets.
+
+### GitOps labels fail-closed
+
+If `export.pullRequest.labels` is set and the forge rejects the labels
+API, PR create and update fail instead of succeeding unlabeled. Grant
+the forge label permission or drop `labels`.
 
 ## v0.1.24 to v0.1.25
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -249,7 +249,7 @@ Doctor is single-context. `--all-contexts` and `--contexts` are rejected.
 |-------|----------|-------------|
 | Kubernetes version | Yes | Server version is 1.32 or newer |
 | `pods/resize` | Yes | Discovery lists the `pods/resize` subresource |
-| Prometheus | No | Skipped when no address was seen (none set, or listing failed with no objects). Also skipped for in-cluster DNS (`.svc` / `.cluster.local`). Other addresses, including `service.namespace` without `.svc`, are GET `/-/healthy` from this host (SSRF-checked first). A 401/403 on an address that sets `bearerTokenSecret` or `headers` is skipped (this host does not send the operator's auth). Optional failures print `WARN`, not `FAIL`. |
+| Prometheus | No | Skip-without-ping is `WARN` (`ok:false`), not Pass: no address was seen (none set, or listing failed with no objects). Also `WARN` for in-cluster DNS (`.svc` / `.cluster.local`) and for HTTP 401/403 on an address that sets `bearerTokenSecret` or `headers` (this host does not send the operator's auth). Other addresses, including `service.namespace` without `.svc`, are GET `/-/healthy` from this host (SSRF-checked first). Optional failures print `WARN`, not `FAIL`. |
 
 Exit 0 when every required check passes. A failed Prometheus check is
 printed as `WARN` and does not change the exit code. The ping runs on
@@ -267,8 +267,8 @@ kubectl attune version
 
 `--output` / `-o` is supported with:
 
-- `status`: JSON or YAML of raw `AttunePolicy` objects
-- `diff`: YAML patch manifests
+- `status` only: `-o json` or `-o yaml` dumps raw `AttunePolicy` objects
+- `diff`: `-o yaml` prints YAML patch manifests (not raw policy objects)
 - `savings` and `recommendations`: CSV (header plus one data row per
   policy or container; no totals row). Recommendations CSV includes
   `grade` after `mem_rec` (same A-F bands as the table GRADE column,
@@ -294,11 +294,11 @@ with `kubectl get attunepolicy -o json|yaml`.
 | `--namespace` | `-n` | Target namespace (defaults to current context) |
 | `--all-namespaces` | `-A` | List across all namespaces |
 | `--kubeconfig` | | Path to kubeconfig file |
-| `--output` | `-o` | Output raw `AttunePolicy` objects as `json` or `yaml` (`status` and `diff`) |
+| `--output` | `-o` | `status`: raw `AttunePolicy` objects as `json` or `yaml`. `diff`: YAML patch manifests (`-o yaml` only). `savings` and `recommendations`: `csv` |
 | `--watch` | `-w` | Continuously refresh status every 10 seconds (`status` only) |
 | `--sort-by` | | Sort output: `name`, `namespace`, `savings`, `age` (`status` and `savings` only) |
 | `--filter` | | Filter by condition: `degraded`, `pending`, `collecting`, `ready`, `noworkloads` (`status` only) |
-| `--all-contexts` | | Query all kubeconfig contexts and merge results (`status`, `savings`, `recommendations`, `history` only) |
+| `--all-contexts` | | Query all kubeconfig contexts and merge results (`status`, `savings`, `recommendations`, `history`, `diff`) |
 | `--contexts` | | Comma-separated list of specific kubeconfig contexts to query (same commands as `--all-contexts`) |
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,11 @@ kubectl attune status
 kubectl attune status -n production
 kubectl attune status -A
 kubectl attune status --watch          # live-refresh every 10s
+kubectl attune status --sort-by savings
+kubectl attune status --filter pending
+kubectl attune status --contexts prod-east,prod-west
+kubectl attune status --all-contexts
+kubectl attune savings --sort-by savings -A
 ```
 
 | Flag | Description |
@@ -295,6 +300,14 @@ with `kubectl get attunepolicy -o json|yaml`.
 | `--filter` | | Filter by condition: `degraded`, `pending`, `collecting`, `ready`, `noworkloads` (`status` only) |
 | `--all-contexts` | | Query all kubeconfig contexts and merge results (`status`, `savings`, `recommendations`, `history` only) |
 | `--contexts` | | Comma-separated list of specific kubeconfig contexts to query (same commands as `--all-contexts`) |
+
+```bash
+kubectl attune status --sort-by savings
+kubectl attune status --filter pending
+kubectl attune status --contexts prod-east,prod-west
+kubectl attune status --all-contexts
+kubectl attune savings --sort-by savings -A
+```
 
 ## Manager Binary Flags
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -519,7 +519,7 @@ See the [startup boost guide](../guides/startup-boost.md) for details.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `memory.memoryFromCpuRatio` | string | (none) | Derives memory recommendation from CPU instead of querying Prometheus for memory metrics. The value is a ratio of GiB per core (e.g., `"2.0"` means 1 core = 2 GiB memory). Useful for JVM and heap-bound workloads where memory is proportional to CPU. |
+| `memory.memoryFromCpuRatio` | string | (none) | Derives memory from the CPU recommendation (GiB per core) instead of the memory signal from the active source (Prometheus usage or VPA memory target). For example, `"2.0"` means 1 core = 2 GiB memory. Useful for JVM and heap-bound workloads where memory is proportional to CPU. The derived value still goes through min/max/change caps. |
 
 ### SLO Guardrails
 
@@ -554,6 +554,9 @@ updateStrategy:
 |-------|------|---------|-------------|
 | `metricsSource.vpa.name` | string | (required) | Name of the VerticalPodAutoscaler object to consume recommendations from |
 | `metricsSource.vpa.namespace` | string | (policy namespace) | Namespace of the VPA. Defaults to the policy's namespace. |
+
+`memory.memoryFromCpuRatio` applies here too: when set, memory is derived
+from the CPU recommendation instead of the VPA memory target.
 
 At most one of `prometheus`, `datadog`, `cloudwatch`, or `vpa` may be set
 on a policy or on `AttuneDefaults` / `AttuneNamespaceDefaults`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -375,7 +375,7 @@ All fields from `AttuneDefaults` are available in
 | Section | Fields |
 |---------|--------|
 | `metricsSource` | `prometheus.address`, `prometheus.headers`, `prometheus.queryParameters`, `prometheus.bearerTokenSecret`, `prometheus.tls`, `datadog.site`, `datadog.apiKeySecretRef`, `cloudwatch.region`, `cloudwatch.clusterName`, `cloudwatch.roleArn`, `historyWindow`, `minimumDataPoints`, `queryStep`, `rateWindow`, `podAggregation`, `cpuRecordingMetric`, `memoryRecordingMetric` |
-| `cpu` | `percentile`, `overhead`, `minAllowed`, `maxAllowed`, `controlledValues`, `burstSensitivity`, `allowDecrease`, `startupBoost`, `maxChangePercent`, `maxIncreasePercent`, `maxDecreasePercent`, `memoryFromCpuRatio` |
+| `cpu` | `percentile`, `overhead`, `minAllowed`, `maxAllowed`, `controlledValues`, `burstSensitivity`, `allowDecrease`, `startupBoost`, `maxChangePercent`, `maxIncreasePercent`, `maxDecreasePercent` |
 | `memory` | Same as `cpu` (no `startupBoost`), plus `decreaseUsageMarginPercent` and `memoryFromCpuRatio` |
 | `updateStrategy` | `type`, `cooldown`, `autoRevert`, `resizeMethod`, `initialSizing`, `maxConcurrentResizes`, `maxStatusRecommendations`, `includeExplanationsInStatus`, `maxTotalCpuIncrease`, `maxTotalMemoryIncrease`, `schedule`, `export`, `canary`, `safetyObservationPeriod`, `sloGuardrails`, `templatePersistence` |
 | `costPricing` | `cpuPerCoreHour`, `memoryPerGiBHour` |

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -104,7 +104,7 @@ echo
 banner "Step 2: Install cert-manager and Prometheus"
 
 info "Installing cert-manager..."
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml >/dev/null
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.21.1/cert-manager.yaml >/dev/null
 wait_for "cert-manager webhook ready" 120 \
   "kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=5s"
 

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -356,11 +356,20 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
 
+	// Bound PromQL (safety observation and recommendations) so a hung
+	// Prometheus cannot stall the whole reconcile.
+	promTimeout := r.PrometheusTimeout
+	if promTimeout <= 0 {
+		promTimeout = 5 * time.Minute
+	}
+	workloadCtx, workloadCancel := context.WithTimeout(ctx, promTimeout)
+	defer workloadCancel()
+
 	// Check pending safety observations from previous resizes before computing
 	// new recommendations. Uses already-discovered workloads for provenance.
 	var safetyObservationsPending bool
 	if autoRevertEnabled(policy.Spec.UpdateStrategy) {
-		safetyObservationsPending = r.checkPendingSafetyObservations(ctx, &policy, collector, workloads)
+		safetyObservationsPending = r.checkPendingSafetyObservations(workloadCtx, &policy, collector, workloads)
 	}
 
 	logger.Info("Discovered workloads", "count", len(workloads))
@@ -373,14 +382,6 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: r.parseCooldown(&policy)}, nil
 	}
 
-	// Step 4-8: Process each workload with a timeout to prevent indefinite
-	// stalls when Prometheus is unresponsive.
-	promTimeout := r.PrometheusTimeout
-	if promTimeout <= 0 {
-		promTimeout = 5 * time.Minute
-	}
-	workloadCtx, workloadCancel := context.WithTimeout(ctx, promTimeout)
-	defer workloadCancel()
 	// One NS-wide pod list shared by metrics sampling and later resize/status
 	// paths (avoids per-workload List during sampling then a second full List).
 	var podsByWorkload map[string][]corev1.Pod

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -2896,6 +2896,32 @@ func TestResolveDatadogCollector_WithAppKey(t *testing.T) {
 	assert.NotNil(t, collector, "collector should succeed when app-key is present")
 }
 
+func TestResolveDatadogCollector_RejectsInvalidSite(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd-keys", Namespace: "default"},
+		Data: map[string][]byte{
+			"api-key": []byte("test-api-key"),
+		},
+	}
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Datadog: &attunev1alpha1.DatadogConfig{
+					Site:            "evil.example",
+					APIKeySecretRef: attunev1alpha1.SecretKeyRef{Name: "dd-keys", Key: "api-key"},
+				},
+			},
+		},
+	}
+	reconciler := newReconcilerWithClient(secret)
+
+	collector, _, err := reconciler.resolveDatadogCollector(context.Background(), policy)
+	require.Error(t, err)
+	assert.Nil(t, collector)
+	assert.Contains(t, err.Error(), "not a recognized Datadog site")
+}
+
 func TestResolveDatadogCollector_MissingSecret(t *testing.T) {
 	policy := &attunev1alpha1.AttunePolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -1931,6 +1931,39 @@ func TestComputeRecommendations_InWindowSampleOlderThanFreshnessIsStale(t *testi
 	assert.True(t, rec.LastDataTime.Equal(&metav1.Time{Time: old}))
 }
 
+// TestComputeRecommendations_NewestNonFiniteDoesNotRefreshLastDataTime is
+// the live-red contract: NaN/Inf at now must not advance LastDataTime or
+// clear stale. Removing the finite-only filter fails this test.
+func TestComputeRecommendations_NewestNonFiniteDoesNotRefreshLastDataTime(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.MetricsSource.MinimumDataPoints = int32Ptr(1)
+	deploy := newTestDeployment("api-server", "default", nil)
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	reconciler := newReconcilerWithClient()
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	old := now.Add(-30 * time.Minute)
+	mc := &mockCollector{
+		queryRangeGroupedFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
+			return map[string][]rsmetrics.Sample{
+				"main": {
+					{Timestamp: old, Value: 0.1},
+					{Timestamp: now, Value: math.NaN()},
+					{Timestamp: now, Value: math.Inf(1)},
+				},
+			}, nil
+		},
+	}
+
+	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.True(t, rec.Stale, "newest NaN/Inf must not refresh LastDataTime; 30m-old finite sample is stale")
+	require.NotNil(t, rec.LastDataTime)
+	assert.True(t, rec.LastDataTime.Equal(&metav1.Time{Time: old}), "LastDataTime must stay the last finite sample, not now")
+	assert.False(t, rec.LastDataTime.Time.Equal(now), "NaN/Inf at now must not become LastDataTime")
+}
+
 func TestComputeRecommendations_ExpiredReuseIsDropped(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	deploy := newTestDeployment("api-server", "default", nil)
@@ -1960,6 +1993,36 @@ func TestComputeRecommendations_ExpiredReuseIsDropped(t *testing.T) {
 	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Nil(t, rec, "reuse must expire when LastDataTime is older than 3*queryStep")
+}
+
+func TestComputeRecommendations_ReuseIgnoresMissingLastDataTime(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	deploy := newTestDeployment("api-server", "default", nil)
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	reconciler := newReconcilerWithClient()
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	cpuRec, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+	policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+		Workload:     "api-server",
+		Kind:         "Deployment",
+		LastDataTime: nil,
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name:        "main",
+			Recommended: attunev1alpha1.ResourceValues{CPURequest: cpuRec},
+		}},
+	}}
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return nil, nil
+		},
+	}
+
+	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, rec, "reuse must refuse a prior rec with missing LastDataTime")
 }
 
 func TestComputeRecommendations_ReuseIgnoresDifferentKind(t *testing.T) {
@@ -2190,6 +2253,58 @@ func TestComputeRecommendations_PartialQueryErrorTracksFailedMetricType(t *testi
 	require.NotNil(t, rec)
 	assert.Equal(t, 1, qErrors)
 	assert.Equal(t, []string{"memory"}, failedMetricTypes)
+}
+
+// TestComputeRecommendations_SeriesCappedUsesPartialData is the live-red
+// contract: ErrSeriesCapped is a soft error. Treating it as a hard fail
+// reuses the prior stale row and fails this test.
+func TestComputeRecommendations_SeriesCappedUsesPartialData(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.MetricsSource.MinimumDataPoints = int32Ptr(1)
+	deploy := newTestDeployment("api-server", "default", nil)
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	reconciler := newReconcilerWithClient()
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	priorData := metav1.NewTime(now.Add(-2 * time.Minute))
+	priorCPU, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+	priorMem, err := resource.ParseQuantity("256Mi")
+	require.NoError(t, err)
+	policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+		Workload:     "api-server",
+		Kind:         "Deployment",
+		LastDataTime: &priorData,
+		Stale:        false,
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "main",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    priorCPU,
+				MemoryRequest: priorMem,
+			},
+		}},
+	}}
+
+	fresh := now.Add(-30 * time.Second)
+	mc := &mockCollector{
+		queryRangeGroupedFunc: func(_ context.Context, query string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
+			samples := []rsmetrics.Sample{{Timestamp: fresh, Value: 0.1}}
+			if !strings.Contains(query, "cpu_usage_seconds_total") {
+				samples = []rsmetrics.Sample{{Timestamp: fresh, Value: 128 * 1024 * 1024}}
+			}
+			return map[string][]rsmetrics.Sample{"main": samples}, fmt.Errorf("%w: kept 1 series", rsmetrics.ErrSeriesCapped)
+		},
+	}
+
+	rec, qErrors, _, _, seriesCapped, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.True(t, seriesCapped, "ErrSeriesCapped must surface as seriesCapped, not a hard query error")
+	assert.Equal(t, 0, qErrors, "series cap is a soft error; partial samples must not increment queryErrors")
+	require.NotNil(t, rec)
+	assert.False(t, rec.Stale, "partial capped samples must produce a fresh rec, not reuse the prior status row")
+	require.NotNil(t, rec.LastDataTime)
+	assert.True(t, rec.LastDataTime.Equal(&metav1.Time{Time: fresh}), "LastDataTime must come from the partial samples")
+	assert.False(t, rec.LastDataTime.Equal(&priorData), "must not reuse the prior status LastDataTime")
 }
 
 func TestComputeRecommendations_ContextCancelledDuringParallelQueries(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -6232,6 +6232,93 @@ func TestCheckPendingSafetyObservations_UnsafeVerdictReverts(t *testing.T) {
 	assert.True(t, foundResize, "should have called UpdateResize to revert the pod")
 }
 
+func TestCheckPendingSafetyObservations_RevertUsesWithoutCancel(t *testing.T) {
+	// PromQL can spend the whole PrometheusTimeout. RevertPod must not
+	// inherit that dead deadline (same class as persist confirm).
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cancelled-ctx-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "nginx",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
+	}
+
+	policy := newTestPolicy("test-policy", "default")
+	reconciler, _ := newSafetyTestReconciler(pod)
+	reconciler.Clientset = &cancelAwareResizeClientset{Interface: reconciler.Clientset}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	reconciler.checkPendingSafetyObservations(ctx, policy, nil, safetyWorkloads())
+
+	var foundResize bool
+	for _, a := range reconciler.Clientset.(*cancelAwareResizeClientset).Interface.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			foundResize = true
+		}
+	}
+	assert.True(t, foundResize, "revert must still UpdateResize after a spent Prometheus deadline")
+}
+
+type cancelAwareResizeClientset struct {
+	kubernetes.Interface
+}
+
+func (c *cancelAwareResizeClientset) CoreV1() corev1client.CoreV1Interface {
+	return &cancelAwareResizeCoreV1{CoreV1Interface: c.Interface.CoreV1()}
+}
+
+type cancelAwareResizeCoreV1 struct {
+	corev1client.CoreV1Interface
+}
+
+func (c *cancelAwareResizeCoreV1) Pods(namespace string) corev1client.PodInterface {
+	return &cancelAwareResizePods{PodInterface: c.CoreV1Interface.Pods(namespace)}
+}
+
+type cancelAwareResizePods struct {
+	corev1client.PodInterface
+}
+
+func (p *cancelAwareResizePods) UpdateResize(ctx context.Context, name string, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return p.PodInterface.UpdateResize(ctx, name, pod, opts)
+}
+
 func TestCheckPendingSafetyObservations_UnsafeVerdictMarksHistoryReverted(t *testing.T) {
 	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
 	pod := &corev1.Pod{

--- a/internal/controller/conditions_test.go
+++ b/internal/controller/conditions_test.go
@@ -1472,7 +1472,7 @@ func TestCheckQuotaCompatibility_ListError(t *testing.T) {
 			current:   zeroCurrent,
 			target:    increase,
 			wantErr:   true,
-			errSubstr: "unavailable",
+			errSubstr: "ResourceQuota list unavailable; skipping request increase; check RBAC list/watch on resourcequotas and limitranges",
 		},
 		{
 			name: "ResourceQuota list error allows decrease",
@@ -1492,7 +1492,7 @@ func TestCheckQuotaCompatibility_ListError(t *testing.T) {
 			current:   zeroCurrent,
 			target:    increase,
 			wantErr:   true,
-			errSubstr: "unavailable",
+			errSubstr: "LimitRange list unavailable; skipping request increase; check RBAC list/watch on resourcequotas and limitranges",
 		},
 		{
 			name: "LimitRange list error allows decrease",

--- a/internal/controller/conditions_test.go
+++ b/internal/controller/conditions_test.go
@@ -728,6 +728,124 @@ func TestCheckQuotaCompatibility_MemoryQuotaExceeded(t *testing.T) {
 	assert.Contains(t, err.Error(), "exceed ResourceQuota")
 }
 
+func TestCheckQuotaHeadroom_ResourceNameAliases(t *testing.T) {
+	cpu100, err := resource.ParseQuantity("100m")
+	require.NoError(t, err)
+	cpu150, err := resource.ParseQuantity("150m")
+	require.NoError(t, err)
+	cpu200, err := resource.ParseQuantity("200m")
+	require.NoError(t, err)
+	cpu500, err := resource.ParseQuantity("500m")
+	require.NoError(t, err)
+	mem128, err := resource.ParseQuantity("128Mi")
+	require.NoError(t, err)
+	mem190, err := resource.ParseQuantity("190Mi")
+	require.NoError(t, err)
+	mem200, err := resource.ParseQuantity("200Mi")
+	require.NoError(t, err)
+	mem256, err := resource.ParseQuantity("256Mi")
+	require.NoError(t, err)
+	mem512, err := resource.ParseQuantity("512Mi")
+	require.NoError(t, err)
+	lim400, err := resource.ParseQuantity("400m")
+	require.NoError(t, err)
+	lim450, err := resource.ParseQuantity("450m")
+	require.NoError(t, err)
+	lim500, err := resource.ParseQuantity("500m")
+	require.NoError(t, err)
+	lim800, err := resource.ParseQuantity("800m")
+	require.NoError(t, err)
+
+	req := func(cpu, mem resource.Quantity) corev1.ResourceRequirements {
+		return corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    cpu,
+				corev1.ResourceMemory: mem,
+			},
+		}
+	}
+	reqLim := func(cpu, mem, limCPU, limMem resource.Quantity) corev1.ResourceRequirements {
+		return corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    cpu,
+				corev1.ResourceMemory: mem,
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    limCPU,
+				corev1.ResourceMemory: limMem,
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		hard    corev1.ResourceList
+		used    corev1.ResourceList
+		current corev1.ResourceRequirements
+		target  corev1.ResourceRequirements
+		wantErr string
+	}{
+		{
+			name:    "cpu alias blocks increase when headroom is insufficient",
+			hard:    corev1.ResourceList{corev1.ResourceCPU: cpu200},
+			used:    corev1.ResourceList{corev1.ResourceCPU: cpu150},
+			current: req(cpu100, mem256),
+			target:  req(cpu500, mem256),
+			wantErr: "exceed ResourceQuota",
+		},
+		{
+			name:    "requests.cpu still blocks increase when headroom is insufficient",
+			hard:    corev1.ResourceList{corev1.ResourceRequestsCPU: cpu200},
+			used:    corev1.ResourceList{corev1.ResourceRequestsCPU: cpu150},
+			current: req(cpu100, mem256),
+			target:  req(cpu500, mem256),
+			wantErr: "exceed ResourceQuota",
+		},
+		{
+			name:    "memory alias blocks increase when headroom is insufficient",
+			hard:    corev1.ResourceList{corev1.ResourceMemory: mem200},
+			used:    corev1.ResourceList{corev1.ResourceMemory: mem190},
+			current: req(cpu100, mem128),
+			target:  req(cpu100, mem512),
+			wantErr: "exceed ResourceQuota",
+		},
+		{
+			name:    "cpu alias allows increase when headroom is sufficient",
+			hard:    corev1.ResourceList{corev1.ResourceCPU: cpu500},
+			used:    corev1.ResourceList{corev1.ResourceCPU: cpu100},
+			current: req(cpu100, mem256),
+			target:  req(cpu200, mem256),
+		},
+		{
+			name:    "limits.cpu blocks limit increase when headroom is insufficient",
+			hard:    corev1.ResourceList{corev1.ResourceLimitsCPU: lim500},
+			used:    corev1.ResourceList{corev1.ResourceLimitsCPU: lim450},
+			current: reqLim(cpu100, mem256, lim400, mem512),
+			target:  reqLim(cpu100, mem256, lim800, mem512),
+			wantErr: "exceed ResourceQuota",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quota := corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "compute"},
+				Status: corev1.ResourceQuotaStatus{
+					Hard: tt.hard,
+					Used: tt.used,
+				},
+			}
+			got := checkQuotaHeadroom(quota, tt.current, tt.target)
+			if tt.wantErr == "" {
+				assert.NoError(t, got)
+				return
+			}
+			require.Error(t, got)
+			assert.Contains(t, got.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestCheckQuotaCompatibility_LimitsAboveMaximum(t *testing.T) {
 	lr := &corev1.LimitRange{
 		ObjectMeta: metav1.ObjectMeta{Name: "limits", Namespace: "default"},
@@ -1310,64 +1428,109 @@ func TestNewSafetyMonitor_EmptyGuardrails(t *testing.T) {
 
 // ---------- checkQuotaCompatibility List failure paths ----------
 
-func TestCheckQuotaCompatibility_LimitRangeListError(t *testing.T) {
-	scheme := testScheme()
+func TestCheckQuotaCompatibility_ListError(t *testing.T) {
+	cpu100, err := resource.ParseQuantity("100m")
+	require.NoError(t, err)
+	cpu500, err := resource.ParseQuantity("500m")
+	require.NoError(t, err)
+	mem256, err := resource.ParseQuantity("256Mi")
+	require.NoError(t, err)
 
-	// Inject a List error only for LimitRange objects.
-	c := fake.NewClientBuilder().WithScheme(scheme).
-		WithInterceptorFuncs(interceptor.Funcs{
-			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-				if _, ok := list.(*corev1.LimitRangeList); ok {
-					return fmt.Errorf("simulated LimitRange list failure")
-				}
-				return cl.List(ctx, list, opts...)
-			},
-		}).
-		Build()
-
-	r := NewAttunePolicyReconciler()
-	r.Client = c
-
-	target := corev1.ResourceRequirements{
+	increase := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    cpu500,
+			corev1.ResourceMemory: mem256,
+		},
+	}
+	decrease := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    cpu100,
+			corev1.ResourceMemory: mem256,
+		},
+	}
+	currentHigh := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    cpu500,
+			corev1.ResourceMemory: mem256,
 		},
 	}
 
-	// Should log-and-continue (no error returned) with empty LimitRange list.
-	err := r.checkQuotaCompatibility(context.Background(), "default", zeroCurrent, target)
-	assert.NoError(t, err)
-}
-
-func TestCheckQuotaCompatibility_ResourceQuotaListError(t *testing.T) {
-	scheme := testScheme()
-
-	// Inject a List error only for ResourceQuota objects.
-	c := fake.NewClientBuilder().WithScheme(scheme).
-		WithInterceptorFuncs(interceptor.Funcs{
-			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-				if _, ok := list.(*corev1.ResourceQuotaList); ok {
-					return fmt.Errorf("simulated ResourceQuota list failure")
-				}
-				return cl.List(ctx, list, opts...)
+	tests := []struct {
+		name      string
+		failOn    func(client.ObjectList) bool
+		current   corev1.ResourceRequirements
+		target    corev1.ResourceRequirements
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "ResourceQuota list error blocks request increase",
+			failOn: func(list client.ObjectList) bool {
+				_, ok := list.(*corev1.ResourceQuotaList)
+				return ok
 			},
-		}).
-		Build()
-
-	r := NewAttunePolicyReconciler()
-	r.Client = c
-
-	target := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			current:   zeroCurrent,
+			target:    increase,
+			wantErr:   true,
+			errSubstr: "unavailable",
+		},
+		{
+			name: "ResourceQuota list error allows decrease",
+			failOn: func(list client.ObjectList) bool {
+				_, ok := list.(*corev1.ResourceQuotaList)
+				return ok
+			},
+			current: currentHigh,
+			target:  decrease,
+		},
+		{
+			name: "LimitRange list error blocks request increase",
+			failOn: func(list client.ObjectList) bool {
+				_, ok := list.(*corev1.LimitRangeList)
+				return ok
+			},
+			current:   zeroCurrent,
+			target:    increase,
+			wantErr:   true,
+			errSubstr: "unavailable",
+		},
+		{
+			name: "LimitRange list error allows decrease",
+			failOn: func(list client.ObjectList) bool {
+				_, ok := list.(*corev1.LimitRangeList)
+				return ok
+			},
+			current: currentHigh,
+			target:  decrease,
 		},
 	}
 
-	// Should log-and-continue (no error returned) with empty ResourceQuota list.
-	err := r.checkQuotaCompatibility(context.Background(), "default", zeroCurrent, target)
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := testScheme()
+			c := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						if tt.failOn(list) {
+							return fmt.Errorf("simulated list failure")
+						}
+						return cl.List(ctx, list, opts...)
+					},
+				}).
+				Build()
+
+			r := NewAttunePolicyReconciler()
+			r.Client = c
+
+			got := r.checkQuotaCompatibility(context.Background(), "default", tt.current, tt.target)
+			if !tt.wantErr {
+				assert.NoError(t, got)
+				return
+			}
+			require.Error(t, got)
+			assert.Contains(t, got.Error(), tt.errSubstr)
+		})
+	}
 }
 
 // ---------- SetNowFunc nil path ----------

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -194,9 +194,10 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 		// IMDS credentials. Status is a short static message only.
 		if res.URL != "" {
 			logger.Error(err, "GitOps PR opened but labels were not applied",
-				"provider", provider, "repository", cfg.Repository)
+				"provider", provider, "repository", cfg.Repository,
+				"url", res.URL, "labels", cfg.Labels)
 			setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRFailed,
-				fmt.Sprintf("PR open; labels not applied: %s", res.URL))
+				fmt.Sprintf("PR open; failed applying configured labels on %s", res.URL))
 			operatormetrics.GitOpsPRTotal.WithLabelValues(policy.Namespace, policy.Name, "failed").Inc()
 			r.touchGitOpsPRAnnotation(policy, res.URL)
 			setGitOpsPRDriftAnnotation(policy, fp)

--- a/internal/controller/gitops_pr.go
+++ b/internal/controller/gitops_pr.go
@@ -192,6 +192,17 @@ func (r *AttunePolicyReconciler) reconcileGitOpsPullRequest(
 	if err != nil {
 		// Never include raw API bodies or error strings that might echo
 		// IMDS credentials. Status is a short static message only.
+		if res.URL != "" {
+			logger.Error(err, "GitOps PR opened but labels were not applied",
+				"provider", provider, "repository", cfg.Repository)
+			setGitOpsPRCondition(policy, metav1.ConditionFalse, attunev1alpha1.ReasonGitOpsPRFailed,
+				fmt.Sprintf("PR open; labels not applied: %s", res.URL))
+			operatormetrics.GitOpsPRTotal.WithLabelValues(policy.Namespace, policy.Name, "failed").Inc()
+			r.touchGitOpsPRAnnotation(policy, res.URL)
+			setGitOpsPRDriftAnnotation(policy, fp)
+			r.persistGitOpsPRAnnotations(ctx, policy)
+			return
+		}
 		logger.Error(err, "GitOps PR create/update failed", "provider", provider, "repository", cfg.Repository)
 		reason := attunev1alpha1.ReasonGitOpsPRFailed
 		msg := "PR API request failed"

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -591,6 +591,56 @@ func (leakingPRClient) CreateOrUpdate(_ context.Context, _ gitops.PRRequest) (gi
 	return gitops.PRResult{}, fmt.Errorf("github create PR: status 403: ami-secret-should-not-leak")
 }
 
+// labelsFailedPRClient returns a PR URL plus a label-apply error so the
+// controller must persist the URL instead of wiping it.
+type labelsFailedPRClient struct{}
+
+func (labelsFailedPRClient) CreateOrUpdate(_ context.Context, _ gitops.PRRequest) (gitops.PRResult, error) {
+	return gitops.PRResult{
+		URL:    "https://github.com/org/repo/pull/7",
+		Number: 7,
+	}, fmt.Errorf("%w: github apply labels: status 403", gitops.ErrLabelsApplied)
+}
+
+func TestReconcileGitOpsPullRequest_LabelFailureKeepsURL(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	en := true
+	dry := false
+	policy := gitOpsEnabledPolicy("p", "default", dry, nil)
+	policy.Spec.UpdateStrategy.Export.PullRequest.Enabled = &en
+	dep := gitOpsDriftDeployment("api", "default", "1")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, dep).
+		WithStatusSubresource(&attunev1alpha1.AttunePolicy{}).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = c
+	r.gitopsPRClient = labelsFailedPRClient{}
+
+	r.reconcileGitOpsPullRequest(context.Background(), policy, []client.Object{dep}, gitOpsCPURec("api", "100m"))
+
+	var reason, message string
+	for _, cond := range policy.Status.Conditions {
+		if cond.Type == attunev1alpha1.ConditionGitOpsPullRequest {
+			reason = cond.Reason
+			message = cond.Message
+		}
+	}
+	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRFailed, reason)
+	assert.Contains(t, message, "PR open; labels not applied")
+	assert.Contains(t, message, "https://github.com/org/repo/pull/7")
+	assert.Equal(t, "https://github.com/org/repo/pull/7", policy.Annotations[annotationGitOpsPRURL])
+	assert.Equal(t, "https://github.com/org/repo/pull/7", gitOpsStoredURL(policy))
+
+	stored := &attunev1alpha1.AttunePolicy{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(policy), stored))
+	assert.Equal(t, "https://github.com/org/repo/pull/7", stored.Annotations[annotationGitOpsPRURL])
+	assert.NotEmpty(t, stored.Annotations[annotationGitOpsPRLastAttempt])
+}
+
 func itoaPR(n int) string {
 	if n < 0 {
 		n = 0

--- a/internal/controller/gitops_pr_test.go
+++ b/internal/controller/gitops_pr_test.go
@@ -630,7 +630,7 @@ func TestReconcileGitOpsPullRequest_LabelFailureKeepsURL(t *testing.T) {
 		}
 	}
 	assert.Equal(t, attunev1alpha1.ReasonGitOpsPRFailed, reason)
-	assert.Contains(t, message, "PR open; labels not applied")
+	assert.Contains(t, message, "failed applying configured labels")
 	assert.Contains(t, message, "https://github.com/org/repo/pull/7")
 	assert.Equal(t, "https://github.com/org/repo/pull/7", policy.Annotations[annotationGitOpsPRURL])
 	assert.Equal(t, "https://github.com/org/repo/pull/7", gitOpsStoredURL(policy))

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -779,7 +779,7 @@ func (r *AttunePolicyReconciler) checkQuotaCompatibility(ctx context.Context, na
 	if err := r.List(ctx, &limitRangeList, client.InNamespace(namespace)); err != nil {
 		logger.V(1).Info("Could not list LimitRanges", "error", err)
 		if requestIncrease {
-			return fmt.Errorf("LimitRange list unavailable; skipping request increase")
+			return fmt.Errorf("LimitRange list unavailable; skipping request increase; check RBAC list/watch on resourcequotas and limitranges")
 		}
 	}
 
@@ -787,7 +787,7 @@ func (r *AttunePolicyReconciler) checkQuotaCompatibility(ctx context.Context, na
 	if err := r.List(ctx, &quotaList, client.InNamespace(namespace)); err != nil {
 		logger.V(1).Info("Could not list ResourceQuotas", "error", err)
 		if requestIncrease {
-			return fmt.Errorf("ResourceQuota list unavailable; skipping request increase")
+			return fmt.Errorf("ResourceQuota list unavailable; skipping request increase; check RBAC list/watch on resourcequotas and limitranges")
 		}
 	}
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -772,16 +772,23 @@ func (r *AttunePolicyReconciler) setDegradedCondition(policy *attunev1alpha1.Att
 // LimitRange or ResourceQuota constraints in the namespace.
 func (r *AttunePolicyReconciler) checkQuotaCompatibility(ctx context.Context, namespace string, currentResources, target corev1.ResourceRequirements) error {
 	logger := log.FromContext(ctx)
+	requestIncrease := resourcesIncreaseRequests(currentResources, target)
 
 	// Check LimitRange per-container min/max.
 	var limitRangeList corev1.LimitRangeList
 	if err := r.List(ctx, &limitRangeList, client.InNamespace(namespace)); err != nil {
 		logger.V(1).Info("Could not list LimitRanges", "error", err)
+		if requestIncrease {
+			return fmt.Errorf("LimitRange list unavailable; skipping request increase")
+		}
 	}
 
 	var quotaList corev1.ResourceQuotaList
 	if err := r.List(ctx, &quotaList, client.InNamespace(namespace)); err != nil {
 		logger.V(1).Info("Could not list ResourceQuotas", "error", err)
+		if requestIncrease {
+			return fmt.Errorf("ResourceQuota list unavailable; skipping request increase")
+		}
 	}
 
 	return checkQuotaCompatibilityFromLists(limitRangeList.Items, quotaList.Items, currentResources, target)
@@ -850,9 +857,7 @@ func checkQuotaHeadroom(quota corev1.ResourceQuota, current, target corev1.Resou
 	memDelta := target.Requests.Memory().Value() - current.Requests.Memory().Value()
 
 	if cpuDelta > 0 {
-		hardCPU, hasHard := quota.Status.Hard[corev1.ResourceRequestsCPU]
-		usedCPU, hasUsed := quota.Status.Used[corev1.ResourceRequestsCPU]
-		if hasHard && hasUsed {
+		if hardCPU, usedCPU, ok := quotaHardUsed(quota, corev1.ResourceRequestsCPU, corev1.ResourceCPU); ok {
 			headroom := hardCPU.MilliValue() - usedCPU.MilliValue()
 			if cpuDelta > headroom {
 				return fmt.Errorf("CPU increase of %dm would exceed ResourceQuota %s (headroom: %dm)",
@@ -862,9 +867,7 @@ func checkQuotaHeadroom(quota corev1.ResourceQuota, current, target corev1.Resou
 	}
 
 	if memDelta > 0 {
-		hardMem, hasHard := quota.Status.Hard[corev1.ResourceRequestsMemory]
-		usedMem, hasUsed := quota.Status.Used[corev1.ResourceRequestsMemory]
-		if hasHard && hasUsed {
+		if hardMem, usedMem, ok := quotaHardUsed(quota, corev1.ResourceRequestsMemory, corev1.ResourceMemory); ok {
 			headroom := hardMem.Value() - usedMem.Value()
 			if memDelta > headroom {
 				return fmt.Errorf("memory increase of %s would exceed ResourceQuota %s (headroom: %s)",
@@ -875,7 +878,59 @@ func checkQuotaHeadroom(quota corev1.ResourceQuota, current, target corev1.Resou
 		}
 	}
 
+	if target.Limits != nil {
+		cpuLimDelta := target.Limits.Cpu().MilliValue() - current.Limits.Cpu().MilliValue()
+		memLimDelta := target.Limits.Memory().Value() - current.Limits.Memory().Value()
+		if cpuLimDelta > 0 {
+			hardCPU, hasHard := quota.Status.Hard[corev1.ResourceLimitsCPU]
+			usedCPU, hasUsed := quota.Status.Used[corev1.ResourceLimitsCPU]
+			if hasHard && hasUsed {
+				headroom := hardCPU.MilliValue() - usedCPU.MilliValue()
+				if cpuLimDelta > headroom {
+					return fmt.Errorf("CPU limit increase of %dm would exceed ResourceQuota %s (headroom: %dm)",
+						cpuLimDelta, quota.Name, headroom)
+				}
+			}
+		}
+		if memLimDelta > 0 {
+			hardMem, hasHard := quota.Status.Hard[corev1.ResourceLimitsMemory]
+			usedMem, hasUsed := quota.Status.Used[corev1.ResourceLimitsMemory]
+			if hasHard && hasUsed {
+				headroom := hardMem.Value() - usedMem.Value()
+				if memLimDelta > headroom {
+					return fmt.Errorf("memory limit increase of %s would exceed ResourceQuota %s (headroom: %s)",
+						resource.NewQuantity(memLimDelta, resource.BinarySI).String(),
+						quota.Name,
+						resource.NewQuantity(headroom, resource.BinarySI).String())
+				}
+			}
+		}
+	}
+
 	return nil
+}
+
+// quotaHardUsed resolves a ResourceQuota hard/used pair, preferring the
+// requests.* name and falling back to the cpu/memory alias.
+func quotaHardUsed(quota corev1.ResourceQuota, preferred, alias corev1.ResourceName) (hard, used resource.Quantity, ok bool) {
+	hard, hasHard := quota.Status.Hard[preferred]
+	if !hasHard {
+		hard, hasHard = quota.Status.Hard[alias]
+	}
+	used, hasUsed := quota.Status.Used[preferred]
+	if !hasUsed {
+		used, hasUsed = quota.Status.Used[alias]
+	}
+	return hard, used, hasHard && hasUsed
+}
+
+// resourcesIncreaseRequests reports whether target raises CPU or memory
+// requests relative to current.
+func resourcesIncreaseRequests(current, target corev1.ResourceRequirements) bool {
+	if target.Requests.Cpu().MilliValue() > current.Requests.Cpu().MilliValue() {
+		return true
+	}
+	return target.Requests.Memory().Value() > current.Requests.Memory().Value()
 }
 
 // markLatestCycleReverted marks history entries from the most recent resize

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -648,6 +648,14 @@ func (r *AttunePolicyReconciler) promQLBuilder(policy *attunev1alpha1.AttunePoli
 func (r *AttunePolicyReconciler) resolveDatadogCollector(ctx context.Context, policy *attunev1alpha1.AttunePolicy) (rsmetrics.MetricsCollector, rsmetrics.QueryBuilder, error) {
 	dd := policy.Spec.MetricsSource.Datadog
 
+	site := dd.Site
+	if site == "" {
+		site = "datadoghq.com"
+	}
+	if err := validation.DatadogSite(site); err != nil {
+		return nil, nil, fmt.Errorf("datadog site: %w", err)
+	}
+
 	// Read API key from the referenced Secret.
 	apiKey, err := r.readSecretKey(ctx, policy.Namespace, dd.APIKeySecretRef.Name, dd.APIKeySecretRef.Key)
 	if err != nil {
@@ -657,17 +665,15 @@ func (r *AttunePolicyReconciler) resolveDatadogCollector(ctx context.Context, po
 	// Read optional app key from the same Secret (key "app-key").
 	appKey, _ := r.readSecretKey(ctx, policy.Namespace, dd.APIKeySecretRef.Name, "app-key")
 
-	site := dd.Site
-	if site == "" {
-		site = "datadoghq.com"
-	}
-
 	// Cache the collector keyed by site + API key (non-crypto identifier), with full
 	// TTL eviction, capacity bound, and race-safe LoadOrStore.
 	// We avoid hashing the actual secret bytes to satisfy CodeQL "weak crypto on sensitive data".
 	cacheKey := fmt.Sprintf("datadog:%s|%s", site, secretForCacheKey(apiKey))
 	collector, err := r.getOrCreateCollectorByKey(cacheKey, "datadog:"+site, func() (rsmetrics.MetricsCollector, error) {
-		inner := rsmetrics.NewDatadogCollector(site, apiKey, appKey, log.FromContext(ctx).WithName("datadog"))
+		inner, innerErr := rsmetrics.NewDatadogCollector(site, apiKey, appKey, log.FromContext(ctx).WithName("datadog"))
+		if innerErr != nil {
+			return nil, innerErr
+		}
 		// Datadog: 300 requests/hour => ~0.08 QPS; burst of 3 for concurrent queries.
 		return rsmetrics.NewRateLimitedCollector(inner, 0.08, 3), nil
 	})

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -673,7 +673,10 @@ func (r *AttunePolicyReconciler) resizeContainer(
 			WorkloadName:      workloadName,
 		}
 		revertFailed := false
-		if revertErr := monitor.RevertPod(ctx, revertRecord); revertErr != nil {
+		revertCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), safetyRevertTimeout)
+		revertErr := monitor.RevertPod(revertCtx, revertRecord)
+		cancel()
+		if revertErr != nil {
 			logger.Error(revertErr, "Failed to revert pod after "+reason, "pod", pod.Name)
 			operatormetrics.RevertFailuresTotal.WithLabelValues(pod.Namespace, workloadName, reason).Inc()
 			revertFailed = true
@@ -822,6 +825,9 @@ const (
 	confirmTrackingAttempts = 3
 	confirmTrackingTimeout  = 5 * time.Second
 	confirmTrackingBackoff  = 50 * time.Millisecond
+	// safetyRevertTimeout is used with context.WithoutCancel so a spent
+	// PrometheusTimeout cannot cancel rollback.
+	safetyRevertTimeout = 5 * time.Second
 )
 
 // confirmTrackingAnnotations returns the live pod when a Clientset Get shows

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -1353,7 +1353,7 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 	if checks != nil {
 		if targetIncreasesRequests(pod, containerRec.Name, target) &&
 			(checks.quotaListErr != nil || checks.limitRangeListErr != nil) {
-			return true, "quota list unavailable; skipping request increase"
+			return true, "quota list unavailable; skipping request increase; check RBAC list/watch on resourcequotas and limitranges"
 		}
 		if err := checkQuotaCompatibilityFromLists(checks.limitRanges, checks.quotas, currentRes, target); err != nil {
 			return true, "quota/limitrange violation: " + err.Error()

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -1215,10 +1215,12 @@ type nodePodCache struct {
 }
 
 type resizePreChecks struct {
-	nodeCache   sync.Map // string -> *corev1.Node
-	nodePods    sync.Map // string -> nodePodCache
-	limitRanges []corev1.LimitRange
-	quotas      []corev1.ResourceQuota
+	nodeCache         sync.Map // string -> *corev1.Node
+	nodePods          sync.Map // string -> nodePodCache
+	limitRanges       []corev1.LimitRange
+	quotas            []corev1.ResourceQuota
+	limitRangeListErr error
+	quotaListErr      error
 }
 
 // buildResizePreChecks pre-fetches namespace-scoped LimitRanges and
@@ -1226,18 +1228,22 @@ type resizePreChecks struct {
 // share the data without duplicate API calls.
 func (r *AttunePolicyReconciler) buildResizePreChecks(ctx context.Context, policy *attunev1alpha1.AttunePolicy) *resizePreChecks {
 	logger := log.FromContext(ctx)
+	checks := &resizePreChecks{}
 	var limitRanges corev1.LimitRangeList
 	if err := r.List(ctx, &limitRanges, client.InNamespace(policy.Namespace)); err != nil {
 		logger.Info("Could not pre-fetch LimitRanges, quota pre-checks skipped", "error", err)
+		checks.limitRangeListErr = err
+	} else {
+		checks.limitRanges = limitRanges.Items
 	}
 	var quotas corev1.ResourceQuotaList
 	if err := r.List(ctx, &quotas, client.InNamespace(policy.Namespace)); err != nil {
 		logger.Info("Could not pre-fetch ResourceQuotas, quota pre-checks skipped", "error", err)
+		checks.quotaListErr = err
+	} else {
+		checks.quotas = quotas.Items
 	}
-	return &resizePreChecks{
-		limitRanges: limitRanges.Items,
-		quotas:      quotas.Items,
-	}
+	return checks
 }
 
 // shouldSkipResize runs pre-checks and returns whether to skip the resize
@@ -1335,7 +1341,20 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 			corev1.ResourceMemory: containerRec.Current.MemoryRequest.DeepCopy(),
 		},
 	}
+	if !containerRec.Current.CPULimit.IsZero() || !containerRec.Current.MemoryLimit.IsZero() {
+		currentRes.Limits = corev1.ResourceList{}
+		if !containerRec.Current.CPULimit.IsZero() {
+			currentRes.Limits[corev1.ResourceCPU] = containerRec.Current.CPULimit.DeepCopy()
+		}
+		if !containerRec.Current.MemoryLimit.IsZero() {
+			currentRes.Limits[corev1.ResourceMemory] = containerRec.Current.MemoryLimit.DeepCopy()
+		}
+	}
 	if checks != nil {
+		if targetIncreasesRequests(pod, containerRec.Name, target) &&
+			(checks.quotaListErr != nil || checks.limitRangeListErr != nil) {
+			return true, "quota list unavailable; skipping request increase"
+		}
 		if err := checkQuotaCompatibilityFromLists(checks.limitRanges, checks.quotas, currentRes, target); err != nil {
 			return true, "quota/limitrange violation: " + err.Error()
 		}

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -164,6 +164,14 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 	monitor := r.newSafetyMonitor(logger, collector, policy.Spec.UpdateStrategy.SLOGuardrails)
 	observationPeriod := getObservationPeriod(policy)
 
+	// Revert must not inherit a spent PrometheusTimeout. PromQL/throttle
+	// checks use ctx (workloadCtx); rollback uses a fresh deadline.
+	revertPod := func(record safety.ResizeRecord) error {
+		revertCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), safetyRevertTimeout)
+		defer cancel()
+		return monitor.RevertPod(revertCtx, record)
+	}
+
 	// Build a set of workload names this policy targets for provenance checks.
 	workloadNames := make(map[string]bool, len(workloads))
 	for _, w := range workloads {
@@ -226,7 +234,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 						if v := safety.CheckCriticalStatuses(pod, record); v != nil {
 							logger.Info("Critical safety event detected during observation period, reverting early",
 								"pod", pod.Name, "container", record.Container, "reason", v.Reason)
-							if revertErr := monitor.RevertPod(ctx, record); revertErr != nil {
+							if revertErr := revertPod(record); revertErr != nil {
 								logger.Error(revertErr, "Failed to revert pod during early critical check", "pod", pod.Name)
 								continue
 							}
@@ -274,7 +282,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 			if !verdict.Safe {
 				logger.Info("Deferred safety violation detected, reverting",
 					"pod", pod.Name, "container", record.Container, "reason", verdict.Reason)
-				if revertErr := monitor.RevertPod(ctx, record); revertErr != nil {
+				if revertErr := revertPod(record); revertErr != nil {
 					logger.Error(revertErr, "Failed to revert pod during safety observation", "pod", pod.Name)
 					revertFailed = true
 					continue

--- a/internal/controller/vpa.go
+++ b/internal/controller/vpa.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,6 +67,7 @@ func (r *AttunePolicyReconciler) computeVPARecommendationsForWorkload(
 	const vpaDataPoints = 1
 
 	var containerRecs []attunev1alpha1.ContainerRecommendation
+	eligibleContainers := 0
 
 	for _, container := range containers {
 		containerName := container.Name
@@ -76,6 +78,7 @@ func (r *AttunePolicyReconciler) computeVPARecommendationsForWorkload(
 				"reason", pkgdefaults.ExclusionReason(policy, containerName))
 			continue
 		}
+		eligibleContainers++
 
 		vpaRec, found := vpaByContainer[containerName]
 		if !found {
@@ -122,12 +125,27 @@ func (r *AttunePolicyReconciler) computeVPARecommendationsForWorkload(
 		cRec.Recommended.CPURequest = cpuRec
 		explanation.CPU = toAPIRecommendationExplanation(cpuExplain)
 
-		// Compute memory recommendation through the standard engine pipeline.
-		memRec, memExplain, _ := memEngine.RecommendWithExplanation(memProfile, cRec.Current.MemoryRequest)
+		// Compute memory recommendation. When memoryFromCpuRatio is set,
+		// derive memory from the CPU recommendation instead of the VPA
+		// memory target (same as the Prometheus path).
 		memAllowDecrease := policy.Spec.Memory.AllowDecrease != nil && *policy.Spec.Memory.AllowDecrease
-		memRec = r.enforceAllowDecrease(memAllowDecrease, memRec, cRec.Current.MemoryRequest, &memExplain, policy, containerName, "memory")
-		cRec.Recommended.MemoryRequest = memRec
-		explanation.Memory = toAPIRecommendationExplanation(memExplain)
+		if policy.Spec.Memory.MemoryFromCPURatio != nil && *policy.Spec.Memory.MemoryFromCPURatio != "" && explanation.CPU != nil {
+			ratio := parseFloat64Ratio(*policy.Spec.Memory.MemoryFromCPURatio)
+			memRec, memExplain, applied := deriveMemoryFromCPU(
+				cpuRec, ratio, memEngine, vpaDataPoints, cRec.Current.MemoryRequest, memAllowDecrease)
+			if applied {
+				cRec.Recommended.MemoryRequest = memRec
+				memExplain.FinalAdjustment = appendNote(memExplain.FinalAdjustment,
+					fmt.Sprintf("derived from CPU via memoryFromCpuRatio=%s", *policy.Spec.Memory.MemoryFromCPURatio))
+				explanation.Memory = toAPIRecommendationExplanation(memExplain)
+			}
+		}
+		if explanation.Memory == nil {
+			memRec, memExplain, _ := memEngine.RecommendWithExplanation(memProfile, cRec.Current.MemoryRequest)
+			memRec = r.enforceAllowDecrease(memAllowDecrease, memRec, cRec.Current.MemoryRequest, &memExplain, policy, containerName, "memory")
+			cRec.Recommended.MemoryRequest = memRec
+			explanation.Memory = toAPIRecommendationExplanation(memExplain)
+		}
 		explanation.CPU.FinalAdjustment = appendNote(explanation.CPU.FinalAdjustment, "source: VPA")
 		explanation.Memory.FinalAdjustment = appendNote(explanation.Memory.FinalAdjustment, "source: VPA")
 
@@ -151,6 +169,17 @@ func (r *AttunePolicyReconciler) computeVPARecommendationsForWorkload(
 	}
 
 	if len(containerRecs) == 0 {
+		// Only reuse when an eligible container had no VPA rec.
+		// Exclude-all must still return nil so status drops the rec.
+		if eligibleContainers > 0 {
+			freshness := recommendationFreshnessBound(0)
+			if reused := reuseStaleRecommendation(policy, workloadKindName(workload), workload.GetName(), now, freshness); reused != nil {
+				logger.Info("Reusing prior recommendation as stale; VPA returned no container recommendations",
+					"workload", workload.GetName(),
+					"kind", workloadKindName(workload))
+				return reused, maxDataPoints, nil
+			}
+		}
 		return nil, maxDataPoints, nil
 	}
 

--- a/internal/controller/vpa_test.go
+++ b/internal/controller/vpa_test.go
@@ -161,6 +161,120 @@ func TestComputeVPARecommendationsForWorkload_NoMatchingContainer(t *testing.T) 
 	assert.Nil(t, rec, "no matching container should result in no recommendation")
 }
 
+func TestComputeVPARecommendationsForWorkload_MemoryFromCPURatio(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.MetricsSource.Prometheus = nil
+	policy.Spec.MetricsSource.VPA = &attunev1alpha1.VPAConfig{Name: "my-vpa"}
+	ratio := "2.0"
+	policy.Spec.Memory.MemoryFromCPURatio = &ratio
+
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+
+	vpaCPU, err := resource.ParseQuantity("1000m")
+	require.NoError(t, err)
+	vpaMem, err := resource.ParseQuantity("128Mi")
+	require.NoError(t, err)
+	vpaRecs := []rsmetrics.VPAContainerRecommendation{
+		{
+			ContainerName: "main",
+			CPUTarget:     vpaCPU,
+			MemoryTarget:  vpaMem,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(deploy).
+		Build()
+
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = testScheme()
+
+	rec, _, err := reconciler.computeVPARecommendationsForWorkload(
+		context.Background(), policy, deploy, vpaRecs, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Len(t, rec.Containers, 1)
+
+	cRec := rec.Containers[0]
+	// VPA memory target 128Mi plus ~30% overhead is ~166Mi. Ratio 2.0
+	// from the CPU rec is several times larger.
+	floor, err := resource.ParseQuantity("256Mi")
+	require.NoError(t, err)
+	assert.True(t, cRec.Recommended.MemoryRequest.Cmp(floor) > 0,
+		"memoryFromCpuRatio should derive memory from CPU, not the 128Mi VPA target (got %s)",
+		cRec.Recommended.MemoryRequest.String())
+	require.NotNil(t, cRec.Explanation)
+	require.NotNil(t, cRec.Explanation.Memory)
+	assert.Contains(t, cRec.Explanation.Memory.FinalAdjustment, "memoryFromCpuRatio=2.0")
+}
+
+func TestComputeVPARecommendationsForWorkload_ReusesStaleWhenNoContainerRecs(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.MetricsSource.Prometheus = nil
+	policy.Spec.MetricsSource.VPA = &attunev1alpha1.VPAConfig{Name: "my-vpa"}
+
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	priorData := metav1.NewTime(now.Add(-time.Minute))
+	cpuRec, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+	memRec, err := resource.ParseQuantity("256Mi")
+	require.NoError(t, err)
+	policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+		Workload:     "api-server",
+		Kind:         "Deployment",
+		LastDataTime: &priorData,
+		Stale:        false,
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "main",
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    cpuRec,
+				MemoryRequest: memRec,
+			},
+		}},
+	}}
+
+	// VPA has a rec for a different container, so this workload yields zero recs.
+	vpaCPU, err := resource.ParseQuantity("250m")
+	require.NoError(t, err)
+	vpaMem, err := resource.ParseQuantity("512Mi")
+	require.NoError(t, err)
+	vpaRecs := []rsmetrics.VPAContainerRecommendation{
+		{
+			ContainerName: "web",
+			CPUTarget:     vpaCPU,
+			MemoryTarget:  vpaMem,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(deploy).
+		Build()
+
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = testScheme()
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	rec, _, err := reconciler.computeVPARecommendationsForWorkload(
+		context.Background(), policy, deploy, vpaRecs, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, rec, "empty VPA recs must reuse the prior recommendation, not drop it")
+	assert.True(t, rec.Stale, "reused rec after empty VPA recs must be marked stale")
+	require.NotNil(t, rec.LastDataTime)
+	assert.True(t, rec.LastDataTime.Equal(&priorData))
+	require.Len(t, rec.Containers, 1)
+	assert.True(t, rec.Containers[0].Recommended.CPURequest.Equal(cpuRec))
+	assert.True(t, rec.Containers[0].Recommended.MemoryRequest.Equal(memRec))
+	assert.False(t, policy.Status.Recommendations[0].Stale, "reuse must DeepCopy, not mutate status in place")
+}
+
 func newVPAPolicy(name, namespace, vpaName string) *attunev1alpha1.AttunePolicy {
 	return &attunev1alpha1.AttunePolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -495,21 +495,53 @@ func gitopsCheckRedirect(*http.Request, []*http.Request) error {
 	return errGitOpsRedirect
 }
 
+// lookupIPAddr is the DNS hook used by GitOps SSRF checks. Tests replace it
+// to simulate rebinding (allowlisted IP, then IMDS).
+var lookupIPAddr = func(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return net.DefaultResolver.LookupIPAddr(ctx, host)
+}
+
 // gitopsSafeTransport checks the request URL host (the SSRF target) before
 // the request is sent. The inner transport may use HTTPS_PROXY; the proxy
 // hop itself is not the SSRF target. allowPrivate permits RFC1918/ULA
 // forges. Loopback, link-local, unspecified, and AWS IPv6 IMDS stay blocked.
 func gitopsSafeTransport(allowPrivate bool) http.RoundTripper {
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
 	return &gitopsSSRFTransport{
 		allowPrivate: allowPrivate,
 		base: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return gitopsDialContext(ctx, network, addr, allowPrivate, dialer)
+			},
 			ResponseHeaderTimeout: 30 * time.Second,
 			IdleConnTimeout:       90 * time.Second,
 			MaxIdleConnsPerHost:   10,
 		},
 	}
+}
+
+func gitopsDialContext(ctx context.Context, network, addr string, allowPrivate bool, dialer *net.Dialer) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("gitops dial: invalid address %q: %w", addr, err)
+	}
+	if validation.GitOpsBlockedHost(host) {
+		return nil, fmt.Errorf("%w: host %q is a disallowed address", ErrSSRFBlocked, host)
+	}
+	ips, err := lookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("gitops dial: DNS resolution failed")
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("gitops dial: DNS resolution failed")
+	}
+	for _, ip := range ips {
+		if gitopsDialBlocked(ip.IP, allowPrivate) {
+			return nil, fmt.Errorf("%w: host %q resolved to a disallowed address", ErrSSRFBlocked, host)
+		}
+	}
+	return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
 }
 
 type gitopsSSRFTransport struct {
@@ -522,7 +554,10 @@ func (t *gitopsSSRFTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	if host == "" {
 		return nil, fmt.Errorf("gitops dial: invalid address")
 	}
-	ips, err := net.DefaultResolver.LookupIPAddr(req.Context(), host)
+	if validation.GitOpsBlockedHost(host) {
+		return nil, fmt.Errorf("%w: host %q is a disallowed address", ErrSSRFBlocked, host)
+	}
+	ips, err := lookupIPAddr(req.Context(), host)
 	if err != nil {
 		return nil, fmt.Errorf("gitops dial: DNS resolution failed")
 	}

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -37,6 +37,32 @@ var errGitOpsRedirect = errors.New("redirects are not allowed")
 // ErrSSRFBlocked is returned when the GitOps HTTP dial refuses the resolved address.
 var ErrSSRFBlocked = errors.New("gitops SSRF blocked")
 
+// ErrLabelsApplied is returned with a populated PRResult when the PR exists
+// but applying labels failed. Callers must persist the URL.
+var ErrLabelsApplied = errors.New("labels applied failed")
+
+type gitopsRequestHostKey struct{}
+
+func withGitOpsRequestHost(ctx context.Context, host string) context.Context {
+	return context.WithValue(ctx, gitopsRequestHostKey{}, host)
+}
+
+func gitopsRequestHost(ctx context.Context) string {
+	host, _ := ctx.Value(gitopsRequestHostKey{}).(string)
+	return host
+}
+
+func gitopsSameHost(dialHost, requestHost string) bool {
+	a := strings.TrimSuffix(strings.ToLower(dialHost), ".")
+	b := strings.TrimSuffix(strings.ToLower(requestHost), ".")
+	if a == b {
+		return true
+	}
+	ipA := net.ParseIP(a)
+	ipB := net.ParseIP(b)
+	return ipA != nil && ipB != nil && ipA.Equal(ipB)
+}
+
 // PRRequest is the input for create-or-update PR.
 type PRRequest struct {
 	Title  string
@@ -144,7 +170,8 @@ func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 			return PRResult{}, fmt.Errorf("github update PR: status %d", code)
 		}
 		if err := c.applyIssueLabels(ctx, httpClient, base, pr.Number, req.Labels); err != nil {
-			return PRResult{}, err
+			return PRResult{URL: pr.HTMLURL, Number: pr.Number, Updated: true},
+				fmt.Errorf("%w: %w", ErrLabelsApplied, err)
 		}
 		return PRResult{URL: pr.HTMLURL, Number: pr.Number, Updated: true}, nil
 	}
@@ -178,7 +205,8 @@ func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		return PRResult{}, fmt.Errorf("github create PR decode: %w", err)
 	}
 	if err := c.applyIssueLabels(ctx, httpClient, base, created.Number, req.Labels); err != nil {
-		return PRResult{}, err
+		return PRResult{URL: created.HTMLURL, Number: created.Number, Updated: false},
+			fmt.Errorf("%w: %w", ErrLabelsApplied, err)
 	}
 	return PRResult{URL: created.HTMLURL, Number: created.Number, Updated: false}, nil
 }
@@ -548,6 +576,12 @@ func gitopsDialContext(ctx context.Context, network, addr string, allowPrivate b
 	if err != nil {
 		return nil, fmt.Errorf("gitops dial: invalid address %q: %w", addr, err)
 	}
+	// HTTPS_PROXY / HTTP_PROXY hops are not the SSRF target. Dial them with
+	// the default dialer. The request URL host is checked in RoundTrip and
+	// pin-dialed below when this addr is the request host (direct).
+	if reqHost := gitopsRequestHost(ctx); reqHost != "" && !gitopsSameHost(host, reqHost) {
+		return dialer.DialContext(ctx, network, addr)
+	}
 	if validation.GitOpsBlockedHost(host) {
 		return nil, fmt.Errorf("%w: host %q is a disallowed address", ErrSSRFBlocked, host)
 	}
@@ -588,7 +622,7 @@ func (t *gitopsSSRFTransport) RoundTrip(req *http.Request) (*http.Response, erro
 			return nil, fmt.Errorf("%w: host %q resolved to a disallowed address", ErrSSRFBlocked, host)
 		}
 	}
-	return t.base.RoundTrip(req)
+	return t.base.RoundTrip(req.WithContext(withGitOpsRequestHost(req.Context(), host)))
 }
 
 func gitopsDialBlocked(ip net.IP, allowPrivate bool) bool {

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -34,6 +34,9 @@ import (
 
 var errGitOpsRedirect = errors.New("redirects are not allowed")
 
+// errGitOpsEmptyDNS is wrapped when DNS returns no addresses (fail closed).
+var errGitOpsEmptyDNS = errors.New("empty address list")
+
 // ErrSSRFBlocked is returned when the GitOps HTTP dial refuses the resolved address.
 var ErrSSRFBlocked = errors.New("gitops SSRF blocked")
 
@@ -585,12 +588,9 @@ func gitopsDialContext(ctx context.Context, network, addr string, allowPrivate b
 	if validation.GitOpsBlockedHost(host) {
 		return nil, fmt.Errorf("%w: host %q is a disallowed address", ErrSSRFBlocked, host)
 	}
-	ips, err := lookupIPAddr(ctx, host)
+	ips, err := gitopsResolveHost(ctx, host)
 	if err != nil {
-		return nil, fmt.Errorf("gitops dial: DNS resolution failed")
-	}
-	if len(ips) == 0 {
-		return nil, fmt.Errorf("gitops dial: DNS resolution failed")
+		return nil, err
 	}
 	for _, ip := range ips {
 		if gitopsDialBlocked(ip.IP, allowPrivate) {
@@ -613,9 +613,9 @@ func (t *gitopsSSRFTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	if validation.GitOpsBlockedHost(host) {
 		return nil, fmt.Errorf("%w: host %q is a disallowed address", ErrSSRFBlocked, host)
 	}
-	ips, err := lookupIPAddr(req.Context(), host)
+	ips, err := gitopsResolveHost(req.Context(), host)
 	if err != nil {
-		return nil, fmt.Errorf("gitops dial: DNS resolution failed")
+		return nil, err
 	}
 	for _, ip := range ips {
 		if gitopsDialBlocked(ip.IP, t.allowPrivate) {
@@ -623,6 +623,19 @@ func (t *gitopsSSRFTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		}
 	}
 	return t.base.RoundTrip(req.WithContext(withGitOpsRequestHost(req.Context(), host)))
+}
+
+// gitopsResolveHost looks up host and fails closed on resolver errors or
+// an empty address list. The host is always named and the cause is wrapped.
+func gitopsResolveHost(ctx context.Context, host string) ([]net.IPAddr, error) {
+	ips, err := lookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("gitops dial: DNS resolution failed for %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("gitops dial: DNS resolution failed for %q: %w", host, errGitOpsEmptyDNS)
+	}
+	return ips, nil
 }
 
 func gitopsDialBlocked(ip net.IP, allowPrivate bool) bool {

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -143,6 +143,9 @@ func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		if code < 200 || code >= 300 {
 			return PRResult{}, fmt.Errorf("github update PR: status %d", code)
 		}
+		if err := c.applyIssueLabels(ctx, httpClient, base, pr.Number, req.Labels); err != nil {
+			return PRResult{}, err
+		}
 		return PRResult{URL: pr.HTMLURL, Number: pr.Number, Updated: true}, nil
 	}
 
@@ -174,12 +177,27 @@ func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 	if err := json.Unmarshal(respBody, &created); err != nil {
 		return PRResult{}, fmt.Errorf("github create PR decode: %w", err)
 	}
-	// Labels (best-effort)
-	if len(req.Labels) > 0 && created.Number > 0 {
-		labURL := fmt.Sprintf("%s/repos/%s/issues/%d/labels", base, c.Repository, created.Number)
-		_, _, _ = c.doJSON(ctx, httpClient, http.MethodPost, labURL, map[string]interface{}{"labels": req.Labels})
+	if err := c.applyIssueLabels(ctx, httpClient, base, created.Number, req.Labels); err != nil {
+		return PRResult{}, err
 	}
 	return PRResult{URL: created.HTMLURL, Number: created.Number, Updated: false}, nil
+}
+
+// applyIssueLabels POSTs configured labels onto the GitHub issue/PR.
+// Failures are returned (not swallowed) so reconcile can retry.
+func (c *GitHubClient) applyIssueLabels(ctx context.Context, httpClient HTTPDoer, apiBase string, number int, labels []string) error {
+	if len(labels) == 0 || number <= 0 {
+		return nil
+	}
+	labURL := fmt.Sprintf("%s/repos/%s/issues/%d/labels", apiBase, c.Repository, number)
+	_, code, err := c.doJSON(ctx, httpClient, http.MethodPost, labURL, map[string]interface{}{"labels": labels})
+	if err != nil {
+		return fmt.Errorf("github apply labels: %w", err)
+	}
+	if code < 200 || code >= 300 {
+		return fmt.Errorf("github apply labels: status %d", code)
+	}
+	return nil
 }
 
 // ensureHeadBranch creates req head from base with an empty bootstrap commit when
@@ -351,7 +369,11 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 	}
 	if len(existing) > 0 {
 		patchURL := fmt.Sprintf("%s/projects/%s/merge_requests/%d", base, project, existing[0].IID)
-		payload := map[string]string{"title": req.Title, "description": req.Body}
+		payload := map[string]interface{}{
+			"title":       req.Title,
+			"description": req.Body,
+			"labels":      strings.Join(req.Labels, ","),
+		}
 		_, code, err := c.doJSON(ctx, httpClient, http.MethodPut, patchURL, payload)
 		if err != nil {
 			return PRResult{}, err

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -421,6 +421,110 @@ func TestGitLabClient_EnsureHead_FileExistsOnBase_UsesUpdate(t *testing.T) {
 	assert.Contains(t, commitBodies[1], `"update"`)
 }
 
+func TestGitHubClient_Create_Labels403ReturnsStatusNotToken(t *testing.T) {
+	t.Parallel()
+	const token = "super-secret-gh-token"
+	client := &GitHubClient{
+		Token:      token,
+		Repository: "org/repo",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls"):
+				return jsonResp(200, "[]"), nil
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/ref/heads/"):
+				return jsonResp(200, map[string]interface{}{
+					"object": map[string]string{"sha": "abc"},
+				}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls"):
+				return jsonResp(201, map[string]interface{}{
+					"number": 7, "html_url": "https://github.com/org/repo/pull/7",
+				}), nil
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/labels"):
+				return jsonResp(403, `{"message":"Resource not accessible by integration `+token+`"}`), nil
+			default:
+				return jsonResp(500, `{"message":"unexpected `+r.Method+` `+r.URL.Path+`"}`), nil
+			}
+		}),
+	}
+	_, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+		Labels: []string{"attune", "rightsizing"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 403")
+	assert.NotContains(t, err.Error(), token)
+}
+
+func TestGitHubClient_Update_AppliesLabels(t *testing.T) {
+	t.Parallel()
+	var labelPosted bool
+	var labelBody string
+	client := &GitHubClient{
+		Token:      "tok",
+		Repository: "org/repo",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls") {
+				return jsonResp(200, []map[string]interface{}{
+					{
+						"number":   9,
+						"html_url": "https://github.com/org/repo/pull/9",
+						"head":     map[string]interface{}{"ref": "attune/x"},
+					},
+				}), nil
+			}
+			if r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/pulls/9") {
+				return jsonResp(200, map[string]interface{}{}), nil
+			}
+			if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/issues/9/labels") {
+				b, _ := io.ReadAll(r.Body)
+				labelPosted = true
+				labelBody = string(b)
+				return jsonResp(200, `[]`), nil
+			}
+			return jsonResp(500, `{"message":"unexpected `+r.Method+` `+r.URL.Path+`"}`), nil
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+		Labels: []string{"attune"},
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Updated)
+	assert.True(t, labelPosted, "update must POST /issues/{n}/labels")
+	assert.Contains(t, labelBody, "attune")
+}
+
+func TestGitLabClient_Update_IncludesLabels(t *testing.T) {
+	t.Parallel()
+	var putBody string
+	client := &GitLabClient{
+		Token:   "gl-token",
+		Project: "g/p",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Method == http.MethodGet {
+				return jsonResp(200, []map[string]interface{}{
+					{"iid": 3, "web_url": "https://gitlab.com/g/p/-/merge_requests/3"},
+				}), nil
+			}
+			if r.Method == http.MethodPut {
+				b, _ := io.ReadAll(r.Body)
+				putBody = string(b)
+				return jsonResp(200, `{}`), nil
+			}
+			return jsonResp(500, `{"message":"unexpected"}`), nil
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+		Labels: []string{"attune", "rightsizing"},
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Updated)
+	assert.Contains(t, putBody, `"labels"`)
+	assert.Contains(t, putBody, "attune")
+	assert.Contains(t, putBody, "rightsizing")
+}
+
 func TestGitHubClient_CreatePRErrorOmitsResponseBody(t *testing.T) {
 	t.Parallel()
 	const planted = "ami-secret-should-not-leak"

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -446,11 +446,14 @@ func TestGitHubClient_Create_Labels403ReturnsStatusNotToken(t *testing.T) {
 			}
 		}),
 	}
-	_, err := client.CreateOrUpdate(context.Background(), PRRequest{
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
 		Title: "t", Body: "b", Head: "attune/x", Base: "main",
 		Labels: []string{"attune", "rightsizing"},
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrLabelsApplied)
+	assert.Equal(t, "https://github.com/org/repo/pull/7", res.URL)
+	assert.Equal(t, 7, res.Number)
 	assert.Contains(t, err.Error(), "status 403")
 	assert.NotContains(t, err.Error(), token)
 }

--- a/internal/gitops/transport_test.go
+++ b/internal/gitops/transport_test.go
@@ -17,8 +17,16 @@ the License.
 package gitops
 
 import (
+	"context"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptrace"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,4 +57,91 @@ func TestGitopsDialBlocked_AWSIMDSv6(t *testing.T) {
 	require.NotNil(t, imds)
 	assert.True(t, gitopsDialBlocked(imds, false))
 	assert.True(t, gitopsDialBlocked(imds, true), "IPv6 IMDS stays blocked when allowPrivate is set")
+}
+
+func TestGitopsSafeTransport_DNSRebindBlocked(t *testing.T) {
+	public := net.ParseIP("1.1.1.1")
+	imds := net.ParseIP("169.254.169.254")
+	require.NotNil(t, public)
+	require.NotNil(t, imds)
+
+	var lookups atomic.Int32
+	orig := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = orig })
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		if lookups.Add(1) == 1 {
+			return []net.IPAddr{{IP: public}}, nil
+		}
+		return []net.IPAddr{{IP: imds}}, nil
+	}
+
+	var wroteMu sync.Mutex
+	var wroteHeaders bool
+	var wroteRequest bool
+	client := newGitOpsHTTPClient(false)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://forge.example/api", strings.NewReader(`{"token":"must-not-leak"}`))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer must-not-leak")
+	req.Header.Set("PRIVATE-TOKEN", "must-not-leak")
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), &httptrace.ClientTrace{
+		WroteHeaders: func() {
+			wroteMu.Lock()
+			wroteHeaders = true
+			wroteMu.Unlock()
+		},
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			wroteMu.Lock()
+			wroteRequest = true
+			wroteMu.Unlock()
+		},
+	}))
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSSRFBlocked)
+	assert.GreaterOrEqual(t, lookups.Load(), int32(2), "dial must re-resolve so a rebind is visible")
+	wroteMu.Lock()
+	defer wroteMu.Unlock()
+	assert.False(t, wroteHeaders, "must not write Authorization/PRIVATE-TOKEN to the rebound address")
+	assert.False(t, wroteRequest, "must not send the request body to the rebound address")
+}
+
+func TestGitopsSafeTransport_DNSRebindBlockedIMDSv6AllowPrivate(t *testing.T) {
+	private := net.ParseIP("10.1.2.3")
+	imds := net.ParseIP("fd00:ec2::254")
+	require.NotNil(t, private)
+	require.NotNil(t, imds)
+
+	var lookups atomic.Int32
+	orig := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = orig })
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		if lookups.Add(1) == 1 {
+			return []net.IPAddr{{IP: private}}, nil
+		}
+		return []net.IPAddr{{IP: imds}}, nil
+	}
+
+	client := newGitOpsHTTPClient(true)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://forge.example/api", strings.NewReader(`{"token":"must-not-leak"}`))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer must-not-leak")
+	req.Header.Set("PRIVATE-TOKEN", "must-not-leak")
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSSRFBlocked)
+	assert.GreaterOrEqual(t, lookups.Load(), int32(2), "dial must re-resolve so a rebind is visible")
 }

--- a/internal/gitops/transport_test.go
+++ b/internal/gitops/transport_test.go
@@ -18,10 +18,13 @@ package gitops
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/http/httptrace"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -144,4 +147,116 @@ func TestGitopsSafeTransport_DNSRebindBlockedIMDSv6AllowPrivate(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrSSRFBlocked)
 	assert.GreaterOrEqual(t, lookups.Load(), int32(2), "dial must re-resolve so a rebind is visible")
+}
+
+func TestGitopsSafeTransport_HTTPSProxyPrivateNotSSRF(t *testing.T) {
+	// Corporate HTTPS_PROXY is often RFC1918. SSRF is the request host
+	// (the forge), not the proxy hop DialContext sees.
+	orig := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = orig })
+	lookupIPAddr = func(_ context.Context, host string) ([]net.IPAddr, error) {
+		if host == "forge.example" {
+			return []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}, nil
+		}
+		if ip := net.ParseIP(host); ip != nil {
+			return []net.IPAddr{{IP: ip}}, nil
+		}
+		return nil, errors.New("unexpected lookup")
+	}
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "[]")
+	}))
+	t.Cleanup(proxy.Close)
+
+	dialer := &net.Dialer{Timeout: 2 * time.Second}
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &gitopsSSRFTransport{
+			allowPrivate: false,
+			base: &http.Transport{
+				Proxy: func(*http.Request) (*url.URL, error) {
+					return url.Parse(proxy.URL)
+				},
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return gitopsDialContext(ctx, network, addr, false, dialer)
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://forge.example/api", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	if resp != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	require.NoError(t, err, "HTTPS_PROXY to a private hop must not return ErrSSRFBlocked")
+}
+
+func TestGitopsSafeTransport_HTTPSProxyPrivateIPNotSSRF(t *testing.T) {
+	orig := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = orig })
+	lookupIPAddr = func(_ context.Context, host string) ([]net.IPAddr, error) {
+		if host == "forge.example" {
+			return []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}, nil
+		}
+		if ip := net.ParseIP(host); ip != nil {
+			return []net.IPAddr{{IP: ip}}, nil
+		}
+		return nil, errors.New("unexpected lookup")
+	}
+
+	dialer := &net.Dialer{Timeout: 200 * time.Millisecond}
+	client := &http.Client{
+		Timeout: time.Second,
+		Transport: &gitopsSSRFTransport{
+			allowPrivate: false,
+			base: &http.Transport{
+				Proxy: func(*http.Request) (*url.URL, error) {
+					return url.Parse("http://10.1.2.3:9")
+				},
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return gitopsDialContext(ctx, network, addr, false, dialer)
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://forge.example/api", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	if resp != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrSSRFBlocked, "RFC1918 HTTPS_PROXY hop is not the SSRF target")
+}
+
+func TestGitopsSafeTransport_AllowPrivateBlocksIMDSv6RequestHost(t *testing.T) {
+	orig := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = orig })
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("fd00:ec2::254")}}, nil
+	}
+
+	client := newGitOpsHTTPClient(true)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://forge.example/latest/meta-data", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	if resp != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSSRFBlocked, "allowPrivate still blocks fd00:ec2::254 as request host")
 }

--- a/internal/gitops/transport_test.go
+++ b/internal/gitops/transport_test.go
@@ -240,6 +240,57 @@ func TestGitopsSafeTransport_HTTPSProxyPrivateIPNotSSRF(t *testing.T) {
 	assert.NotErrorIs(t, err, ErrSSRFBlocked, "RFC1918 HTTPS_PROXY hop is not the SSRF target")
 }
 
+func TestGitopsResolveHost_DNSErrorIncludesHost(t *testing.T) {
+	orig := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = orig })
+	dnsErr := errors.New("no such host")
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		return nil, dnsErr
+	}
+
+	_, err := gitopsResolveHost(context.Background(), "forge.example")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, dnsErr)
+	assert.Contains(t, err.Error(), `DNS resolution failed for "forge.example"`)
+
+	dialer := &net.Dialer{Timeout: time.Second}
+	_, err = gitopsDialContext(context.Background(), "tcp", "forge.example:443", false, dialer)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, dnsErr)
+	assert.Contains(t, err.Error(), `DNS resolution failed for "forge.example"`)
+}
+
+func TestGitopsResolveHost_EmptyDNSFailsClosed(t *testing.T) {
+	orig := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = orig })
+	lookupIPAddr = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		return nil, nil
+	}
+
+	_, err := gitopsResolveHost(context.Background(), "forge.example")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errGitOpsEmptyDNS)
+	assert.Contains(t, err.Error(), `DNS resolution failed for "forge.example"`)
+
+	called := false
+	rt := &gitopsSSRFTransport{
+		base: roundTripFuncTransport(func(*http.Request) (*http.Response, error) {
+			called = true
+			return nil, errors.New("base must not be called on empty DNS")
+		}),
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://forge.example/api", nil)
+	require.NoError(t, err)
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errGitOpsEmptyDNS)
+	assert.Contains(t, err.Error(), `DNS resolution failed for "forge.example"`)
+	assert.False(t, called, "RoundTrip must fail closed before the inner transport")
+}
+
 func TestGitopsSafeTransport_AllowPrivateBlocksIMDSv6RequestHost(t *testing.T) {
 	orig := lookupIPAddr
 	t.Cleanup(func() { lookupIPAddr = orig })

--- a/internal/metrics/datadog.go
+++ b/internal/metrics/datadog.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -28,7 +29,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	"github.com/attune-io/attune/internal/validation"
 )
+
+var errDatadogRedirect = errors.New("datadog redirects are not allowed")
 
 // datadogSeriesResponse models the JSON response from /api/v1/query.
 type datadogSeriesResponse struct {
@@ -60,21 +65,29 @@ type DatadogCollector struct {
 // NewDatadogCollector creates a collector that queries the Datadog API.
 // site is the Datadog site (e.g. "datadoghq.com"), apiKey and appKey are
 // authentication credentials read from a Kubernetes Secret.
-func NewDatadogCollector(site, apiKey, appKey string, logger logr.Logger) *DatadogCollector {
+func NewDatadogCollector(site, apiKey, appKey string, logger logr.Logger) (*DatadogCollector, error) {
 	if site == "" {
 		site = "datadoghq.com"
 	}
+	if err := validation.DatadogSite(site); err != nil {
+		return nil, fmt.Errorf("datadog site: %w", err)
+	}
 	return &DatadogCollector{
 		httpClient: &http.Client{
-			Timeout:   30 * time.Second,
-			Transport: &http.Transport{Proxy: http.ProxyFromEnvironment},
+			Timeout:       30 * time.Second,
+			Transport:     &http.Transport{Proxy: http.ProxyFromEnvironment},
+			CheckRedirect: datadogCheckRedirect,
 		},
 		baseURL:       fmt.Sprintf("https://api.%s", site),
 		apiKey:        apiKey,
 		appKey:        appKey,
 		logger:        logger,
 		cpuMetricName: "kubernetes.cpu.usage.total",
-	}
+	}, nil
+}
+
+func datadogCheckRedirect(*http.Request, []*http.Request) error {
+	return errDatadogRedirect
 }
 
 // QueryRange executes a Datadog metric query and returns flattened samples.

--- a/internal/metrics/datadog_test.go
+++ b/internal/metrics/datadog_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -361,7 +362,8 @@ func TestLatestSampleValue(t *testing.T) {
 }
 
 func TestNewDatadogCollector_Defaults(t *testing.T) {
-	c := NewDatadogCollector("", "api", "app", logr.Discard())
+	c, err := NewDatadogCollector("", "api", "app", logr.Discard())
+	require.NoError(t, err)
 	require.NotNil(t, c)
 	assert.Equal(t, "https://api.datadoghq.com", c.baseURL)
 	assert.Equal(t, "api", c.apiKey)
@@ -369,12 +371,48 @@ func TestNewDatadogCollector_Defaults(t *testing.T) {
 	assert.Equal(t, "kubernetes.cpu.usage.total", c.cpuMetricName)
 	require.NotNil(t, c.httpClient)
 	assert.Equal(t, 30*time.Second, c.httpClient.Timeout)
+	require.NotNil(t, c.httpClient.CheckRedirect)
 }
 
 func TestNewDatadogCollector_CustomSite(t *testing.T) {
-	c := NewDatadogCollector("datadoghq.eu", "k", "a", logr.Discard())
+	c, err := NewDatadogCollector("datadoghq.eu", "k", "a", logr.Discard())
+	require.NoError(t, err)
 	require.NotNil(t, c)
 	assert.Equal(t, "https://api.datadoghq.eu", c.baseURL)
+}
+
+func TestNewDatadogCollector_RejectsInvalidSite(t *testing.T) {
+	c, err := NewDatadogCollector("evil.example", "k", "a", logr.Discard())
+	require.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), "not a recognized Datadog site")
+
+	c, err = NewDatadogCollector("datadoghq.com.evil.example", "k", "a", logr.Discard())
+	require.Error(t, err)
+	assert.Nil(t, c)
+}
+
+func TestNewDatadogCollector_DoesNotFollowRedirects(t *testing.T) {
+	var sawEvil atomic.Bool
+	evil := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		sawEvil.Store(true)
+		assert.Empty(t, r.Header.Get("DD-API-KEY"), "API key must not be sent to the redirect target")
+	}))
+	defer evil.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, evil.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+
+	c, err := NewDatadogCollector("datadoghq.com", "secret-api-key", "app", logr.Discard())
+	require.NoError(t, err)
+	c.baseURL = origin.URL
+
+	_, err = c.QueryRangeGrouped(context.Background(), "avg:system.cpu.user{*}", time.Unix(1700000000, 0), time.Unix(1700000600, 0), time.Minute)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errDatadogRedirect)
+	assert.False(t, sawEvil.Load(), "must not follow redirect to attacker host")
 }
 
 // Verify DatadogCollector implements MetricsCollector.

--- a/internal/validation/datadog.go
+++ b/internal/validation/datadog.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package validation
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 // validDatadogSites is the allowlist of Datadog site values used to
 // construct https://api.<site>. Empty site means the caller default.
@@ -37,7 +41,17 @@ func DatadogSite(site string) error {
 		return nil
 	}
 	if !validDatadogSites[site] {
-		return fmt.Errorf("site %q is not a recognized Datadog site", site)
+		return fmt.Errorf("site %q is not a recognized Datadog site (allowed: %s)", site, datadogAllowedSites())
 	}
 	return nil
+}
+
+// datadogAllowedSites returns the allowlist in stable sorted order for errors.
+func datadogAllowedSites() string {
+	sites := make([]string, 0, len(validDatadogSites))
+	for s := range validDatadogSites {
+		sites = append(sites, s)
+	}
+	sort.Strings(sites)
+	return strings.Join(sites, ", ")
 }

--- a/internal/validation/datadog.go
+++ b/internal/validation/datadog.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import "fmt"
+
+// validDatadogSites is the allowlist of Datadog site values used to
+// construct https://api.<site>. Empty site means the caller default.
+var validDatadogSites = map[string]bool{
+	"datadoghq.com":     true,
+	"datadoghq.eu":      true,
+	"us3.datadoghq.com": true,
+	"us5.datadoghq.com": true,
+	"ap1.datadoghq.com": true,
+	"ddog-gov.com":      true,
+}
+
+// DatadogSite reports whether site is empty (caller default) or an
+// allowlisted Datadog site. Invalid values must not be interpolated
+// into https://api.<site>.
+func DatadogSite(site string) error {
+	if site == "" {
+		return nil
+	}
+	if !validDatadogSites[site] {
+		return fmt.Errorf("site %q is not a recognized Datadog site", site)
+	}
+	return nil
+}

--- a/internal/validation/datadog_test.go
+++ b/internal/validation/datadog_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatadogSite(t *testing.T) {
+	t.Parallel()
+	valid := []string{
+		"",
+		"datadoghq.com",
+		"datadoghq.eu",
+		"us3.datadoghq.com",
+		"us5.datadoghq.com",
+		"ap1.datadoghq.com",
+		"ddog-gov.com",
+	}
+	for _, site := range valid {
+		assert.NoError(t, DatadogSite(site), "expected valid: %q", site)
+	}
+
+	err := DatadogSite("evil.example")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a recognized Datadog site")
+
+	err = DatadogSite("datadoghq.com.evil.example")
+	require.Error(t, err)
+}

--- a/internal/validation/datadog_test.go
+++ b/internal/validation/datadog_test.go
@@ -40,8 +40,10 @@ func TestDatadogSite(t *testing.T) {
 
 	err := DatadogSite("evil.example")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not a recognized Datadog site")
+	assert.Contains(t, err.Error(), `site "evil.example" is not a recognized Datadog site`)
+	assert.Contains(t, err.Error(), "allowed: ap1.datadoghq.com, datadoghq.com, datadoghq.eu, ddog-gov.com, us3.datadoghq.com, us5.datadoghq.com")
 
 	err = DatadogSite("datadoghq.com.evil.example")
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed:")
 }

--- a/internal/validation/gitops.go
+++ b/internal/validation/gitops.go
@@ -54,19 +54,8 @@ func GitOpsAPIURLAllowingPrivate(address string, allowPrivate bool) error {
 		return fmt.Errorf("host is required")
 	}
 
-	blockedHosts := []string{
-		"metadata.google.internal",
-		"metadata.internal",
-		"instance-data.ec2.internal",
-		"169.254.169.254",
-		"fd00:ec2::254",
-		"localhost",
-	}
-	lowerHost := strings.ToLower(hostname)
-	for _, blocked := range blockedHosts {
-		if lowerHost == blocked {
-			return fmt.Errorf("address must not target cloud metadata endpoint %q", hostname)
-		}
+	if GitOpsBlockedHost(hostname) {
+		return fmt.Errorf("address must not target cloud metadata endpoint %q", hostname)
 	}
 
 	if ip := net.ParseIP(hostname); ip != nil {
@@ -79,6 +68,22 @@ func GitOpsAPIURLAllowingPrivate(address string, allowPrivate bool) error {
 		}
 	}
 	return nil
+}
+
+// GitOpsBlockedHost reports metadata and loopback hostnames that must never
+// be dialed, including when allowPrivateEndpoints is set.
+func GitOpsBlockedHost(host string) bool {
+	switch strings.ToLower(strings.TrimSuffix(host, ".")) {
+	case "metadata.google.internal",
+		"metadata.internal",
+		"instance-data.ec2.internal",
+		"169.254.169.254",
+		"fd00:ec2::254",
+		"localhost":
+		return true
+	default:
+		return false
+	}
 }
 
 // awsIMDSv6 is the AWS EC2 Instance Metadata Service v2 IPv6 endpoint.

--- a/internal/validation/gitops_test.go
+++ b/internal/validation/gitops_test.go
@@ -138,6 +138,18 @@ func TestGitOpsAPIURL_AllowPrivateRFC1918(t *testing.T) {
 	assert.Error(t, GitOpsAPIURL("https://10.96.0.1/"), "default still blocks RFC1918")
 }
 
+func TestGitOpsBlockedHost(t *testing.T) {
+	t.Parallel()
+	assert.True(t, GitOpsBlockedHost("metadata.google.internal"))
+	assert.True(t, GitOpsBlockedHost("METADATA.GOOGLE.INTERNAL"))
+	assert.True(t, GitOpsBlockedHost("metadata.google.internal."))
+	assert.True(t, GitOpsBlockedHost("169.254.169.254"))
+	assert.True(t, GitOpsBlockedHost("fd00:ec2::254"))
+	assert.True(t, GitOpsBlockedHost("localhost"))
+	assert.False(t, GitOpsBlockedHost("api.github.com"))
+	assert.False(t, GitOpsBlockedHost("ghe.example.com"))
+}
+
 func TestGitOpsAlwaysBlockedIP(t *testing.T) {
 	t.Parallel()
 	assert.True(t, GitOpsAlwaysBlockedIP(net.ParseIP("127.0.0.1")))

--- a/internal/webhook/defaults_validation.go
+++ b/internal/webhook/defaults_validation.go
@@ -237,7 +237,7 @@ func validateResourceConfigFields(prefix string, rc *attunev1alpha1.ResourceConf
 	}
 
 	// MemoryFromCPURatio (only meaningful on memory, but validate on any ResourceConfig)
-	if err := validateMemoryFromCPURatio(rc.MemoryFromCPURatio); err != nil {
+	if err := validateMemoryFromCPURatio(prefix+".memoryFromCpuRatio", rc.MemoryFromCPURatio); err != nil {
 		return err
 	}
 

--- a/internal/webhook/defaults_validation_test.go
+++ b/internal/webhook/defaults_validation_test.go
@@ -961,7 +961,7 @@ func TestDefaultsValidator_ProviderFieldConstraints(t *testing.T) {
 					APIKeySecretRef: attunev1alpha1.SecretKeyRef{Name: "dd-key", Key: "api-key"},
 				},
 			},
-			wantErr: "is not a recognized Datadog site",
+			wantErr: "metricsSource.datadog.site:",
 		},
 		{
 			name: "cloudwatch missing region",

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -589,12 +589,7 @@ func validateMetricsSourceProviderFields(ms *attunev1alpha1.MetricsSource) error
 		}
 	}
 	if dd := ms.Datadog; dd != nil {
-		validSites := map[string]bool{
-			"datadoghq.com": true, "datadoghq.eu": true,
-			"us3.datadoghq.com": true, "us5.datadoghq.com": true,
-			"ap1.datadoghq.com": true, "ddog-gov.com": true,
-		}
-		if dd.Site != "" && !validSites[dd.Site] {
+		if err := validation.DatadogSite(dd.Site); err != nil {
 			return fmt.Errorf("metricsSource.datadog.site %q is not a recognized Datadog site", dd.Site)
 		}
 		if dd.APIKeySecretRef.Name == "" {

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -590,7 +590,7 @@ func validateMetricsSourceProviderFields(ms *attunev1alpha1.MetricsSource) error
 	}
 	if dd := ms.Datadog; dd != nil {
 		if err := validation.DatadogSite(dd.Site); err != nil {
-			return fmt.Errorf("metricsSource.datadog.site %q is not a recognized Datadog site", dd.Site)
+			return fmt.Errorf("metricsSource.datadog.site: %w", err)
 		}
 		if dd.APIKeySecretRef.Name == "" {
 			return fmt.Errorf("metricsSource.datadog.apiKeySecretRef.name is required")

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -410,22 +410,22 @@ func validateOverhead(resource, overhead string) error {
 	return nil
 }
 
-func validateMemoryFromCPURatio(ratio *string) error {
+func validateMemoryFromCPURatio(fieldPath string, ratio *string) error {
 	if ratio == nil || *ratio == "" {
 		return nil
 	}
 	v, err := strconv.ParseFloat(*ratio, 64)
 	if err != nil {
-		return fmt.Errorf("memory.memoryFromCpuRatio %q is not a valid number: %w", *ratio, err)
+		return fmt.Errorf("%s %q is not a valid number: %w", fieldPath, *ratio, err)
 	}
 	if math.IsNaN(v) || math.IsInf(v, 0) {
-		return fmt.Errorf("memory.memoryFromCpuRatio must be a finite number, got %s", *ratio)
+		return fmt.Errorf("%s must be a finite number, got %s", fieldPath, *ratio)
 	}
 	if v <= 0 {
-		return fmt.Errorf("memory.memoryFromCpuRatio must be positive, got %s", *ratio)
+		return fmt.Errorf("%s must be positive, got %s", fieldPath, *ratio)
 	}
 	if v > 1000 { //nolint:mnd // 1000 matches the controller ceiling for GiB-per-core ratios
-		return fmt.Errorf("memory.memoryFromCpuRatio must be <= 1000, got %s", *ratio)
+		return fmt.Errorf("%s must be <= 1000, got %s", fieldPath, *ratio)
 	}
 	return nil
 }

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -1229,7 +1229,10 @@ func TestValidate_DatadogInvalidSite(t *testing.T) {
 
 	_, err := validator.ValidateCreate(context.Background(), policy)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "metricsSource.datadog.site:")
 	assert.Contains(t, err.Error(), "not a recognized Datadog site")
+	assert.Contains(t, err.Error(), "allowed:")
+	assert.Contains(t, err.Error(), "datadoghq.com")
 }
 
 func TestValidate_DatadogMissingSecret(t *testing.T) {

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -784,9 +784,22 @@ func TestValidate_MemoryFromCPURatioInvalid(t *testing.T) {
 
 			_, err := validator.ValidateCreate(context.Background(), policy)
 			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "memory.memoryFromCpuRatio")
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
+}
+
+func TestValidate_CPUMemoryFromCPURatioFieldPath(t *testing.T) {
+	validator := &AttunePolicyValidator{}
+	policy := validPolicy()
+	nan := "NaN"
+	policy.Spec.CPU.MemoryFromCPURatio = &nan
+
+	_, err := validator.ValidateCreate(context.Background(), policy)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cpu.memoryFromCpuRatio")
+	assert.NotContains(t, err.Error(), "memory.memoryFromCpuRatio")
 }
 
 func TestValidate_MemoryFromCPURatioValid(t *testing.T) {

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,19 @@
       ],
       "depNameTemplate": "quay.io/prometheus/prometheus",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^\\.github/workflows/.*\\.ya?ml$",
+        "^Makefile$"
+      ],
+      "matchStrings": [
+        "CERT_MANAGER_VERSION:\\s*[\"']?(?<currentValue>v[^\"'\\s]+)[\"']?",
+        "CERT_MANAGER_VERSION\\s*\\?=\\s*[\"']?(?<currentValue>v[^\"'\\s]+)[\"']?"
+      ],
+      "depNameTemplate": "cert-manager/cert-manager",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
This MPI cycle tightens quota, GitOps, Datadog, and doctor behavior that was wrong or undocumented after the stale-reuse wave.

## Problem

- ResourceQuota headroom only read `requests.cpu` / `requests.memory`, so the common `hard.cpu` / `hard.memory` aliases never blocked increases. List errors fail-opened.
- The VPA recommend path ignored `memory.memoryFromCpuRatio` and dropped recs instead of stale reuse.
- GitOps SSRF resolved the forge host, then dialed again. A short-TTL rebind could send the PAT to IMDS. The first dial-pin attempt then treated `HTTPS_PROXY` as the SSRF target (regression of the #620 lesson).
- `kubectl attune doctor` printed Prometheus `ok` when it never pinged an address.
- GitHub label POST errors were discarded. After we started failing those, a 403 after a successful PR create hid the PR URL and started the 24h cooldown.

## Change

- Resolve quota keys as `requests.*` then `cpu`/`memory`. Fail-closed List errors on request increases. VPA applies `memoryFromCpuRatio` and reuses stale recs.
- Pin GitOps dial to the SSRF-checked request host. Skip the check on the proxy hop. Keep IMDS blocked. Persist the PR URL when labels fail after create. Safety revert uses `WithoutCancel` so a spent Prometheus timeout cannot skip rollback.
- Recheck Datadog `site` at collector construction and refuse redirects. Doctor WARN when no Prometheus address is pinged.
- CI: cert-manager `v1.21.1` plus Renovate tracking, full matrix on `workflow_dispatch`, narrower PR benches.
- Docs: configuration, troubleshooting, safety, CLI, upgrading.

## Validation

- `make verify-quick` (lint, 2226 unit tests with `-race`, 93.0% internal coverage, helm lint/unittest, CRD freshness, doc defaults)
- Targeted red/green tests for quota aliases, GitOps proxy vs rebind, doctor skip, series-cap, NaN last-data, nil `LastDataTime`

Release PR #601 (v0.1.26) stays user-gated. Do not merge it from this PR.
