### PR TITLE
test: assert live restore on revert and resize direction on pause workloads

### DIFF
--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -530,37 +530,58 @@ func TestE2E_AutoMode_ResizesRunningPod(t *testing.T) {
 	t.Parallel()
 	ns := uniqueNS("auto")
 	createNamespace(t, ns)
-	createDeployment(t, "auto-app", ns, "250m", "256Mi", 1)
+	createDeployment(t, "auto-app", ns, "500m", "256Mi", 1)
 	waitForDeploymentReady(t, "auto-app", ns, 60*time.Second)
 
-	createPolicy(t, "auto-policy", ns, "auto-app", attunev1alpha1.UpdateTypeAuto)
+	// Idle pause: pin MaxAllowed below start so a cost-multiplying increase
+	// cannot satisfy waitForResize / "something changed".
+	deployName := "auto-app"
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "auto-policy", Namespace: ns},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			TargetRef: attunev1alpha1.TargetRef{Kind: "Deployment", Name: &deployName},
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Prometheus:        &attunev1alpha1.PrometheusConfig{Address: promAddr},
+				MinimumDataPoints: int32Ptr(1),
+				HistoryWindow:     &metav1.Duration{Duration: time.Hour},
+				QueryStep:         &metav1.Duration{Duration: 30 * time.Second},
+				RateWindow:        &metav1.Duration{Duration: 5 * time.Minute},
+			},
+			CPU: attunev1alpha1.ResourceConfig{
+				Percentile:       95,
+				Overhead:         "20",
+				MinAllowed:       quantityPtr("50m"),
+				MaxAllowed:       quantityPtr("250m"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			Memory: attunev1alpha1.ResourceConfig{
+				Percentile:       99,
+				Overhead:         "30",
+				AllowDecrease:    boolPtr(true),
+				MinAllowed:       quantityPtr("64Mi"),
+				MaxAllowed:       quantityPtr("8Gi"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type:       attunev1alpha1.UpdateTypeAuto,
+				Cooldown:   &metav1.Duration{Duration: time.Minute},
+				AutoRevert: boolPtr(true),
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, policy))
 
-	// Wait for resize to complete (pod resources should change).
-	waitForResize(t, "auto-policy", ns, 3*time.Minute)
+	origCPU := resource.MustParse("500m")
+	waitForLiveCPUDecrease(t, "auto-policy", ns, "auto-app", origCPU, 4*time.Minute,
+		"Auto mode should decrease idle pause CPU below start")
 
-	// Verify the pod's resources actually changed.
 	var podList corev1.PodList
 	require.NoError(t, k8sClient.List(ctx, &podList,
 		client.InNamespace(ns),
 		client.MatchingLabels{"app": "auto-app"},
 	))
 	require.NotEmpty(t, podList.Items)
-
-	pod := podList.Items[0]
-
-	// Verify the resize actually changed the pod's resources.
-	// We don't assert direction (up/down) because the recommendation
-	// depends on actual Prometheus data which varies per run.
-	origCPU := resource.MustParse("250m")
-	origMem := resource.MustParse("256Mi")
-	cpuReq := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
-	memReq := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
-	assert.True(t, cpuReq.Cmp(origCPU) != 0 || memReq.Cmp(origMem) != 0,
-		"at least one resource should have changed after resize, cpu=%s mem=%s",
-		cpuReq.String(), memReq.String())
-
-	// Verify pod is still Running.
-	assert.Equal(t, corev1.PodRunning, pod.Status.Phase)
+	assert.Equal(t, corev1.PodRunning, podList.Items[0].Status.Phase)
 }
 
 func TestE2E_OneShotMode_ResizesOnePod(t *testing.T) {
@@ -583,59 +604,59 @@ func TestE2E_OneShotMode_ResizesOnePod(t *testing.T) {
 
 func TestE2E_AutoMode_RecordsResizeHistory(t *testing.T) {
 	t.Parallel()
-	ns := uniqueNS("revert")
+	ns := uniqueNS("history")
 	createNamespace(t, ns)
 
-	// Deploy a pod with a liveness probe that checks for a file.
-	// After resize, the annotation change triggers the operator's observation.
-	// We use a pod that will fail its liveness probe to trigger restarts.
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "revert-app",
-			Namespace: ns,
-			Labels:    map[string]string{"app": "revert-app"},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(1),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "revert-app"},
+	// History bookkeeping only (not a safety-revert test). Live restore after
+	// OOM/SLO is covered by TestE2E_OOMKill_TriggersRevert and slo-guardrails.
+	createDeployment(t, "history-app", ns, "500m", "256Mi", 1)
+	waitForDeploymentReady(t, "history-app", ns, 60*time.Second)
+
+	deployName := "history-app"
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "history-policy", Namespace: ns},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			TargetRef: attunev1alpha1.TargetRef{Kind: "Deployment", Name: &deployName},
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Prometheus:        &attunev1alpha1.PrometheusConfig{Address: promAddr},
+				MinimumDataPoints: int32Ptr(1),
+				HistoryWindow:     &metav1.Duration{Duration: time.Hour},
+				QueryStep:         &metav1.Duration{Duration: 30 * time.Second},
+				RateWindow:        &metav1.Duration{Duration: 5 * time.Minute},
 			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": "revert-app"},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "app",
-							Image: "registry.k8s.io/pause:3.9",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
-								},
-							},
-						},
-					},
-				},
+			CPU: attunev1alpha1.ResourceConfig{
+				Percentile:       95,
+				Overhead:         "20",
+				MinAllowed:       quantityPtr("50m"),
+				MaxAllowed:       quantityPtr("250m"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			Memory: attunev1alpha1.ResourceConfig{
+				Percentile:       99,
+				Overhead:         "30",
+				AllowDecrease:    boolPtr(true),
+				MinAllowed:       quantityPtr("64Mi"),
+				MaxAllowed:       quantityPtr("8Gi"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type:       attunev1alpha1.UpdateTypeAuto,
+				Cooldown:   &metav1.Duration{Duration: time.Minute},
+				AutoRevert: boolPtr(true),
 			},
 		},
 	}
-	require.NoError(t, k8sClient.Create(ctx, deploy))
-	waitForDeploymentReady(t, "revert-app", ns, 60*time.Second)
+	require.NoError(t, k8sClient.Create(ctx, policy))
 
-	policy := createPolicy(t, "revert-policy", ns, "revert-app", attunev1alpha1.UpdateTypeAuto)
+	waitForLiveCPUDecrease(t, "history-policy", ns, "history-app", resource.MustParse("500m"), 4*time.Minute,
+		"history test needs a successful resize first")
 
-	// Wait for initial resize.
-	waitForResize(t, "revert-policy", ns, 3*time.Minute)
-
-	// Verify the resize occurred and check that history entries exist.
 	var updatedPolicy attunev1alpha1.AttunePolicy
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
-		Name: policy.Name, Namespace: ns,
+		Name: "history-policy", Namespace: ns,
 	}, &updatedPolicy))
 	assert.NotEmpty(t, updatedPolicy.Status.ResizeHistory,
-		"resize history should have at least one entry")
+		"resize history should have at least one entry after a live resize")
 }
 
 func TestE2E_MultiContainer_ExcludesSidecar(t *testing.T) {
@@ -707,7 +728,7 @@ func TestE2E_MultiContainer_ExcludesSidecar(t *testing.T) {
 				Percentile:       95,
 				Overhead:         "20",
 				MinAllowed:       quantityPtr("50m"),
-				MaxAllowed:       quantityPtr("4000m"),
+				MaxAllowed:       quantityPtr("100m"),
 				MaxChangePercent: int32Ptr(100),
 			},
 			Memory: attunev1alpha1.ResourceConfig{
@@ -728,9 +749,10 @@ func TestE2E_MultiContainer_ExcludesSidecar(t *testing.T) {
 	}
 	require.NoError(t, k8sClient.Create(ctx, policy))
 
-	waitForResize(t, "multi-policy", ns, 3*time.Minute)
+	// App starts at 250m; MaxAllowed 100m forces a decrease on the app only.
+	waitForLiveCPUDecrease(t, "multi-policy", ns, "multi-app", resource.MustParse("250m"), 4*time.Minute,
+		"app container CPU should decrease while sidecar is excluded")
 
-	// Verify only app container was resized.
 	var podList corev1.PodList
 	require.NoError(t, k8sClient.List(ctx, &podList,
 		client.InNamespace(ns),
@@ -752,10 +774,8 @@ func TestE2E_MultiContainer_ExcludesSidecar(t *testing.T) {
 		}
 		if c.Name == "app" {
 			origCPU := resource.MustParse("250m")
-			origMem := resource.MustParse("256Mi")
-			assert.True(t, c.Resources.Requests.Cpu().Cmp(origCPU) != 0 ||
-				c.Resources.Requests.Memory().Cmp(origMem) != 0,
-				"app container should have at least one resource changed")
+			assert.Less(t, c.Resources.Requests.Cpu().MilliValue(), origCPU.MilliValue(),
+				"app container CPU should decrease from start, got %s", c.Resources.Requests.Cpu().String())
 		}
 	}
 }
@@ -1714,32 +1734,67 @@ func TestE2E_OOMKill_TriggersRevert(t *testing.T) {
 		return false, nil
 	}), "timed out waiting for OOMKill")
 
