### PR TITLE
fix: prefer last rec over template-live and drop leftover limits on hold

### DIFF
--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -2221,8 +2221,9 @@ func TestComputeRecommendations_CPUAllNaNMemoryValid(t *testing.T) {
 
 // TestComputeRecommendations_OneSidedMemoryGapDoesNotRecommendTemplate is
 // the live-red contract: CPU series can be fresh while memory is empty or
-// all NaN. The missing-memory arm must not emit the pod-template request
-// (256Mi) as a fresh apply target after a live increase to 1Gi.
+// all NaN. The missing-memory arm must stay fresh and keep live/last
+// (1Gi), not the pod-template request (256Mi). A Stale early-return would
+// still pass if the hold were deleted.
 func TestComputeRecommendations_OneSidedMemoryGapDoesNotRecommendTemplate(t *testing.T) {
 	templateMem := resource.MustParse("256Mi")
 	liveMem := resource.MustParse("1Gi")
@@ -2241,10 +2242,13 @@ func TestComputeRecommendations_OneSidedMemoryGapDoesNotRecommendTemplate(t *tes
 		memorySamples map[string][]rsmetrics.Sample
 		useLivePod    bool
 		usePriorRec   bool
+		liveRequest   string
 	}{
 		{name: "empty memory samples, live 1Gi", useLivePod: true},
 		{name: "NaN memory samples, live 1Gi", memorySamples: map[string][]rsmetrics.Sample{"main": nanSamples}, useLivePod: true},
 		{name: "empty memory samples, last rec 1Gi", usePriorRec: true},
+		// Finding 2: pods still at the template must not overwrite last rec.
+		{name: "empty memory samples, live at template, last rec 1Gi", useLivePod: true, usePriorRec: true, liveRequest: "256Mi"},
 	}
 
 	for _, tt := range tests {
@@ -2272,7 +2276,11 @@ func TestComputeRecommendations_OneSidedMemoryGapDoesNotRecommendTemplate(t *tes
 
 			var pods []corev1.Pod
 			if tt.useLivePod {
-				pods = []corev1.Pod{*newResizePod("api-server", "500m", "1Gi", "1000m", "1Gi")}
+				liveReq := "1Gi"
+				if tt.liveRequest != "" {
+					liveReq = tt.liveRequest
+				}
+				pods = []corev1.Pod{*newResizePod("api-server", "500m", liveReq, "1000m", "1Gi")}
 			}
 
 			reconciler := newReconcilerWithClient()
@@ -2293,18 +2301,151 @@ func TestComputeRecommendations_OneSidedMemoryGapDoesNotRecommendTemplate(t *tes
 			require.NoError(t, err)
 			require.NotNil(t, rec, "CPU-only data must still produce a recommendation")
 			require.Len(t, rec.Containers, 1)
+			require.False(t, rec.Stale,
+				"held missing-memory arm must stay fresh; a stale-skip would green without a hold")
 
 			got := rec.Containers[0].Recommended.MemoryRequest
-			if rec.Stale {
-				return
-			}
-			assert.False(t, got.Equal(templateMem),
-				"fresh rec must not recommend template memory %s when memory samples are missing (got %s)",
-				templateMem.String(), got.String())
 			assert.True(t, got.Equal(liveMem),
 				"fresh rec must keep live/last memory %s, got %s", liveMem.String(), got.String())
 		})
 	}
+}
+
+// TestComputeRecommendations_OneSidedCPUGapDoesNotRecommendTemplate is the
+// CPU twin of the memory-gap hold: memory series can be fresh while CPU
+// is empty or all NaN. The missing-CPU arm must stay fresh at live/last,
+// not the pod-template request.
+func TestComputeRecommendations_OneSidedCPUGapDoesNotRecommendTemplate(t *testing.T) {
+	templateCPU := resource.MustParse("100m")
+	liveCPU := resource.MustParse("500m")
+
+	nanSamples := make([]rsmetrics.Sample, 50)
+	now := time.Now()
+	for i := range nanSamples {
+		nanSamples[i] = rsmetrics.Sample{
+			Timestamp: now.Add(-time.Duration(50-i) * time.Hour),
+			Value:     math.NaN(),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		cpuSamples  map[string][]rsmetrics.Sample
+		useLivePod  bool
+		usePriorRec bool
+		liveRequest string
+	}{
+		{name: "empty CPU samples, live 500m", useLivePod: true},
+		{name: "NaN CPU samples, live 500m", cpuSamples: map[string][]rsmetrics.Sample{"main": nanSamples}, useLivePod: true},
+		{name: "empty CPU samples, last rec 500m", usePriorRec: true},
+		{name: "empty CPU samples, live at template, last rec 500m", useLivePod: true, usePriorRec: true, liveRequest: "100m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := newTestPolicy("test-policy", "default")
+			deploy := newTestDeployment("api-server", "default", nil)
+			deploy.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = templateCPU.DeepCopy()
+
+			if tt.usePriorRec {
+				priorData := metav1.NewTime(now.Add(-time.Minute))
+				policy.Status.Recommendations = []attunev1alpha1.WorkloadRecommendation{{
+					Workload:     "api-server",
+					Kind:         "Deployment",
+					LastDataTime: &priorData,
+					Stale:        false,
+					Containers: []attunev1alpha1.ContainerRecommendation{{
+						Name: "main",
+						Recommended: attunev1alpha1.ResourceValues{
+							CPURequest:    liveCPU.DeepCopy(),
+							MemoryRequest: resource.MustParse("1Gi"),
+						},
+					}},
+				}}
+			}
+
+			var pods []corev1.Pod
+			if tt.useLivePod {
+				liveReq := "500m"
+				if tt.liveRequest != "" {
+					liveReq = tt.liveRequest
+				}
+				pods = []corev1.Pod{*newResizePod("api-server", liveReq, "1Gi", "1000m", "1Gi")}
+			}
+
+			reconciler := newReconcilerWithClient()
+			mc := &mockCollector{
+				queryRangeGroupedFunc: func(_ context.Context, query string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
+					if strings.Contains(query, "cpu_usage_seconds_total") {
+						if tt.cpuSamples != nil {
+							return tt.cpuSamples, nil
+						}
+						return map[string][]rsmetrics.Sample{}, nil
+					}
+					return map[string][]rsmetrics.Sample{"main": generateSamples(200, 256*1024*1024)}, nil
+				},
+			}
+
+			rec, _, _, _, _, err := reconciler.computeRecommendations(
+				context.Background(), policy, deploy, mc, nil, nil, nil, nil, pods)
+			require.NoError(t, err)
+			require.NotNil(t, rec, "memory-only data must still produce a recommendation")
+			require.Len(t, rec.Containers, 1)
+			require.False(t, rec.Stale,
+				"held missing-CPU arm must stay fresh; a stale-skip would green without a hold")
+
+			got := rec.Containers[0].Recommended.CPURequest
+			assert.True(t, got.Equal(liveCPU),
+				"fresh rec must keep live/last CPU %s, got %s", liveCPU.String(), got.String())
+		})
+	}
+}
+
+// TestComputeRecommendations_HoldDropsLeftoverTemplateLimit is the live-red
+// contract for a hold whose live request has no limit: Recommended must
+// not keep the template limit, or clampRequestsToLimits shrinks the hold.
+func TestComputeRecommendations_HoldDropsLeftoverTemplateLimit(t *testing.T) {
+	templateMem := resource.MustParse("256Mi")
+	templateLim := resource.MustParse("512Mi")
+	liveMem := resource.MustParse("1Gi")
+
+	policy := newTestPolicy("test-policy", "default")
+	deploy := newTestDeployment("api-server", "default", nil)
+	deploy.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = templateMem.DeepCopy()
+	deploy.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = templateLim.DeepCopy()
+
+	pod := newResizePod("api-server", "500m", "1Gi", "1000m", "1Gi")
+	delete(pod.Spec.Containers[0].Resources.Limits, corev1.ResourceMemory)
+
+	reconciler := newReconcilerWithClient()
+	mc := &mockCollector{
+		queryRangeGroupedFunc: func(_ context.Context, query string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
+			if strings.Contains(query, "memory_working_set_bytes") {
+				return map[string][]rsmetrics.Sample{}, nil
+			}
+			return map[string][]rsmetrics.Sample{"main": generateSamples(200, 0.1)}, nil
+		},
+	}
+
+	rec, _, _, _, _, err := reconciler.computeRecommendations(
+		context.Background(), policy, deploy, mc, nil, nil, nil, nil, []corev1.Pod{*pod})
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Len(t, rec.Containers, 1)
+	require.False(t, rec.Stale, "held live memory must stay fresh")
+
+	got := rec.Containers[0]
+	assert.True(t, got.Recommended.MemoryRequest.Equal(liveMem),
+		"held memory request must stay live %s, got %s", liveMem.String(), got.Recommended.MemoryRequest.String())
+	assert.True(t, got.Recommended.MemoryLimit.IsZero(),
+		"held rec must not keep template memory limit %s when live has none, got %s",
+		templateLim.String(), got.Recommended.MemoryLimit.String())
+
+	target, clamped := buildResizeTarget(got)
+	gotTargetMem := target.Requests[corev1.ResourceMemory]
+	assert.True(t, gotTargetMem.Equal(liveMem),
+		"resize target must keep held %s, got %s", liveMem.String(), gotTargetMem.String())
+	assert.Empty(t, clamped, "leftover template limit must not clamp the held request")
 }
 
 func TestComputeRecommendations_QueryError(t *testing.T) {

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -554,7 +554,10 @@ func reuseStaleRecommendation(policy *attunev1alpha1.AttunePolicy, kind, workloa
 
 // holdMissingResourceRequest copies live (max request across pods) or last
 // successful Recommended into Current and Recommended for a resource that
-// had no usable series. Returns false when no hold value exists.
+// had no usable series. When both exist, the larger request wins so a
+// last rec is not overwritten by pods still at the template. A zero live
+// limit is applied too; leaving the template limit would clamp the hold.
+// Returns false when no hold value exists.
 func holdMissingResourceRequest(
 	rec *attunev1alpha1.ContainerRecommendation,
 	res corev1.ResourceName,
@@ -564,32 +567,49 @@ func holdMissingResourceRequest(
 	if rec == nil {
 		return false
 	}
-	req, lim, ok := liveResourceHold(pods, rec.Name, res)
-	if !ok {
-		req, lim, ok = priorResourceHold(prior, res)
-	}
-	if !ok {
+	if res != corev1.ResourceCPU && res != corev1.ResourceMemory {
 		return false
 	}
+	liveReq, liveLim, liveOK := liveResourceHold(pods, rec.Name, res)
+	priorReq, priorLim, priorOK := priorResourceHold(prior, res)
+	if !liveOK && !priorOK {
+		return false
+	}
+
+	req, lim := liveReq, liveLim
+	// Prefer last rec when it is larger than live, or when live is still
+	// the template Current (in-place resize not applied yet).
+	if priorOK {
+		templateReq := requestFromResourceValues(rec.Current, res)
+		if !liveOK || priorReq.Cmp(liveReq) > 0 || liveReq.Equal(templateReq) {
+			req, lim = priorReq, priorLim
+		}
+	}
+
 	switch res {
 	case corev1.ResourceCPU:
 		rec.Current.CPURequest = req.DeepCopy()
 		rec.Recommended.CPURequest = req.DeepCopy()
-		if !lim.IsZero() {
-			rec.Current.CPULimit = lim.DeepCopy()
-			rec.Recommended.CPULimit = lim.DeepCopy()
-		}
+		rec.Current.CPULimit = lim.DeepCopy()
+		rec.Recommended.CPULimit = lim.DeepCopy()
 	case corev1.ResourceMemory:
 		rec.Current.MemoryRequest = req.DeepCopy()
 		rec.Recommended.MemoryRequest = req.DeepCopy()
-		if !lim.IsZero() {
-			rec.Current.MemoryLimit = lim.DeepCopy()
-			rec.Recommended.MemoryLimit = lim.DeepCopy()
-		}
-	default:
-		return false
+		rec.Current.MemoryLimit = lim.DeepCopy()
+		rec.Recommended.MemoryLimit = lim.DeepCopy()
 	}
 	return true
+}
+
+func requestFromResourceValues(v attunev1alpha1.ResourceValues, res corev1.ResourceName) k8sresource.Quantity {
+	switch res {
+	case corev1.ResourceCPU:
+		return v.CPURequest
+	case corev1.ResourceMemory:
+		return v.MemoryRequest
+	default:
+		return k8sresource.Quantity{}
+	}
 }
 
 func liveResourceHold(pods []corev1.Pod, container string, res corev1.ResourceName) (req, lim k8sresource.Quantity, ok bool) {

--- a/internal/controller/prometheus_test.go
+++ b/internal/controller/prometheus_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
@@ -308,4 +309,93 @@ func TestDeriveMemoryFromCPU_ExactMath(t *testing.T) {
 	pctDiff := float64(diff) / float64(twoGi.Value()) * 100
 	assert.InDelta(t, 0, pctDiff, 5,
 		"memory %s should be within 5%% of 2Gi (got %.1f%% diff)", memRec.String(), pctDiff)
+}
+
+func TestHoldMissingResourceRequest_PrefersLargerLastRecOverTemplateLive(t *testing.T) {
+	templateMem := resource.MustParse("256Mi")
+	lastRec := resource.MustParse("1Gi")
+	rec := &attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Current: attunev1alpha1.ResourceValues{
+			MemoryRequest: templateMem.DeepCopy(),
+			MemoryLimit:   resource.MustParse("512Mi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			MemoryRequest: templateMem.DeepCopy(),
+			MemoryLimit:   resource.MustParse("512Mi"),
+		},
+	}
+	// Pods still at the template; last rec is the in-place target.
+	pod := newResizePod("api-server", "500m", "256Mi", "1000m", "512Mi")
+	prior := &attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Recommended: attunev1alpha1.ResourceValues{
+			MemoryRequest: lastRec.DeepCopy(),
+		},
+	}
+
+	ok := holdMissingResourceRequest(rec, corev1.ResourceMemory, []corev1.Pod{*pod}, prior)
+	require.True(t, ok)
+	assert.True(t, rec.Recommended.MemoryRequest.Equal(lastRec),
+		"must keep last rec %s over template-live %s, got %s",
+		lastRec.String(), templateMem.String(), rec.Recommended.MemoryRequest.String())
+}
+
+func TestHoldMissingResourceRequest_LargerLiveBeatsSmallerLastRec(t *testing.T) {
+	liveMem := resource.MustParse("1Gi")
+	rec := &attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Current: attunev1alpha1.ResourceValues{
+			MemoryRequest: resource.MustParse("256Mi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			MemoryRequest: resource.MustParse("256Mi"),
+		},
+	}
+	pod := newResizePod("api-server", "500m", "1Gi", "1000m", "1Gi")
+	prior := &attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Recommended: attunev1alpha1.ResourceValues{
+			MemoryRequest: resource.MustParse("256Mi"),
+		},
+	}
+
+	ok := holdMissingResourceRequest(rec, corev1.ResourceMemory, []corev1.Pod{*pod}, prior)
+	require.True(t, ok)
+	assert.True(t, rec.Recommended.MemoryRequest.Equal(liveMem),
+		"larger live %s must beat last rec 256Mi, got %s",
+		liveMem.String(), rec.Recommended.MemoryRequest.String())
+}
+
+func TestHoldMissingResourceRequest_ZeroLiveLimitClearsTemplateLimit(t *testing.T) {
+	liveMem := resource.MustParse("1Gi")
+	rec := &attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Current: attunev1alpha1.ResourceValues{
+			MemoryRequest: resource.MustParse("256Mi"),
+			MemoryLimit:   resource.MustParse("512Mi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			MemoryRequest: resource.MustParse("256Mi"),
+			MemoryLimit:   resource.MustParse("512Mi"),
+		},
+	}
+	pod := newResizePod("api-server", "500m", "1Gi", "1000m", "1Gi")
+	delete(pod.Spec.Containers[0].Resources.Limits, corev1.ResourceMemory)
+
+	ok := holdMissingResourceRequest(rec, corev1.ResourceMemory, []corev1.Pod{*pod}, nil)
+	require.True(t, ok)
+	assert.True(t, rec.Recommended.MemoryRequest.Equal(liveMem),
+		"held request must stay live %s, got %s", liveMem.String(), rec.Recommended.MemoryRequest.String())
+	assert.True(t, rec.Recommended.MemoryLimit.IsZero(),
+		"held rec must not keep template memory limit when live has none, got %s",
+		rec.Recommended.MemoryLimit.String())
+	assert.True(t, rec.Current.MemoryLimit.IsZero(),
+		"Current limit must also drop so quota/undo does not keep the template limit")
+
+	target, clamped := buildResizeTarget(*rec)
+	gotTargetMem := target.Requests[corev1.ResourceMemory]
+	assert.True(t, gotTargetMem.Equal(liveMem),
+		"resize target must keep held %s, got %s", liveMem.String(), gotTargetMem.String())
+	assert.Empty(t, clamped, "leftover template limit must not clamp the held request")
 }

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -915,7 +915,8 @@ func resizedContainersContains(list, container string) bool {
 // the named container exists on the pod. rec.Current is the workload
 // template and is stale after an in-place resize. Undo annotations and
 // quota deltas must use live values. Falls back to rec.Current when the
-// pod is nil or the container is missing.
+// pod is nil or the container is missing. Keys absent on the live
+// container keep rec.Current (do not invent zero).
 func liveContainerCurrent(pod *corev1.Pod, rec attunev1alpha1.ContainerRecommendation) attunev1alpha1.ResourceValues {
 	if pod == nil {
 		return rec.Current
@@ -924,7 +925,9 @@ func liveContainerCurrent(pod *corev1.Pod, rec attunev1alpha1.ContainerRecommend
 	if c == nil {
 		return rec.Current
 	}
-	cur := attunev1alpha1.ResourceValues{}
+	// Start from rec.Current so missing live keys (no limit) do not invent
+	// zero and wipe the snapshot used for quota deltas and undo.
+	cur := rec.Current
 	if req, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
 		cur.CPURequest = req.DeepCopy()
 	}

--- a/internal/controller/resize_live_current_test.go
+++ b/internal/controller/resize_live_current_test.go
@@ -146,3 +146,25 @@ func TestLiveContainerCurrent_PrefersLiveOverTemplate(t *testing.T) {
 	assert.Equal(t, rec.Current, liveContainerCurrent(nil, rec),
 		"nil pod must fall back to rec.Current")
 }
+
+func TestLiveContainerCurrent_MissingKeysKeepCurrent(t *testing.T) {
+	pod := newResizePod("api-server", "500m", "1Gi", "1000m", "2Gi")
+	delete(pod.Spec.Containers[0].Resources.Limits, corev1.ResourceMemory)
+	rec := attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("500m"),
+			CPULimit:      resource.MustParse("1000m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+			MemoryLimit:   resource.MustParse("512Mi"),
+		},
+	}
+
+	got := liveContainerCurrent(pod, rec)
+	assert.True(t, got.MemoryRequest.Equal(resource.MustParse("1Gi")),
+		"live memory request must overlay Current, got %s", got.MemoryRequest.String())
+	assert.True(t, got.MemoryLimit.Equal(resource.MustParse("512Mi")),
+		"missing live limit must keep rec.Current, not invent zero; got %s", got.MemoryLimit.String())
+	assert.True(t, got.CPULimit.Equal(resource.MustParse("1000m")),
+		"present live CPU limit must still overlay Current")
+}


### PR DESCRIPTION
Follow-up to #625. The one-sided hold could still drop a last rec and clamp a live request to a leftover template limit.

## Problem

- The #625 contract test returned early when the rec was stale, so deleting the hold stayed green.
- Live pods still at the template request beat a larger last rec, so a cooldown or canary skip could overwrite 1Gi with 256Mi.
- Holding a live 1Gi request left the template 512Mi limit in place. clampRequestsToLimits then applied 512Mi.

## Change

- Hold tests require a fresh rec at live or last rec (CPU-gap twin included).
- Prefer max(live, prior), and prior when live still equals the template.
- Copy a zero live limit onto the hold so clamp cannot shrink to the leftover template limit. Quota/undo merge missing live keys with rec.Current.

## Validation

- go test ./internal/controller/... -race -count=1 (964 passed)
- make verify-quick (2257 tests, 93.1% coverage)

Release PR #601 stays user-gated.
