### PR TITLE
fix: datadog app-key cache and nan-inf sample accounting

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,7 +17,7 @@ recommendations, and promoting to Canary mode, all in about five minutes.
 
 !!! info "Prerequisites"
     - **Kubernetes 1.32+** — 1.32 requires the `InPlacePodVerticalScaling` feature gate; 1.33–1.34 beta enabled by default; **1.35+ GA**.
-    - **A metrics source** — Prometheus (default), Datadog, or CloudWatch Container Insights. This guide uses Prometheus; see [Datadog Setup](../guides/datadog-setup.md) or [CloudWatch Setup](../guides/cloudwatch-setup.md) for alternatives.
+    - **A metrics source** — Prometheus (default), Datadog, or CloudWatch Container Insights. This guide uses Prometheus; see [Datadog Setup](../guides/datadog-setup.md) or [CloudWatch Setup](../guides/cloudwatch-setup.md) for alternatives. At most one metrics provider may be set; AttuneDefaults inherit a provider only when the policy set none.
     - **Attune installed** — see [Installation](installation.md) for Helm and raw manifest options. Default Helm install needs **cert-manager** (or `--set webhooks.enabled=false`).
     - **Cluster preflight** — `kubectl attune doctor` checks Kubernetes 1.32+ and `pods/resize` before you wait on recommendations.
     - **Prometheus reachability** — the chart NetworkPolicy allows Prometheus egress on port **9090** by default. If your Service listens on port **80** (common with `prometheus-server.monitoring:80`), set `--set networkPolicy.prometheusPort=80` at install time or you will get no data.

--- a/docs/guides/cloudwatch-setup.md
+++ b/docs/guides/cloudwatch-setup.md
@@ -153,6 +153,7 @@ kubectl get attunepolicy my-app -n production -o wide
 |-----------|---------|
 | `Ready: True, Reason: Monitoring` | CloudWatch reachable, recommendations computed |
 | `Ready: False, Reason: InsufficientData` | CloudWatch reachable but not enough history yet |
+| `Ready: False, Reason: PrometheusUnavailable` | IAM, AssumeRole, or CloudWatch query failure |
 
 Check the operator logs for CloudWatch-specific messages:
 
@@ -243,9 +244,9 @@ additional Secrets.
   configuration.
 - **No auto-discovery.** The `region` and `clusterName` fields are
   always required. The operator does not auto-detect the EKS cluster.
-- **One metrics source per policy.** A policy cannot combine CloudWatch
-  and Prometheus data. Set `metricsSource.cloudwatch` or
-  `metricsSource.prometheus`, not both.
+- **Exclusive provider.** At most one of prometheus, datadog, cloudwatch,
+  or vpa. If the policy already sets any provider, cluster AttuneDefaults
+  does not merge another.
 - **Safety monitor throttle detection** uses the same metrics source as
   recommendations. CloudWatch Container Insights does not expose CFS
   throttle metrics (`container_cpu_cfs_throttled_periods_total`), so

--- a/docs/guides/datadog-setup.md
+++ b/docs/guides/datadog-setup.md
@@ -110,6 +110,7 @@ kubectl get attunepolicy my-app -n production -o wide
 |-----------|---------|
 | `Ready: True, Reason: Monitoring` | Datadog reachable, recommendations computed |
 | `Ready: False, Reason: InsufficientData` | Datadog reachable but not enough history yet |
+| `Ready: False, Reason: PrometheusUnavailable` | Missing Secret, Datadog 403, or Datadog 429 |
 
 If the condition message mentions a Datadog API error, check the
 operator logs:
@@ -125,7 +126,7 @@ kubectl logs -n attune-system deployment/attune \
 |-------|-------|-----|
 | `cannot read Datadog API key` | Secret not found or missing key | Verify the Secret exists in the policy namespace with the correct key name |
 | `datadog API returned 403` | Invalid API key or insufficient permissions | Regenerate the API key in the Datadog console |
-| `datadog API returned 429` | Rate limited | Add an `app-key` to the Secret for higher limits; the operator rate-limits to ~0.08 QPS per collector |
+| `datadog API returned 429` | Rate limited | Add an `app-key` to the existing Secret for higher limits; the next reconcile builds a new collector. The operator rate-limits to ~0.08 QPS per collector |
 | `empty result from Datadog instant query` | No metrics for the workload | Verify the Datadog Agent is collecting Kubernetes metrics for the target namespace and pods |
 
 ## Rate limiting
@@ -139,7 +140,9 @@ If you have many policies using Datadog, consider:
 
 - Adding an Application key to increase the rate limit
 - Using cluster-wide or namespace defaults to share the collector across
-  policies (the operator caches collectors by site + API key)
+  policies (the operator caches collectors by site + API key + app-key).
+  Adding or rotating `app-key` takes effect on the next reconcile. Do not
+  restart the operator.
 
 ## Using Datadog as the cluster default
 
@@ -206,9 +209,9 @@ spec:
 - **No auto-discovery.** Unlike Prometheus, Datadog has no in-cluster
   service to discover automatically. The `apiKeySecretRef` is always
   required.
-- **One metrics source per policy.** A policy cannot combine Datadog and
-  Prometheus data. Set `metricsSource.datadog` or
-  `metricsSource.prometheus`, not both.
+- **Exclusive provider.** At most one of prometheus, datadog, cloudwatch,
+  or vpa. If the policy already sets any provider, cluster AttuneDefaults
+  does not merge another.
 - **Safety monitor throttle detection** uses the same metrics source as
   recommendations. Datadog does not expose CFS throttle metrics
   (`container_cpu_cfs_throttled_periods_total`), so CPU throttle-based

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -32,9 +32,10 @@ See [Scaling: PrometheusSeriesCapped](scaling.md#ready-reason-prometheusseriesca
 
 **Symptom**: Ready condition is `False` with reason `PrometheusUnavailable`.
 
-**Cause**: `PrometheusUnavailable` means the controller could not use
-Prometheus for this reconcile. The condition message tells you which step
-failed:
+**Cause**: `PrometheusUnavailable` means the controller could not use the
+metrics backend (Prometheus, Datadog, or CloudWatch) for this reconcile.
+The reason name is unchanged for all three backends. The condition
+message tells you which step failed:
 
 - `Cannot resolve Prometheus config` means address resolution failed. The
   operator checks (in order): policy spec, one defaults source
@@ -47,6 +48,11 @@ failed:
   expired before all Prometheus queries completed.
 - `Prometheus query errors (` means Prometheus answered, but one or more
   metric queries failed. This can still happen when Prometheus is reachable.
+- `cannot read Datadog API key`, `datadog API returned 403`, or
+  `datadog API returned 429` means the Datadog Secret is missing, the
+  API key is rejected, or Datadog rate-limited the collector.
+- `loading AWS config`, `AccessDeniedException`, or `AssumeRole` means
+  CloudWatch IAM credentials, role assumption, or `GetMetricData` failed.
 
 If the condition message includes `Cannot resolve Prometheus config: SSRF blocked`,
 the configured address points at `localhost`, `127.0.0.1`, `::1`, or a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -158,6 +158,7 @@ Shows the stored recommendation reasoning for a single policy, including
 percentile selection, overhead, confidence adjustment, bounds, and
 change filtering for CPU and memory. It also prints the effective values for
 all controller-applied defaults: `type`, `cooldown`, `queryStep`,
+Metrics source (`prometheus` / `datadog` / `cloudwatch` / `vpa`),
 `minimumDataPoints`, `historyWindow`, `resizeMethod`, `autoRevert`,
 `initialSizing`, `maxConcurrentResizes`, `rateWindow`, `export`,
 `templatePersistence`, budget caps (`maxTotalCPUIncrease`,
@@ -320,7 +321,7 @@ typically set via the Helm chart `values.yaml` rather than directly.
 | `--health-probe-bind-address` | `:8081` | Address the health/readiness probe endpoint binds to |
 | `--leader-elect` | `false` | Enable leader election (required for HA with multiple replicas) |
 | `--enable-webhooks` | `true` | Enable admission webhooks for defaulting and validation (requires cert-manager) |
-| `--collector-ttl` | `10m` | How long unused Prometheus collectors stay cached before eviction |
+| `--collector-ttl` | `10m` | How long unused collectors (Prometheus, Datadog, CloudWatch) stay cached before eviction |
 | `--zap-log-level` | `info` | Log verbosity: `debug`, `info`, `error`, or integer (higher = more verbose) |
 | `--zap-encoder` | `json` | Log format: `json` (default) or `console` (human-readable) |
 | `--zap-stacktrace-level` | `error` | Minimum level for automatic stacktrace capture |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -149,7 +149,7 @@ For detailed PromQL expressions and alert tuning, see the
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `collectorTTL` | string | `"10m"` | How long unused Prometheus collectors stay cached before eviction. Maps to the `--collector-ttl` manager flag. Increase if policies frequently rotate Prometheus addresses; decrease in memory-constrained environments. |
+| `collectorTTL` | string | `"10m"` | How long unused collectors (Prometheus, Datadog, CloudWatch) stay cached before eviction. Maps to the `--collector-ttl` manager flag. Increase if policies frequently rotate Prometheus addresses; decrease in memory-constrained environments. |
 
 ## Prometheus Query Timeout
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -296,7 +296,7 @@ Total times all Prometheus samples for a container metric were non-finite
 |-------|-------------|
 | `namespace` | Policy namespace |
 | `policy` | Policy name |
-| `container` | Container name |
+| `container` | Container name. Collector-dropped NaN/Inf use `container=untracked` so scrape cardinality stays bounded. |
 | `metric_type` | `cpu` or `memory` |
 
 ### attune_capacity_skip_total

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -8667,8 +8667,8 @@ func TestComputeRecommendations_NanInfSamplesMetric(t *testing.T) {
 	assert.Nil(t, rec, "should produce no recommendation when all data is NaN/Inf")
 	afterCPU := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "untracked", "cpu"))
 	afterMem := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "untracked", "memory"))