-	// Phase 4: Wait for the safety monitor to detect OOMKill and record a
-	// Reverted entry in the resize history.
+	// Phase 4: Wait for OOMKill revert in history, then prove live resources
+	// were restored to the pre-resize Guaranteed requests (500m / 64Mi).
+	origCPU := resource.MustParse("500m")
+	origMem := resource.MustParse("64Mi")
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var p attunev1alpha1.AttunePolicy
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "oom-policy", Namespace: ns}, &p); err != nil {
 			return false, nil
 		}
+		oomRevert := false
 		for _, h := range p.Status.ResizeHistory {
-			if h.Result == attunev1alpha1.ResizeResultReverted {
-				t.Logf("Revert detected: workload=%s container=%s resource=%s", h.Workload, h.Container, h.Resource)
-				return true, nil
+			if h.Result == attunev1alpha1.ResizeResultReverted &&
+				(h.Reason == "oomkill" || strings.Contains(strings.ToLower(h.Reason), "oom")) {
+				t.Logf("OOM revert detected: workload=%s container=%s reason=%s",
+					h.Workload, h.Container, h.Reason)
+				oomRevert = true
+				break
+			}
+		}
+		if !oomRevert {
+			return false, nil
+		}
+		var pods corev1.PodList
+		if err := k8sClient.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{"app": "oom-app"}); err != nil {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase != corev1.PodRunning {
+				continue
+			}
+			for _, c := range pod.Spec.Containers {
+				if c.Name != "app" {
+					continue
+				}
+				cpu := c.Resources.Requests.Cpu()
+				mem := c.Resources.Requests.Memory()
+				if cpu != nil && mem != nil &&
+					cpu.Cmp(origCPU) == 0 && mem.Cmp(origMem) == 0 {
+					t.Logf("live resources restored on %s: cpu=%s mem=%s",
+						pod.Name, cpu.String(), mem.String())
+					return true, nil
+				}
+				t.Logf("waiting for restore on %s: cpu=%s mem=%s (want %s/%s)",
+					pod.Name, cpu, mem, origCPU.String(), origMem.String())
 			}
 		}
 		return false, nil
