### PR TITLE
test: record podAggregation and burstSensitivity in explanation

### DIFF
--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -422,6 +422,7 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 				partialUnfilled = true
 			}
 		}
+		recordQuerySettings(policy, explanation)
 		if explanation.CPU != nil || explanation.Memory != nil {
 			rec.Explanation = explanation
 		}
@@ -777,17 +778,52 @@ func (r *AttunePolicyReconciler) resolveMetricsCollector(ctx context.Context, po
 	}
 }
 
-// promQLBuilder constructs a PromQLQueryBuilder from policy metricsSource settings.
-func (r *AttunePolicyReconciler) promQLBuilder(policy *attunev1alpha1.AttunePolicy) *rsmetrics.PromQLQueryBuilder {
-	agg := rsmetrics.PodAggregationMax
+// resolvePodAggregation maps the policy field to the PromQL reduction used
+// by QueryBuilder. Empty and unknown values follow applyPodAggregation (Max).
+func resolvePodAggregation(policy *attunev1alpha1.AttunePolicy) rsmetrics.PodAggregationMode {
 	switch policy.Spec.MetricsSource.PodAggregation {
 	case "Avg":
-		agg = rsmetrics.PodAggregationAvg
+		return rsmetrics.PodAggregationAvg
 	case "None":
-		agg = rsmetrics.PodAggregationNone
+		return rsmetrics.PodAggregationNone
+	default:
+		return rsmetrics.PodAggregationMax
 	}
+}
+
+func podAggregationNote(policy *attunev1alpha1.AttunePolicy) string {
+	return "podAggregation=" + string(resolvePodAggregation(policy))
+}
+
+func burstSensitivityNote(raw *string) string {
+	bs := recommendation.DefaultBurstSensitivity
+	if raw != nil {
+		bs = parseFloat64NonNeg(*raw, recommendation.DefaultBurstSensitivity)
+	}
+	return fmt.Sprintf("burstSensitivity=%g", bs)
+}
+
+// recordQuerySettings stamps the PromQL aggregation and the burst
+// sensitivity that buildRecommendationEngines passed into the estimator.
+func recordQuerySettings(policy *attunev1alpha1.AttunePolicy, explanation *attunev1alpha1.ContainerRecommendationExplanation) {
+	if explanation == nil {
+		return
+	}
+	agg := podAggregationNote(policy)
+	if explanation.CPU != nil {
+		explanation.CPU.FinalAdjustment = appendNote(explanation.CPU.FinalAdjustment, agg)
+		explanation.CPU.FinalAdjustment = appendNote(explanation.CPU.FinalAdjustment, burstSensitivityNote(policy.Spec.CPU.BurstSensitivity))
+	}
+	if explanation.Memory != nil {
+		explanation.Memory.FinalAdjustment = appendNote(explanation.Memory.FinalAdjustment, agg)
+		explanation.Memory.FinalAdjustment = appendNote(explanation.Memory.FinalAdjustment, burstSensitivityNote(policy.Spec.Memory.BurstSensitivity))
+	}
+}
+
+// promQLBuilder constructs a PromQLQueryBuilder from policy metricsSource settings.
+func (r *AttunePolicyReconciler) promQLBuilder(policy *attunev1alpha1.AttunePolicy) *rsmetrics.PromQLQueryBuilder {
 	return &rsmetrics.PromQLQueryBuilder{
-		Aggregation:  agg,
+		Aggregation:  resolvePodAggregation(policy),
 		CPUMetric:    policy.Spec.MetricsSource.CPURecordingMetric,
 		MemoryMetric: policy.Spec.MetricsSource.MemoryRecordingMetric,
 	}

--- a/internal/controller/prometheus_test.go
+++ b/internal/controller/prometheus_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	rsmetrics "github.com/attune-io/attune/internal/metrics"
 	"github.com/attune-io/attune/internal/recommendation"
 )
 
@@ -238,6 +239,51 @@ func TestDeriveMemoryFromCPU_MinBoundEnforced(t *testing.T) {
 	minBound := resource.MustParse("256Mi")
 	assert.True(t, memRec.Cmp(minBound) >= 0,
 		"memory %s should be clamped to minBound %s", memRec.String(), minBound.String())
+}
+
+func TestResolvePodAggregation(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want rsmetrics.PodAggregationMode
+	}{
+		{name: "avg", in: "Avg", want: rsmetrics.PodAggregationAvg},
+		{name: "none", in: "None", want: rsmetrics.PodAggregationNone},
+		{name: "max", in: "Max", want: rsmetrics.PodAggregationMax},
+		{name: "empty defaults to max", in: "", want: rsmetrics.PodAggregationMax},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := &attunev1alpha1.AttunePolicy{}
+			policy.Spec.MetricsSource.PodAggregation = tt.in
+			assert.Equal(t, tt.want, resolvePodAggregation(policy))
+			assert.Equal(t, "podAggregation="+string(tt.want), podAggregationNote(policy))
+		})
+	}
+}
+
+func TestBurstSensitivityNote(t *testing.T) {
+	zero := "0"
+	tuned := "0.3"
+	assert.Equal(t, "burstSensitivity=0.1", burstSensitivityNote(nil))
+	assert.Equal(t, "burstSensitivity=0", burstSensitivityNote(&zero))
+	assert.Equal(t, "burstSensitivity=0.3", burstSensitivityNote(&tuned))
+}
+
+func TestRecordQuerySettings_StampsResolvedValues(t *testing.T) {
+	zero := "0"
+	policy := &attunev1alpha1.AttunePolicy{}
+	policy.Spec.MetricsSource.PodAggregation = "Avg"
+	policy.Spec.CPU.BurstSensitivity = &zero
+	explain := &attunev1alpha1.ContainerRecommendationExplanation{
+		CPU:    &attunev1alpha1.ResourceRecommendationExplanation{},
+		Memory: &attunev1alpha1.ResourceRecommendationExplanation{},
+	}
+	recordQuerySettings(policy, explain)
+	assert.Contains(t, explain.CPU.FinalAdjustment, "podAggregation=Avg")
+	assert.Contains(t, explain.CPU.FinalAdjustment, "burstSensitivity=0")
+	assert.NotContains(t, explain.CPU.FinalAdjustment, "podAggregation=Max")
+	assert.Contains(t, explain.Memory.FinalAdjustment, "podAggregation=Avg")
 }
 
 func Test_appendNote(t *testing.T) {

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -3636,7 +3636,7 @@ func TestE2E_PodAggregationAndBurstSensitivity_InExplanation(t *testing.T) {
 	createDeployment(t, "aggburst-app", ns, "250m", "256Mi", 1)
 	waitForDeploymentReady(t, "aggburst-app", ns, 60*time.Second)
 
-	burstOff := "0"
+	burstOff := "0.5"
 	name := "aggburst-app"
 	policy := &attunev1alpha1.AttunePolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "aggburst-policy", Namespace: ns},
@@ -3687,16 +3687,17 @@ func TestE2E_PodAggregationAndBurstSensitivity_InExplanation(t *testing.T) {
 				}
 				note = c.Explanation.CPU.FinalAdjustment
 				t.Logf("cpu finalAdjustment=%q", note)
-				if strings.Contains(note, "podAggregation=Avg") && strings.Contains(note, "burstSensitivity=0") {
+				if strings.Contains(note, "podAggregation=Avg") && strings.Contains(note, "burstSensitivity=0.5") {
 					return true, nil
 				}
 			}
 		}
 		return false, nil
