### PR TITLE
test: harden budget caps, discovered-only, and webhook e2e asserts

### DIFF
--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -8904,6 +8904,8 @@ func TestExecuteResizes_BudgetCapsDefersExcessiveIncrease(t *testing.T) {
 	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 	reconciler, _ := newResizeReconciler(pod, deploy)
+	recorder := events.NewFakeRecorder(10)
+	reconciler.Recorder = recorder
 
 	policy := newTestPolicy("test-policy", "default")
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
@@ -8914,9 +8916,44 @@ func TestExecuteResizes_BudgetCapsDefersExcessiveIncrease(t *testing.T) {
 		newResizeRecommendation("api-server", "200m", "256Mi", "0", "0", "800m", "256Mi", "0", "0"),
 	}
 
-	count, _ := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+	beforeBudget := promtestutil.ToFloat64(operatormetrics.BudgetExhaustedTotal.WithLabelValues("default", "test-policy"))
+	count, history := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
 		recommendations, podMap("api-server", pod), nil, nil)
 	assert.Equal(t, 0, count, "resize should be deferred when CPU increase exceeds budget")
+	assert.Empty(t, history, "budget gate must not record Success history")
+	afterBudget := promtestutil.ToFloat64(operatormetrics.BudgetExhaustedTotal.WithLabelValues("default", "test-policy"))
+	assert.Equal(t, beforeBudget+1, afterBudget, "BudgetExhaustedTotal should increment")
+
+	// status.workloads.resized is set only from executeResizes count (and Success
+	// history self-heal). Both must stay zero when the gate fires.
+	policy.Status.Workloads.Resized = safeInt32(count)
+	if policy.Status.Workloads.Resized == 0 {
+		resizedWorkloads := make(map[string]bool)
+		for _, h := range history {
+			if isSuccessfulInPlaceHistory(h) {
+				resizedWorkloads[h.Workload] = true
+			}
+		}
+		if derived := safeInt32(len(resizedWorkloads)); derived > policy.Status.Workloads.Resized {
+			policy.Status.Workloads.Resized = derived
+		}
+	}
+	assert.Equal(t, int32(0), policy.Status.Workloads.Resized,
+		"workloads.resized must stay 0 when budget defers the only increase")
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "BudgetExhausted") {
+				found = true
+			}
+		default:
+			goto doneEvents
+		}
+	}
+doneEvents:
+	assert.True(t, found, "BudgetExhausted event must fire when increase exceeds budget")
 }
 
 func TestExecuteResizes_BudgetCapsAllowsWithinBudget(t *testing.T) {

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -1033,9 +1033,9 @@ func TestE2E_BudgetCaps_LimitsPerCycleIncrease(t *testing.T) {
 
 	waitForPolicyDiscovered(t, "budinc-policy", ns, 2*time.Minute)
 
-	// Wait for an increase recommendation that exceeds the 20m budget, or for
-	// the gate event itself.
-	var sawBigIncrease bool
+	// Wait until the budget gate fires. A large increase rec alone is not
+	// enough: cooldown, change filter, or query gaps can also leave the pod
+	// at 50m without proving maxTotalCpuIncrease ran.
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		if policyHasEvent(t, ns, "budinc-policy", "BudgetExhausted") {
 			return true, nil
@@ -1052,34 +1052,16 @@ func TestE2E_BudgetCaps_LimitsPerCycleIncrease(t *testing.T) {
 				inc := c.Recommended.CPURequest.MilliValue() - c.Current.CPURequest.MilliValue()
 				t.Logf("rec current=%s rec=%s increase=%dm",
 					c.Current.CPURequest.String(), c.Recommended.CPURequest.String(), inc)
-				if inc > 20 {
-					sawBigIncrease = true
-					return true, nil
-				}
 			}
 		}
 		return false, nil
-	}), "timed out waiting for CPU increase rec > 20m (burn) or BudgetExhausted")
+	}), "timed out waiting for BudgetExhausted (CPU increase over maxTotalCpuIncrease)")
 
-	// Wait until the controller has attempted the resize (BudgetExhausted) or
-	// we can prove the live pod never left 50m after a big increase rec.
-	require.NoError(t, wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		if policyHasEvent(t, ns, "budinc-policy", "BudgetExhausted") {
-			return true, nil
-		}
-		return sawBigIncrease && countPodsWithCPURequest(t, ns, app, origCPU) == 1, nil
-	}), "timed out waiting for BudgetExhausted or stable deferred pod")
-
-	// Live pod is the source of truth: CPU must not have increased past budget.
-	// status.workloads.resized can be sticky/misleading if any other resource
-	// path ever counted; with memory pinned it should stay 0, but we do not
-	// hard-fail on it if the live pod and gate event are correct.
 	stillAtOrig := countPodsWithCPURequest(t, ns, app, origCPU)
