### PR TITLE
fix: do not apply template requests on one-sided sample gaps

### DIFF
--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -48,6 +48,14 @@ same window. After it expires, the rec drops and Ready can become
 `InsufficientData`. Stale recs no longer count toward
 `workloads.withRecommendations` or savings gauges.
 
+### One-sided Prometheus sample gap
+
+If Prometheus has fresh samples for only one resource (CPU or memory)
+and the other series is empty or all NaN, Attune no longer recommends
+the pod-template request for the missing arm. After an in-place resize
+the template can be stale (256Mi while the live pod is already 1Gi).
+The missing arm now holds the live request or the last rec instead.
+
 ### CloudWatch pod prefix
 
 CloudWatch `SEARCH` no longer emits `PodName="prefix*"`. Quoted CloudWatch

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -2219,6 +2219,94 @@ func TestComputeRecommendations_CPUAllNaNMemoryValid(t *testing.T) {
 		"Memory recommendation should change when memory samples are valid")
 }
 
+// TestComputeRecommendations_OneSidedMemoryGapDoesNotRecommendTemplate is
+// the live-red contract: CPU series can be fresh while memory is empty or
+// all NaN. The missing-memory arm must not emit the pod-template request
+// (256Mi) as a fresh apply target after a live increase to 1Gi.
+func TestComputeRecommendations_OneSidedMemoryGapDoesNotRecommendTemplate(t *testing.T) {
+	templateMem := resource.MustParse("256Mi")
+	liveMem := resource.MustParse("1Gi")
+
+	nanSamples := make([]rsmetrics.Sample, 50)
+	now := time.Now()
+	for i := range nanSamples {
+		nanSamples[i] = rsmetrics.Sample{
+			Timestamp: now.Add(-time.Duration(50-i) * time.Hour),
+			Value:     math.NaN(),
+		}
+	}
+
+	tests := []struct {
+		name          string
+		memorySamples map[string][]rsmetrics.Sample
+		useLivePod    bool
+		usePriorRec   bool
+	}{
+		{name: "empty memory samples, live 1Gi", useLivePod: true},
+		{name: "NaN memory samples, live 1Gi", memorySamples: map[string][]rsmetrics.Sample{"main": nanSamples}, useLivePod: true},
+		{name: "empty memory samples, last rec 1Gi", usePriorRec: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := newTestPolicy("test-policy", "default")
+			deploy := newTestDeployment("api-server", "default", nil)
+			deploy.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = templateMem.DeepCopy()
+
+			if tt.usePriorRec {
+				priorData := metav1.NewTime(now.Add(-time.Minute))
+				policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+					Workload:     "api-server",
+					Kind:         "Deployment",
+					LastDataTime: &priorData,
+					Stale:        false,
+					Containers: []attunev1alpha1.ContainerRecommendation{{
+						Name: "main",
+						Recommended: attunev1alpha1.ResourceValues{
+							CPURequest:    resource.MustParse("500m"),
+							MemoryRequest: liveMem.DeepCopy(),
+						},
+					}},
+				}}
+			}
+
+			var pods []corev1.Pod
+			if tt.useLivePod {
+				pods = []corev1.Pod{*newResizePod("api-server", "500m", "1Gi", "1000m", "1Gi")}
+			}
+
+			reconciler := newReconcilerWithClient()
+			mc := &mockCollector{
+				queryRangeGroupedFunc: func(_ context.Context, query string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
+					if strings.Contains(query, "memory_working_set_bytes") {
+						if tt.memorySamples != nil {
+							return tt.memorySamples, nil
+						}
+						return map[string][]rsmetrics.Sample{}, nil
+					}
+					return map[string][]rsmetrics.Sample{"main": generateSamples(200, 0.1)}, nil
+				},
+			}
+
+			rec, _, _, _, _, err := reconciler.computeRecommendations(
+				context.Background(), policy, deploy, mc, nil, nil, nil, nil, pods)
+			require.NoError(t, err)
+			require.NotNil(t, rec, "CPU-only data must still produce a recommendation")
+			require.Len(t, rec.Containers, 1)
+
+			got := rec.Containers[0].Recommended.MemoryRequest
+			if rec.Stale {
+				return
+			}
+			assert.False(t, got.Equal(templateMem),
+				"fresh rec must not recommend template memory %s when memory samples are missing (got %s)",
+				templateMem.String(), got.String())
+			assert.True(t, got.Equal(liveMem),
+				"fresh rec must keep live/last memory %s, got %s", liveMem.String(), got.String())
+		})
+	}
+}
+
 func TestComputeRecommendations_QueryError(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	deploy := newTestDeployment("api-server", "default", nil)
@@ -5227,6 +5315,9 @@ func TestReconcile_PrometheusUnavailable(t *testing.T) {
 func TestReconcile_PrometheusQueryErrorsMentionBlockedDataTypes(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	// Live pod lets the missing-memory arm hold current requests so the
+	// CPU-only rec stays fresh (template is not a hybrid apply target).
+	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
 
 	reconciler, fakeClient := newReconcilerForReconcile(&mockCollector{
 		queryRangeGroupedFunc: func(_ context.Context, query string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
@@ -5235,7 +5326,7 @@ func TestReconcile_PrometheusQueryErrorsMentionBlockedDataTypes(t *testing.T) {
 			}
 			return map[string][]rsmetrics.Sample{"main": generateSamples(200, 0.1)}, nil
 		},
-	}, policy, deploy)
+	}, policy, deploy, pod)
 
 	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -288,6 +288,10 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 
 	var containerRecs []attunev1alpha1.ContainerRecommendation
 	eligibleContainers := 0
+	// True when a container had data for only one resource and neither live
+	// pods nor a prior rec could hold the missing arm (template must not
+	// become a fresh apply target).
+	partialUnfilled := false
 
 	for _, container := range containers {
 		containerName := container.Name
@@ -367,6 +371,7 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 		explanation := &attunev1alpha1.ContainerRecommendationExplanation{}
 
 		// Compute CPU recommendation.
+		cpuApplied := false
 		if cpuProfile.DataPoints >= int(minimumDataPoints) {
 			cpuRec, cpuExplain, _ := cpuEngine.RecommendWithExplanation(cpuProfile, rec.Current.CPURequest)
 			// CPU AllowDecrease defaults to true (nil || *ptr) because CPU
@@ -375,11 +380,13 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 			cpuRec = r.enforceAllowDecrease(cpuAllowDecrease, cpuRec, rec.Current.CPURequest, &cpuExplain, policy, containerName, "CPU")
 			rec.Recommended.CPURequest = cpuRec
 			explanation.CPU = toAPIRecommendationExplanation(cpuExplain)
+			cpuApplied = true
 		}
 
 		// Compute memory recommendation.
 		// When memoryFromCpuRatio is set, derive memory from the CPU
 		// recommendation instead of using Prometheus memory metrics.
+		memApplied := false
 		if policy.Spec.Memory.MemoryFromCPURatio != nil && *policy.Spec.Memory.MemoryFromCPURatio != "" && explanation.CPU != nil {
 			ratio := parseFloat64Ratio(*policy.Spec.Memory.MemoryFromCPURatio)
 			allowDecrease := policy.Spec.Memory.AllowDecrease != nil && *policy.Spec.Memory.AllowDecrease
@@ -390,6 +397,7 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 				memExplain.FinalAdjustment = appendNote(memExplain.FinalAdjustment,
 					fmt.Sprintf("derived from CPU via memoryFromCpuRatio=%s", *policy.Spec.Memory.MemoryFromCPURatio))
 				explanation.Memory = toAPIRecommendationExplanation(memExplain)
+				memApplied = true
 			}
 		} else if memProfile.DataPoints >= int(minimumDataPoints) {
 			memRec, memExplain, _ := memEngine.RecommendWithExplanation(memProfile, rec.Current.MemoryRequest)
@@ -399,6 +407,20 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 			memRec = r.enforceAllowDecrease(memAllowDecrease, memRec, rec.Current.MemoryRequest, &memExplain, policy, containerName, "memory")
 			rec.Recommended.MemoryRequest = memRec
 			explanation.Memory = toAPIRecommendationExplanation(memExplain)
+			memApplied = true
+		}
+
+		// One-sided Prometheus gap: keep live (or last rec) on the missing
+		// arm. Template Current must not become a fresh apply target after
+		// an in-place increase (1Gi live, 256Mi template).
+		if !cpuApplied || !memApplied {
+			prior := priorContainerRecommendation(policy, workloadKindName(workload), workload.GetName(), containerName)
+			if !cpuApplied && !holdMissingResourceRequest(&rec, corev1.ResourceCPU, pods, prior) {
+				partialUnfilled = true
+			}
+			if !memApplied && !holdMissingResourceRequest(&rec, corev1.ResourceMemory, pods, prior) {
+				partialUnfilled = true
+			}
 		}
 		if explanation.CPU != nil || explanation.Memory != nil {
 			rec.Explanation = explanation
@@ -488,12 +510,13 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 	}
 	lastDataTime := metav1.NewTime(last)
 	freshness := recommendationFreshnessBound(queryStep)
-	stale := now.Sub(last) > freshness
+	stale := now.Sub(last) > freshness || partialUnfilled
 	if stale {
 		logger.Info("Recommendation is stale; last Prometheus data is older than freshness bound",
 			"workload", workload.GetName(),
 			"lastDataTime", lastDataTime,
-			"freshnessBound", freshness)
+			"freshnessBound", freshness,
+			"partialUnfilled", partialUnfilled)
 	}
 	return &attunev1alpha1.WorkloadRecommendation{
 		Containers:   containerRecs,
@@ -525,6 +548,113 @@ func reuseStaleRecommendation(policy *attunev1alpha1.AttunePolicy, kind, workloa
 		rec := prior.DeepCopy()
 		rec.Stale = true
 		return rec
+	}
+	return nil
+}
+
+// holdMissingResourceRequest copies live (max request across pods) or last
+// successful Recommended into Current and Recommended for a resource that
+// had no usable series. Returns false when no hold value exists.
+func holdMissingResourceRequest(
+	rec *attunev1alpha1.ContainerRecommendation,
+	res corev1.ResourceName,
+	pods []corev1.Pod,
+	prior *attunev1alpha1.ContainerRecommendation,
+) bool {
+	if rec == nil {
+		return false
+	}
+	req, lim, ok := liveResourceHold(pods, rec.Name, res)
+	if !ok {
+		req, lim, ok = priorResourceHold(prior, res)
+	}
+	if !ok {
+		return false
+	}
+	switch res {
+	case corev1.ResourceCPU:
+		rec.Current.CPURequest = req.DeepCopy()
+		rec.Recommended.CPURequest = req.DeepCopy()
+		if !lim.IsZero() {
+			rec.Current.CPULimit = lim.DeepCopy()
+			rec.Recommended.CPULimit = lim.DeepCopy()
+		}
+	case corev1.ResourceMemory:
+		rec.Current.MemoryRequest = req.DeepCopy()
+		rec.Recommended.MemoryRequest = req.DeepCopy()
+		if !lim.IsZero() {
+			rec.Current.MemoryLimit = lim.DeepCopy()
+			rec.Recommended.MemoryLimit = lim.DeepCopy()
+		}
+	default:
+		return false
+	}
+	return true
+}
+
+func liveResourceHold(pods []corev1.Pod, container string, res corev1.ResourceName) (req, lim k8sresource.Quantity, ok bool) {
+	for i := range pods {
+		c := findContainerByName(&pods[i], container)
+		if c == nil {
+			continue
+		}
+		q, has := c.Resources.Requests[res]
+		if !has || q.IsZero() {
+			continue
+		}
+		if !ok || q.Cmp(req) > 0 {
+			req = q.DeepCopy()
+			if l, hasLim := c.Resources.Limits[res]; hasLim && !l.IsZero() {
+				lim = l.DeepCopy()
+			} else {
+				lim = k8sresource.Quantity{}
+			}
+			ok = true
+		}
+	}
+	return req, lim, ok
+}
+
+func priorResourceHold(prior *attunev1alpha1.ContainerRecommendation, res corev1.ResourceName) (req, lim k8sresource.Quantity, ok bool) {
+	if prior == nil {
+		return req, lim, false
+	}
+	switch res {
+	case corev1.ResourceCPU:
+		req = prior.Recommended.CPURequest
+		lim = prior.Recommended.CPULimit
+		if req.IsZero() {
+			req = prior.Current.CPURequest
+			lim = prior.Current.CPULimit
+		}
+	case corev1.ResourceMemory:
+		req = prior.Recommended.MemoryRequest
+		lim = prior.Recommended.MemoryLimit
+		if req.IsZero() {
+			req = prior.Current.MemoryRequest
+			lim = prior.Current.MemoryLimit
+		}
+	}
+	return req, lim, !req.IsZero()
+}
+
+func priorContainerRecommendation(policy *attunev1alpha1.AttunePolicy, kind, workload, container string) *attunev1alpha1.ContainerRecommendation {
+	if policy == nil || workload == "" || container == "" {
+		return nil
+	}
+	for i := range policy.Status.Recommendations {
+		prior := &policy.Status.Recommendations[i]
+		if prior.Workload != workload {
+			continue
+		}
+		if kind != "" && prior.Kind != kind {
+			continue
+		}
+		for j := range prior.Containers {
+			if prior.Containers[j].Name == container {
+				return &prior.Containers[j]
+			}
+		}
 	}
 	return nil
 }

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -633,8 +633,10 @@ func (r *AttunePolicyReconciler) resizeContainer(
 			break
 		}
 	}
