### PR TITLE
fix: use Metrics query wording and lock jitter skip

### DIFF
--- a/docs/getting-started/first-30-days.md
+++ b/docs/getting-started/first-30-days.md
@@ -62,8 +62,9 @@ What to check during this phase:
 
 - **Ready shows `NoWorkloadsFound`?** Your `targetRef.name` or `kind` doesn't
   match any workload. Check spelling and namespace.
-- **Ready shows `MetricsUnavailable`?** The operator can't reach your
-  Prometheus instance. Verify the address and network policy.
+- **Ready shows `MetricsUnavailable`?** The operator could not use the
+  configured metrics backend (Prometheus, Datadog, or CloudWatch). Check
+  the Ready message and [troubleshooting](../guides/troubleshooting.md#metricsunavailable).
 - **Progress percentage is climbing?** Everything is working. Wait for it
   to reach 100%.
 

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -185,7 +185,7 @@ patches become slow under conflict retries:
 1. **Prometheus payload and server load** (common with high-replica workloads).
    Symptom: slow or timed-out range queries, high Prometheus memory/CPU,
    `attune_reconcile_duration_seconds` P99 large,
-   `Prometheus query timeout exceeded` on Ready. Fix: reduce `historyWindow`,
+   `Metrics query timeout exceeded` on Ready. Fix: reduce `historyWindow`,
    increase `queryStep`, increase `prometheusTimeout` only after cutting cost,
    add recording rules or Prometheus capacity. See
    [Large Deployments](#large-deployments-high-replica-counts).

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -45,10 +45,10 @@ The condition message tells you which step failed:
 - `Cannot create metrics collector`, `reading secret`, or transport errors
   like `TLS handshake timeout` mean the address was found but auth, headers,
   bearer token secret, CA bundle, or TLS setup failed.
-- `Prometheus query timeout exceeded` means the reconcile-level timeout
-  expired before all Prometheus queries completed.
-- `Prometheus query errors (` means Prometheus answered, but one or more
-  metric queries failed. This can still happen when Prometheus is reachable.
+- `Metrics query timeout exceeded` means the reconcile-level timeout
+  expired before all backend queries completed.
+- `Metrics query errors (` means the backend answered, but one or more
+  metric queries failed. This can still happen when the backend is reachable.
 - `cannot read Datadog API key`, `datadog API returned 403`, or
   `datadog API returned 429` means the Datadog Secret is missing, the
   API key is rejected, or Datadog rate-limited the collector.
@@ -99,10 +99,10 @@ verify the credentials and connection details before changing timeouts:
 3. Test the exact Prometheus URL from inside the cluster with the same auth
    mechanism the operator uses.
 
-If the condition message includes `Prometheus query timeout exceeded`, the
+If the condition message includes `Metrics query timeout exceeded`, the
 operator's reconcile-level timeout expired before all workload queries
-completed. This typically happens when Prometheus is slow to respond
-(not down, just overloaded) or when a policy targets many workloads.
+completed. This typically happens when the metrics backend is slow to
+respond (not down, just overloaded) or when a policy targets many workloads.
 
 **Fix query timeouts**:
 
@@ -113,7 +113,7 @@ completed. This typically happens when Prometheus is slow to respond
 3. Check Prometheus health: high query latency often indicates Prometheus
    itself needs more resources or recording rules.
 
-If the condition message includes `Prometheus query errors (`, Prometheus was
+If the condition message includes `Metrics query errors (`, the backend was
 reachable but one or more metric queries still failed.
 
 **Fix query errors**:

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -1060,11 +1060,11 @@ func (r *AttunePolicyReconciler) setReadyCondition(
 	if workloadsWithRecs > 0 {
 		message := fmt.Sprintf("Watching %d workloads, %d with recommendations", workloadCount, workloadsWithRecs)
 		if totalQueryErrors > 0 {
-			message = fmt.Sprintf("%s; Prometheus query errors (%d) prevented %s data collection for part of the recommendation set, check operator logs",
+			message = fmt.Sprintf("%s; Metrics query errors (%d) prevented %s data collection for part of the recommendation set, check operator logs",
 				message, totalQueryErrors, blockedDataTypes)
 		}
 		if promTimedOut {
-			message += "; Prometheus query timeout exceeded, some workloads may have incomplete data"
+			message += "; Metrics query timeout exceeded, some workloads may have incomplete data"
 		}
 		meta.SetStatusCondition(&policy.Status.Conditions, metav1.Condition{
 			Type:               attunev1alpha1.ConditionReady,
@@ -1089,10 +1089,10 @@ func (r *AttunePolicyReconciler) setReadyCondition(
 		eta.Truncate(time.Minute))
 	if promTimedOut {
 		reason = attunev1alpha1.ReasonMetricsUnavailable
-		message = fmt.Sprintf("Prometheus query timeout exceeded after %s; some workloads may not have been queried", effectiveTimeout)
+		message = fmt.Sprintf("Metrics query timeout exceeded after %s; some workloads may not have been queried", effectiveTimeout)
 	} else if totalQueryErrors > 0 {
 		reason = attunev1alpha1.ReasonMetricsUnavailable
-		message = fmt.Sprintf("Prometheus query errors (%d) prevented %s data collection; check operator logs", totalQueryErrors, blockedDataTypes)
+		message = fmt.Sprintf("Metrics query errors (%d) prevented %s data collection; check operator logs", totalQueryErrors, blockedDataTypes)
 	}
 	meta.SetStatusCondition(&policy.Status.Conditions, metav1.Condition{
 		Type:               attunev1alpha1.ConditionReady,

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -13288,6 +13288,34 @@ func TestReconcile_InsufficientDataShortCooldownDoesNotJitter(t *testing.T) {
 		"InsufficientData must not add RequeueJitter when cooldown < queryStep")
 }
 
+func TestReconcile_MetricsUnavailableDoesNotJitter(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Cooldown = &metav1.Duration{Duration: 1 * time.Minute}
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+
+	reconciler, fakeClient := newReconcilerForReconcile(&mockCollector{
+		queryRangeGroupedFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) (map[string][]rsmetrics.Sample, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
+	}, policy, deploy)
+	reconciler.RequeueJitter = 2 * time.Minute
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1*time.Minute, result.RequeueAfter,
+		"MetricsUnavailable must not add RequeueJitter")
+
+	var updated attunev1alpha1.AttunePolicy
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "test-policy", Namespace: "default",
+	}, &updated))
+	cond := meta.FindStatusCondition(updated.Status.Conditions, attunev1alpha1.ConditionReady)
+	require.NotNil(t, cond)
+	assert.Equal(t, attunev1alpha1.ReasonMetricsUnavailable, cond.Reason)
+}
+
 func TestReconcile_SufficientDataRequeuesAtCooldown(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	policy.Spec.UpdateStrategy.Cooldown = &metav1.Duration{Duration: 2 * time.Hour}

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -5549,7 +5549,7 @@ func TestReconcile_PrometheusQueryErrorsMentionBlockedDataTypes(t *testing.T) {
 	assert.Equal(t, metav1.ConditionTrue, cond.Status)
 	assert.Equal(t, attunev1alpha1.ReasonMonitoring, cond.Reason)
 	assert.Contains(t, cond.Message, "Watching 1 workloads, 1 with recommendations")
-	assert.Contains(t, cond.Message, "Prometheus query errors (1)")
+	assert.Contains(t, cond.Message, "Metrics query errors (1)")
 	assert.Contains(t, cond.Message, "memory data collection")
 	assert.NotContains(t, cond.Message, "CPU and/or memory")
 }
@@ -5580,7 +5580,7 @@ func TestReconcile_PrometheusQueryErrorsMentionCPUAndMemoryWhenBothFail(t *testi
 	require.NotNil(t, cond)
 	assert.Equal(t, metav1.ConditionFalse, cond.Status)
 	assert.Equal(t, attunev1alpha1.ReasonMetricsUnavailable, cond.Reason)
-	assert.Contains(t, cond.Message, "Prometheus query errors (2)")
+	assert.Contains(t, cond.Message, "Metrics query errors (2)")
 	assert.Contains(t, cond.Message, "CPU and memory data collection")
 }
 
@@ -12861,7 +12861,7 @@ func TestSetReadyCondition(t *testing.T) {
 			queryErrorTypes:   map[string]struct{}{"CPU": {}},
 			wantStatus:        metav1.ConditionTrue,
 			wantReason:        attunev1alpha1.ReasonMonitoring,
-			wantMsgContains:   "Prometheus query errors (2) prevented CPU data collection",
+			wantMsgContains:   "Metrics query errors (2) prevented CPU data collection",
 		},
 		{
 			name:              "ready with recommendations and both CPU and memory errors",
@@ -12881,7 +12881,7 @@ func TestSetReadyCondition(t *testing.T) {
 			promTimedOut:      true,
 			wantStatus:        metav1.ConditionTrue,
 			wantReason:        attunev1alpha1.ReasonMonitoring,
-			wantMsgContains:   "Prometheus query timeout exceeded",
+			wantMsgContains:   "Metrics query timeout exceeded",
 		},
 		{
 			name:              "not ready collecting data",
@@ -12902,7 +12902,7 @@ func TestSetReadyCondition(t *testing.T) {
 			maxDataPoints:     0,
 			wantStatus:        metav1.ConditionFalse,
 			wantReason:        attunev1alpha1.ReasonMetricsUnavailable,
-			wantMsgContains:   "Prometheus query errors (1) prevented memory data collection",
+			wantMsgContains:   "Metrics query errors (1) prevented memory data collection",
 		},
 		{
 			name:              "not ready max data points exceeds minimum clamps remaining to 0",
@@ -12923,7 +12923,7 @@ func TestSetReadyCondition(t *testing.T) {
 			promTimeout:       5 * time.Minute,
 			wantStatus:        metav1.ConditionFalse,
 			wantReason:        attunev1alpha1.ReasonMetricsUnavailable,
-			wantMsgContains:   "Prometheus query timeout exceeded after 5m0s",
+			wantMsgContains:   "Metrics query timeout exceeded after 5m0s",
 		},
 		{
 			name:              "ready with timeout and query errors combined",
@@ -12935,7 +12935,7 @@ func TestSetReadyCondition(t *testing.T) {
 			promTimeout:       5 * time.Minute,
 			wantStatus:        metav1.ConditionTrue,
 			wantReason:        attunev1alpha1.ReasonMonitoring,
-			wantMsgContains:   "Prometheus query timeout exceeded",
+			wantMsgContains:   "Metrics query timeout exceeded",
 		},
 	}
 

--- a/internal/controller/prometheus_test.go
+++ b/internal/controller/prometheus_test.go
@@ -606,5 +606,11 @@ func TestRecommendContainer_SkipAndProduce(t *testing.T) {
 		assert.Greater(t, pts, 0)
 		assert.Equal(t, "main", rec.Name)
 		assert.True(t, unfilled, "memory arm has no samples and no hold source")
+		currentCPU := container.Resources.Requests[corev1.ResourceCPU]
+		assert.False(t, rec.Recommended.CPURequest.IsZero(), "CPU arm must write a recommended request")
+		assert.False(t, rec.Recommended.CPURequest.Equal(currentCPU),
+			"CPU rec must differ from the 500m current request")
+		require.NotNil(t, rec.Explanation)
+		require.NotNil(t, rec.Explanation.CPU)
 	})
 }


### PR DESCRIPTION
## Summary

Cycle 2 follow-up after `MetricsUnavailable` landed. Ready query messages no longer say Prometheus when Datadog or CloudWatch failed. Tests lock the jitter skip and the extracted CPU rec.

## Change

- Ready timeout and query-error messages use `Metrics query` wording.
- `TestReconcile_MetricsUnavailableDoesNotJitter` keeps `RequeueAfter` at cooldown when `RequeueJitter` is 2m.
- `TestRecommendContainer_SkipAndProduce` asserts a non-zero CPU rec that differs from the 500m current request.
- First-30-days no longer tells a Datadog user to check a Prometheus address.

## Validation

- `go test ./internal/controller/ -race -count=1 -run TestRecommendContainer_SkipAndProduce|TestReconcile_MetricsUnavailableDoesNotJitter|TestSetReadyCondition|TestReconcile_PrometheusQueryErrors`

## Issues

No new issue numbers. Follow-up to PR #654.