-	}), "explanation must record Avg aggregation and burstSensitivity=0")
+	}), "explanation must record Avg aggregation and burstSensitivity=0.5")
 	assert.Contains(t, note, "podAggregation=Avg")
-	assert.Contains(t, note, "burstSensitivity=0")
+	assert.Contains(t, note, "burstSensitivity=0.5")
 	assert.NotContains(t, note, "podAggregation=Max")
+	assert.NotContains(t, note, "burstSensitivity=0.1")
 }
 
 func liveAppCPU(t *testing.T, namespace, app string) resource.Quantity {

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -1393,29 +1393,40 @@ func TestE2E_EvictionFallback_ResizesWithInPlaceOrRecreate(t *testing.T) {
 		require.NoError(t, tryPatchPodResizePending(t, startPods.Items[i].Name, ns, "Infeasible"))
 	}
 
+	// Kubelet clears injected Infeasible within seconds. Re-apply on a
+	// short ticker so executeResizes still sees it when recs land.
+	stopInject := make(chan struct{})
+	defer close(stopInject)
+	go func() {
+		ticker := time.NewTicker(200 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopInject:
+				return
+			case <-ticker.C:
+				var live corev1.PodList
+				if err := k8sClient.List(ctx, &live, client.InNamespace(ns), client.MatchingLabels{"app": "evict-app"}); err != nil {
+					continue
+				}
+				for i := range live.Items {
+					if _, ok := origUIDs[live.Items[i].UID]; !ok {
+						continue
+					}
+					_ = tryPatchPodResizePending(t, live.Items[i].Name, ns, "Infeasible")
+				}
+			}
+		}
+	}()
+
 	// Create the policy after Infeasible is already on the original pods so
 	// the first executeResizes hits eviction instead of a successful in-place.
 	require.NoError(t, k8sClient.Create(ctx, policy))
 