-	}), "timed out waiting for safety revert after OOMKill")
+	}), "timed out waiting for OOMKill revert to restore live pod resources")
 
 	var finalPolicy attunev1alpha1.AttunePolicy
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "oom-policy", Namespace: ns}, &finalPolicy))
-	hasRevert := false
+	hasOOMRevert := false
 	for i, h := range finalPolicy.Status.ResizeHistory {
-		t.Logf("  [%d] workload=%s container=%s resource=%s result=%s", i, h.Workload, h.Container, h.Resource, h.Result)
-		if h.Result == attunev1alpha1.ResizeResultReverted {
-			hasRevert = true
+		t.Logf("  [%d] workload=%s container=%s resource=%s result=%s reason=%s",
+			i, h.Workload, h.Container, h.Resource, h.Result, h.Reason)
+		if h.Result == attunev1alpha1.ResizeResultReverted &&
+			(h.Reason == "oomkill" || strings.Contains(strings.ToLower(h.Reason), "oom")) {
+			hasOOMRevert = true
 		}
 	}
-	assert.True(t, hasRevert, "resize history should contain a Reverted entry after OOMKill")
+	assert.True(t, hasOOMRevert, "resize history should contain an OOMKill Reverted entry")
 }
 
 func TestE2E_MultiReplica_ProgressiveResize(t *testing.T) {
@@ -1849,7 +1904,7 @@ func TestE2E_GuaranteedQoS_RequestsAndLimits(t *testing.T) {
 				Overhead:         "20",
 				ControlledValues: &controlledBoth,
 				MinAllowed:       quantityPtr("50m"),
-				MaxAllowed:       quantityPtr("4000m"),
+				MaxAllowed:       quantityPtr("100m"),
 				MaxChangePercent: int32Ptr(100),
 			},
 			Memory: attunev1alpha1.ResourceConfig{
@@ -1872,9 +1927,9 @@ func TestE2E_GuaranteedQoS_RequestsAndLimits(t *testing.T) {
 
 	// Guaranteed QoS with memory resize forces a container restart, so allow
 	// extra time for the resize + restart + readiness cycle.
-	waitForResize(t, "qos-policy", ns, 5*time.Minute)
-
-	// Re-fetch pods after resize (the pod may have restarted from memory resize).
+	origCPU := resource.MustParse("250m")
+	waitForLiveCPUDecrease(t, "qos-policy", ns, "qos-app", origCPU, 6*time.Minute,
+		"Guaranteed QoS idle pause should decrease CPU below start")
 	waitForDeploymentReady(t, "qos-app", ns, 120*time.Second)
 
 	var podList corev1.PodList
@@ -1887,12 +1942,8 @@ func TestE2E_GuaranteedQoS_RequestsAndLimits(t *testing.T) {
 		"CPU requests and limits should match after resize (Guaranteed QoS)")
 	assert.Equal(t, c.Resources.Requests.Memory().Value(), c.Resources.Limits.Memory().Value(),
 		"memory requests and limits should match after resize (Guaranteed QoS)")
-
-	// At least one resource should have changed from the initial values.
-	origCPU := resource.MustParse("250m")
-	origMem := resource.MustParse("256Mi")
-	assert.True(t, c.Resources.Requests.Cpu().Cmp(origCPU) != 0 || c.Resources.Requests.Memory().Cmp(origMem) != 0,
-		"at least one resource should have changed, cpu=%s mem=%s", c.Resources.Requests.Cpu().String(), c.Resources.Requests.Memory().String())
+	assert.Less(t, c.Resources.Requests.Cpu().MilliValue(), origCPU.MilliValue(),
+		"CPU should decrease from start, got %s", c.Resources.Requests.Cpu().String())
 }
 
 func TestE2E_LabelSelector_MultipleWorkloads(t *testing.T) {
@@ -2244,7 +2295,7 @@ func TestE2E_MultiContainer_SequentialResize(t *testing.T) {
 				Percentile:       95,
 				Overhead:         "20",
 				MinAllowed:       quantityPtr("50m"),
-				MaxAllowed:       quantityPtr("4000m"),
+				MaxAllowed:       quantityPtr("100m"),
 				MaxChangePercent: int32Ptr(100),
 			},
 			Memory: attunev1alpha1.ResourceConfig{
@@ -2266,7 +2317,7 @@ func TestE2E_MultiContainer_SequentialResize(t *testing.T) {
 
 	waitForResize(t, "multi-resize-policy", ns, 3*time.Minute)
 
-	// Verify both containers were resized.
+	// Verify both containers were resized downward (MaxAllowed 100m < 250m start).
 	var podList corev1.PodList
 	require.NoError(t, k8sClient.List(ctx, &podList,
 		client.InNamespace(ns),
@@ -2276,19 +2327,19 @@ func TestE2E_MultiContainer_SequentialResize(t *testing.T) {
 
 	pod := podList.Items[0]
 	origCPU := resource.MustParse("250m")
-	origMem := resource.MustParse("256Mi")
-	resizedContainers := 0
+	decreasedContainers := 0
 	for _, c := range pod.Spec.Containers {
-		cpuChanged := c.Resources.Requests.Cpu().Cmp(origCPU) != 0
-		memChanged := c.Resources.Requests.Memory().Cmp(origMem) != 0
-		if cpuChanged || memChanged {
-			resizedContainers++
-			t.Logf("container %s resized: cpu=%s mem=%s",
-				c.Name, c.Resources.Requests.Cpu(), c.Resources.Requests.Memory())
+		cpu := c.Resources.Requests.Cpu()
+		if cpu != nil && cpu.Cmp(origCPU) < 0 {
+			decreasedContainers++
+			t.Logf("container %s CPU decreased: cpu=%s mem=%s",
+				c.Name, cpu.String(), c.Resources.Requests.Memory())
+		} else {
+			t.Logf("container %s CPU not decreased: cpu=%s", c.Name, cpu)
 		}
 	}
-	assert.Equal(t, 2, resizedContainers,
-		"both containers should be resized; sequential UpdateResize requires fresh resourceVersion propagation")
+	assert.Equal(t, 2, decreasedContainers,
+		"both containers should decrease CPU; sequential UpdateResize requires fresh resourceVersion")
 
 	// Verify resize history records both containers.
 	var p attunev1alpha1.AttunePolicy

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -1734,28 +1734,37 @@ func TestE2E_OOMKill_TriggersRevert(t *testing.T) {
 		return false, nil
 	}), "timed out waiting for OOMKill")
 
-	// Phase 4: Wait for OOMKill revert in history, then prove live resources
-	// were restored to the pre-resize Guaranteed requests (500m / 64Mi).
-	origCPU := resource.MustParse("500m")
-	origMem := resource.MustParse("64Mi")
+	// Phase 4: Wait for an OOMKill Reverted history row (not any revert).
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var p attunev1alpha1.AttunePolicy
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "oom-policy", Namespace: ns}, &p); err != nil {
 			return false, nil
 		}
-		oomRevert := false
 		for _, h := range p.Status.ResizeHistory {
 			if h.Result == attunev1alpha1.ResizeResultReverted &&
 				(h.Reason == "oomkill" || strings.Contains(strings.ToLower(h.Reason), "oom")) {
 				t.Logf("OOM revert detected: workload=%s container=%s reason=%s",
 					h.Workload, h.Container, h.Reason)
-				oomRevert = true
-				break
+				return true, nil
 			}
 		}
-		if !oomRevert {
-			return false, nil
+		return false, nil
+	}), "timed out waiting for OOMKill Reverted history")
+
+	// Pause so Auto cannot immediately re-decrease (cooldown is 1m, but pause
+	// is the hard stop). Then require live requests back at pre-resize values.
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var p attunev1alpha1.AttunePolicy
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "oom-policy", Namespace: ns}, &p); err != nil {
+			return err
 		}
+		p.Spec.Paused = boolPtr(true)
+		return k8sClient.Update(ctx, &p)
+	}))
+
+	origCPU := resource.MustParse("500m")
+	origMem := resource.MustParse("64Mi")
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var pods corev1.PodList
 		if err := k8sClient.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{"app": "oom-app"}); err != nil {
 			return false, nil

--- a/test/e2e/auto-mode/chainsaw-test.yaml
+++ b/test/e2e/auto-mode/chainsaw-test.yaml
@@ -141,22 +141,25 @@ spec:
             timeout: 5m
             content: |
               set -e
+              cpu_milli() {
+                v=$1
+                case "$v" in
+                  *m) echo "${v%m}" ;;
+                  "") echo 0 ;;
+                  *) echo $((v * 1000)) ;;
+                esac
+              }
               for i in $(seq 1 60); do
                 RESIZED=$(kubectl get attunepolicy auto-test -n e2e-auto-mode \
-                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null)
+                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null || true)
                 CPU=$(kubectl get pods -n e2e-auto-mode -l app=auto-app \
                   -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
-                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ -n "$CPU" ] && [ "$CPU" != "500m" ]; then
-                  case "$CPU" in
-                    1|1000m|2|2000m|4000m)
-                      echo "FAIL: idle pause resized CPU up to $CPU"
-                      exit 1
-                      ;;
-                  esac
-                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (below 500m start)"
+                milli=$(cpu_milli "$CPU")
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ "$milli" -gt 0 ] && [ "$milli" -lt 500 ]; then
+                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (${milli}m < 500m start)"
                   exit 0
                 fi
