### PR TITLE
fix: match gitlab mrs to basebranch and tighten gitops tests

### DIFF
--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -413,19 +415,43 @@ func TestPingPrometheusHealthy(t *testing.T) {
 		t.Cleanup(srv.Close)
 		err := pingPrometheusHealthy(ctx, pingTestURL(srv.URL))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "loopback")
+		var uerr *url.Error
+		require.ErrorAs(t, err, &uerr)
+		assert.EqualError(t, uerr.Err, `address must not target loopback/metadata IP "127.0.0.1"`)
 	})
+}
 
-	t.Run("redirect to cloud metadata is rejected", func(t *testing.T) {
-		t.Parallel()
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "http://metadata.google.internal/-/healthy", http.StatusFound)
-		}))
-		t.Cleanup(srv.Close)
-		err := pingPrometheusHealthy(ctx, pingTestURL(srv.URL))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "metadata")
+// TestPingPrometheusHealthy_RedirectToCloudMetadata is not Parallel: it
+// wraps DefaultTransport so a missing CheckRedirect cannot hide behind
+// "lookup metadata.google.internal" (that string still contains "metadata").
+func TestPingPrometheusHealthy_RedirectToCloudMetadata(t *testing.T) {
+	var sawMetadata atomic.Bool
+	orig := http.DefaultTransport
+	http.DefaultTransport = pingRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if strings.EqualFold(r.URL.Hostname(), "metadata.google.internal") {
+			sawMetadata.Store(true)
+			return nil, errors.New("test: followed redirect to cloud metadata")
+		}
+		return orig.RoundTrip(r)
 	})
+	t.Cleanup(func() { http.DefaultTransport = orig })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://metadata.google.internal/-/healthy", http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+	err := pingPrometheusHealthy(context.Background(), pingTestURL(srv.URL))
+	require.Error(t, err)
+	var uerr *url.Error
+	require.ErrorAs(t, err, &uerr)
+	assert.EqualError(t, uerr.Err, `address must not target cloud metadata endpoint "metadata.google.internal"`)
+	assert.False(t, sawMetadata.Load(), "must not follow redirect to metadata.google.internal")
+}
+
+type pingRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f pingRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }
 
 func TestPrintDoctorResults_OptionalWarn(t *testing.T) {

--- a/docs/guides/gitops-integration.md
+++ b/docs/guides/gitops-integration.md
@@ -262,9 +262,14 @@ clears (`NoDrift`).
 
 ### Branch bootstrap
 
-The operator updates an existing open PR whose head branch is
-`attune/recommendations-<ns>-<policy>`. When no open PR exists and that head
-branch is **missing** on the remote, Attune creates it automatically:
+The operator updates an existing open PR or MR only when **head/source is
+the Attune branch** (`attune/recommendations-<ns>-<policy>`) **and the
+target is `baseBranch`** (default `main`). Changing `baseBranch` or
+retargeting the existing PR/MR can leave the old one open and create a
+new one against the current `baseBranch`.
+
+When no matching open PR/MR exists and that head branch is **missing**
+on the remote, Attune creates it automatically:
 
 - **GitHub:** empty bootstrap commit on the new branch (same tree as
   `baseBranch`, so the PR has a single commit delta).
@@ -281,5 +286,6 @@ On GitLab, if `.attune/RECOMMENDATION_DRIFT.md` already exists on
 non-empty.
 
 If bootstrap fails (token scopes, missing `baseBranch`, network), status shows
-`PullRequestFailed` with a redacted API error.
+`PullRequestFailed` with the static message `PR API request failed`.
+The condition does not include the API response body.
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1120,7 +1120,7 @@ branch) leaves the live template unchanged, so drift stays true.
 ### GitOps PR failing
 
 **Symptom**: Status condition `GitOpsPullRequest` is `False` with reason
-`PullRequestFailed`, Events or metrics show
+`PullRequestFailed` or `GitOpsEndpointBlocked`, Events or metrics show
 `attune_gitops_pr_total{result="failed"}`, or the `AttuneGitOpsPRFailures`
 alert fires.
 