-	assert.Equal(t, beforeCPU+3, afterCPU, "collector must increment for each dropped CPU NaN/Inf point")
-	assert.Equal(t, beforeMem+3, afterMem, "collector must increment for each dropped memory NaN/Inf point")
+	assert.Equal(t, beforeCPU+1, afterCPU, "collector must increment once when the CPU series is entirely non-finite")
+	assert.Equal(t, beforeMem+1, afterMem, "collector must increment once when the memory series is entirely non-finite")
 }
 
 func TestExecuteResizes_RequestClampedMetric(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -3223,6 +3223,39 @@ func TestResolveDatadogCollector_CachesCollector(t *testing.T) {
 	assert.Same(t, c1, c2, "second call should return cached collector")
 }
 
+func TestResolveDatadogCollector_AddingAppKeyRecreatesCollector(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd-keys", Namespace: "default"},
+		Data: map[string][]byte{
+			"api-key": []byte("test-api-key"),
+		},
+	}
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Datadog: &attunev1alpha1.DatadogConfig{
+					Site:            "datadoghq.com",
+					APIKeySecretRef: attunev1alpha1.SecretKeyRef{Name: "dd-keys", Key: "api-key"},
+				},
+			},
+		},
+	}
+	reconciler := newReconcilerWithClient(secret)
+
+	c1, _, err1 := reconciler.resolveDatadogCollector(context.Background(), policy)
+	require.NoError(t, err1)
+
+	var current corev1.Secret
+	require.NoError(t, reconciler.Get(context.Background(), types.NamespacedName{Name: "dd-keys", Namespace: "default"}, &current))
+	current.Data["app-key"] = []byte("test-app-key")
+	require.NoError(t, reconciler.Update(context.Background(), &current))
+
+	c2, _, err2 := reconciler.resolveDatadogCollector(context.Background(), policy)
+	require.NoError(t, err2)
+	assert.NotSame(t, c1, c2, "inserting app-key must create a new collector")
+}
+
 // ---------- resolveCloudWatchCollector ----------
 
 func TestResolveCloudWatchCollector_CreatesCollector(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"strings"
 	"sync"
@@ -1663,6 +1665,34 @@ func TestGetOrCreateCollector_EvictionClosesCollector(t *testing.T) {
 
 	assert.True(t, closable.closed,
 		"Close() should be called on evicted collector that implements io.Closer")
+}
+
+func TestGetOrCreateCollector_EvictionClosesRateLimitedInner(t *testing.T) {
+	inner := &closableMockCollector{}
+	wrapped := rsmetrics.NewRateLimitedCollector(inner, 10, 20)
+
+	now := time.Now()
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.CollectorTTL = time.Millisecond
+	reconciler.MetricsFactory = func(_ string, _ *rsmetrics.CollectorOptions) (rsmetrics.MetricsCollector, error) {
+		return &closableMockCollector{}, nil
+	}
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	reconciler.collectors.Store("http://old:9090", &collectorEntry{
+		collector: wrapped,
+		lastUsed:  now,
+	})
+
+	now = now.Add(2 * time.Millisecond)
+
+	_, err := reconciler.getOrCreateCollector(
+		&attunev1alpha1.PrometheusConfig{Address: "http://new:9090"}, nil,
+	)
+	require.NoError(t, err)
+
+	assert.True(t, inner.closed,
+		"RateLimitedCollector.Close must reach the inner collector on eviction")
 }
 
 func TestGetOrCreateCollector_ConcurrentRaceClosesUnused(t *testing.T) {
@@ -8601,25 +8631,44 @@ func TestComputeRecommendations_NanInfSamplesMetric(t *testing.T) {
 	deploy := newTestDeployment("api-server", "default", nil)
 	reconciler := newReconcilerWithClient()
 
-	// Return NaN/Inf samples so BuildProfile yields 0 data points.
-	mc := &mockCollector{
-		queryRangeGroupedFunc: func(_ context.Context, query string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
-			return map[string][]rsmetrics.Sample{
-				"main": {
-					{Timestamp: time.Now().Add(-1 * time.Hour), Value: math.NaN()},
-					{Timestamp: time.Now().Add(-2 * time.Hour), Value: math.Inf(1)},
-					{Timestamp: time.Now().Add(-3 * time.Hour), Value: math.Inf(-1)},
-				},
-			}, nil
-		},
-	}
+	// Real Prometheus collector: NaN/Inf are dropped before samples leave,
+	// so the operator counter must increment at the collector, not only
+	// when a mock skips that filter.
+	response := `{
+		"status": "success",
+		"data": {
+			"resultType": "matrix",
+			"result": [
+				{
+					"metric": {"container": "main"},
+					"values": [
+						[1700000000, "NaN"],
+						[1700000060, "Inf"],
+						[1700000120, "-Inf"]
+					]
+				}
+			]
+		}
+	}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(response))
+	}))
+	defer server.Close()
 
-	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "cpu"))
-	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, mc, nil, nil, nil, nil, nil)
+	collector, err := rsmetrics.NewPrometheusCollector(server.URL, logr.Discard(), http.DefaultTransport)
+	require.NoError(t, err)
+
+	beforeCPU := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "cpu"))
+	beforeMem := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "memory"))
+	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, collector, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 	assert.Nil(t, rec, "should produce no recommendation when all data is NaN/Inf")
-	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "cpu"))
-	assert.Equal(t, before+1, after, "NanInfSamplesTotal should increment for CPU")
+	afterCPU := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "cpu"))
+	afterMem := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "memory"))
+	assert.Equal(t, beforeCPU+3, afterCPU, "collector must increment for each dropped CPU NaN/Inf point")
+	assert.Equal(t, beforeMem+3, afterMem, "collector must increment for each dropped memory NaN/Inf point")
 }
 
 func TestExecuteResizes_RequestClampedMetric(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -8660,13 +8660,13 @@ func TestComputeRecommendations_NanInfSamplesMetric(t *testing.T) {
 	collector, err := rsmetrics.NewPrometheusCollector(server.URL, logr.Discard(), http.DefaultTransport)
 	require.NoError(t, err)
 
-	beforeCPU := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "cpu"))
-	beforeMem := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "memory"))
+	beforeCPU := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "untracked", "cpu"))
+	beforeMem := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "untracked", "memory"))
 	rec, _, _, _, _, err := reconciler.computeRecommendations(context.Background(), policy, deploy, collector, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 	assert.Nil(t, rec, "should produce no recommendation when all data is NaN/Inf")
-	afterCPU := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "cpu"))
-	afterMem := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "main", "memory"))
+	afterCPU := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "untracked", "cpu"))
+	afterMem := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("default", "test-policy", "untracked", "memory"))
 	assert.Equal(t, beforeCPU+3, afterCPU, "collector must increment for each dropped CPU NaN/Inf point")
 	assert.Equal(t, beforeMem+3, afterMem, "collector must increment for each dropped memory NaN/Inf point")
 }

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -842,19 +842,28 @@ func (r *AttunePolicyReconciler) resolveDatadogCollector(ctx context.Context, po
 		return nil, nil, fmt.Errorf("datadog site: %w", err)
 	}
 
-	// Read API key from the referenced Secret.
-	apiKey, err := r.readSecretKey(ctx, policy.Namespace, dd.APIKeySecretRef.Name, dd.APIKeySecretRef.Key)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot read Datadog API key: %w", err)
+	// One Get for the API-key Secret. API key is required; app-key is optional
+	// (absent key is empty). Other Get errors already fail the required key.
+	var secret corev1.Secret
+	secretNS := policy.Namespace
+	secretName := dd.APIKeySecretRef.Name
+	if err := r.Get(ctx, types.NamespacedName{Namespace: secretNS, Name: secretName}, &secret); err != nil {
+		return nil, nil, fmt.Errorf("cannot read Datadog API key: %w", fmt.Errorf("reading secret %s/%s: %w", secretNS, secretName, err))
+	}
+	apiKeyData, ok := secret.Data[dd.APIKeySecretRef.Key]
+	if !ok {
+		return nil, nil, fmt.Errorf("cannot read Datadog API key: %w", fmt.Errorf("key %q not found in secret %s/%s", dd.APIKeySecretRef.Key, secretNS, secretName))
+	}
+	apiKey := string(apiKeyData)
+	var appKey string
+	if appKeyData, ok := secret.Data["app-key"]; ok {
+		appKey = string(appKeyData)
 	}
 
-	// Read optional app key from the same Secret (key "app-key").
-	appKey, _ := r.readSecretKey(ctx, policy.Namespace, dd.APIKeySecretRef.Name, "app-key")
-
-	// Cache the collector keyed by site + API key (non-crypto identifier), with full
-	// TTL eviction, capacity bound, and race-safe LoadOrStore.
-	// We avoid hashing the actual secret bytes to satisfy CodeQL "weak crypto on sensitive data".
-	cacheKey := fmt.Sprintf("datadog:%s|%s", site, secretForCacheKey(apiKey))
+	// Cache keyed by site + API key + app key (non-crypto identifiers) so
+	// adding or rotating app-key creates a new collector. Full TTL eviction,
+	// capacity bound, and race-safe LoadOrStore.
+	cacheKey := fmt.Sprintf("datadog:%s|%s|%s", site, secretForCacheKey(apiKey), secretForCacheKey(appKey))
 	collector, err := r.getOrCreateCollectorByKey(cacheKey, "datadog:"+site, func() (rsmetrics.MetricsCollector, error) {
 		inner, innerErr := rsmetrics.NewDatadogCollector(site, apiKey, appKey, log.FromContext(ctx).WithName("datadog"))
 		if innerErr != nil {

--- a/internal/controller/prometheus.go
+++ b/internal/controller/prometheus.go
@@ -268,11 +268,13 @@ func (r *AttunePolicyReconciler) computeRecommendations(
 	var cpuErr, memErr, cpuCapped, memCapped bool
 	var qg errgroup.Group
 	qg.Go(func() error {
-		cpuSamplesByContainer, cpuErr, cpuCapped = queryMetricsGrouped(ctx, collector, qb, policy.Namespace, podRegex, "cpu", start, now, queryStep, rateWindow)
+		cpuCtx := rsmetrics.WithNanInfLabels(ctx, policy.Namespace, policy.Name, "cpu")
+		cpuSamplesByContainer, cpuErr, cpuCapped = queryMetricsGrouped(cpuCtx, collector, qb, policy.Namespace, podRegex, "cpu", start, now, queryStep, rateWindow)
 		return nil
 	})
 	qg.Go(func() error {
-		memSamplesByContainer, memErr, memCapped = queryMetricsGrouped(ctx, collector, qb, policy.Namespace, podRegex, "memory", start, now, queryStep, rateWindow)
+		memCtx := rsmetrics.WithNanInfLabels(ctx, policy.Namespace, policy.Name, "memory")
+		memSamplesByContainer, memErr, memCapped = queryMetricsGrouped(memCtx, collector, qb, policy.Namespace, podRegex, "memory", start, now, queryStep, rateWindow)
 		return nil
 	})
 	_ = qg.Wait()

--- a/internal/controller/prometheus_test.go
+++ b/internal/controller/prometheus_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package controller
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,6 +42,106 @@ func newTestMemEngine() *recommendation.RecommendationEngine {
 		100,                        // maxIncreasePct (wide)
 		100,                        // maxDecreasePct (wide)
 	)
+}
+
+func TestSamplesForContainer(t *testing.T) {
+	named := []rsmetrics.Sample{{Value: 1.5}}
+	fallback := []rsmetrics.Sample{{Value: 9.0}}
+
+	tests := []struct {
+		name      string
+		grouped   map[string][]rsmetrics.Sample
+		container string
+		want      []rsmetrics.Sample
+	}{
+		{
+			name: "named-key hit",
+			grouped: map[string][]rsmetrics.Sample{
+				"web": named,
+				"":    fallback,
+			},
+			container: "web",
+			want:      named,
+		},
+		{
+			name: "empty-key fallback",
+			grouped: map[string][]rsmetrics.Sample{
+				"": fallback,
+			},
+			container: "web",
+			want:      fallback,
+		},
+		{
+			name:      "nil map",
+			grouped:   nil,
+			container: "web",
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := samplesForContainer(tt.grouped, tt.container)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLatestFiniteSampleTime(t *testing.T) {
+	t1 := time.Unix(1000, 0)
+	t2 := time.Unix(2000, 0)
+	t3 := time.Unix(3000, 0)
+	t4 := time.Unix(4000, 0)
+
+	tests := []struct {
+		name   string
+		groups []map[string][]rsmetrics.Sample
+		want   time.Time
+	}{
+		{
+			name: "newest finite across two groups",
+			groups: []map[string][]rsmetrics.Sample{
+				{
+					"web": {
+						{Timestamp: t1, Value: 1.0},
+						{Timestamp: t4, Value: math.NaN()},
+					},
+				},
+				{
+					"db": {
+						{Timestamp: t3, Value: math.Inf(1)},
+						{Timestamp: t2, Value: 2.0},
+						{Timestamp: t4, Value: math.Inf(-1)},
+					},
+				},
+			},
+			want: t2,
+		},
+		{
+			name: "zero time when every point is non-finite",
+			groups: []map[string][]rsmetrics.Sample{
+				{
+					"web": {
+						{Timestamp: t3, Value: math.NaN()},
+						{Timestamp: t4, Value: math.Inf(1)},
+					},
+				},
+				{
+					"db": {
+						{Timestamp: t2, Value: math.Inf(-1)},
+					},
+				},
+			},
+			want: time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := latestFiniteSampleTime(tt.groups...)
+			assert.True(t, got.Equal(tt.want), "got %v want %v", got, tt.want)
+		})
+	}
 }
 
 func Test_secretForCacheKey(t *testing.T) {

--- a/internal/controller/vpa_test.go
+++ b/internal/controller/vpa_test.go
@@ -519,6 +519,117 @@ func TestResolveMetricsCollector_VPA(t *testing.T) {
 	assert.Nil(t, qb, "VPA source should return nil query builder")
 }
 
+func defaultsWithPrometheus() *attunev1alpha1.AttuneDefaults {
+	return &attunev1alpha1.AttuneDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: attunev1alpha1.AttuneDefaultsSpec{
+			MetricsSource: &attunev1alpha1.MetricsSource{
+				Prometheus: &attunev1alpha1.PrometheusConfig{
+					Address: "http://prometheus.monitoring.svc:9090",
+				},
+			},
+		},
+	}
+}
+
+func TestResolveMetricsCollector_Datadog(t *testing.T) {
+	defaults := defaultsWithPrometheus()
+
+	t.Run("policy Datadog wins over defaults Prometheus", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "dd-keys", Namespace: "default"},
+			Data: map[string][]byte{
+				"api-key": []byte("test-api-key-12345"),
+			},
+		}
+		policy := &attunev1alpha1.AttunePolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "dd-policy", Namespace: "default"},
+			Spec: attunev1alpha1.AttunePolicySpec{
+				MetricsSource: attunev1alpha1.MetricsSource{
+					Datadog: &attunev1alpha1.DatadogConfig{
+						Site:            "datadoghq.com",
+						APIKeySecretRef: attunev1alpha1.SecretKeyRef{Name: "dd-keys", Key: "api-key"},
+					},
+				},
+			},
+		}
+
+		scheme := testScheme()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+		reconciler := NewAttunePolicyReconciler()
+		reconciler.Client = fakeClient
+		reconciler.Scheme = scheme
+
+		collector, qb, err := reconciler.resolveMetricsCollector(
+			context.Background(), policy, defaults,
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, collector)
+		assert.IsType(t, &rsmetrics.DatadogQueryBuilder{}, qb)
+	})
+
+	t.Run("missing Secret is an error not Prometheus", func(t *testing.T) {
+		policy := &attunev1alpha1.AttunePolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "dd-policy", Namespace: "default"},
+			Spec: attunev1alpha1.AttunePolicySpec{
+				MetricsSource: attunev1alpha1.MetricsSource{
+					Datadog: &attunev1alpha1.DatadogConfig{
+						Site:            "datadoghq.com",
+						APIKeySecretRef: attunev1alpha1.SecretKeyRef{Name: "missing-keys", Key: "api-key"},
+					},
+				},
+			},
+		}
+
+		scheme := testScheme()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		reconciler := NewAttunePolicyReconciler()
+		reconciler.Client = fakeClient
+		reconciler.Scheme = scheme
+
+		collector, qb, err := reconciler.resolveMetricsCollector(
+			context.Background(), policy, defaults,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Datadog API key")
+		assert.Nil(t, collector, "missing Secret must not fall through to Prometheus")
+		assert.Nil(t, qb)
+	})
+}
+
+func TestResolveMetricsCollector_CloudWatch(t *testing.T) {
+	defaults := defaultsWithPrometheus()
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cw-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			MetricsSource: attunev1alpha1.MetricsSource{
+				CloudWatch: &attunev1alpha1.CloudWatchConfig{
+					Region:      "us-east-1",
+					ClusterName: "test-cluster",
+				},
+			},
+		},
+	}
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+
+	collector, qb, err := reconciler.resolveMetricsCollector(
+		context.Background(), policy, defaults,
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, collector)
+	cwQB, ok := qb.(*rsmetrics.CloudWatchQueryBuilder)
+	require.True(t, ok, "policy CloudWatch must win over defaults Prometheus")
+	assert.Equal(t, "test-cluster", cwQB.ClusterName)
+}
+
 func TestReconcile_VPASource_EmptyRecommendations(t *testing.T) {
 	policy := newVPAPolicy("vpa-policy", "default", "empty-vpa")
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})

--- a/internal/metrics/cloudwatch.go
+++ b/internal/metrics/cloudwatch.go
@@ -159,7 +159,7 @@ func (c *CloudWatchCollector) QueryRangeGrouped(ctx context.Context, query strin
 				if i >= len(result.Values) {
 					break
 				}
-				grouped[container] = appendFiniteScaled(ctx, container, grouped[container], ts, result.Values[i], isCPU)
+				grouped[container] = appendFiniteScaled(ctx, grouped[container], ts, result.Values[i], isCPU)
 			}
 		}
 

--- a/internal/metrics/cloudwatch.go
+++ b/internal/metrics/cloudwatch.go
@@ -155,11 +155,17 @@ func (c *CloudWatchCollector) QueryRangeGrouped(ctx context.Context, query strin
 				continue
 			}
 
+			hadPoints := false
+			before := len(grouped[container])
 			for i, ts := range result.Timestamps {
 				if i >= len(result.Values) {
 					break
 				}
-				grouped[container] = appendFiniteScaled(ctx, grouped[container], ts, result.Values[i], isCPU)
+				hadPoints = true
+				grouped[container] = appendFiniteScaled(grouped[container], ts, result.Values[i], isCPU)
+			}
+			if hadPoints && len(grouped[container]) == before {
+				recordDroppedNonFinite(ctx, metricTypeFromCPU(isCPU))
 			}
 		}
 

--- a/internal/metrics/cloudwatch.go
+++ b/internal/metrics/cloudwatch.go
@@ -159,7 +159,7 @@ func (c *CloudWatchCollector) QueryRangeGrouped(ctx context.Context, query strin
 				if i >= len(result.Values) {
 					break
 				}
-				grouped[container] = appendFiniteScaled(grouped[container], ts, result.Values[i], isCPU)
+				grouped[container] = appendFiniteScaled(ctx, container, grouped[container], ts, result.Values[i], isCPU)
 			}
 		}
 

--- a/internal/metrics/cloudwatch.go
+++ b/internal/metrics/cloudwatch.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -160,20 +159,7 @@ func (c *CloudWatchCollector) QueryRangeGrouped(ctx context.Context, query strin
 				if i >= len(result.Values) {
 					break
 				}
-				value := result.Values[i]
-				// Skip non-finite values from CloudWatch (e.g., insufficient
-				// data for a statistic returns NaN).
-				if math.IsNaN(value) || math.IsInf(value, 0) {
-					continue
-				}
-				// Container Insights CPU is in nanocores; convert to cores.
-				if isCPU {
-					value /= 1e9
-				}
-				grouped[container] = append(grouped[container], Sample{
-					Timestamp: ts,
-					Value:     value,
-				})
+				grouped[container] = appendFiniteScaled(grouped[container], ts, result.Values[i], isCPU)
 			}
 		}
 

--- a/internal/metrics/cloudwatch_test.go
+++ b/internal/metrics/cloudwatch_test.go
@@ -28,8 +28,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/go-logr/logr"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/attune-io/attune/internal/operatormetrics"
 )
 
 // mockCloudWatchClient implements CloudWatchAPI for testing.
@@ -362,12 +365,16 @@ func TestCloudWatchCollector_QueryRangeGrouped_NaNInfFiltered(t *testing.T) {
 	query, err := json.Marshal(spec)
 	require.NoError(t, err)
 
-	grouped, err := c.QueryRangeGrouped(context.Background(), string(query),
+	ctx := WithNanInfLabels(context.Background(), "cw-ns", "cw-policy", "memory")
+	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("cw-ns", "cw-policy", "main", "memory"))
+	grouped, err := c.QueryRangeGrouped(ctx, string(query),
 		ts1.Add(-time.Hour), ts5, time.Minute)
 	require.NoError(t, err)
 	require.Len(t, grouped["main"], 2, "NaN, +Inf, and -Inf samples should be filtered out")
 	assert.InDelta(t, 0.25, grouped["main"][0].Value, 0.001)
 	assert.InDelta(t, 0.75, grouped["main"][1].Value, 0.001)
+	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("cw-ns", "cw-policy", "main", "memory"))
+	assert.Equal(t, before+3, after, "each dropped NaN/Inf point must increment the counter")
 }
 
 func TestCloudWatchCollector_QueryRangeGrouped_ShortValuesNoPanic(t *testing.T) {

--- a/internal/metrics/cloudwatch_test.go
+++ b/internal/metrics/cloudwatch_test.go
@@ -366,14 +366,14 @@ func TestCloudWatchCollector_QueryRangeGrouped_NaNInfFiltered(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := WithNanInfLabels(context.Background(), "cw-ns", "cw-policy", "memory")
-	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("cw-ns", "cw-policy", "main", "memory"))
+	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("cw-ns", "cw-policy", "untracked", "memory"))
 	grouped, err := c.QueryRangeGrouped(ctx, string(query),
 		ts1.Add(-time.Hour), ts5, time.Minute)
 	require.NoError(t, err)
 	require.Len(t, grouped["main"], 2, "NaN, +Inf, and -Inf samples should be filtered out")
 	assert.InDelta(t, 0.25, grouped["main"][0].Value, 0.001)
 	assert.InDelta(t, 0.75, grouped["main"][1].Value, 0.001)
-	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("cw-ns", "cw-policy", "main", "memory"))
+	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("cw-ns", "cw-policy", "untracked", "memory"))
 	assert.Equal(t, before+3, after, "each dropped NaN/Inf point must increment the counter")
 }
 

--- a/internal/metrics/cloudwatch_test.go
+++ b/internal/metrics/cloudwatch_test.go
@@ -374,7 +374,48 @@ func TestCloudWatchCollector_QueryRangeGrouped_NaNInfFiltered(t *testing.T) {
 	assert.InDelta(t, 0.25, grouped["main"][0].Value, 0.001)
 	assert.InDelta(t, 0.75, grouped["main"][1].Value, 0.001)
 	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("cw-ns", "cw-policy", "untracked", "memory"))
-	assert.Equal(t, before+3, after, "each dropped NaN/Inf point must increment the counter")
+	assert.Equal(t, before, after, "mixed finite+NaN series must not increment the unusable-series counter")
+}
+
+func TestCloudWatchCollector_QueryRangeGrouped_AllNonFiniteIncrementsOnce(t *testing.T) {
+	ts1 := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	ts2 := ts1.Add(1 * time.Minute)
+	ts3 := ts1.Add(2 * time.Minute)
+
+	mock := &mockCloudWatchClient{
+		getMetricDataFn: func(_ context.Context, _ *cloudwatch.GetMetricDataInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
+			return &cloudwatch.GetMetricDataOutput{
+				MetricDataResults: []cwtypes.MetricDataResult{
+					{
+						Label:      aws.String("metric pod-a main"),
+						Timestamps: []time.Time{ts1, ts2, ts3},
+						Values:     []float64{math.NaN(), math.Inf(1), math.Inf(-1)},
+					},
+				},
+			}, nil
+		},
+	}
+
+	c := NewCloudWatchCollectorWithClient(mock, "c", logr.Discard())
+	spec := CloudWatchQuerySpec{
+		Metric:      "container_memory_working_set",
+		ClusterName: "c",
+		Namespace:   "ns",
+		PodPrefix:   "pod-",
+		Period:      300,
+		Stat:        "Average",
+	}
+	query, err := json.Marshal(spec)
+	require.NoError(t, err)
+
+	ctx := WithNanInfLabels(context.Background(), "cw-ns", "cw-policy", "memory")
+	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("cw-ns", "cw-policy", "untracked", "memory"))
+	grouped, err := c.QueryRangeGrouped(ctx, string(query),
+		ts1.Add(-time.Hour), ts3, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, grouped["main"], "all-non-finite series keeps no samples")
+	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("cw-ns", "cw-policy", "untracked", "memory"))
+	assert.Equal(t, before+1, after, "all-non-finite series increments the counter once")
 }
 
 func TestCloudWatchCollector_QueryRangeGrouped_ShortValuesNoPanic(t *testing.T) {

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -339,7 +339,7 @@ func (c *PrometheusCollector) QueryRangeGrouped(ctx context.Context, query strin
 		for _, sp := range series.Values {
 			v := float64(sp.Value)
 			if math.IsNaN(v) || math.IsInf(v, 0) {
-				recordDroppedNonFinite(ctx, container, fallbackMetricType(query))
+				recordDroppedNonFinite(ctx, fallbackMetricType(query))
 				continue
 			}
 			grouped[container] = append(grouped[container], Sample{

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -336,16 +336,19 @@ func (c *PrometheusCollector) QueryRangeGrouped(ctx context.Context, query strin
 	grouped := make(map[string][]Sample, len(matrix))
 	for _, series := range matrix {
 		container := string(series.Metric[model.LabelName("container")])
+		before := len(grouped[container])
 		for _, sp := range series.Values {
 			v := float64(sp.Value)
 			if math.IsNaN(v) || math.IsInf(v, 0) {
-				recordDroppedNonFinite(ctx, fallbackMetricType(query))
 				continue
 			}
 			grouped[container] = append(grouped[container], Sample{
 				Timestamp: sp.Timestamp.Time(),
 				Value:     v,
 			})
+		}
+		if len(series.Values) > 0 && len(grouped[container]) == before {
+			recordDroppedNonFinite(ctx, fallbackMetricType(query))
 		}
 	}
 

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -339,6 +339,7 @@ func (c *PrometheusCollector) QueryRangeGrouped(ctx context.Context, query strin
 		for _, sp := range series.Values {
 			v := float64(sp.Value)
 			if math.IsNaN(v) || math.IsInf(v, 0) {
+				recordDroppedNonFinite(ctx, container, fallbackMetricType(query))
 				continue
 			}
 			grouped[container] = append(grouped[container], Sample{

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -28,10 +28,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/attune-io/attune/internal/operatormetrics"
 	"github.com/attune-io/attune/internal/throttle"
 )
 
@@ -216,11 +218,15 @@ func TestQueryRangeGrouped_NaNInfFiltered(t *testing.T) {
 	end := time.Unix(1700000300, 0)
 	step := 60 * time.Second
 
-	grouped, err := collector.QueryRangeGrouped(context.Background(), "cpu_usage", start, end, step)
+	ctx := WithNanInfLabels(context.Background(), "prom-ns", "prom-policy", "cpu")
+	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("prom-ns", "prom-policy", "app", "cpu"))
+	grouped, err := collector.QueryRangeGrouped(ctx, "cpu_usage", start, end, step)
 	require.NoError(t, err)
 	require.Len(t, grouped["app"], 2, "NaN, +Inf, and -Inf samples should be filtered out")
 	assert.InDelta(t, 0.25, grouped["app"][0].Value, 0.001)
 	assert.InDelta(t, 0.75, grouped["app"][1].Value, 0.001)
+	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("prom-ns", "prom-policy", "app", "cpu"))
+	assert.Equal(t, before+3, after, "each dropped NaN/Inf point must increment the counter")
 }
 
 func TestQuery_Success(t *testing.T) {

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -226,7 +226,47 @@ func TestQueryRangeGrouped_NaNInfFiltered(t *testing.T) {
 	assert.InDelta(t, 0.25, grouped["app"][0].Value, 0.001)
 	assert.InDelta(t, 0.75, grouped["app"][1].Value, 0.001)
 	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("prom-ns", "prom-policy", "untracked", "cpu"))
-	assert.Equal(t, before+3, after, "each dropped NaN/Inf point must increment the counter")
+	assert.Equal(t, before, after, "mixed finite+NaN series must not increment the unusable-series counter")
+}
+
+func TestQueryRangeGrouped_AllNonFiniteIncrementsOnce(t *testing.T) {
+	response := `{
+		"status": "success",
+		"data": {
+			"resultType": "matrix",
+			"result": [
+				{
+					"metric": {"__name__": "cpu_usage", "container": "app"},
+					"values": [
+						[1700000000, "NaN"],
+						[1700000060, "Inf"],
+						[1700000120, "-Inf"]
+					]
+				}
+			]
+		}
+	}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	collector, err := NewPrometheusCollector(server.URL, logr.Discard(), http.DefaultTransport)
+	require.NoError(t, err)
+
+	start := time.Unix(1700000000, 0)
+	end := time.Unix(1700000300, 0)
+	step := 60 * time.Second
+
+	ctx := WithNanInfLabels(context.Background(), "prom-ns", "prom-policy", "cpu")
+	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("prom-ns", "prom-policy", "untracked", "cpu"))
+	grouped, err := collector.QueryRangeGrouped(ctx, "cpu_usage", start, end, step)
+	require.NoError(t, err)
+	assert.Empty(t, grouped["app"], "all-non-finite series keeps no samples")
+	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("prom-ns", "prom-policy", "untracked", "cpu"))
+	assert.Equal(t, before+1, after, "all-non-finite series increments the counter once")
 }
 
 func TestQuery_Success(t *testing.T) {

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -219,13 +219,13 @@ func TestQueryRangeGrouped_NaNInfFiltered(t *testing.T) {
 	step := 60 * time.Second
 
 	ctx := WithNanInfLabels(context.Background(), "prom-ns", "prom-policy", "cpu")
-	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("prom-ns", "prom-policy", "app", "cpu"))
+	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("prom-ns", "prom-policy", "untracked", "cpu"))
 	grouped, err := collector.QueryRangeGrouped(ctx, "cpu_usage", start, end, step)
 	require.NoError(t, err)
 	require.Len(t, grouped["app"], 2, "NaN, +Inf, and -Inf samples should be filtered out")
 	assert.InDelta(t, 0.25, grouped["app"][0].Value, 0.001)
 	assert.InDelta(t, 0.75, grouped["app"][1].Value, 0.001)