-                echo "Waiting... resized=$RESIZED cpu=$CPU"
+                echo "Waiting... resized=$RESIZED cpu=$CPU milli=$milli"
                 sleep 5
               done
               echo "No downward resize within timeout"

--- a/test/e2e/auto-mode/chainsaw-test.yaml
+++ b/test/e2e/auto-mode/chainsaw-test.yaml
@@ -102,7 +102,7 @@ spec:
                   percentile: 95
                   overhead: "20"
                   minAllowed: 50m
-                  maxAllowed: "4000m"
+                  maxAllowed: "250m"
                   maxChangePercent: 100
                 memory:
                   percentile: 99
@@ -140,17 +140,28 @@ spec:
         - script:
             timeout: 5m
             content: |
+              set -e
               for i in $(seq 1 60); do
                 RESIZED=$(kubectl get attunepolicy auto-test -n e2e-auto-mode \
                   -o jsonpath='{.status.workloads.resized}' 2>/dev/null)
-                if [ "$RESIZED" -ge 1 ] 2>/dev/null; then
-                  echo "Resize confirmed: $RESIZED pod(s) resized"
+                CPU=$(kubectl get pods -n e2e-auto-mode -l app=auto-app \
+                  -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ -n "$CPU" ] && [ "$CPU" != "500m" ]; then
+                  case "$CPU" in
+                    1|1000m|2|2000m|4000m)
+                      echo "FAIL: idle pause resized CPU up to $CPU"
+                      exit 1
+                      ;;
+                  esac
+                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (below 500m start)"
                   exit 0
                 fi
+                echo "Waiting... resized=$RESIZED cpu=$CPU"
                 sleep 5
               done
-              echo "No resize occurred within timeout"
+              echo "No downward resize within timeout"
               kubectl get attunepolicy auto-test -n e2e-auto-mode -o yaml
