### PR TITLE
fix: do not immediately revert a resize for transient notready

### DIFF
--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -28,8 +28,11 @@ The recommended production path is Recommend, then Canary, then Auto.
 ## Auto-revert triggers
 
 When `autoRevert: true` (the default), the safety monitor checks each
-resized pod for the following conditions. Any match triggers an immediate
-revert via `UpdateResize`:
+resized pod for the following conditions. A match during the observation
+period reverts the resize via `UpdateResize`. Right after apply, only
+OOMKill and restart+2 revert immediately. NotReady, throttle, and SLO
+wait for the observation period (they are often transient while the
+container adjusts):
 
 ### OOMKill
 
@@ -86,6 +89,8 @@ if condition.Type == PodReady && condition.Status != ConditionTrue
 ```
 
 The pod's Ready condition is `False`, meaning readiness probes are failing.
+This check runs only after the observation period. A brief Ready=False
+right after `UpdateResize` does not revert.
 
 **Mitigation**: verify that readiness probes are not sensitive to resource
 allocation changes. Some applications expose health endpoints that degrade
@@ -212,13 +217,14 @@ sequenceDiagram
     participant K as K8s API
 
     E->>K: UpdateResize (new resources)
-    E->>S: CheckPod(record)
-    S->>K: Get pod status
-    alt OOMKill / Restart / NotReady
+    E->>K: Get pod status
+    E->>S: CheckCriticalStatuses(pod)
+    alt OOMKill / Restart+2
         S-->>E: Verdict{Safe: false}
         E->>S: RevertPod(record)
         S->>K: UpdateResize (original resources)
-    else Healthy
+    else NotReady / throttle / SLO / healthy
+        Note over E,S: Defer non-critical checks to observation
         S-->>E: Verdict{Safe: true}
     end
 ```

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -710,7 +710,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 		RestartCount:      restartCount,
 		WorkloadName:      workloadName,
 	}