-	exhausted := policyHasEvent(t, ns, "budinc-policy", "BudgetExhausted")
 	var p attunev1alpha1.AttunePolicy
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "budinc-policy", Namespace: ns}, &p))
-	t.Logf("resized=%d stillAtOrig=%d BudgetExhausted=%v sawBigIncrease=%v",
-		p.Status.Workloads.Resized, stillAtOrig, exhausted, sawBigIncrease)
+	t.Logf("resized=%d stillAtOrig=%d BudgetExhausted=true",
+		p.Status.Workloads.Resized, stillAtOrig)
 
 	require.Equal(t, 1, stillAtOrig,
 		"pod CPU must remain at original 50m when increase exceeds maxTotalCpuIncrease")
@@ -1091,12 +1073,9 @@ func TestE2E_BudgetCaps_LimitsPerCycleIncrease(t *testing.T) {
 	require.NotNil(t, liveCPU)
 	assert.LessOrEqual(t, liveCPU.MilliValue(), origCPU.MilliValue()+cpuBudget.MilliValue(),
 		"live CPU must not exceed original+budget, got %s", liveCPU.String())
-	assert.True(t, exhausted || sawBigIncrease,
-		"expected BudgetExhausted and/or observed increase rec > budget")
-	if p.Status.Workloads.Resized != 0 {
-		t.Logf("WARN: status.workloads.resized=%d while live CPU stayed gated; treating live pod as authority",
-			p.Status.Workloads.Resized)
-	}
+	// Memory is pinned min=max so no free memory path can bump resized.
+	assert.Equal(t, int32(0), p.Status.Workloads.Resized,
+		"increase larger than maxTotalCpuIncrease must not set workloads.resized")
 }
 
 // TestE2E_GuaranteedQoS_CPUResizeWithMemoryHeld verifies that when memory
@@ -1321,12 +1300,23 @@ func TestE2E_BearerToken_Authenticates(t *testing.T) {
 
 	// Prometheus doesn't require auth, but the operator should successfully
 	// read the Secret, inject the bearer token, and query without error.
+	// Discovered alone only proves targetRef listing; withRecommendations
+	// proves the authenticated collector path returned samples.
 	waitForPolicyDiscovered(t, "bearer-policy", ns, 2*time.Minute)
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var p attunev1alpha1.AttunePolicy
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "bearer-policy", Namespace: ns}, &p); err != nil {
+			return false, nil
+		}
+		return p.Status.Workloads.WithRecommendations >= 1, nil
+	}), "policy with bearer token should produce recommendations")
 
 	var p attunev1alpha1.AttunePolicy
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "bearer-policy", Namespace: ns}, &p))
 	assert.Equal(t, int32(1), p.Status.Workloads.Discovered,
 		"policy with bearer token should discover workloads")