+              kubectl get pods -n e2e-auto-mode -l app=auto-app -o yaml
               exit 1
   catch:
     - describe:

--- a/test/e2e/canary-rollout/chainsaw-test.yaml
+++ b/test/e2e/canary-rollout/chainsaw-test.yaml
@@ -106,7 +106,7 @@ spec:
                   percentile: 95
                   overhead: "20"
                   minAllowed: 50m
-                  maxAllowed: "4000m"
+                  maxAllowed: "250m"
                   controlledValues: RequestsAndLimits
                   maxChangePercent: 100
                 memory:
@@ -145,17 +145,28 @@ spec:
         - script:
             timeout: 5m
             content: |
+              set -e
               for i in $(seq 1 60); do
                 RESIZED=$(kubectl get attunepolicy canary-test -n e2e-canary-rollout \
                   -o jsonpath='{.status.workloads.resized}' 2>/dev/null)
-                if [ "$RESIZED" -ge 1 ] 2>/dev/null; then
-                  echo "Resize confirmed: $RESIZED pod(s) resized"
+                CPU=$(kubectl get pods -n e2e-canary-rollout -l app=canary-app \
+                  -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ -n "$CPU" ] && [ "$CPU" != "500m" ]; then
+                  case "$CPU" in
+                    1|1000m|2|2000m|4000m)
+                      echo "FAIL: idle pause resized CPU up to $CPU"
+                      exit 1
+                      ;;
+                  esac
+                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (below 500m start)"
                   exit 0
                 fi
+                echo "Waiting... resized=$RESIZED cpu=$CPU"
                 sleep 5
               done
-              echo "No resize occurred within timeout"
+              echo "No downward resize within timeout"
               kubectl get attunepolicy canary-test -n e2e-canary-rollout -o yaml
+              kubectl get pods -n e2e-canary-rollout -l app=canary-app -o yaml
               exit 1
     - name: verify-canary-fraction
       try:

--- a/test/e2e/canary-rollout/chainsaw-test.yaml
+++ b/test/e2e/canary-rollout/chainsaw-test.yaml
@@ -157,14 +157,23 @@ spec:
               for i in $(seq 1 60); do
                 RESIZED=$(kubectl get attunepolicy canary-test -n e2e-canary-rollout \
                   -o jsonpath='{.status.workloads.resized}' 2>/dev/null || true)
-                CPU=$(kubectl get pods -n e2e-canary-rollout -l app=canary-app \
-                  -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
-                milli=$(cpu_milli "$CPU")
-                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ "$milli" -gt 0 ] && [ "$milli" -lt 500 ]; then
-                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (${milli}m < 500m start)"
+                # Canary resizes a subset; items[0] may still be at 500m.
+                CPUS=$(kubectl get pods -n e2e-canary-rollout -l app=canary-app \
+                  -o jsonpath='{range .items[*]}{.spec.containers[0].resources.requests.cpu}{"\n"}{end}' 2>/dev/null || true)
+                decreased=0
+                for CPU in $CPUS; do
+                  milli=$(cpu_milli "$CPU")
+                  if [ "$milli" -gt 0 ] && [ "$milli" -lt 500 ]; then
+                    decreased=1
+                    dec_cpu=$CPU
+                    dec_milli=$milli
+                  fi
+                done
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ "$decreased" = "1" ]; then
+                  echo "Resize confirmed: resized=$RESIZED liveCPU=$dec_cpu (${dec_milli}m < 500m start)"
                   exit 0
                 fi
-                echo "Waiting... resized=$RESIZED cpu=$CPU milli=$milli"
+                echo "Waiting... resized=$RESIZED cpus=$(echo $CPUS | tr '\n' ' ')"
                 sleep 5
               done
               echo "No downward resize within timeout"

--- a/test/e2e/canary-rollout/chainsaw-test.yaml
+++ b/test/e2e/canary-rollout/chainsaw-test.yaml
@@ -146,22 +146,25 @@ spec:
             timeout: 5m
             content: |
               set -e
+              cpu_milli() {
+                v=$1
+                case "$v" in
+                  *m) echo "${v%m}" ;;
+                  "") echo 0 ;;
+                  *) echo $((v * 1000)) ;;
+                esac
+              }
               for i in $(seq 1 60); do
                 RESIZED=$(kubectl get attunepolicy canary-test -n e2e-canary-rollout \
-                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null)
+                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null || true)
                 CPU=$(kubectl get pods -n e2e-canary-rollout -l app=canary-app \
                   -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
-                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ -n "$CPU" ] && [ "$CPU" != "500m" ]; then
-                  case "$CPU" in
-                    1|1000m|2|2000m|4000m)
-                      echo "FAIL: idle pause resized CPU up to $CPU"
-                      exit 1
-                      ;;
-                  esac
-                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (below 500m start)"
+                milli=$(cpu_milli "$CPU")
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ "$milli" -gt 0 ] && [ "$milli" -lt 500 ]; then
+                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (${milli}m < 500m start)"
                   exit 0
                 fi
-                echo "Waiting... resized=$RESIZED cpu=$CPU"
+                echo "Waiting... resized=$RESIZED cpu=$CPU milli=$milli"
                 sleep 5
               done
               echo "No downward resize within timeout"

--- a/test/e2e/concurrent-resize/chainsaw-test.yaml
+++ b/test/e2e/concurrent-resize/chainsaw-test.yaml
@@ -128,17 +128,31 @@ spec:
         - script:
             timeout: 5m
             content: |