-	if reason, err := r.runImmediateSafetyCheck(ctx, policy, monitor, record); err != nil {
+	if reason, err := r.runImmediateSafetyCheck(ctx, policy, record); err != nil {
 		return history, resizeOutcomeInPlace
 	} else if reason != "" {
 		revert(reason)

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -39,33 +39,32 @@ import (
 	"github.com/attune-io/attune/internal/throttle"
 )
 
-// runImmediateSafetyCheck performs an immediate safety check on a freshly
-// resized pod. If auto-revert is not enabled it returns ("", nil). A non-nil
-// error means the check itself failed (the caller should defer to the
-// observation cycle). A non-empty revertReason means the pod is unsafe and
-// should be reverted.
+// runImmediateSafetyCheck performs an immediate post-apply safety check on a
+// freshly resized pod. Only critical statuses (OOMKill, restart+2) revert
+// immediately; NotReady, throttle, and SLO wait for the observation period.
+// If auto-revert is not enabled it returns ("", nil). A non-nil error means
+// the check itself failed (the caller should defer to the observation cycle).
+// A non-empty revertReason means the pod is unsafe and should be reverted.
 func (r *AttunePolicyReconciler) runImmediateSafetyCheck(
 	ctx context.Context,
 	policy *attunev1alpha1.AttunePolicy,
-	monitor *safety.Monitor,
 	record safety.ResizeRecord,
 ) (revertReason string, err error) {
 	if !autoRevertEnabled(policy.Spec.UpdateStrategy) {
 		return "", nil
 	}
-	record.ObservationEnd = record.ResizedAt.Add(getObservationPeriod(policy))
 
 	logger := log.FromContext(ctx)
-	verdict, checkErr := monitor.CheckPod(ctx, record, record.ResizedAt)
-	if checkErr != nil {
-		logger.Error(checkErr, "Safety check failed, deferring to observation cycle",
+	pod, getErr := r.Clientset.CoreV1().Pods(record.Namespace).Get(ctx, record.PodName, metav1.GetOptions{})
+	if getErr != nil {
+		logger.Error(getErr, "Safety check failed, deferring to observation cycle",
 			"pod", record.PodName)
-		return "", checkErr
+		return "", getErr
 	}
-	if !verdict.Safe {
+	if v := safety.CheckCriticalStatuses(pod, record); v != nil {
 		logger.Info("Safety violation detected, reverting",
-			"pod", record.PodName, "reason", verdict.Reason)
-		return verdict.Reason, nil
+			"pod", record.PodName, "reason", v.Reason)
+		return v.Reason, nil
 	}
 	return "", nil
 }

--- a/internal/controller/safety_test.go
+++ b/internal/controller/safety_test.go
@@ -113,7 +113,6 @@ func TestRunImmediateSafetyCheck_AutoRevertDisabled(t *testing.T) {
 	reason, err := r.runImmediateSafetyCheck(
 		context.Background(),
 		policy,
-		nil, // monitor not needed when autoRevert is disabled
 		safety.ResizeRecord{},
 	)
 	assert.NoError(t, err)
@@ -139,7 +138,6 @@ func TestRunImmediateSafetyCheck_CheckPodError(t *testing.T) {
 	}
 
 	ctx := log.IntoContext(context.Background(), logr.Discard())
-	monitor := safety.NewMonitor(cs, logr.Discard())
 
 	record := safety.ResizeRecord{
 		PodName:   "test-pod",
@@ -154,8 +152,8 @@ func TestRunImmediateSafetyCheck_CheckPodError(t *testing.T) {
 		},
 	}
 
-	reason, err := r.runImmediateSafetyCheck(ctx, policy, monitor, record)
-	assert.Error(t, err, "should propagate CheckPod error")
+	reason, err := r.runImmediateSafetyCheck(ctx, policy, record)
+	assert.Error(t, err, "should propagate Get error")
 	assert.Empty(t, reason, "no revert reason when the check itself fails")
 }
 
@@ -189,7 +187,6 @@ func TestRunImmediateSafetyCheck_UnsafePod(t *testing.T) {
 	}
 
 	ctx := log.IntoContext(context.Background(), logr.Discard())
-	monitor := safety.NewMonitor(cs, logr.Discard())
 
 	record := safety.ResizeRecord{
 		PodName:      "test-pod",
@@ -205,7 +202,7 @@ func TestRunImmediateSafetyCheck_UnsafePod(t *testing.T) {
 		},
 	}
 
-	reason, err := r.runImmediateSafetyCheck(ctx, policy, monitor, record)
+	reason, err := r.runImmediateSafetyCheck(ctx, policy, record)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, reason, "should return a revert reason for unsafe pod")
 	assert.Contains(t, reason, "restart", "reason should mention restart increase")
@@ -248,7 +245,6 @@ func TestRunImmediateSafetyCheck_SafePod(t *testing.T) {
 	}
 
 	ctx := log.IntoContext(context.Background(), logr.Discard())
-	monitor := safety.NewMonitor(cs, logr.Discard())
 
 	record := safety.ResizeRecord{
 		PodName:      "healthy-pod",
@@ -264,7 +260,66 @@ func TestRunImmediateSafetyCheck_SafePod(t *testing.T) {
 		},
 	}
 
-	reason, err := r.runImmediateSafetyCheck(ctx, policy, monitor, record)
+	reason, err := r.runImmediateSafetyCheck(ctx, policy, record)
 	assert.NoError(t, err)
 	assert.Empty(t, reason, "healthy pod should not trigger revert")
+}
+
+func TestRunImmediateSafetyCheck_NotReadyDoesNotRevert(t *testing.T) {
+	// Ready=False with no OOM and no extra restarts is transient during
+	// adjustment. Immediate check must not revert; full CheckPod would.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "notready-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "main",
+					Ready:        false,
+					RestartCount: 0,
+				},
+			},
+		},
+	}
+
+	cs := kubefake.NewSimpleClientset(pod)
+	r := NewAttunePolicyReconciler()
+	r.Clientset = cs
+
+	policy := &attunev1alpha1.AttunePolicy{
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				AutoRevert: boolPtr(true),
+			},
+		},
+	}
+
+	ctx := log.IntoContext(context.Background(), logr.Discard())
+
+	record := safety.ResizeRecord{
+		PodName:      "notready-pod",
+		Namespace:    "default",
+		Container:    "main",
+		ResizedAt:    time.Now(),
+		RestartCount: 0,
+		OriginalResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+	}
+
+	reason, err := r.runImmediateSafetyCheck(ctx, policy, record)
+	assert.NoError(t, err)
+	assert.Empty(t, reason, "transient not-ready must not trigger immediate revert")
+	assert.NotEqual(t, "notready", reason, "immediate check must not use full CheckPod")
 }


### PR DESCRIPTION
Immediate post-apply safety no longer treats a transient Ready=False as a revert.

## Problem

After `UpdateResize`, Kubernetes often reports Ready=False while the
container is still adjusting. The immediate safety path called full
`CheckPod`, which treats Ready=False as `notready` and reverted the
resize before the observation period could distinguish a probe blip
from a real failure.

Observation-period safety already deferred NotReady, throttle, and SLO.
The immediate path did not.

## Change

- `runImmediateSafetyCheck` Gets the live pod and runs
  `CheckCriticalStatuses` only (OOMKill after resize, restart count +2).
- NotReady, throttle, and SLO stay on the observation-period path.
- `docs/architecture/safety.md` matches that split (intro, NotReady
  section, revert sequence diagram).

## Validation

- Red/green: `TestRunImmediateSafetyCheck_NotReadyDoesNotRevert`
- `go test ./internal/controller/... ./internal/safety/...`
- `make verify-quick` (2258 tests, 93.1% coverage)

Release PR #601 stays user-gated.