+	assert.GreaterOrEqual(t, p.Status.Workloads.WithRecommendations, int32(1),
+		"bearer token path must complete Prometheus queries")
 }
 
 func TestE2E_EvictionFallback_ResizesWithInPlaceOrRecreate(t *testing.T) {

--- a/test/e2e/exclude-containers/chainsaw-test.yaml
+++ b/test/e2e/exclude-containers/chainsaw-test.yaml
@@ -3,7 +3,9 @@ kind: Test
 metadata:
   name: exclude-containers
 spec:
-  description: Verify that excludedContainers skips sidecar containers in multi-container pods
+  description: >
+    Verify excludedContainers omits the sidecar from status.recommendations
+    while the app container is recommended
   timeouts:
     apply: 30s
     assert: 2m
@@ -91,18 +93,32 @@ spec:
                 namespace: e2e-exclude-containers
               status:
                 readyReplicas: 1
-    - name: verify-policy-discovers-workload
+    - name: verify-sidecar-excluded-from-recommendations
       try:
-        - assert:
-            resource:
-              apiVersion: attune.io/v1alpha1
-              kind: AttunePolicy
-              metadata:
-                name: exclude-sidecar
-                namespace: e2e-exclude-containers
-              status:
-                workloads:
-                  discovered: 1
+        - script:
+            timeout: 3m
+            content: |
+              set -e
+              for i in $(seq 1 36); do
+                names=$(kubectl get attunepolicy exclude-sidecar -n e2e-exclude-containers \
+                  -o jsonpath='{.status.recommendations[*].containers[*].name}' 2>/dev/null || true)
+                recs=$(kubectl get attunepolicy exclude-sidecar -n e2e-exclude-containers \
+                  -o jsonpath='{.status.workloads.withRecommendations}' 2>/dev/null || true)
+                if echo " $names " | grep -q ' istio-proxy '; then
+                  echo "FAIL: excluded sidecar appeared in recommendations: $names"
+                  kubectl get attunepolicy exclude-sidecar -n e2e-exclude-containers -o yaml
+                  exit 1
+                fi
+                if [ "${recs:-0}" -ge 1 ] 2>/dev/null && echo " $names " | grep -q ' app '; then
+                  echo "OK: recommendations include app only (names='$names')"
+                  exit 0
+                fi
+                echo "Waiting... recs=$recs names='$names'"
+                sleep 5
+              done
+              echo "FAIL: timed out waiting for app-only recommendations"
+              kubectl get attunepolicy exclude-sidecar -n e2e-exclude-containers -o yaml
+              exit 1
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1

--- a/test/e2e/hpa-conflict/chainsaw-test.yaml
+++ b/test/e2e/hpa-conflict/chainsaw-test.yaml
@@ -101,18 +101,29 @@ spec:
                 namespace: e2e-hpa-conflict
               status:
                 readyReplicas: 2
-    - name: verify-policy-reconciles-despite-hpa
+    - name: verify-hpa-conflict-warning
       try:
-        - assert:
-            resource:
-              apiVersion: attune.io/v1alpha1
-              kind: AttunePolicy
-              metadata:
-                name: hpa-conflict-test
-                namespace: e2e-hpa-conflict
-              status:
-                workloads:
-                  discovered: 1
+        - script:
+            timeout: 3m
+            content: |
+              set -e
+              for i in $(seq 1 36); do
+                discovered=$(kubectl get attunepolicy hpa-conflict-test -n e2e-hpa-conflict \
+                  -o jsonpath='{.status.workloads.discovered}' 2>/dev/null || true)
+                events=$(kubectl get events -n e2e-hpa-conflict \
+                  --field-selector involvedObject.name=hpa-conflict-test,involvedObject.kind=AttunePolicy,reason=HPAConflict \
+                  -o jsonpath='{.items[*].reason}' 2>/dev/null || true)
+                if [ "$discovered" = "1" ] && echo "$events" | grep -q HPAConflict; then
+                  echo "OK: discovered=1 and HPAConflict warning event present"
+                  exit 0
+                fi
+                echo "Waiting... discovered=$discovered events='$events'"
+                sleep 5
+              done
+              echo "FAIL: timed out waiting for HPAConflict event with discovered=1"
+              kubectl get attunepolicy hpa-conflict-test -n e2e-hpa-conflict -o yaml
+              kubectl get events -n e2e-hpa-conflict --sort-by='.lastTimestamp' | tail -20
+              exit 1
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1

--- a/test/e2e/observe-mode/chainsaw-test.yaml
+++ b/test/e2e/observe-mode/chainsaw-test.yaml
@@ -3,7 +3,9 @@ kind: Test
 metadata:
   name: observe-mode
 spec:
-  description: Verify that an AttunePolicy in Observe mode reaches a condition without generating recommendations or performing resizes
+  description: >
+    Verify Observe mode computes data (withRecommendations) but does not
+    surface status.recommendations and never resizes
   timeouts:
     apply: 30s
     assert: 2m
@@ -82,43 +84,46 @@ spec:
                 namespace: e2e-observe-mode
               status:
                 readyReplicas: 1
-    - name: verify-policy-has-condition
+    - name: verify-observe-collects-without-surfacing-or-resizing
       try:
         - script:
             timeout: 3m
             content: |
-              # The operator may transition quickly from InsufficientData to Monitoring
-              # when minimumDataPoints is 1 and Prometheus scrapes fast. Accept either
-              # state as valid — both prove the policy discovered the workload.
+              set -e
+              # Observe computes recs internally (withRecommendations) but leaves
+              # status.recommendations empty and never resizes. resized=0 alone
+              # is not enough: a crashed operator also never resizes.
               for i in $(seq 1 36); do
                 reason=$(kubectl get attunepolicy observe-test -n e2e-observe-mode \
-                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' 2>/dev/null)
+                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' 2>/dev/null || true)
                 discovered=$(kubectl get attunepolicy observe-test -n e2e-observe-mode \
-                  -o jsonpath='{.status.workloads.discovered}' 2>/dev/null)
-                if [ "$discovered" = "1" ]; then
-                  if [ "$reason" = "InsufficientData" ] || [ "$reason" = "Monitoring" ]; then
-                    echo "OK: workloads discovered=$discovered, Ready reason=$reason"
-                    exit 0
-                  fi
+                  -o jsonpath='{.status.workloads.discovered}' 2>/dev/null || true)
+                recs=$(kubectl get attunepolicy observe-test -n e2e-observe-mode \
+                  -o jsonpath='{.status.workloads.withRecommendations}' 2>/dev/null || true)
+                surfaced=$(kubectl get attunepolicy observe-test -n e2e-observe-mode \
+                  -o jsonpath='{.status.recommendations[*].workload}' 2>/dev/null || true)
+                resized=$(kubectl get attunepolicy observe-test -n e2e-observe-mode \
+                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null || true)
+                if [ "${resized:-0}" -ge 1 ] 2>/dev/null; then
+                  echo "FAIL: Observe mode resized a workload (resized=$resized)"
+                  kubectl get attunepolicy observe-test -n e2e-observe-mode -o yaml
+                  exit 1
                 fi
-                echo "Waiting... discovered=$discovered reason=$reason"
+                if [ -n "$surfaced" ]; then
+                  echo "FAIL: Observe mode surfaced recommendations ($surfaced)"
+                  kubectl get attunepolicy observe-test -n e2e-observe-mode -o yaml
+                  exit 1
+                fi
+                if [ "$discovered" = "1" ] && [ "${recs:-0}" -ge 1 ] 2>/dev/null; then
+                  echo "OK: Observe collected data without surfacing or resizing (reason=$reason recs=$recs)"
+                  exit 0
+                fi
+                echo "Waiting... discovered=$discovered recs=$recs reason=$reason resized=$resized"
                 sleep 5
               done
-              echo "FAIL: timed out waiting for policy to discover workloads"
+              echo "FAIL: timed out waiting for Observe withRecommendations>=1 and empty recommendations"
               kubectl get attunepolicy observe-test -n e2e-observe-mode -o yaml
               exit 1
-    - name: verify-no-resizes
-      try:
-        - assert:
-            resource:
-              apiVersion: attune.io/v1alpha1
-              kind: AttunePolicy
-              metadata:
-                name: observe-test
-                namespace: e2e-observe-mode
-              status:
-                workloads:
-                  resized: 0
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1

--- a/test/e2e/query-parameters/chainsaw-test.yaml
+++ b/test/e2e/query-parameters/chainsaw-test.yaml
@@ -80,18 +80,25 @@ spec:
                 namespace: e2e-query-parameters
               status:
                 readyReplicas: 1
-    - name: verify-policy-discovers-workload
+    - name: verify-query-parameters-still-produce-recommendations
       try:
-        - assert:
-            resource:
-              apiVersion: attune.io/v1alpha1
-              kind: AttunePolicy
-              metadata:
-                name: qp-test
-                namespace: e2e-query-parameters
-              status:
-                workloads:
-                  discovered: 1
+        - script:
+            timeout: 3m
+            content: |
+              set -e
+              for i in $(seq 1 36); do
+                recs=$(kubectl get attunepolicy qp-test -n e2e-query-parameters \
+                  -o jsonpath='{.status.workloads.withRecommendations}' 2>/dev/null || true)
+                if [ "${recs:-0}" -ge 1 ] 2>/dev/null; then
+                  echo "OK: queryParameters still allow recommendations (withRecommendations=$recs)"
+                  exit 0
+                fi
+                echo "Waiting... withRecommendations=$recs"
+                sleep 5
+              done
+              echo "FAIL: timed out waiting for recommendations with queryParameters"
+              kubectl get attunepolicy qp-test -n e2e-query-parameters -o yaml
+              exit 1
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1

--- a/test/e2e/recommend-mode/chainsaw-test.yaml
+++ b/test/e2e/recommend-mode/chainsaw-test.yaml
@@ -3,7 +3,8 @@ kind: Test
 metadata:
   name: recommend-mode
 spec:
-  description: Verify that an AttunePolicy in Recommend mode discovers workloads and reaches Ready condition
+  description: >
+    Verify Recommend mode surfaces recommendations and never resizes
   timeouts:
     apply: 30s
     assert: 2m
@@ -93,44 +94,39 @@ spec:
                 namespace: e2e-recommend-mode
               status:
                 readyReplicas: 1
-    - name: verify-status
+    - name: verify-recommend-surfaces-recs-without-resize
       try:
         - script:
             timeout: 3m
             content: |
-              # The operator may transition quickly from InsufficientData to Monitoring
-              # when minimumDataPoints is 1 and Prometheus scrapes fast. Accept either
-              # state as valid — both prove the policy discovered the workload and
-              # the controller reconciled it.
+              set -e
+              # resized=0 alone is weak: prove recommendations were produced.
               for i in $(seq 1 36); do
                 reason=$(kubectl get attunepolicy recommend-test -n e2e-recommend-mode \
-                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' 2>/dev/null)
+                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' 2>/dev/null || true)
                 discovered=$(kubectl get attunepolicy recommend-test -n e2e-recommend-mode \
-                  -o jsonpath='{.status.workloads.discovered}' 2>/dev/null)
-                if [ "$discovered" = "1" ]; then
-                  if [ "$reason" = "InsufficientData" ] || [ "$reason" = "Monitoring" ]; then
-                    echo "OK: workloads discovered=$discovered, Ready reason=$reason"
-                    exit 0
-                  fi
+                  -o jsonpath='{.status.workloads.discovered}' 2>/dev/null || true)
+                recs=$(kubectl get attunepolicy recommend-test -n e2e-recommend-mode \
+                  -o jsonpath='{.status.workloads.withRecommendations}' 2>/dev/null || true)
+                surfaced=$(kubectl get attunepolicy recommend-test -n e2e-recommend-mode \
+                  -o jsonpath='{.status.recommendations[*].workload}' 2>/dev/null || true)
+                resized=$(kubectl get attunepolicy recommend-test -n e2e-recommend-mode \
+                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null || true)
+                if [ "${resized:-0}" -ge 1 ] 2>/dev/null; then
+                  echo "FAIL: Recommend mode resized a workload (resized=$resized)"
+                  kubectl get attunepolicy recommend-test -n e2e-recommend-mode -o yaml
+                  exit 1
                 fi
-                echo "Waiting... discovered=$discovered reason=$reason"
+                if [ "$discovered" = "1" ] && [ "${recs:-0}" -ge 1 ] 2>/dev/null && [ -n "$surfaced" ]; then
+                  echo "OK: Recommend surfaced recs without resizing (reason=$reason recs=$recs workloads=$surfaced)"
+                  exit 0
+                fi
+                echo "Waiting... discovered=$discovered recs=$recs surfaced='$surfaced' reason=$reason"
                 sleep 5
               done
-              echo "FAIL: timed out waiting for policy to discover workloads"
+              echo "FAIL: timed out waiting for Recommend recommendations with resized=0"
               kubectl get attunepolicy recommend-test -n e2e-recommend-mode -o yaml
               exit 1
-    - name: verify-no-resizes
-      try:
-        - assert:
-            resource:
-              apiVersion: attune.io/v1alpha1
-              kind: AttunePolicy
-              metadata:
-                name: recommend-test
-                namespace: e2e-recommend-mode
-              status:
-                workloads:
-                  resized: 0
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1

--- a/test/e2e/requests-only/chainsaw-test.yaml
+++ b/test/e2e/requests-only/chainsaw-test.yaml
@@ -3,7 +3,9 @@ kind: Test
 metadata:
   name: requests-only
 spec:
-  description: Verify that an AttunePolicy with controlledValues RequestsOnly is accepted and reconciles
+  description: >
+    Verify RequestsOnly keeps recommended limits at the current limits
+    (does not scale limits with the request recommendation)
   timeouts:
     apply: 30s
     assert: 2m
@@ -82,18 +84,34 @@ spec:
                 namespace: e2e-requests-only
               status:
                 readyReplicas: 1
-    - name: verify-policy-reconciles
+    - name: verify-recommended-limits-unchanged
       try:
-        - assert:
-            resource:
-              apiVersion: attune.io/v1alpha1
-              kind: AttunePolicy
-              metadata:
-                name: reqonly-test
-                namespace: e2e-requests-only
-              status:
-                workloads:
-                  discovered: 1
+        - script:
+            timeout: 3m
+            content: |
+              set -e
+              for i in $(seq 1 36); do
+                cpu_lim=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
+                  -o jsonpath='{.status.recommendations[0].containers[0].recommended.cpuLimit}' 2>/dev/null || true)
+                mem_lim=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
+                  -o jsonpath='{.status.recommendations[0].containers[0].recommended.memoryLimit}' 2>/dev/null || true)
+                recs=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
+                  -o jsonpath='{.status.workloads.withRecommendations}' 2>/dev/null || true)
+                if [ "${recs:-0}" -ge 1 ] 2>/dev/null; then
+                  if [ "$cpu_lim" = "500m" ] && { [ "$mem_lim" = "512Mi" ] || [ "$mem_lim" = "536870912" ]; }; then
+                    echo "OK: RequestsOnly kept recommended limits at current (cpu=$cpu_lim mem=$mem_lim)"
+                    exit 0
+                  fi
+                  echo "FAIL: RequestsOnly changed recommended limits (cpu=$cpu_lim mem=$mem_lim)"
+                  kubectl get attunepolicy reqonly-test -n e2e-requests-only -o yaml
+                  exit 1
+                fi
+                echo "Waiting... recs=$recs cpu_lim=$cpu_lim mem_lim=$mem_lim"
+                sleep 5
+              done
+              echo "FAIL: timed out waiting for recommendations under RequestsOnly"
+              kubectl get attunepolicy reqonly-test -n e2e-requests-only -o yaml
+              exit 1
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1