@@ -1128,12 +1128,25 @@ alert fires.
 update a PR. Common cases:
 
 1. Token Secret missing, wrong key, or RBAC cannot read Secrets.
-2. Invalid `provider` / `repository` / optional `apiUrl` (including SSRF
-   rejection of http, userinfo, loopback, link-local, private RFC1918,
-   and cloud metadata hosts). GitOps `apiUrl` is stricter than
-   Prometheus: in-cluster private addresses are not allowed.
+2. Invalid `provider` / `repository` / optional `apiUrl`. Preflight
+   rejects a non-HTTPS URL, userinfo, loopback, link-local (including
+   IMDS), or a private RFC1918/ULA host when
+   `allowPrivateEndpoints` is false. Dial-time SSRF still blocks
+   loopback, link-local, and IMDS even when
+   `allowPrivateEndpoints: true`. Set that flag only for self-hosted
+   forges on RFC1918/ULA. GitOps `apiUrl` is stricter than Prometheus:
+   in-cluster loopback and metadata addresses stay blocked.
 3. Forge API error (auth, branch protection, missing head branch before
-   bootstrap, rate limits).
+   bootstrap, rate limits). Status is the static message
+   `PR API request failed` (no API body).
+
+Match the condition **message** to the check that failed:
+
+| Message | When |
+|---------|------|
+| `apiUrl is not an allowed HTTPS host` | Preflight on `apiUrl` (reason `GitOpsEndpointBlocked`) |
+| `GitOps API URL resolved to a disallowed address` | Dial-time SSRF (reason `GitOpsEndpointBlocked`) |
+| `PR API request failed` | Forge API error after the URL was allowed (reason `PullRequestFailed`) |
 
 **Fix**:
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -83,6 +83,14 @@ If `export.pullRequest.labels` is set and the forge rejects the labels
 API, PR create and update fail instead of succeeding unlabeled. Grant
 the forge label permission or drop `labels`.
 
+### GitLab merge request matching
+
+The GitLab list call now filters by source branch, target branch
+(`baseBranch`, default `main`), and `per_page=100`. Attune updates an
+existing open MR only when that MR's target is `baseBranch`. An MR
+whose target is not `baseBranch` is not kept in sync. Attune may open
+a new MR against `baseBranch` and leave the old one open.
+
 ## v0.1.24 to v0.1.25
 
 v0.1.25 is a GitOps reliability patch. Existing policy YAML keeps working.

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -1877,7 +1877,11 @@ func TestComputeRecommendations_QueryGapsReusePriorAsStale(t *testing.T) {
 	}
 }
 
