### PR TITLE
fix: stop gitlab label wipe and empty rebase bootstrap

### DIFF
--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -91,6 +91,18 @@ existing open MR only when that MR's target is `baseBranch`. An MR
 whose target is not `baseBranch` is not kept in sync. Attune may open
 a new MR against `baseBranch` and leave the old one open.
 
+### GitLab update no longer clears labels
+
+A GitLab MR update used to send an empty `labels` field when
+`export.pullRequest.labels` was unset. GitLab treats that as "remove
+every label." Updates now omit `labels` unless the policy sets them.
+
+### GitLab re-bootstrap after merge
+
+After the first Attune MR merges, the next drift cycle writes a new
+marker commit (timestamped) so GitLab can open another MR. A reused
+empty marker file no longer blocks the next cycle.
+
 ## v0.1.24 to v0.1.25
 
 v0.1.25 is a GitOps reliability patch. Existing policy YAML keeps working.

--- a/internal/gitops/client.go
+++ b/internal/gitops/client.go
@@ -113,6 +113,14 @@ type GitLabClient struct {
 
 const bootstrapCommitMessage = "chore(attune): bootstrap recommendation branch"
 
+const gitlabMarkerPath = ".attune/RECOMMENDATION_DRIFT.md"
+
+const gitlabMarkerPreamble = "Attune recommendation drift branch.\n\nSee the merge request description for the drift table. Apply template patches via `kubectl attune diff` or your GitOps pipeline.\n"
+
+func gitlabBootstrapMarkerContent() string {
+	return gitlabMarkerPreamble + "\nbootstrapped: " + time.Now().UTC().Format(time.RFC3339Nano) + "\n"
+}
+
 func (c *GitHubClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRResult, error) {
 	if c.Token == "" || c.Repository == "" {
 		return PRResult{}, fmt.Errorf("github: token and repository required")
@@ -420,7 +428,10 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		payload := map[string]interface{}{
 			"title":       req.Title,
 			"description": req.Body,
-			"labels":      strings.Join(req.Labels, ","),
+		}
+		// GitLab treats labels="" as unassign-all. Omit when unset (GitHub no-ops).
+		if len(req.Labels) > 0 {
+			payload["labels"] = strings.Join(req.Labels, ",")
 		}
 		_, code, err := c.doJSON(ctx, httpClient, http.MethodPut, patchURL, payload)
 		if err != nil {
@@ -442,7 +453,9 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 		"description":   req.Body,
 		"source_branch": req.Head,
 		"target_branch": req.Base,
-		"labels":        strings.Join(req.Labels, ","),
+	}
+	if len(req.Labels) > 0 {
+		payload["labels"] = strings.Join(req.Labels, ",")
 	}
 	respBody, code, err := c.doJSON(ctx, httpClient, http.MethodPost, createURL, payload)
 	if err != nil {
@@ -461,27 +474,51 @@ func (c *GitLabClient) CreateOrUpdate(ctx context.Context, req PRRequest) (PRRes
 	return PRResult{URL: created.WebURL, Number: created.IID, Updated: false}, nil
 }
 
-// ensureHeadBranch creates the source branch from base with a bootstrap commit
-// when missing. GitLab rejects MRs with no commit delta, so we add a small
-// marker file under .attune/ rather than an empty commit.
+// ensureHeadBranch ensures head has a commit that is not on base.
+// GitLab rejects MRs with no commit delta, so a marker file under .attune/
+// is created or updated. Content includes a unique timestamp so a second
+// bootstrap after merge is not an empty update. If head already exists
+// (GET 200; typical after merge without delete-source-branch), the marker
+// is updated in place. Callers must not invoke this on the existing-open-MR
+// path (that path must not rewrite the branch).
 func (c *GitLabClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer, apiBase, projectEscaped, head, baseBranch string) error {
 	branchURL := fmt.Sprintf("%s/projects/%s/repository/branches/%s", apiBase, projectEscaped, url.PathEscape(head))
 	_, code, err := c.doJSON(ctx, httpClient, http.MethodGet, branchURL, nil)
 	if err != nil {
 		return fmt.Errorf("gitlab check head branch: %w", err)
 	}
-	if code >= 200 && code < 300 {
-		return nil
-	}
-	if code != http.StatusNotFound {
+	if code != http.StatusNotFound && (code < 200 || code >= 300) {
 		return fmt.Errorf("gitlab check head branch: status %d", code)
 	}
 
-	// Create branch + bootstrap file commit in one request (start_branch).
-	// Prefer "create"; if the marker already exists on base (prior merge),
-	// retry with "update" so re-bootstrap still produces a non-empty delta.
 	commitURL := fmt.Sprintf("%s/projects/%s/repository/commits", apiBase, projectEscaped)
-	markerContent := "Attune recommendation drift branch.\n\nSee the merge request description for the drift table. Apply template patches via `kubectl attune diff` or your GitOps pipeline.\n"
+	markerContent := gitlabBootstrapMarkerContent()
+
+	if code >= 200 && code < 300 {
+		// Head exists. Update the marker so a new MR has a non-empty delta.
+		payload := map[string]interface{}{
+			"branch":         head,
+			"commit_message": bootstrapCommitMessage,
+			"actions": []map[string]string{
+				{
+					"action":    "update",
+					"file_path": gitlabMarkerPath,
+					"content":   markerContent,
+				},
+			},
+		}
+		_, code, err := c.doJSON(ctx, httpClient, http.MethodPost, commitURL, payload)
+		if err != nil {
+			return fmt.Errorf("gitlab update head marker: %w", err)
+		}
+		if code < 200 || code >= 300 {
+			return fmt.Errorf("gitlab update head marker: status %d", code)
+		}
+		return nil
+	}
+
+	// Branch missing: create from base. Prefer "create"; if the marker already
+	// exists on base (prior merge), retry with "update".
 	for _, action := range []string{"create", "update"} {
 		payload := map[string]interface{}{
 			"branch":         head,
@@ -490,7 +527,7 @@ func (c *GitLabClient) ensureHeadBranch(ctx context.Context, httpClient HTTPDoer
 			"actions": []map[string]string{
 				{
 					"action":    action,
-					"file_path": ".attune/RECOMMENDATION_DRIFT.md",
+					"file_path": gitlabMarkerPath,
 					"content":   markerContent,
 				},
 			},

--- a/internal/gitops/client_test.go
+++ b/internal/gitops/client_test.go
@@ -436,6 +436,8 @@ func TestGitLabClient_ListOpenMRsNoMatchingTargetCreates(t *testing.T) {
 				return jsonResp(200, map[string]interface{}{
 					"name": "attune/x",
 				}), nil
+			case r.Method == http.MethodPost && strings.Contains(path, "/repository/commits"):
+				return jsonResp(201, map[string]string{"id": "c1"}), nil
 			case r.Method == http.MethodPost && strings.HasSuffix(path, "/merge_requests"):
 				b, _ := io.ReadAll(r.Body)
 				createBody = string(b)
@@ -507,6 +509,8 @@ func TestGitLabClient_MissingConfigAndCreateErrors(t *testing.T) {
 						return jsonResp(200, "[]"), nil
 					case r.Method == http.MethodGet && strings.Contains(path, "/repository/branches/"):
 						return jsonResp(200, map[string]interface{}{"name": "attune/x"}), nil
+					case r.Method == http.MethodPost && strings.Contains(path, "/repository/commits"):
+						return jsonResp(201, map[string]string{"id": "c1"}), nil
 					case r.Method == http.MethodPost && strings.HasSuffix(path, "/merge_requests"):
 						return jsonResp(tc.createCode, tc.createBody), nil
 					default:
@@ -543,6 +547,8 @@ func TestGitOpsClients_EscapeWeirdBranchNames(t *testing.T) {
 				case r.Method == http.MethodGet && strings.Contains(path, "/repository/branches/"):
 					branchEscapedPath = r.URL.EscapedPath()
 					return jsonResp(200, map[string]interface{}{"name": head}), nil
+				case r.Method == http.MethodPost && strings.Contains(path, "/repository/commits"):
+					return jsonResp(201, map[string]string{"id": "c1"}), nil
 				case r.Method == http.MethodPost && strings.HasSuffix(path, "/merge_requests"):
 					return jsonResp(201, map[string]interface{}{
 						"iid": 4, "web_url": "https://gitlab.com/g/p/-/merge_requests/4",
@@ -788,6 +794,90 @@ func TestGitLabClient_Update_IncludesLabels(t *testing.T) {
 	assert.Contains(t, putBody, `"labels"`)
 	assert.Contains(t, putBody, "attune")
 	assert.Contains(t, putBody, "rightsizing")
+}
+
+func TestGitLabClient_Update_OmitsEmptyLabels(t *testing.T) {
+	t.Parallel()
+	var putBody string
+	client := &GitLabClient{
+		Token:   "gl-token",
+		Project: "g/p",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Method == http.MethodGet {
+				return jsonResp(200, []map[string]interface{}{
+					{"iid": 3, "web_url": "https://gitlab.com/g/p/-/merge_requests/3", "target_branch": "main"},
+				}), nil
+			}
+			if r.Method == http.MethodPut {
+				b, _ := io.ReadAll(r.Body)
+				putBody = string(b)
+				return jsonResp(200, `{}`), nil
+			}
+			return jsonResp(500, `{"message":"unexpected"}`), nil
+		}),
+	}
+	res, err := client.CreateOrUpdate(context.Background(), PRRequest{
+		Title: "t", Body: "b", Head: "attune/x", Base: "main",
+		// Labels nil: GitLab treats "labels":"" as unassign-all.
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Updated)
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(putBody), &payload))
+	_, hasLabels := payload["labels"]
+	assert.False(t, hasLabels, `PUT must omit "labels" when none are configured; empty string wipes MR labels`)
+	assert.NotContains(t, putBody, `"labels"`)
+}
+
+func TestGitLabClient_EnsureHead_SecondBootstrapUpdatesDistinctContent(t *testing.T) {
+	t.Parallel()
+	var commitBodies []string
+	branchExists := false
+	client := &GitLabClient{
+		Token:   "gl-token",
+		Project: "g/p",
+		HTTP: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			path := r.URL.Path
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(path, "/repository/branches/"):
+				if branchExists {
+					return jsonResp(200, map[string]interface{}{"name": "attune/x"}), nil
+				}
+				return jsonResp(404, `{"message":"404 Branch Not Found"}`), nil
+			case r.Method == http.MethodPost && strings.Contains(path, "/repository/commits"):
+				b, _ := io.ReadAll(r.Body)
+				commitBodies = append(commitBodies, string(b))
+				branchExists = true
+				return jsonResp(201, map[string]string{"id": "c1"}), nil
+			default:
+				return jsonResp(500, `{"message":"unexpected `+r.Method+` `+path+`"}`), nil
+			}
+		}),
+	}
+	ctx := context.Background()
+	base := "https://gitlab.com/api/v4"
+	project := url.PathEscape("g/p")
+	require.NoError(t, client.ensureHeadBranch(ctx, client.HTTP, base, project, "attune/x", "main"))
+	require.NoError(t, client.ensureHeadBranch(ctx, client.HTTP, base, project, "attune/x", "main"))
+	require.Len(t, commitBodies, 2, "second ensureHead must POST a marker update when the head branch already exists")
+
+	type commitPayload struct {
+		StartBranch string `json:"start_branch"`
+		Actions     []struct {
+			Action  string `json:"action"`
+			Content string `json:"content"`
+		} `json:"actions"`
+	}
+	var first, second commitPayload
+	require.NoError(t, json.Unmarshal([]byte(commitBodies[0]), &first))
+	require.NoError(t, json.Unmarshal([]byte(commitBodies[1]), &second))
+	require.NotEmpty(t, first.Actions)
+	require.NotEmpty(t, second.Actions)
+	assert.Equal(t, "create", first.Actions[0].Action)
+	assert.Equal(t, "update", second.Actions[0].Action)
+	assert.NotEqual(t, first.Actions[0].Content, second.Actions[0].Content,
+		"second bootstrap must change marker content so GitLab accepts a new commit")
+	assert.Empty(t, second.StartBranch, "existing head must be updated in place, not rewritten from start_branch")
 }
 
 func TestGitHubClient_CreatePRErrorOmitsResponseBody(t *testing.T) {


### PR DESCRIPTION
GitLab GitOps updates were wiping labels and could not open a second MR after merge.

## Problem

- MR update always sent `labels: ""`. GitLab treats that as remove every label. Policies that do not set pullRequest.labels stripped human and project labels on every refresh.
- ensureHeadBranch reused the same marker file bytes after merge, so GitLab rejected an empty commit and the next drift cycle failed.

## Change

- Omit `labels` on GitLab update unless the policy sets them.
- Marker content includes a timestamp so a later bootstrap produces a real commit.
- Upgrade notes for both behaviors.

## Validation

- go test ./internal/gitops/... -race -count=1

Release PR #601 stays user-gated.