--- a/test/e2e/vpa-conflict/chainsaw-test.yaml
+++ b/test/e2e/vpa-conflict/chainsaw-test.yaml
@@ -133,18 +133,29 @@ spec:
                 namespace: e2e-vpa-conflict
               status:
                 readyReplicas: 1
-    - name: verify-policy-reconciles-despite-vpa
+    - name: verify-vpa-conflict-warning
       try:
-        - assert:
-            resource:
-              apiVersion: attune.io/v1alpha1
-              kind: AttunePolicy
-              metadata:
-                name: vpa-conflict-test
-                namespace: e2e-vpa-conflict
-              status:
-                workloads:
-                  discovered: 1
+        - script:
+            timeout: 3m
+            content: |
+              set -e
+              for i in $(seq 1 36); do
+                discovered=$(kubectl get attunepolicy vpa-conflict-test -n e2e-vpa-conflict \
+                  -o jsonpath='{.status.workloads.discovered}' 2>/dev/null || true)
+                events=$(kubectl get events -n e2e-vpa-conflict \
+                  --field-selector involvedObject.name=vpa-conflict-test,involvedObject.kind=AttunePolicy,reason=VPAConflict \
+                  -o jsonpath='{.items[*].reason}' 2>/dev/null || true)
+                if [ "$discovered" = "1" ] && echo "$events" | grep -q VPAConflict; then
+                  echo "OK: discovered=1 and VPAConflict warning event present"
+                  exit 0
+                fi
+                echo "Waiting... discovered=$discovered events='$events'"
+                sleep 5
+              done
+              echo "FAIL: timed out waiting for VPAConflict event with discovered=1"
+              kubectl get attunepolicy vpa-conflict-test -n e2e-vpa-conflict -o yaml
+              kubectl get events -n e2e-vpa-conflict --sort-by='.lastTimestamp' | tail -20
+              exit 1
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1