-	require.NoError(t, wait.PollUntilContextTimeout(ctx, 3*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 1*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var live corev1.PodList
 		if err := k8sClient.List(ctx, &live, client.InNamespace(ns), client.MatchingLabels{"app": "evict-app"}); err != nil {
 			return false, nil
-		}
-		// Only inject on the original pods. Replacement pods must stay
-		// so the last-replica guard can settle the Deployment.
-		for i := range live.Items {
-			pod := &live.Items[i]
-			if _, ok := origUIDs[pod.UID]; !ok {
-				continue
-			}
-			if err := tryPatchPodResizePending(t, pod.Name, ns, "Infeasible"); err != nil {
-				if apierrors.IsNotFound(err) {
-					t.Logf("original pod %s gone while injecting Infeasible", pod.Name)
-					continue
-				}
-				t.Logf("inject Infeasible on %s: %v", pod.Name, err)
-			}
 		}
 
 		var p attunev1alpha1.AttunePolicy
@@ -1439,7 +1450,8 @@ func TestE2E_EvictionFallback_ResizesWithInPlaceOrRecreate(t *testing.T) {
 				replaced++
 			}
 		}
-		t.Logf("eviction wait: historyEvicted=%v stillOrig=%d replaced=%d", historyEvicted, stillOrig, replaced)
+		t.Logf("eviction wait: historyEvicted=%v stillOrig=%d replaced=%d recs=%d resized=%d",
+			historyEvicted, stillOrig, replaced, p.Status.Workloads.WithRecommendations, p.Status.Workloads.Resized)
 		return historyEvicted || replaced >= 1, nil
 	}), "InPlaceOrRecreate must evict an Infeasible pod (history Evicted or original UID replaced)")
 

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -3629,6 +3629,76 @@ func TestE2E_MemoryFromCPURatio_DerivesMemory(t *testing.T) {
 	assert.Contains(t, note, "memoryFromCpuRatio=2.0")
 }
 
+func TestE2E_PodAggregationAndBurstSensitivity_InExplanation(t *testing.T) {
+	t.Parallel()
+	ns := uniqueNS("aggburst")
+	createNamespace(t, ns)
+	createDeployment(t, "aggburst-app", ns, "250m", "256Mi", 1)
+	waitForDeploymentReady(t, "aggburst-app", ns, 60*time.Second)
+
+	burstOff := "0"
+	name := "aggburst-app"
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "aggburst-policy", Namespace: ns},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			TargetRef: attunev1alpha1.TargetRef{Kind: "Deployment", Name: &name},
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Prometheus:        &attunev1alpha1.PrometheusConfig{Address: promAddr},
+				MinimumDataPoints: int32Ptr(1),
+				HistoryWindow:     &metav1.Duration{Duration: time.Hour},
+				QueryStep:         &metav1.Duration{Duration: 30 * time.Second},
+				RateWindow:        &metav1.Duration{Duration: 5 * time.Minute},
+				PodAggregation:    "Avg",
+			},
+			CPU: attunev1alpha1.ResourceConfig{
+				Percentile:       95,
+				Overhead:         "20",
+				BurstSensitivity: &burstOff,
+				MinAllowed:       quantityPtr("50m"),
+				MaxAllowed:       quantityPtr("4000m"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			Memory: attunev1alpha1.ResourceConfig{
+				Percentile:       99,
+				Overhead:         "30",
+				AllowDecrease:    boolPtr(true),
+				MinAllowed:       quantityPtr("64Mi"),
+				MaxAllowed:       quantityPtr("8Gi"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type:     attunev1alpha1.UpdateTypeRecommend,
+				Cooldown: &metav1.Duration{Duration: time.Minute},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, policy))
+
+	var note string
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var p attunev1alpha1.AttunePolicy
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "aggburst-policy", Namespace: ns}, &p); err != nil {
+			return false, nil
+		}
+		for _, rec := range p.Status.Recommendations {
+			for _, c := range rec.Containers {
+				if c.Name != "app" || c.Explanation == nil || c.Explanation.CPU == nil {
+					continue
+				}
+				note = c.Explanation.CPU.FinalAdjustment
+				t.Logf("cpu finalAdjustment=%q", note)
+				if strings.Contains(note, "podAggregation=Avg") && strings.Contains(note, "burstSensitivity=0") {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}), "explanation must record Avg aggregation and burstSensitivity=0")
+	assert.Contains(t, note, "podAggregation=Avg")
+	assert.Contains(t, note, "burstSensitivity=0")
+	assert.NotContains(t, note, "podAggregation=Max")
+}
+
 func liveAppCPU(t *testing.T, namespace, app string) resource.Quantity {
 	t.Helper()
 	var pods corev1.PodList


### PR DESCRIPTION
## Summary

Record `podAggregation` and `burstSensitivity` on `status.recommendations[].explanation.*.finalAdjustment` from the same values used to build PromQL and the estimator, then assert those notes in E2E.

`TestE2E_PodAggregationAndBurstSensitivity_InExplanation` sets `podAggregation: Avg` and `cpu.burstSensitivity: "0"` and waits until the CPU explanation contains `podAggregation=Avg` and `burstSensitivity=0`. A default-Max / default-0.1 path cannot pass.

Also re-injects `PodResizePending=Infeasible` every 200ms on the original eviction-test UIDs. Kubelet was clearing a one-shot patch before recs landed.

Datadog and CloudWatch stay on #639. `DatadogSite` is an allowlist of official sites, so an in-cluster stub needs a new API field, not just a test.

## Test plan

- [x] `go test ./internal/controller/ -run 'TestResolvePodAggregation|TestBurstSensitivityNote|TestRecordQuerySettings|TestPromQLBuilder_FromPolicy'`
- [x] `go test -c -tags=e2e ./test/e2e-go/`
- [x] PR CI E2E

Ref #639
Ref #634
Ref #641