+              set -e
+              cpu_milli() {
+                v=$1
+                case "$v" in
+                  *m) echo "${v%m}" ;;
+                  "") echo 0 ;;
+                  *) echo $((v * 1000)) ;;
+                esac
+              }
               for i in $(seq 1 60); do
                 RESIZED=$(kubectl get attunepolicy concurrent-test -n e2e-concurrent-resize \
-                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null)
-                if [ "$RESIZED" -ge 1 ] 2>/dev/null; then
-                  echo "Concurrent resize confirmed: $RESIZED workload(s) resized"
+                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null || true)
+                CPU=$(kubectl get pods -n e2e-concurrent-resize -l app=concurrent-app \
+                  -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
+                milli=$(cpu_milli "$CPU")
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ "$milli" -gt 0 ] && [ "$milli" -lt 100 ]; then
+                  echo "Concurrent resize decrease: resized=$RESIZED liveCPU=$CPU"
                   exit 0
                 fi
+                echo "Waiting... resized=$RESIZED cpu=$CPU milli=$milli"
                 sleep 5
               done
-              echo "No resize occurred within timeout"
+              echo "No downward resize within timeout"
               kubectl get attunepolicy concurrent-test -n e2e-concurrent-resize -o yaml
+              kubectl get pods -n e2e-concurrent-resize -l app=concurrent-app -o yaml
               exit 1
   catch:
     - describe:

--- a/test/e2e/concurrent-resize/chainsaw-test.yaml
+++ b/test/e2e/concurrent-resize/chainsaw-test.yaml
@@ -99,6 +99,8 @@ spec:
                 cpu:
                   percentile: 95
                   overhead: "20"
+                  minAllowed: 1m
+                  maxAllowed: "50m"
                   maxChangePercent: 100
                 memory:
                   percentile: 99

--- a/test/e2e/eviction-fallback/chainsaw-test.yaml
+++ b/test/e2e/eviction-fallback/chainsaw-test.yaml
@@ -129,17 +129,31 @@ spec:
         - script:
             timeout: 5m
             content: |
+              set -e
+              cpu_milli() {
+                v=$1
+                case "$v" in
+                  *m) echo "${v%m}" ;;
+                  "") echo 0 ;;
+                  *) echo $((v * 1000)) ;;
+                esac
+              }
               for i in $(seq 1 60); do
                 RESIZED=$(kubectl get attunepolicy eviction-test -n e2e-eviction-fallback \
-                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null)
-                if [ "$RESIZED" -ge 1 ] 2>/dev/null; then
-                  echo "Eviction-fallback resize confirmed: $RESIZED workload(s) resized"
+                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null || true)
+                CPU=$(kubectl get pods -n e2e-eviction-fallback -l app=eviction-app \
+                  -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
+                milli=$(cpu_milli "$CPU")
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ "$milli" -gt 0 ] && [ "$milli" -lt 500 ]; then
+                  echo "Eviction-fallback decrease: resized=$RESIZED liveCPU=$CPU"
                   exit 0
                 fi
+                echo "Waiting... resized=$RESIZED cpu=$CPU milli=$milli"
                 sleep 5
               done
-              echo "No resize occurred within timeout"
+              echo "No downward resize within timeout"
               kubectl get attunepolicy eviction-test -n e2e-eviction-fallback -o yaml
+              kubectl get pods -n e2e-eviction-fallback -l app=eviction-app -o yaml
               exit 1
   catch:
     - describe:

--- a/test/e2e/eviction-fallback/chainsaw-test.yaml
+++ b/test/e2e/eviction-fallback/chainsaw-test.yaml
@@ -99,6 +99,8 @@ spec:
                 cpu:
                   percentile: 95
                   overhead: "20"
+                  minAllowed: 50m
+                  maxAllowed: "250m"
                   maxChangePercent: 100
                 memory:
                   percentile: 99

--- a/test/e2e/hpa-auto-tune/chainsaw-test.yaml
+++ b/test/e2e/hpa-auto-tune/chainsaw-test.yaml
@@ -123,7 +123,7 @@ spec:
                   percentile: 95
                   overhead: "20"
                   minAllowed: 50m
-                  maxAllowed: "4000m"
+                  maxAllowed: "250m"
                   maxChangePercent: 100
                 memory:
                   percentile: 99

--- a/test/e2e/hpa-auto-tune/chainsaw-test.yaml
+++ b/test/e2e/hpa-auto-tune/chainsaw-test.yaml
@@ -151,14 +151,26 @@ spec:
         - script:
             timeout: 5m
             content: |