+	current := liveContainerCurrent(pod, containerRec)
+
 	if anySuccess {
-		if curLim := containerRec.Current.MemoryLimit; !curLim.IsZero() {
+		if curLim := current.MemoryLimit; !curLim.IsZero() {
 			if newLim, ok := target.Limits[corev1.ResourceMemory]; ok && newLim.Cmp(curLim) < 0 {
 				operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
 					policy.Namespace, policy.Name, "applied").Inc()
@@ -642,21 +644,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 		}
 	}
 
-	originalResources := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    containerRec.Current.CPURequest.DeepCopy(),
-			corev1.ResourceMemory: containerRec.Current.MemoryRequest.DeepCopy(),
-		},
-	}
-	if !containerRec.Current.CPULimit.IsZero() || !containerRec.Current.MemoryLimit.IsZero() {
-		originalResources.Limits = make(corev1.ResourceList)
-		if !containerRec.Current.CPULimit.IsZero() {
-			originalResources.Limits[corev1.ResourceCPU] = containerRec.Current.CPULimit.DeepCopy()
-		}
-		if !containerRec.Current.MemoryLimit.IsZero() {
-			originalResources.Limits[corev1.ResourceMemory] = containerRec.Current.MemoryLimit.DeepCopy()
-		}
-	}
+	originalResources := resourceRequirementsFromValues(current)
 
 	var restartCount int32
 	if cs := findContainerStatusByName(pod, containerRec.Name); cs != nil {
@@ -776,13 +764,16 @@ func (r *AttunePolicyReconciler) persistResizeAnnotations(
 		freshPod.Labels[labelTracked] = "true"
 		freshPod.Annotations[annotationPolicy] = policyName
 		appendResizedContainer(freshPod, containerRec.Name)
-		freshPod.Annotations[annotationOriginalCPUPrefix+containerRec.Name] = containerRec.Current.CPURequest.String()
-		freshPod.Annotations[annotationOriginalMemoryPrefix+containerRec.Name] = containerRec.Current.MemoryRequest.String()
-		if !containerRec.Current.CPULimit.IsZero() {
-			freshPod.Annotations[annotationOriginalCPULimitPrefix+containerRec.Name] = containerRec.Current.CPULimit.String()
+		// Snapshot the pre-resize live container. rec.Current is the
+		// pod-template value and is stale after an earlier in-place resize.
+		current := liveContainerCurrent(pod, containerRec)
+		freshPod.Annotations[annotationOriginalCPUPrefix+containerRec.Name] = current.CPURequest.String()
+		freshPod.Annotations[annotationOriginalMemoryPrefix+containerRec.Name] = current.MemoryRequest.String()
+		if !current.CPULimit.IsZero() {
+			freshPod.Annotations[annotationOriginalCPULimitPrefix+containerRec.Name] = current.CPULimit.String()
 		}
-		if !containerRec.Current.MemoryLimit.IsZero() {
-			freshPod.Annotations[annotationOriginalMemoryLimitPrefix+containerRec.Name] = containerRec.Current.MemoryLimit.String()
+		if !current.MemoryLimit.IsZero() {
+			freshPod.Annotations[annotationOriginalMemoryLimitPrefix+containerRec.Name] = current.MemoryLimit.String()
 		}
 		freshPod.Annotations[annotationOriginalRestartCountPrefix+containerRec.Name] = strconv.FormatInt(int64(restartCount), 10)
 
@@ -918,6 +909,57 @@ func resizedContainersContains(list, container string) bool {
 		}
 	}
 	return false
+}
+
+// liveContainerCurrent returns the live container's requests/limits when
+// the named container exists on the pod. rec.Current is the workload
+// template and is stale after an in-place resize. Undo annotations and
+// quota deltas must use live values. Falls back to rec.Current when the
+// pod is nil or the container is missing.
+func liveContainerCurrent(pod *corev1.Pod, rec attunev1alpha1.ContainerRecommendation) attunev1alpha1.ResourceValues {
+	if pod == nil {
+		return rec.Current
+	}
+	c := findContainerByName(pod, rec.Name)
+	if c == nil {
+		return rec.Current
+	}
+	cur := attunev1alpha1.ResourceValues{}
+	if req, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
+		cur.CPURequest = req.DeepCopy()
+	}
+	if req, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+		cur.MemoryRequest = req.DeepCopy()
+	}
+	if lim, ok := c.Resources.Limits[corev1.ResourceCPU]; ok {
+		cur.CPULimit = lim.DeepCopy()
+	}
+	if lim, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
+		cur.MemoryLimit = lim.DeepCopy()
+	}
+	return cur
+}
+
+// resourceRequirementsFromValues copies request/limit quantities into a
+// ResourceRequirements. Zero limits are omitted so pods without limits
+// stay limit-free.
+func resourceRequirementsFromValues(v attunev1alpha1.ResourceValues) corev1.ResourceRequirements {
+	req := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    v.CPURequest.DeepCopy(),
+			corev1.ResourceMemory: v.MemoryRequest.DeepCopy(),
+		},
+	}
+	if !v.CPULimit.IsZero() || !v.MemoryLimit.IsZero() {
+		req.Limits = corev1.ResourceList{}
+		if !v.CPULimit.IsZero() {
+			req.Limits[corev1.ResourceCPU] = v.CPULimit.DeepCopy()
+		}
+		if !v.MemoryLimit.IsZero() {
+			req.Limits[corev1.ResourceMemory] = v.MemoryLimit.DeepCopy()
+		}
+	}
+	return req
 }
 
 // buildResizeTarget constructs the target ResourceRequirements from a container recommendation.