-func TestComputeRecommendations_LastDataTimeOlderThanHistoryWindowIsStale(t *testing.T) {
+// TestComputeRecommendations_LastDataTimeOlderThanFreshnessBoundIsStale
+// covers the live stale check (now.Sub(last) > 3*queryStep). A
+// historyWindow comparison cannot fire: the range is [now-window, now],
+// so last is never older than historyWindow.
+func TestComputeRecommendations_LastDataTimeOlderThanFreshnessBoundIsStale(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	policy.Spec.MetricsSource.HistoryWindow = &metav1.Duration{Duration: 2 * time.Hour}
 	policy.Spec.MetricsSource.MinimumDataPoints = int32Ptr(1)
@@ -1886,8 +1890,7 @@ func TestComputeRecommendations_LastDataTimeOlderThanHistoryWindowIsStale(t *tes
 	reconciler := newReconcilerWithClient()
 	reconciler.SetNowFunc(func() time.Time { return now })
 
-	// 30m is inside the 2h history window (old check never fired) and
-	// outside 3*queryStep (15m). The mock still ignores start/end.
+	// 30m is inside the 2h history window and outside 3*queryStep (15m).
 	old := now.Add(-30 * time.Minute)
 	mc := &mockCollector{
 		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
@@ -1898,7 +1901,7 @@ func TestComputeRecommendations_LastDataTimeOlderThanHistoryWindowIsStale(t *tes
 	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
-	assert.True(t, rec.Stale, "last sample older than 3*queryStep must mark the rec stale even when inside historyWindow")
+	assert.True(t, rec.Stale, "last sample older than 3*queryStep must mark the rec stale")
 	require.NotNil(t, rec.LastDataTime)
 	assert.True(t, rec.LastDataTime.Equal(&metav1.Time{Time: old}), "LastDataTime is the last non-empty sample, not now")
 }

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -337,7 +337,7 @@ func (c *GitHubClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer
 
 func (c *GitHubClient) doJSON(ctx context.Context, httpClient HTTPDoer, method, rawURL string, payload interface{}) ([]byte, int, error) {
 	if err := validation.GitOpsAPIURLAllowingPrivate(rawURL, c.AllowPrivate); err != nil {
-		return nil, 0, fmt.Errorf("gitops api url rejected")
+		return nil, 0, fmt.Errorf("gitops api url rejected: %w", err)
 	}
 	var rdr io.Reader
 	if payload != nil {
@@ -382,8 +382,11 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 	}
 	project := url.PathEscape(c.Project)
 
-	listURL := fmt.Sprintf("%s/projects/%s/merge_requests?state=opened&source_branch=%s",
-		base, project, url.QueryEscape(req.Head))
+	// Find existing open MR for this source branch. Filter by target_branch and
+	// request per_page=100 so we do not miss the MR when the project has many
+	// open MRs (default list page size is 20).
+	listURL := fmt.Sprintf("%s/projects/%s/merge_requests?state=opened&source_branch=%s&target_branch=%s&per_page=100",
+		base, project, url.QueryEscape(req.Head), url.QueryEscape(req.Base))
 	body, code, err := c.doJSON(ctx, httpClient, http.MethodGet, listURL, nil)
 	if err != nil {
 		return PRResult{}, err
@@ -392,14 +395,24 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		return PRResult{}, fmt.Errorf("gitlab list MRs: status %d", code)
 	}
 	var existing []struct {
-		IID    int    `json:"iid"`
-		WebURL string `json:"web_url"`
+		IID          int    `json:"iid"`
+		WebURL       string `json:"web_url"`
+		TargetBranch string `json:"target_branch"`
 	}
 	if err := json.Unmarshal(body, &existing); err != nil {
 		return PRResult{}, fmt.Errorf("gitlab list MRs decode: %w", err)
 	}
 	if len(existing) > 0 {
-		patchURL := fmt.Sprintf("%s/projects/%s/merge_requests/%d", base, project, existing[0].IID)
+		mr := existing[0]
+		// Prefer an entry whose target matches when the response still includes
+		// unrelated MRs (ignored target_branch filter).
+		for i := range existing {
+			if existing[i].TargetBranch == req.Base {
+				mr = existing[i]
+				break
+			}
+		}
+		patchURL := fmt.Sprintf("%s/projects/%s/merge_requests/%d", base, project, mr.IID)
 		payload := map[string]interface{}{
 			"title":       req.Title,
 			"description": req.Body,
@@ -412,7 +425,7 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		if code < 200 || code >= 300 {
 			return PRResult{}, fmt.Errorf("gitlab update MR: status %d", code)
 		}
-		return PRResult{URL: existing[0].WebURL, Number: existing[0].IID, Updated: true}, nil
+		return PRResult{URL: mr.WebURL, Number: mr.IID, Updated: true}, nil
 	}
 
 	if err := c.ensureHeadBranch(ctx, httpClient, base, project, req.Head, req.Base); err != nil {
@@ -506,7 +519,7 @@ func (c *GitLabClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer
 
 func (c *GitLabClient) doJSON(ctx context.Context, httpClient HTTPDoer, method, rawURL string, payload interface{}) ([]byte, int, error) {
 	if err := validation.GitOpsAPIURLAllowingPrivate(rawURL, c.AllowPrivate); err != nil {
-		return nil, 0, fmt.Errorf("gitops api url rejected")
+		return nil, 0, fmt.Errorf("gitops api url rejected: %w", err)
 	}
 	var rdr io.Reader
 	if payload != nil {
@@ -585,17 +598,9 @@ func gitopsDialContext(ctx context.Context, network, addr string, allowPrivate b
 	if reqHost := gitopsRequestHost(ctx); reqHost != "" && !gitopsSameHost(host, reqHost) {
 		return dialer.DialContext(ctx, network, addr)
 	}
-	if validation.GitOpsBlockedHost(host) {
-		return nil, fmt.Errorf("%w: host %q is a disallowed address", ErrSSRFBlocked, host)
-	}
-	ips, err := gitopsResolveHost(ctx, host)
+	ips, err := gitopsAuthorizeHost(ctx, host, allowPrivate)
 	if err != nil {
 		return nil, err
-	}
-	for _, ip := range ips {
-		if gitopsDialBlocked(ip.IP, allowPrivate) {
-			return nil, fmt.Errorf("%w: host %q resolved to a disallowed address", ErrSSRFBlocked, host)
-		}
 	}
 	return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
 }
@@ -610,19 +615,28 @@ func (t *gitopsSSRFTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	if host == "" {
 		return nil, fmt.Errorf("gitops dial: invalid address")
 	}
+	if _, err := gitopsAuthorizeHost(req.Context(), host, t.allowPrivate); err != nil {
+		return nil, err
+	}
+	return t.base.RoundTrip(req.WithContext(withGitOpsRequestHost(req.Context(), host)))
+}
+
+// gitopsAuthorizeHost resolves host and rejects metadata, loopback, and
+// (unless allowPrivate) RFC1918/ULA. Callers that pin-dial use the addresses.
+func gitopsAuthorizeHost(ctx context.Context, host string, allowPrivate bool) ([]net.IPAddr, error) {
 	if validation.GitOpsBlockedHost(host) {
 		return nil, fmt.Errorf("%w: host %q is a disallowed address", ErrSSRFBlocked, host)
 	}
-	ips, err := gitopsResolveHost(req.Context(), host)
+	ips, err := gitopsResolveHost(ctx, host)
 	if err != nil {
 		return nil, err
 	}
 	for _, ip := range ips {
-		if gitopsDialBlocked(ip.IP, t.allowPrivate) {
+		if gitopsDialBlocked(ip.IP, allowPrivate) {
 			return nil, fmt.Errorf("%w: host %q resolved to a disallowed address", ErrSSRFBlocked, host)
 		}
 	}
-	return t.base.RoundTrip(req.WithContext(withGitOpsRequestHost(req.Context(), host)))
+	return ips, nil
 }
 
 // gitopsResolveHost looks up host and fails closed on resolver errors or

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -402,16 +402,20 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 	if err := json.Unmarshal(body, &existing); err != nil {
 		return PRResult{}, fmt.Errorf("gitlab list MRs decode: %w", err)
 	}
-	if len(existing) > 0 {
-		mr := existing[0]
-		// Prefer an entry whose target matches when the response still includes
-		// unrelated MRs (ignored target_branch filter).
-		for i := range existing {
-			if existing[i].TargetBranch == req.Base {
-				mr = existing[i]
-				break
-			}
+	var mr struct {
+		IID          int    `json:"iid"`
+		WebURL       string `json:"web_url"`
+		TargetBranch string `json:"target_branch"`
+	}
+	matched := false
+	for i := range existing {
+		if existing[i].TargetBranch == req.Base {
+			mr = existing[i]
+			matched = true
+			break
 		}
+	}
+	if matched {
 		patchURL := fmt.Sprintf("%s/projects/%s/merge_requests/%d", base, project, mr.IID)
 		payload := map[string]interface{}{
 			"title":       req.Title,

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -214,17 +214,24 @@ func TestGitLabClient_Create_BootstrapsMissingHead(t *testing.T) {
 
 func TestGitLabClient_Update(t *testing.T) {
 	t.Parallel()
+	var putMethod, putPath, putBody string
 	client := &GitLabClient{
 		Token:   "gl-token",
 		Project: "g/p",
 		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			if r.Method == http.MethodGet {
-				body, _ := json.Marshal([]map[string]interface{}{
+				return jsonResp(200, []map[string]interface{}{
 					{"iid": 3, "web_url": "https://gitlab.com/g/p/-/merge_requests/3"},
-				})
-				return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(string(body))), Header: make(http.Header)}, nil
+				}), nil
 			}
-			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+			if r.Method == http.MethodPut {
+				b, _ := io.ReadAll(r.Body)
+				putMethod = r.Method
+				putPath = r.URL.Path
+				putBody = string(b)
+				return jsonResp(200, `{}`), nil
+			}
+			return jsonResp(500, `{"message":"unexpected"}`), nil
 		}),
 	}
 	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
@@ -233,6 +240,10 @@ func TestGitLabClient_Update(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, res.Updated)
 	assert.Equal(t, 3, res.Number)
+	assert.Equal(t, http.MethodPut, putMethod, "update must PUT the existing MR")
+	assert.Contains(t, putPath, "/merge_requests/3")
+	assert.Contains(t, putBody, `"title":"t"`)
+	assert.Contains(t, putBody, `"description":"b"`)
 }
 
 func TestGitHubClient_UpdateExisting(t *testing.T) {

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -221,7 +221,7 @@ func TestGitLabClient_Update(t *testing.T) {
 		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			if r.Method == http.MethodGet {
 				return jsonResp(200, []map[string]interface{}{
-					{"iid": 3, "web_url": "https://gitlab.com/g/p/-/merge_requests/3"},
+					{"iid": 3, "web_url": "https://gitlab.com/g/p/-/merge_requests/3", "target_branch": "main"},
 				}), nil
 			}
 			if r.Method == http.MethodPut {
@@ -413,6 +413,51 @@ func TestGitLabClient_ListOpenMRsPrefersTargetBranch(t *testing.T) {
 	assert.Contains(t, putPath, "/merge_requests/2")
 }
 
+func TestGitLabClient_ListOpenMRsNoMatchingTargetCreates(t *testing.T) {
+	t.Parallel()
+	var methods []string
+	client := &GitLabClient{
+		Token:   "gl-token",
+		Project: "g/p",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			methods = append(methods, r.Method+" "+r.URL.Path)
+			path := r.URL.Path
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(path, "/merge_requests"):
+				// List is non-empty, but no MR targets req.Base (main).
+				return jsonResp(200, []map[string]interface{}{
+					{
+						"iid": 1, "web_url": "https://gitlab.com/g/p/-/merge_requests/1",
+						"target_branch": "develop",
+					},
+				}), nil
+			case r.Method == http.MethodGet && strings.Contains(path, "/repository/branches/"):
+				return jsonResp(200, map[string]interface{}{
+					"name": "attune/x",
+				}), nil
+			case r.Method == http.MethodPost && strings.HasSuffix(path, "/merge_requests"):
+				return jsonResp(201, map[string]interface{}{
+					"iid": 9, "web_url": "https://gitlab.com/g/p/-/merge_requests/9",
+				}), nil
+			default:
+				return jsonResp(500, `{"message":"unexpected `+r.Method+` `+path+`"}`), nil
+			}
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+	})
+	require.NoError(t, err)
+	assert.False(t, res.Updated)
+	assert.Equal(t, 9, res.Number)
+	joined := strings.Join(methods, "\n")
+	assert.Contains(t, joined, "POST")
+	assert.NotContains(t, joined, http.MethodPut)
+	for _, m := range methods {
+		assert.NotContains(t, m, "/merge_requests/1")
+	}
+}
+
 func TestGitHubClient_EnsureHead_RaceRefExists(t *testing.T) {
 	t.Parallel()
 	var headGets int
@@ -586,7 +631,7 @@ func TestGitLabClient_Update_IncludesLabels(t *testing.T) {
 		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			if r.Method == http.MethodGet {
 				return jsonResp(200, []map[string]interface{}{
-					{"iid": 3, "web_url": "https://gitlab.com/g/p/-/merge_requests/3"},
+					{"iid": 3, "web_url": "https://gitlab.com/g/p/-/merge_requests/3", "target_branch": "main"},
 				}), nil
 			}
 			if r.Method == http.MethodPut {

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -344,6 +344,75 @@ func TestGitHubClient_ListOpenPRsUsesHeadFilter(t *testing.T) {
 	assert.Contains(t, listQuery, "base=main")
 }
 
+func TestGitLabClient_ListOpenMRsUsesTargetBranchFilter(t *testing.T) {
+	t.Parallel()
+	var listQuery string
+	client := &GitLabClient{
+		Token:   "gl-token",
+		Project: "g/p",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/merge_requests") {
+				listQuery = r.URL.RawQuery
+				return jsonResp(200, []map[string]interface{}{
+					{
+						"iid": 5, "web_url": "https://gitlab.com/g/p/-/merge_requests/5",
+						"target_branch": "main",
+					},
+				}), nil
+			}
+			if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/merge_requests/5") {
+				return jsonResp(200, map[string]interface{}{}), nil
+			}
+			return jsonResp(500, `{"message":"unexpected"}`), nil
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Updated)
+	assert.Equal(t, 5, res.Number)
+	assert.Contains(t, listQuery, "source_branch=")
+	assert.Contains(t, listQuery, "attune%2Fx")
+	assert.Contains(t, listQuery, "target_branch=main")
+	assert.Contains(t, listQuery, "per_page=100")
+}
+
+func TestGitLabClient_ListOpenMRsPrefersTargetBranch(t *testing.T) {
+	t.Parallel()
+	var putPath string
+	client := &GitLabClient{
+		Token:   "gl-token",
+		Project: "g/p",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/merge_requests") {
+				return jsonResp(200, []map[string]interface{}{
+					{
+						"iid": 1, "web_url": "https://gitlab.com/g/p/-/merge_requests/1",
+						"target_branch": "develop",
+					},
+					{
+						"iid": 2, "web_url": "https://gitlab.com/g/p/-/merge_requests/2",
+						"target_branch": "main",
+					},
+				}), nil
+			}
+			if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/merge_requests/") {
+				putPath = r.URL.Path
+				return jsonResp(200, `{}`), nil
+			}
+			return jsonResp(500, `{"message":"unexpected"}`), nil
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Updated)
+	assert.Equal(t, 2, res.Number)
+	assert.Contains(t, putPath, "/merge_requests/2")
+}
+
 func TestGitHubClient_EnsureHead_RaceRefExists(t *testing.T) {
 	t.Parallel()
 	var headGets int
@@ -601,6 +670,36 @@ type roundTripFuncTransport func(*http.Request) (*http.Response, error)
 
 func (f roundTripFuncTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+func TestGitHubClient_DoJSONWrapsAllowlistCause(t *testing.T) {
+	t.Parallel()
+	client := &GitHubClient{
+		Token:      "tok",
+		Repository: "org/repo",
+		BaseURL:    "http://ghe.example.com",
+	}
+	_, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "h", Base: "main",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gitops api url rejected")
+	assert.Contains(t, err.Error(), "scheme must be https")
+}
+
+func TestGitLabClient_DoJSONWrapsAllowlistCause(t *testing.T) {
+	t.Parallel()
+	client := &GitLabClient{
+		Token:   "gl-token",
+		Project: "g/p",
+		BaseURL: "https://169.254.169.254",
+	}
+	_, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "h", Base: "main",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gitops api url rejected")
+	assert.Contains(t, err.Error(), "169.254.169.254")
 }
 
 func TestRedactToken_Encodings(t *testing.T) {


### PR DESCRIPTION
This cycle hardens tests from #621 and fixes GitLab GitOps matching.

## Problem

- Doctor metadata-redirect test stayed green if `CheckRedirect` was removed, because the follow-up DNS error still contains `metadata`.
- GitLab listed open MRs by source branch only (default page size 20) and, when no target matched `baseBranch`, still updated the first listed MR.

## Change

- Doctor metadata test now fails if the follow-up host is dialed.
- Last-data test name matches the live `3 * queryStep` freshness bound.
- GitLab Update records the PUT.
- GitLab list uses `target_branch` and `per_page=100`. If no MR targets `baseBranch`, Attune creates a new MR instead of patching the first hit.
- `doJSON` wraps the allowlist error cause.
- GitOps, upgrade, and troubleshooting docs match the new matching rule and real condition strings.

## Validation

- `go test ./internal/gitops/... ./cmd/kubectl-attune/... ./internal/controller/... -race -count=1`
- `make verify-quick` (full unit + lint + helm)

Release PR #601 stays user-gated.