+              set -e
+              cpu_milli() {
+                v=$1
+                case "$v" in
+                  *m) echo "${v%m}" ;;
+                  "") echo 0 ;;
+                  *) echo $((v * 1000)) ;;
+                esac
+              }
               for i in $(seq 1 60); do
                 ORIG=$(kubectl get hpa tune-app -n e2e-hpa-auto-tune \
-                  -o jsonpath='{.metadata.annotations.attune\.io/original-target-cpu}' 2>/dev/null)
+                  -o jsonpath='{.metadata.annotations.attune\.io/original-target-cpu}' 2>/dev/null || true)
                 if [ -n "$ORIG" ]; then
                   echo "HPA original-target-cpu annotation found: $ORIG"
                   CURRENT=$(kubectl get hpa tune-app -n e2e-hpa-auto-tune \
-                    -o jsonpath='{.spec.metrics[0].resource.target.averageUtilization}' 2>/dev/null)
-                  echo "Current averageUtilization: $CURRENT"
+                    -o jsonpath='{.spec.metrics[0].resource.target.averageUtilization}' 2>/dev/null || true)
+                  CPU=$(kubectl get pods -n e2e-hpa-auto-tune -l app=tune-app \
+                    -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
+                  milli=$(cpu_milli "$CPU")
+                  echo "Current averageUtilization: $CURRENT liveCPU=$CPU"
                   if [ "$ORIG" != "70" ]; then
                     echo "FAIL: original-target-cpu is '$ORIG', want 70"
                     kubectl get hpa tune-app -n e2e-hpa-auto-tune -o yaml
@@ -169,7 +181,12 @@ spec:
                     kubectl get hpa tune-app -n e2e-hpa-auto-tune -o yaml
                     exit 1
                   fi
-                  echo "OK: HPA target tuned from $ORIG to $CURRENT"
+                  if [ "$milli" -ge 500 ]; then
+                    echo "FAIL: HPA tuned but live CPU did not decrease (cpu=$CPU)"
+                    kubectl get pods -n e2e-hpa-auto-tune -l app=tune-app -o yaml
+                    exit 1
+                  fi
+                  echo "OK: HPA target tuned from $ORIG to $CURRENT and CPU decreased to $CPU"
                   exit 0
                 fi
                 sleep 5

--- a/test/e2e/oneshot-resize/chainsaw-test.yaml
+++ b/test/e2e/oneshot-resize/chainsaw-test.yaml
@@ -105,7 +105,7 @@ spec:
                   percentile: 95
                   overhead: "20"
                   minAllowed: 50m
-                  maxAllowed: "4000m"
+                  maxAllowed: "250m"
                   controlledValues: RequestsAndLimits
                   maxChangePercent: 100
                 memory:
@@ -141,17 +141,28 @@ spec:
         - script:
             timeout: 5m
             content: |
+              set -e
               for i in $(seq 1 60); do
                 RESIZED=$(kubectl get attunepolicy oneshot-test -n e2e-oneshot-resize \
                   -o jsonpath='{.status.workloads.resized}' 2>/dev/null)
-                if [ "$RESIZED" -ge 1 ] 2>/dev/null; then
-                  echo "Resize confirmed: $RESIZED pod(s) resized"
+                CPU=$(kubectl get pods -n e2e-oneshot-resize -l app=test-app \
+                  -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ -n "$CPU" ] && [ "$CPU" != "500m" ]; then
+                  case "$CPU" in
+                    1|1000m|2|2000m|4000m)
+                      echo "FAIL: idle pause resized CPU up to $CPU"
+                      exit 1
+                      ;;
+                  esac
+                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (below 500m start)"
                   exit 0
                 fi
+                echo "Waiting... resized=$RESIZED cpu=$CPU"
                 sleep 5
               done
-              echo "No resize occurred within timeout"
+              echo "No downward resize within timeout"
               kubectl get attunepolicy oneshot-test -n e2e-oneshot-resize -o yaml
+              kubectl get pods -n e2e-oneshot-resize -l app=test-app -o yaml
               exit 1
   catch:
     - describe:

--- a/test/e2e/oneshot-resize/chainsaw-test.yaml
+++ b/test/e2e/oneshot-resize/chainsaw-test.yaml
@@ -142,22 +142,25 @@ spec:
             timeout: 5m
             content: |
               set -e
+              cpu_milli() {
+                v=$1
+                case "$v" in
+                  *m) echo "${v%m}" ;;
+                  "") echo 0 ;;
+                  *) echo $((v * 1000)) ;;
+                esac
+              }
               for i in $(seq 1 60); do
                 RESIZED=$(kubectl get attunepolicy oneshot-test -n e2e-oneshot-resize \
-                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null)
+                  -o jsonpath='{.status.workloads.resized}' 2>/dev/null || true)
                 CPU=$(kubectl get pods -n e2e-oneshot-resize -l app=test-app \
                   -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
-                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ -n "$CPU" ] && [ "$CPU" != "500m" ]; then
-                  case "$CPU" in
-                    1|1000m|2|2000m|4000m)
-                      echo "FAIL: idle pause resized CPU up to $CPU"
-                      exit 1
-                      ;;
-                  esac
-                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (below 500m start)"
+                milli=$(cpu_milli "$CPU")
+                if [ "${RESIZED:-0}" -ge 1 ] 2>/dev/null && [ "$milli" -gt 0 ] && [ "$milli" -lt 500 ]; then
+                  echo "Resize confirmed: resized=$RESIZED liveCPU=$CPU (${milli}m < 500m start)"
                   exit 0
                 fi
-                echo "Waiting... resized=$RESIZED cpu=$CPU"
+                echo "Waiting... resized=$RESIZED cpu=$CPU milli=$milli"
                 sleep 5
               done
               echo "No downward resize within timeout"

--- a/test/e2e/requests-only/chainsaw-test.yaml
+++ b/test/e2e/requests-only/chainsaw-test.yaml
@@ -91,22 +91,26 @@ spec:
             content: |
               set -e
               for i in $(seq 1 36); do
-                cpu_lim=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
-                  -o jsonpath='{.status.recommendations[0].containers[0].recommended.cpuLimit}' 2>/dev/null || true)
-                mem_lim=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
-                  -o jsonpath='{.status.recommendations[0].containers[0].recommended.memoryLimit}' 2>/dev/null || true)
                 recs=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
                   -o jsonpath='{.status.workloads.withRecommendations}' 2>/dev/null || true)