@@ -1340,22 +1382,9 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 		}
 	}
 
-	// Quota/LimitRange violation.
-	currentRes := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    containerRec.Current.CPURequest.DeepCopy(),
-			corev1.ResourceMemory: containerRec.Current.MemoryRequest.DeepCopy(),
-		},
-	}
-	if !containerRec.Current.CPULimit.IsZero() || !containerRec.Current.MemoryLimit.IsZero() {
-		currentRes.Limits = corev1.ResourceList{}
-		if !containerRec.Current.CPULimit.IsZero() {
-			currentRes.Limits[corev1.ResourceCPU] = containerRec.Current.CPULimit.DeepCopy()
-		}
-		if !containerRec.Current.MemoryLimit.IsZero() {
-			currentRes.Limits[corev1.ResourceMemory] = containerRec.Current.MemoryLimit.DeepCopy()
-		}
-	}
+	// Quota/LimitRange violation. Headroom is target minus live requests;
+	// the template (rec.Current) is stale after an in-place resize.
+	currentRes := resourceRequirementsFromValues(liveContainerCurrent(pod, containerRec))
 	if checks != nil {
 		if targetIncreasesRequests(pod, containerRec.Name, target) &&
 			(checks.quotaListErr != nil || checks.limitRangeListErr != nil) {

--- a/internal/controller/resize_live_current_test.go
+++ b/internal/controller/resize_live_current_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+)
+
+// After an in-place resize the pod template (rec.Current) can stay at
+// 256Mi while the live container is 1Gi. Undo annotations and quota
+// headroom must snapshot the live container, not the template.
+
+func TestExecuteResizes_OriginalAnnotationUsesLiveNotTemplate(t *testing.T) {
+	// Live memory is already 1Gi; recommendation Current still has the
+	// template 256Mi. CPU changes so persist runs. Original memory must
+	// be 1Gi so a later revert does not roll back to the template.
+	pod := newResizePodWithStatus("api-server", "500m", "1Gi", "1000m", "2Gi", 0)
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	reconciler, fakeClient := newResizeReconciler(pod, deploy)
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeOneShot
+
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("api-server",
+			"500m", "256Mi", "1000m", "512Mi",
+			"750m", "1Gi", "1500m", "2Gi"),
+	}
+
+	count, history := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy}, recommendations, podMap("api-server", pod), nil, nil)
+	require.Equal(t, 1, count, "CPU change must apply so original annotations persist")
+	require.NotEmpty(t, history)
+
+	var updated corev1.Pod
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: pod.Name, Namespace: "default",
+	}, &updated))
+
+	assert.Equal(t, "1Gi", updated.Annotations[annotationOriginalMemoryPrefix+"main"],
+		"original memory must be the live request, not the 256Mi template")
+	assert.Equal(t, "2Gi", updated.Annotations[annotationOriginalMemoryLimitPrefix+"main"],
+		"original memory limit must be the live limit, not the template")
+	assert.Equal(t, "500m", updated.Annotations[annotationOriginalCPUPrefix+"main"])
+}
+
+func TestShouldSkipResize_QuotaBaselineUsesLiveNotTemplate(t *testing.T) {
+	// Live 1Gi, template Current 256Mi, target 512Mi. Quota has 100Mi
+	// headroom. Template delta looks like +256Mi and would skip; live
+	// delta is a decrease and must pass.
+	quota := corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "compute", Namespace: "default"},
+		Status: corev1.ResourceQuotaStatus{
+			Hard: corev1.ResourceList{
+				corev1.ResourceRequestsMemory: resource.MustParse("2Gi"),
+			},
+			Used: corev1.ResourceList{
+				corev1.ResourceRequestsMemory: resource.MustParse("1948Mi"),
+			},
+		},
+	}
+	r := NewAttunePolicyReconciler()
+	policy := &attunev1alpha1.AttunePolicy{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "app",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			}},
+		},
+	}
+	containerRec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("200m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+		},
+	}
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	checks := &resizePreChecks{quotas: []corev1.ResourceQuota{quota}}
+
+	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, checks)
+	assert.False(t, skip, "decrease from live 1Gi to 512Mi must not use template 256Mi as quota baseline, reason=%q", reason)
+	assert.Empty(t, reason)
+}
+
+func TestLiveContainerCurrent_PrefersLiveOverTemplate(t *testing.T) {
+	pod := newResizePod("api-server", "500m", "1Gi", "1000m", "2Gi")
+	rec := attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("500m"),
+			CPULimit:      resource.MustParse("1000m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+			MemoryLimit:   resource.MustParse("512Mi"),
+		},
+	}
+
+	got := liveContainerCurrent(pod, rec)
+	assert.True(t, got.MemoryRequest.Equal(resource.MustParse("1Gi")),
+		"live memory request must win over template Current, got %s", got.MemoryRequest.String())
+	assert.True(t, got.MemoryLimit.Equal(resource.MustParse("2Gi")),
+		"live memory limit must win over template Current, got %s", got.MemoryLimit.String())
+
+	missing := rec
+	missing.Name = "not-a-container"
+	fallback := liveContainerCurrent(pod, missing)
+	assert.True(t, fallback.MemoryRequest.Equal(resource.MustParse("256Mi")),
+		"missing container must fall back to rec.Current")
+	assert.Equal(t, rec.Current, liveContainerCurrent(nil, rec),
+		"nil pod must fall back to rec.Current")
+}


### PR DESCRIPTION
A one-sided Prometheus gap could recommend the pod-template request and shrink a live container.

## Problem

If CPU samples were fresh and memory was empty or NaN, Attune still built a rec from the Deployment template. LastDataTime came from the CPU series, so the rec was not stale. After a live memory increase (for example 256Mi template, 1Gi live), the next cycle could apply 256Mi and OOM. Quota headroom and safety undo annotations used the same template Current, so a later revert could also restore the template instead of the pre-resize live spec.

## Change

- Hold the missing resource at live max request (or last successful rec). If neither hold exists, mark the rec stale so executeResizes will not apply a template hybrid.
- Snapshot live container requests for quota delta and safety undo annotations.
- Upgrade notes.

## Validation

- go test ./internal/controller/... -race -count=1 (953 passed)
- make verify-quick (2246 tests, 93.0% coverage)

Release PR #601 stays user-gated.
