### PR TITLE
fix: log Metrics query timeout instead of Prometheus

### DIFF
--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -394,7 +394,7 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	wpResult := r.processWorkloads(workloadCtx, &policy, workloads, collector, queryBuilder, podsByWorkload)
 	promTimedOut := workloadCtx.Err() == context.DeadlineExceeded
 	if promTimedOut {
-		logger.Info("Prometheus query timeout exceeded, using partial results",
+		logger.Info("Metrics query timeout exceeded, using partial results",
 			"timeout", promTimeout,
 			"workloadsWithRecommendations", wpResult.workloadsWithRecs,
 			"workloadsTotal", len(workloads))


### PR DESCRIPTION
## Summary

The Ready timeout message already says Metrics. The matching Info log still said Prometheus.

## Change

`logger.Info` at the reconcile timeout site now says `Metrics query timeout exceeded, using partial results`.

## Validation

One-line log string. Existing `setReadyCondition` tests cover the Ready path.

## Issues

Follow-up to PR #655. No new issue numbers.