-                if [ "${recs:-0}" -ge 1 ] 2>/dev/null; then
-                  if [ "$cpu_lim" = "500m" ] && { [ "$mem_lim" = "512Mi" ] || [ "$mem_lim" = "536870912" ]; }; then
-                    echo "OK: RequestsOnly kept recommended limits at current (cpu=$cpu_lim mem=$mem_lim)"
+                rec_cpu=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
+                  -o jsonpath='{.status.recommendations[0].containers[0].recommended.cpuLimit}' 2>/dev/null || true)
+                cur_cpu=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
+                  -o jsonpath='{.status.recommendations[0].containers[0].current.cpuLimit}' 2>/dev/null || true)
+                rec_mem=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
+                  -o jsonpath='{.status.recommendations[0].containers[0].recommended.memoryLimit}' 2>/dev/null || true)
+                cur_mem=$(kubectl get attunepolicy reqonly-test -n e2e-requests-only \
+                  -o jsonpath='{.status.recommendations[0].containers[0].current.memoryLimit}' 2>/dev/null || true)
+                if [ "${recs:-0}" -ge 1 ] 2>/dev/null && [ -n "$rec_cpu" ] && [ -n "$rec_mem" ]; then
+                  if [ "$rec_cpu" = "$cur_cpu" ] && [ "$rec_mem" = "$cur_mem" ]; then
+                    echo "OK: RequestsOnly kept recommended limits at current (cpu=$rec_cpu mem=$rec_mem)"
                     exit 0
                   fi
-                  echo "FAIL: RequestsOnly changed recommended limits (cpu=$cpu_lim mem=$mem_lim)"
+                  echo "FAIL: RequestsOnly changed recommended limits (rec cpu=$rec_cpu/$cur_cpu mem=$rec_mem/$cur_mem)"
                   kubectl get attunepolicy reqonly-test -n e2e-requests-only -o yaml
                   exit 1
                 fi
-                echo "Waiting... recs=$recs cpu_lim=$cpu_lim mem_lim=$mem_lim"
+                echo "Waiting... recs=$recs rec_cpu=$rec_cpu cur_cpu=$cur_cpu rec_mem=$rec_mem"
                 sleep 5
               done
               echo "FAIL: timed out waiting for recommendations under RequestsOnly"

--- a/test/e2e/slo-guardrails/chainsaw-test.yaml
+++ b/test/e2e/slo-guardrails/chainsaw-test.yaml
@@ -104,7 +104,7 @@ spec:
                   percentile: 95
                   overhead: "20"
                   minAllowed: 50m
-                  maxAllowed: "4000m"
+                  maxAllowed: "100m"
                   maxChangePercent: 100
                 memory:
                   percentile: 99
@@ -163,27 +163,33 @@ spec:
       description: |
         After evaluationWindow (1m) elapses post-resize, the safety monitor
         queries vector(1) which returns 1.0, breaching the threshold of 0.5.
-        This triggers an auto-revert. Verify that resizeHistory contains
-        a Reverted entry with reason slo:always-breach.
+        This triggers an auto-revert. Verify history and that live requests
+        are restored to the original 200m / 128Mi.
       try:
         - script:
             timeout: 5m
             content: |
+              set -e
               for i in $(seq 1 60); do
-                # Check resizeHistory for a Reverted entry with SLO reason
                 HISTORY=$(kubectl get attunepolicy slo-test -n e2e-slo-guardrails \
                   -o jsonpath='{range .status.resizeHistory[*]}{.result}={.reason}{"\n"}{end}' 2>/dev/null)
+                CPU=$(kubectl get pods -n e2e-slo-guardrails -l app=slo-app \
+                  -o jsonpath='{.items[0].spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
+                MEM=$(kubectl get pods -n e2e-slo-guardrails -l app=slo-app \
+                  -o jsonpath='{.items[0].spec.containers[0].resources.requests.memory}' 2>/dev/null || true)
                 if echo "$HISTORY" | grep -q "Reverted=slo:always-breach"; then
-                  echo "SLO guardrail revert confirmed:"
-                  echo "$HISTORY"
-                  # Also verify the event was emitted
-                  kubectl get events -n e2e-slo-guardrails --field-selector reason=Reverted \
-                    -o jsonpath='{range .items[*]}{.message}{"\n"}{end}' 2>/dev/null | head -5
-                  exit 0
+                  if [ "$CPU" = "200m" ] && { [ "$MEM" = "128Mi" ] || [ "$MEM" = "134217728" ]; }; then
+                    echo "SLO revert restored live resources: cpu=$CPU mem=$MEM"
+                    echo "$HISTORY"
+                    exit 0
+                  fi
+                  echo "History Reverted but live not restored yet (cpu=$CPU mem=$MEM)"
                 fi
+                echo "Waiting... cpu=$CPU mem=$MEM"
+                echo "$HISTORY"
                 sleep 5
               done
-              echo "Timed out waiting for SLO guardrail revert"
+              echo "Timed out waiting for SLO revert to restore 200m/128Mi"
               echo "--- Policy status ---"
               kubectl get attunepolicy slo-test -n e2e-slo-guardrails -o yaml
               echo "--- Pod status ---"


### PR DESCRIPTION
## Summary

Make safety-revert and idle-pause resize E2E tests fail if the product writes status but does the wrong thing to live pods.

### #635 Live restore
- `slo-guardrails`: after `Reverted=slo:always-breach`, live CPU/memory must be back at 200m / 128Mi.
- `TestE2E_OOMKill_TriggersRevert`: require reason `oomkill` and live restore to 500m / 64Mi.
- `TestE2E_AutoMode_RecordsResizeHistory`: history-only (no fake revert path); stale liveness-probe comments removed.

### #637 Direction
Idle `pause` workloads pin `maxAllowed` below start so a resize-up cannot pass:
- Go: Auto, Guaranteed QoS, sidecar exclude, sequential multi-container.
- Chainsaw: auto-mode, oneshot-resize, canary-rollout, hpa-auto-tune, eviction-fallback, concurrent-resize.

## Test plan
- [x] `go test -c -tags=e2e ./test/e2e-go/`
- [x] `make lint-chainsaw`
- [ ] PR CI E2E

Closes #635
Closes #637