-	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("prom-ns", "prom-policy", "app", "cpu"))
+	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("prom-ns", "prom-policy", "untracked", "cpu"))
 	assert.Equal(t, before+3, after, "each dropped NaN/Inf point must increment the counter")
 }
 

--- a/internal/metrics/datadog.go
+++ b/internal/metrics/datadog.go
@@ -145,21 +145,7 @@ func (c *DatadogCollector) QueryRangeGrouped(ctx context.Context, query string, 
 	grouped := make(map[string][]Sample, len(ddResp.Series))
 	for _, series := range ddResp.Series {
 		container := extractDatadogTag(series.TagSet, "kube_container_name")
-		for _, point := range series.Pointlist {
-			ts := time.Unix(int64(point[0])/1000, 0) // Datadog timestamps are milliseconds
-			value := point[1]
-			if math.IsNaN(value) || math.IsInf(value, 0) {
-				continue
-			}
-			// Convert nanocores to cores for CPU metrics.
-			if isCPU {
-				value /= 1e9
-			}
-			grouped[container] = append(grouped[container], Sample{
-				Timestamp: ts,
-				Value:     value,
-			})
-		}
+		grouped[container] = appendDatadogSamples(grouped[container], series.Pointlist, isCPU)
 	}
 
 	c.logger.V(1).Info("Datadog query completed",
@@ -185,6 +171,23 @@ func (c *DatadogCollector) Query(ctx context.Context, query string, ts time.Time
 // Close is a no-op; the HTTP client does not need explicit cleanup.
 func (c *DatadogCollector) Close() error {
 	return nil
+}
+
+// appendDatadogSamples converts Datadog [timestamp_ms, value] points to
+// Samples, dropping NaN/Inf. CPU values are converted from nanocores to cores.
+func appendDatadogSamples(dst []Sample, points [][2]float64, isCPU bool) []Sample {
+	for _, point := range points {
+		ts := time.Unix(int64(point[0])/1000, 0)
+		value := point[1]
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			continue
+		}
+		if isCPU {
+			value /= 1e9
+		}
+		dst = append(dst, Sample{Timestamp: ts, Value: value})
+	}
+	return dst
 }
 
 // extractDatadogTag extracts a tag value from a Datadog tag set.

--- a/internal/metrics/datadog.go
+++ b/internal/metrics/datadog.go
@@ -180,10 +180,11 @@ func (c *DatadogCollector) Close() error {
 }
 
 // appendFiniteScaled appends a sample after dropping NaN/Inf. CPU values
-// are converted from nanocores to cores.
-func appendFiniteScaled(ctx context.Context, dst []Sample, ts time.Time, value float64, isCPU bool) []Sample {
+// are converted from nanocores to cores. Non-finite points are dropped
+// silently; callers increment attune_nan_inf_samples_total once per
+// series when every point was unusable.
+func appendFiniteScaled(dst []Sample, ts time.Time, value float64, isCPU bool) []Sample {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
-		recordDroppedNonFinite(ctx, metricTypeFromCPU(isCPU))
 		return dst
 	}
 	if isCPU {
@@ -194,10 +195,19 @@ func appendFiniteScaled(ctx context.Context, dst []Sample, ts time.Time, value f
 
 // appendDatadogSamples converts Datadog [timestamp_ms, value] points to
 // Samples, dropping NaN/Inf. CPU values are converted from nanocores to cores.
+// Increments the nan-inf counter once when the series had points and none
+// were finite.
 func appendDatadogSamples(ctx context.Context, dst []Sample, points [][2]float64, isCPU bool) []Sample {
+	if len(points) == 0 {
+		return dst
+	}
+	before := len(dst)
 	for _, point := range points {
 		ts := time.Unix(int64(point[0])/1000, 0)
-		dst = appendFiniteScaled(ctx, dst, ts, point[1], isCPU)
+		dst = appendFiniteScaled(dst, ts, point[1], isCPU)
+	}
+	if len(dst) == before {
+		recordDroppedNonFinite(ctx, metricTypeFromCPU(isCPU))
 	}
 	return dst
 }

--- a/internal/metrics/datadog.go
+++ b/internal/metrics/datadog.go
@@ -145,7 +145,7 @@ func (c *DatadogCollector) QueryRangeGrouped(ctx context.Context, query string, 
 	grouped := make(map[string][]Sample, len(ddResp.Series))
 	for _, series := range ddResp.Series {
 		container := extractDatadogTag(series.TagSet, "kube_container_name")
-		grouped[container] = appendDatadogSamples(grouped[container], series.Pointlist, isCPU)
+		grouped[container] = appendDatadogSamples(ctx, container, grouped[container], series.Pointlist, isCPU)
 	}
 
 	c.logger.V(1).Info("Datadog query completed",
@@ -168,15 +168,22 @@ func (c *DatadogCollector) Query(ctx context.Context, query string, ts time.Time
 	return latestSampleValue(samples, "Datadog")
 }
 
-// Close is a no-op; the HTTP client does not need explicit cleanup.
+// Close releases idle HTTP connections on the collector transport.
 func (c *DatadogCollector) Close() error {
+	if c == nil || c.httpClient == nil {
+		return nil
+	}
+	if t, ok := c.httpClient.Transport.(*http.Transport); ok && t != nil {
+		t.CloseIdleConnections()
+	}
 	return nil
 }
 
 // appendFiniteScaled appends a sample after dropping NaN/Inf. CPU values
 // are converted from nanocores to cores.
-func appendFiniteScaled(dst []Sample, ts time.Time, value float64, isCPU bool) []Sample {
+func appendFiniteScaled(ctx context.Context, container string, dst []Sample, ts time.Time, value float64, isCPU bool) []Sample {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
+		recordDroppedNonFinite(ctx, container, metricTypeFromCPU(isCPU))
 		return dst
 	}
 	if isCPU {
@@ -187,10 +194,10 @@ func appendFiniteScaled(dst []Sample, ts time.Time, value float64, isCPU bool) [
 
 // appendDatadogSamples converts Datadog [timestamp_ms, value] points to
 // Samples, dropping NaN/Inf. CPU values are converted from nanocores to cores.
-func appendDatadogSamples(dst []Sample, points [][2]float64, isCPU bool) []Sample {
+func appendDatadogSamples(ctx context.Context, container string, dst []Sample, points [][2]float64, isCPU bool) []Sample {
 	for _, point := range points {
 		ts := time.Unix(int64(point[0])/1000, 0)
-		dst = appendFiniteScaled(dst, ts, point[1], isCPU)
+		dst = appendFiniteScaled(ctx, container, dst, ts, point[1], isCPU)
 	}
 	return dst
 }

--- a/internal/metrics/datadog.go
+++ b/internal/metrics/datadog.go
@@ -173,19 +173,24 @@ func (c *DatadogCollector) Close() error {
 	return nil
 }
 
+// appendFiniteScaled appends a sample after dropping NaN/Inf. CPU values
+// are converted from nanocores to cores.
+func appendFiniteScaled(dst []Sample, ts time.Time, value float64, isCPU bool) []Sample {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return dst
+	}
+	if isCPU {
+		value /= 1e9
+	}
+	return append(dst, Sample{Timestamp: ts, Value: value})
+}
+
 // appendDatadogSamples converts Datadog [timestamp_ms, value] points to
 // Samples, dropping NaN/Inf. CPU values are converted from nanocores to cores.
 func appendDatadogSamples(dst []Sample, points [][2]float64, isCPU bool) []Sample {
 	for _, point := range points {
 		ts := time.Unix(int64(point[0])/1000, 0)
-		value := point[1]
-		if math.IsNaN(value) || math.IsInf(value, 0) {
-			continue
-		}
-		if isCPU {
-			value /= 1e9
-		}
-		dst = append(dst, Sample{Timestamp: ts, Value: value})
+		dst = appendFiniteScaled(dst, ts, point[1], isCPU)
 	}
 	return dst
 }

--- a/internal/metrics/datadog.go
+++ b/internal/metrics/datadog.go
@@ -145,7 +145,7 @@ func (c *DatadogCollector) QueryRangeGrouped(ctx context.Context, query string, 
 	grouped := make(map[string][]Sample, len(ddResp.Series))
 	for _, series := range ddResp.Series {
 		container := extractDatadogTag(series.TagSet, "kube_container_name")
-		grouped[container] = appendDatadogSamples(ctx, container, grouped[container], series.Pointlist, isCPU)
+		grouped[container] = appendDatadogSamples(ctx, grouped[container], series.Pointlist, isCPU)
 	}
 
 	c.logger.V(1).Info("Datadog query completed",
@@ -181,9 +181,9 @@ func (c *DatadogCollector) Close() error {
 
 // appendFiniteScaled appends a sample after dropping NaN/Inf. CPU values
 // are converted from nanocores to cores.
-func appendFiniteScaled(ctx context.Context, container string, dst []Sample, ts time.Time, value float64, isCPU bool) []Sample {
+func appendFiniteScaled(ctx context.Context, dst []Sample, ts time.Time, value float64, isCPU bool) []Sample {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
-		recordDroppedNonFinite(ctx, container, metricTypeFromCPU(isCPU))
+		recordDroppedNonFinite(ctx, metricTypeFromCPU(isCPU))
 		return dst
 	}
 	if isCPU {
@@ -194,10 +194,10 @@ func appendFiniteScaled(ctx context.Context, container string, dst []Sample, ts 
 
 // appendDatadogSamples converts Datadog [timestamp_ms, value] points to
 // Samples, dropping NaN/Inf. CPU values are converted from nanocores to cores.
-func appendDatadogSamples(ctx context.Context, container string, dst []Sample, points [][2]float64, isCPU bool) []Sample {
+func appendDatadogSamples(ctx context.Context, dst []Sample, points [][2]float64, isCPU bool) []Sample {
 	for _, point := range points {
 		ts := time.Unix(int64(point[0])/1000, 0)
-		dst = appendFiniteScaled(ctx, container, dst, ts, point[1], isCPU)
+		dst = appendFiniteScaled(ctx, dst, ts, point[1], isCPU)
 	}
 	return dst
 }

--- a/internal/metrics/datadog_test.go
+++ b/internal/metrics/datadog_test.go
@@ -31,6 +31,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDatadogCollector_QueryRangeGrouped_NaNInfFiltered(t *testing.T) {
+	// encoding/json cannot transport NaN/Inf; QueryRangeGrouped uses this helper after unmarshal.
+	ts1 := 1700000000000.0
+	points := [][2]float64{
+		{ts1, 250000000},          // 0.25 cores after nanocore conversion
+		{ts1 + 60000, math.NaN()}, // dropped
+		{ts1 + 120000, math.Inf(1)},
+		{ts1 + 180000, math.Inf(-1)},
+		{ts1 + 240000, 750000000}, // 0.75 cores
+	}
+
+	grouped := map[string][]Sample{
+		"main": appendDatadogSamples(nil, points, true),
+	}
+	require.Len(t, grouped["main"], 2, "NaN, +Inf, and -Inf samples should be filtered out")
+	assert.InDelta(t, 0.25, grouped["main"][0].Value, 0.001)
+	assert.InDelta(t, 0.75, grouped["main"][1].Value, 0.001)
+}
+
 func TestDatadogCollector_QueryRangeGrouped(t *testing.T) {
 	// Simulate Datadog /api/v1/query response.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/metrics/datadog_test.go
+++ b/internal/metrics/datadog_test.go
@@ -46,14 +46,14 @@ func TestDatadogCollector_QueryRangeGrouped_NaNInfFiltered(t *testing.T) {
 	}
 
 	ctx := WithNanInfLabels(context.Background(), "dd-ns", "dd-policy", "cpu")
-	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("dd-ns", "dd-policy", "main", "cpu"))
+	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("dd-ns", "dd-policy", "untracked", "cpu"))
 	grouped := map[string][]Sample{
-		"main": appendDatadogSamples(ctx, "main", nil, points, true),
+		"main": appendDatadogSamples(ctx, nil, points, true),
 	}
 	require.Len(t, grouped["main"], 2, "NaN, +Inf, and -Inf samples should be filtered out")
 	assert.InDelta(t, 0.25, grouped["main"][0].Value, 0.001)
 	assert.InDelta(t, 0.75, grouped["main"][1].Value, 0.001)
-	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("dd-ns", "dd-policy", "main", "cpu"))
+	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("dd-ns", "dd-policy", "untracked", "cpu"))
 	assert.Equal(t, before+3, after, "each dropped NaN/Inf point must increment the counter")
 }
 

--- a/internal/metrics/datadog_test.go
+++ b/internal/metrics/datadog_test.go
@@ -54,7 +54,23 @@ func TestDatadogCollector_QueryRangeGrouped_NaNInfFiltered(t *testing.T) {
 	assert.InDelta(t, 0.25, grouped["main"][0].Value, 0.001)
 	assert.InDelta(t, 0.75, grouped["main"][1].Value, 0.001)
 	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("dd-ns", "dd-policy", "untracked", "cpu"))
-	assert.Equal(t, before+3, after, "each dropped NaN/Inf point must increment the counter")
+	assert.Equal(t, before, after, "mixed finite+NaN series must not increment the unusable-series counter")
+}
+
+func TestDatadogCollector_QueryRangeGrouped_AllNonFiniteIncrementsOnce(t *testing.T) {
+	ts1 := 1700000000000.0
+	points := [][2]float64{
+		{ts1, math.NaN()},
+		{ts1 + 60000, math.Inf(1)},
+		{ts1 + 120000, math.Inf(-1)},
+	}
+
+	ctx := WithNanInfLabels(context.Background(), "dd-ns", "dd-policy", "cpu")
+	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("dd-ns", "dd-policy", "untracked", "cpu"))
+	got := appendDatadogSamples(ctx, nil, points, true)
+	assert.Empty(t, got, "all-non-finite series keeps no samples")
+	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("dd-ns", "dd-policy", "untracked", "cpu"))
+	assert.Equal(t, before+1, after, "all-non-finite series increments the counter once")
 }
 
 func TestDatadogCollector_QueryRangeGrouped(t *testing.T) {

--- a/internal/metrics/datadog_test.go
+++ b/internal/metrics/datadog_test.go
@@ -27,8 +27,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/attune-io/attune/internal/operatormetrics"
 )
 
 func TestDatadogCollector_QueryRangeGrouped_NaNInfFiltered(t *testing.T) {
@@ -42,12 +45,16 @@ func TestDatadogCollector_QueryRangeGrouped_NaNInfFiltered(t *testing.T) {
 		{ts1 + 240000, 750000000}, // 0.75 cores
 	}
 
+	ctx := WithNanInfLabels(context.Background(), "dd-ns", "dd-policy", "cpu")
+	before := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("dd-ns", "dd-policy", "main", "cpu"))
 	grouped := map[string][]Sample{
-		"main": appendDatadogSamples(nil, points, true),
+		"main": appendDatadogSamples(ctx, "main", nil, points, true),
 	}
 	require.Len(t, grouped["main"], 2, "NaN, +Inf, and -Inf samples should be filtered out")
 	assert.InDelta(t, 0.25, grouped["main"][0].Value, 0.001)
 	assert.InDelta(t, 0.75, grouped["main"][1].Value, 0.001)
+	after := promtestutil.ToFloat64(operatormetrics.NanInfSamplesTotal.WithLabelValues("dd-ns", "dd-policy", "main", "cpu"))
+	assert.Equal(t, before+3, after, "each dropped NaN/Inf point must increment the counter")
 }
 
 func TestDatadogCollector_QueryRangeGrouped(t *testing.T) {
@@ -320,8 +327,13 @@ func TestDatadogCollector_Query_ReturnsLatestTimestamp(t *testing.T) {
 
 func TestDatadogCollector_Close(t *testing.T) {
 	c := &DatadogCollector{}
-	require.NoError(t, c.Close(), "Close is a no-op and must succeed")
+	require.NoError(t, c.Close(), "nil HTTP client must succeed")
 	require.NoError(t, c.Close(), "Close must be idempotent")
+
+	transport := &http.Transport{}
+	c = &DatadogCollector{httpClient: &http.Client{Transport: transport}}
+	require.NoError(t, c.Close())
+	require.NoError(t, c.Close(), "CloseIdleConnections must be idempotent")
 }
 
 func TestLatestSampleValue(t *testing.T) {

--- a/internal/metrics/naninf.go
+++ b/internal/metrics/naninf.go
@@ -32,7 +32,8 @@ type nanInfLabelContext struct {
 }
 
 // WithNanInfLabels attaches policy identity used when QueryRangeGrouped
-// increments attune_nan_inf_samples_total for a dropped NaN/Inf point.
+// increments attune_nan_inf_samples_total for a series whose samples were
+// all non-finite (NaN or Inf). Mixed series drop the bad points only.
 func WithNanInfLabels(ctx context.Context, namespace, policy, metricType string) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -49,6 +50,9 @@ func WithNanInfLabels(ctx context.Context, namespace, policy, metricType string)
 // not become Prometheus series.
 const nanInfUntrackedContainer = "untracked"
 
+// recordDroppedNonFinite increments attune_nan_inf_samples_total once for
+// an unusable series (it had points and every one was NaN or Inf). Call
+// after the series, never inside the per-point loop.
 func recordDroppedNonFinite(ctx context.Context, fallbackMetricType string) {
 	ns, policy, metricType := "", "", fallbackMetricType
 	if ctx != nil {

--- a/internal/metrics/naninf.go
+++ b/internal/metrics/naninf.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"strings"
+
+	"github.com/attune-io/attune/internal/operatormetrics"
+)
+
+type nanInfLabelKey struct{}
+
+type nanInfLabelContext struct {
+	Namespace  string
+	Policy     string
+	MetricType string
+}
+
+// WithNanInfLabels attaches policy identity used when QueryRangeGrouped
+// increments attune_nan_inf_samples_total for a dropped NaN/Inf point.
+func WithNanInfLabels(ctx context.Context, namespace, policy, metricType string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, nanInfLabelKey{}, nanInfLabelContext{
+		Namespace:  namespace,
+		Policy:     policy,
+		MetricType: metricType,
+	})
+}
+
+func recordDroppedNonFinite(ctx context.Context, container, fallbackMetricType string) {
+	ns, policy, metricType := "", "", fallbackMetricType
+	if ctx != nil {
+		if labels, ok := ctx.Value(nanInfLabelKey{}).(nanInfLabelContext); ok {
+			ns, policy = labels.Namespace, labels.Policy
+			if labels.MetricType != "" {
+				metricType = labels.MetricType
+			}
+		}
+	}
+	if metricType == "" {
+		metricType = "unknown"
+	}
+	operatormetrics.NanInfSamplesTotal.WithLabelValues(ns, policy, container, metricType).Inc()
+}
+
+func fallbackMetricType(query string) string {
+	q := strings.ToLower(query)
+	if strings.Contains(q, "memory") {
+		return "memory"
+	}
+	if strings.Contains(q, "cpu") {
+		return "cpu"
+	}
+	return "unknown"
+}
+
+func metricTypeFromCPU(isCPU bool) string {
+	if isCPU {
+		return "cpu"
+	}
+	return "memory"
+}

--- a/internal/metrics/naninf.go
+++ b/internal/metrics/naninf.go
@@ -44,7 +44,12 @@ func WithNanInfLabels(ctx context.Context, namespace, policy, metricType string)
 	})
 }
 
-func recordDroppedNonFinite(ctx context.Context, container, fallbackMetricType string) {
+// nanInfUntrackedContainer is the container label for collector-dropped
+// NaN/Inf points. Backend series labels are attacker-controlled and must
+// not become Prometheus series.
+const nanInfUntrackedContainer = "untracked"
+
+func recordDroppedNonFinite(ctx context.Context, fallbackMetricType string) {
 	ns, policy, metricType := "", "", fallbackMetricType
 	if ctx != nil {
 		if labels, ok := ctx.Value(nanInfLabelKey{}).(nanInfLabelContext); ok {
@@ -57,7 +62,7 @@ func recordDroppedNonFinite(ctx context.Context, container, fallbackMetricType s
 	if metricType == "" {
 		metricType = "unknown"
 	}
-	operatormetrics.NanInfSamplesTotal.WithLabelValues(ns, policy, container, metricType).Inc()
+	operatormetrics.NanInfSamplesTotal.WithLabelValues(ns, policy, nanInfUntrackedContainer, metricType).Inc()
 }
 
 func fallbackMetricType(query string) string {

--- a/internal/metrics/ratelimit.go
+++ b/internal/metrics/ratelimit.go
@@ -18,12 +18,15 @@ package metrics
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"golang.org/x/time/rate"
 
 	"github.com/attune-io/attune/internal/throttle"
 )
+
+var _ io.Closer = (*RateLimitedCollector)(nil)
 
 // RateLimitedCollector wraps a MetricsCollector with rate limiting.
 type RateLimitedCollector struct {
@@ -125,4 +128,17 @@ func (c *RateLimitedCollector) GetThrottleRatios(ctx context.Context, namespace 
 		out[k] = v
 	}
 	return out, nil
+}
+
+// Close forwards to the inner collector when it implements io.Closer.
+// Production caches *RateLimitedCollector, so eviction must reach
+// PrometheusCollector.Close / DatadogCollector.Close through this wrapper.
+func (c *RateLimitedCollector) Close() error {
+	if c == nil || c.inner == nil {
+		return nil
+	}
+	if closer, ok := c.inner.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
 }

--- a/internal/metrics/ratelimit_test.go
+++ b/internal/metrics/ratelimit_test.go
@@ -62,6 +62,30 @@ func (m *mockCollector) Query(ctx context.Context, query string, ts time.Time) (
 	return 42.0, nil
 }
 
+type closableMockCollector struct {
+	mockCollector
+	closed int
+}
+
+func (m *closableMockCollector) Close() error {
+	m.closed++
+	return nil
+}
+
+func TestRateLimitedCollector_CloseForwards(t *testing.T) {
+	inner := &closableMockCollector{}
+	rl := NewRateLimitedCollector(inner, 10, 20)
+	require.NoError(t, rl.Close())
+	assert.Equal(t, 1, inner.closed)
+	require.NoError(t, rl.Close())
+	assert.Equal(t, 2, inner.closed)
+}
+
+func TestRateLimitedCollector_CloseInnerNotCloser(t *testing.T) {
+	rl := NewRateLimitedCollector(&mockCollector{}, 10, 20)
+	require.NoError(t, rl.Close())
+}
+
 func TestRateLimitedCollector_PassesThrough(t *testing.T) {
 	mock := &mockCollector{}
 	rl := NewRateLimitedCollector(mock, 10, 20)


### PR DESCRIPTION
## Summary

Fix Datadog collector cache identity and make `attune_nan_inf_samples_total` match real backends without unbounded labels.

## Problem

- Adding or rotating Datadog `app-key` kept serving a collector built without `DD-APPLICATION-KEY` because the cache key ignored app-key and a failed `app-key` read was treated as empty.
- Collectors drop NaN/Inf before recommendations, so the operator counter never fired on Prometheus, Datadog, or CloudWatch. Incrementing at collectors with raw backend container names would have been a scrape cardinality bomb. Incrementing per dropped point would have fired the all-series-unusable alert on mixed data.
- `RateLimitedCollector` hid `Close` from cache eviction after app-key rotation.

## Change

- Cache Datadog collectors by site + API key + app-key. One Secret Get; missing `app-key` is empty, other errors propagate.
- Count NaN/Inf at collectors once per series that kept zero finite samples. Label `container=untracked`.
- `RateLimitedCollector.Close` forwards to the inner closer. Datadog `Close` idles HTTP connections.
- Exclusive Datadog/CloudWatch `resolveMetricsCollector` tests (do not fall back to defaults Prometheus).
- Docs: app-key applies on the next reconcile; `PrometheusUnavailable` covers all backends; exclusive-provider inherit rule.

## Validation

- `go test ./internal/metrics/ ./internal/controller/ ./internal/operatormetrics/ -race -count=1`
- `make verify-quick`

Ref #651
Ref #652
