### PR TITLE
test: stop naming concurrent-resize as a live concurrency bound

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -144,10 +144,10 @@ make test-e2e-smoke
 | `test/e2e/opt-out/` | (cross-cutting) | `attune.io/skip` annotation is respected |
 | `test/e2e/exclude-containers/` | (cross-cutting) | `excludedContainers` skips sidecars |
 | `test/e2e/multi-selector/` | (cross-cutting) | Label selector matches multiple deployments |
-| `test/e2e/eviction-fallback/` | (cross-cutting) | InPlaceOrRecreate is accepted and still resizes workloads (in-place path) |
+| `test/e2e/eviction-fallback/` | (cross-cutting) | InPlaceOrRecreate is accepted; Go E2E injects Infeasible and requires Evicted history |
 | `test/e2e/schedule-window/` | (cross-cutting) | Schedule windows block resizes outside the allowed time |
 | `test/e2e/budget-caps/` | (cross-cutting) | Budget caps are accepted and the policy still resizes workloads |
-| `test/e2e/concurrent-resize/` | (cross-cutting) | `maxConcurrentResizes` is accepted and workloads still resize |
+| `test/e2e/concurrent-resize/` | (cross-cutting) | `maxConcurrentResizes` is accepted and live CPU decreases; in-flight bound is unit-tested |
 | `test/e2e/namespace-defaults/` | (cross-cutting) | AttuneNamespaceDefaults overrides cluster defaults |
 | `test/e2e/defaults-merge/` | (cross-cutting) | AttuneDefaults values are inherited by a policy that omits them |
 | `test/e2e/hpa-conflict/` | (cross-cutting) | HPA conflict is warning-only, policy still reconciles |

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -1945,7 +1945,7 @@ func TestE2E_MultiReplica_ProgressiveResize(t *testing.T) {
 		}
 		t.Logf("progressive resize: %d/3 pods decreased from 250m", decreased)
 		return decreased == 3, nil
-	}), "all 3 replicas should eventually decrease with maxConcurrentResizes=1")
+	}), "all 3 replicas should eventually decrease; in-flight maxConcurrentResizes is unit-tested")
 
 	var deploy appsv1.Deployment
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "multi-rep-app", Namespace: ns}, &deploy))

--- a/test/e2e/concurrent-resize/chainsaw-test.yaml
+++ b/test/e2e/concurrent-resize/chainsaw-test.yaml
@@ -1,9 +1,12 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: concurrent-resize
+  name: concurrent-resize-accepted
 spec:
-  description: Verify that an AttunePolicy with maxConcurrentResizes is accepted and discovers workloads
+  description: >
+    Accept maxConcurrentResizes and assert a live CPU decrease.
+    The in-flight semaphore is covered by unit tests; this scenario does
+    not sample pods mid-resize.
   timeouts:
     apply: 30s
     assert: 2m


### PR DESCRIPTION
## Summary

Stop implying that the Chainsaw `concurrent-resize` case measures the in-flight `maxConcurrentResizes` semaphore.

The product limit is in-flight resizes in one reconcile. Completed pods stay resized, so counting pods that differ from the template is not that bound. This PR renames the Chainsaw test to `concurrent-resize-accepted` and updates the testing table. Live CPU decrease stays. The Go multi-replica test still requires all 3 replicas to decrease and `ReadyReplicas == 3`.

Issue 634 stays open for a mid-rollout in-flight sample. Eviction coverage already landed in #646 / #648.

## Test plan

- [x] Description and table only
- [x] PR CI E2E

Ref #634
Ref #641