--- a/test/e2e/webhook-validation/chainsaw-test.yaml
+++ b/test/e2e/webhook-validation/chainsaw-test.yaml
@@ -3,7 +3,9 @@ kind: Test
 metadata:
   name: webhook-validation
 spec:
-  description: Verify that the validating webhook rejects invalid policies
+  description: >
+    Verify CRD schema and validating-webhook rejections with attributed error
+    messages (schema vs webhook)
   timeouts:
     apply: 30s
     assert: 30s
@@ -17,17 +19,21 @@ spec:
               kind: Namespace
               metadata:
                 name: e2e-webhook-validation
-    - name: reject-invalid-overhead
+    - name: reject-schema-invalid-overhead
+      description: >
+        overhead "not-a-number" is rejected by the CRD OpenAPI pattern before
+        the webhook runs
       try:
-        - apply:
-            expect:
-              - check:
-                  ($error != null): true
-            resource:
+        - script:
+            timeout: 30s
+            content: |
+              set -e
+              set +e
+              out=$(kubectl apply -f - 2>&1 <<'YAML'
               apiVersion: attune.io/v1alpha1
               kind: AttunePolicy
               metadata:
-                name: bad-margin
+                name: bad-margin-schema
                 namespace: e2e-webhook-validation
               spec:
                 targetRef:
@@ -43,17 +49,30 @@ spec:
                   percentile: 99
                 updateStrategy:
                   type: Recommend
-    - name: reject-negative-cooldown
+              YAML
+              rc=$?
+              set -e
+              if [ "$rc" -eq 0 ]; then
+                echo "FAIL: invalid overhead was accepted"
+                echo "$out"
+                exit 1
+              fi
+              echo "$out" | grep -qiE 'Invalid value|pattern|admission webhook|denied'
+              echo "OK: CRD/schema rejected not-a-number overhead"
+              echo "$out" | head -5
+    - name: reject-webhook-negative-cooldown
+      description: cooldown -5m is a plain string in the CRD; webhook rejects it
       try:
-        - apply:
-            expect:
-              - check:
-                  ($error != null): true
-            resource:
+        - script:
+            timeout: 30s
+            content: |
+              set -e
+              set +e
+              out=$(kubectl apply -f - 2>&1 <<'YAML'
               apiVersion: attune.io/v1alpha1
               kind: AttunePolicy
               metadata:
-                name: bad-cooldown
+                name: bad-cooldown-neg
                 namespace: e2e-webhook-validation
               spec:
                 targetRef:
@@ -69,6 +88,133 @@ spec:
                 updateStrategy:
                   type: Recommend
                   cooldown: -5m
+              YAML
+              rc=$?
+              set -e
+              if [ "$rc" -eq 0 ]; then
+                echo "FAIL: negative cooldown was accepted"
+                echo "$out"
+                exit 1
+              fi
+              echo "$out" | grep -q 'cooldown must be non-negative'
+              echo "OK: webhook rejected negative cooldown"
+              echo "$out" | head -5
+    - name: reject-webhook-subminute-cooldown
+      description: cooldown 30s passes CRD string type; webhook enforces 1m floor
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              set -e
+              set +e
+              out=$(kubectl apply -f - 2>&1 <<'YAML'
+              apiVersion: attune.io/v1alpha1
+              kind: AttunePolicy
+              metadata:
+                name: bad-cooldown-floor
+                namespace: e2e-webhook-validation
+              spec:
+                targetRef:
+                  kind: Deployment
+                  name: my-app
+                metricsSource:
+                  prometheus:
+                    address: http://prometheus-server.monitoring:80
+                cpu:
+                  percentile: 95
+                memory:
+                  percentile: 99
+                updateStrategy:
+                  type: Recommend
+                  cooldown: 30s
+              YAML
+              rc=$?
+              set -e
+              if [ "$rc" -eq 0 ]; then
+                echo "FAIL: sub-minute cooldown was accepted"
+                echo "$out"
+                exit 1
+              fi
+              echo "$out" | grep -q 'cooldown must be at least 1m'
+              echo "OK: webhook rejected sub-minute cooldown"
+              echo "$out" | head -5
+    - name: reject-webhook-overhead-above-max
+      description: overhead 901 matches CRD number pattern; webhook enforces <=900
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              set -e
+              set +e
+              out=$(kubectl apply -f - 2>&1 <<'YAML'
+              apiVersion: attune.io/v1alpha1
+              kind: AttunePolicy
+              metadata:
+                name: bad-overhead-max
+                namespace: e2e-webhook-validation
+              spec:
+                targetRef:
+                  kind: Deployment
+                  name: my-app
+                metricsSource:
+                  prometheus:
+                    address: http://prometheus-server.monitoring:80
+                cpu:
+                  percentile: 95
+                  overhead: "901"
+                memory:
+                  percentile: 99
+                updateStrategy:
+                  type: Recommend
+              YAML
+              rc=$?
+              set -e
+              if [ "$rc" -eq 0 ]; then
+                echo "FAIL: overhead 901 was accepted"
+                echo "$out"
+                exit 1
+              fi
+              echo "$out" | grep -q 'cpu.overhead must be <= 900'
+              echo "OK: webhook rejected overhead above 900"
+              echo "$out" | head -5
+    - name: reject-webhook-prometheus-ssrf
+      description: IMDS link-local address is blocked by ValidatePrometheusAddress
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              set -e
+              set +e
+              out=$(kubectl apply -f - 2>&1 <<'YAML'
+              apiVersion: attune.io/v1alpha1
+              kind: AttunePolicy
+              metadata:
+                name: bad-prom-ssrf
+                namespace: e2e-webhook-validation
+              spec:
+                targetRef:
+                  kind: Deployment
+                  name: my-app
+                metricsSource:
+                  prometheus:
+                    address: http://169.254.169.254/latest/meta-data/
+                cpu:
+                  percentile: 95
+                memory:
+                  percentile: 99
+                updateStrategy:
+                  type: Recommend
+              YAML
+              rc=$?
+              set -e
+              if [ "$rc" -eq 0 ]; then
+                echo "FAIL: IMDS prometheus address was accepted"
+                echo "$out"
+                exit 1
+              fi
+              echo "$out" | grep -qiE 'metadata|loopback|link-local|must not target'
+              echo "OK: webhook rejected IMDS prometheus address"
+              echo "$out" | head -5
   catch:
     - describe:
         apiVersion: attune.io/v1alpha1

--- a/test/e2e/webhook-validation/chainsaw-test.yaml
+++ b/test/e2e/webhook-validation/chainsaw-test.yaml
@@ -28,8 +28,7 @@ spec:
             timeout: 30s
             content: |
               set -e
-              set +e
-              out=$(kubectl apply -f - 2>&1 <<'YAML'
+              cat > /tmp/bad-margin-schema.yaml <<'YAML'
               apiVersion: attune.io/v1alpha1
               kind: AttunePolicy
               metadata:
@@ -50,6 +49,8 @@ spec:
                 updateStrategy:
                   type: Recommend
               YAML
+              set +e
+              out=$(kubectl apply -f /tmp/bad-margin-schema.yaml 2>&1)
               rc=$?
               set -e
               if [ "$rc" -eq 0 ]; then
@@ -67,8 +68,7 @@ spec:
             timeout: 30s
             content: |
               set -e
-              set +e
-              out=$(kubectl apply -f - 2>&1 <<'YAML'
+              cat > /tmp/bad-cooldown-neg.yaml <<'YAML'
               apiVersion: attune.io/v1alpha1
               kind: AttunePolicy
               metadata:
@@ -89,6 +89,8 @@ spec:
                   type: Recommend
                   cooldown: -5m
               YAML
+              set +e
+              out=$(kubectl apply -f /tmp/bad-cooldown-neg.yaml 2>&1)
               rc=$?
               set -e
               if [ "$rc" -eq 0 ]; then
@@ -106,8 +108,7 @@ spec:
             timeout: 30s
             content: |
               set -e
-              set +e
-              out=$(kubectl apply -f - 2>&1 <<'YAML'
+              cat > /tmp/bad-cooldown-floor.yaml <<'YAML'
               apiVersion: attune.io/v1alpha1
               kind: AttunePolicy
               metadata:
@@ -128,6 +129,8 @@ spec:
                   type: Recommend
                   cooldown: 30s
               YAML
+              set +e
+              out=$(kubectl apply -f /tmp/bad-cooldown-floor.yaml 2>&1)
               rc=$?
               set -e
               if [ "$rc" -eq 0 ]; then
@@ -145,8 +148,7 @@ spec:
             timeout: 30s
             content: |
               set -e
-              set +e
-              out=$(kubectl apply -f - 2>&1 <<'YAML'
+              cat > /tmp/bad-overhead-max.yaml <<'YAML'
               apiVersion: attune.io/v1alpha1
               kind: AttunePolicy
               metadata:
@@ -167,6 +169,8 @@ spec:
                 updateStrategy:
                   type: Recommend
               YAML
+              set +e
+              out=$(kubectl apply -f /tmp/bad-overhead-max.yaml 2>&1)
               rc=$?
               set -e
               if [ "$rc" -eq 0 ]; then
@@ -184,8 +188,7 @@ spec:
             timeout: 30s
             content: |
               set -e
-              set +e
-              out=$(kubectl apply -f - 2>&1 <<'YAML'
+              cat > /tmp/bad-prom-ssrf.yaml <<'YAML'
               apiVersion: attune.io/v1alpha1
               kind: AttunePolicy
               metadata:
@@ -205,6 +208,8 @@ spec:
                 updateStrategy:
                   type: Recommend
               YAML
+              set +e
+              out=$(kubectl apply -f /tmp/bad-prom-ssrf.yaml 2>&1)
               rc=$?
               set -e
               if [ "$rc" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Harden E2E assertions so named features fail closed when broken (audit leftovers after #642).

### #632 BudgetCaps
- Require `BudgetExhausted` event (not a tautology on increase rec alone).
- Hard-assert `status.workloads.resized == 0` with memory still pinned.
- Unit: budget defer leaves empty history, increments `BudgetExhaustedTotal`, emits event, and keeps resized at 0 after history self-heal.

### #633 Discovery-only tests
- `exclude-containers`: recommendations include `app`, never `istio-proxy`.
- `requests-only`: recommended limits stay at current (500m / 512Mi).
- `query-parameters`: `withRecommendations >= 1`.
- `hpa-conflict` / `vpa-conflict`: `HPAConflict` / `VPAConflict` warning events.
- Bearer token Go E2E: `WithRecommendations >= 1`.

### #640 Webhook attribution + positive controls
- Schema vs webhook cases with message checks (negative cooldown, 30s floor, overhead 901, IMDS SSRF).
- Observe: `withRecommendations >= 1`, empty `status.recommendations`, `resized=0`.
- Recommend: surfaced recs and `resized=0`.

## Test plan
- [x] `go test ./internal/controller/ -race -run TestExecuteResizes_BudgetCaps`
- [x] `make lint-chainsaw` + `scripts/test_verify_chainsaw_scripts.sh`
- [x] `go test -c -tags=e2e ./test/e2e-go/`
- [ ] PR CI E2E (Chainsaw + Go)

Closes #632
Closes #633
Closes #640
