### PR TITLE
fix: cut extra live Gets on safety observation and neighbor lists

### DIFF
--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -211,6 +212,10 @@ type AttunePolicyReconciler struct {
 	// so persistent conditions are periodically surfaced without flooding.
 	// Always initialized by NewAttunePolicyReconciler.
 	eventDedup *eventDedup
+
+	// nodeNeighborFlight single-flights the live node pod List used for
+	// neighbor request budget. Per-cycle results live in resizePreChecks.
+	nodeNeighborFlight singleflight.Group
 
 	// gitopsPRClient, when set, is used instead of constructing a GitHub/GitLab
 	// client. Tests inject a fake to count CreateOrUpdate without forge HTTP.

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -4596,6 +4596,73 @@ func TestCheckPendingSafetyObservations_EarlyCriticalOOMKill(t *testing.T) {
 	assert.True(t, foundResize, "OOMKill during observation period should trigger early revert")
 }
 
+func TestCheckPendingSafetyObservations_EarlyCriticalOOMKillNotConfirmed(t *testing.T) {
+	resizedAt := time.Now().UTC().Add(-10 * time.Second).Format(time.RFC3339)
+	listed := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oom-stale",
+			Namespace: "default",
+			Labels:    map[string]string{"attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:     "OOMKilled",
+							FinishedAt: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+		},
+	}
+	live := listed.DeepCopy()
+	live.Status.ContainerStatuses = []corev1.ContainerStatus{
+		{Name: "main", RestartCount: 0},
+	}
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(safetyTestDeploy, listed).Build()
+	clientset := kubefake.NewSimpleClientset(live)
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+
+	for _, a := range clientset.Actions() {
+		assert.False(t, a.GetVerb() == "update" && a.GetSubresource() == "resize",
+			"stale listed OOM must not revert after live confirm is clean")
+	}
+}
+
 func TestCheckPendingSafetyObservations_EarlyCriticalHealthySkipped(t *testing.T) {
 	// Pod was resized recently and is healthy. Early critical check should
 	// NOT trigger a revert even though the observation period hasn't elapsed.
@@ -13895,6 +13962,14 @@ func TestCheckPendingSafetyObservations_AnnotationCleanupPatch(t *testing.T) {
 	require.NoError(t, err)
 	_, hasResizedAt := updated.Annotations[annotationResizedAt]
 	assert.False(t, hasResizedAt, "tracking annotations should be removed after cleanup")
+	_, hasContainers := updated.Annotations[annotationResizedContainers]
+	assert.False(t, hasContainers)
+	_, hasPolicy := updated.Annotations[annotationPolicy]
+	assert.False(t, hasPolicy)
+	_, hasOrigCPU := updated.Annotations[annotationOriginalCPUPrefix+"main"]
+	assert.False(t, hasOrigCPU)
+	_, hasOrigMem := updated.Annotations[annotationOriginalMemoryPrefix+"main"]
+	assert.False(t, hasOrigMem)
 	_, hasTracked := updated.Labels[labelTracked]
 	assert.False(t, hasTracked, "tracked label should be removed after cleanup")
 

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -6531,6 +6531,126 @@ func TestCheckPendingSafetyObservations_UnsafeVerdictReverts(t *testing.T) {
 	assert.True(t, foundResize, "should have called UpdateResize to revert the pod")
 }
 
+func TestCheckPendingSafetyObservations_NotReadyFlapConfirmedBeforeRevert(t *testing.T) {
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	listed := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flap-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
+	}
+	live := listed.DeepCopy()
+	live.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+	}
+
+	policy := newTestPolicy("test-policy", "default")
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(safetyTestDeploy, listed).Build()
+	clientset := kubefake.NewSimpleClientset(live)
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+
+	for _, a := range clientset.Actions() {
+		assert.False(t, a.GetVerb() == "update" && a.GetSubresource() == "resize",
+			"flapping notready must not revert after live confirm")
+	}
+}
+
+func TestCheckPendingSafetyObservations_MultiContainerNoPerContainerGet(t *testing.T) {
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multi-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                      resizedAt,
+				"attune.io/resized-workload":                "api-server",
+				"attune.io/resized-containers":              "app,sidecar",
+				"attune.io/original-cpu-request.app":        "500m",
+				"attune.io/original-memory-request.app":     "512Mi",
+				"attune.io/original-cpu-request.sidecar":    "100m",
+				"attune.io/original-memory-request.sidecar": "128Mi",
+				"attune.io/policy":                          "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}},
+				{Name: "sidecar", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+				}},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 0},
+				{Name: "sidecar", RestartCount: 0},
+			},
+		},
+	}
+
+	policy := newTestPolicy("test-policy", "default")
+	reconciler, _ := newSafetyTestReconciler(pod)
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+
+	gets := 0
+	for _, a := range reconciler.Clientset.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "get" && a.GetResource().Resource == "pods" {
+			gets++
+		}
+	}
+	assert.Equal(t, 0, gets, "safe multi-container observation must not Get per container")
+}
+
 func TestCheckPendingSafetyObservations_RevertUsesWithoutCancel(t *testing.T) {
 	// PromQL can spend the whole PrometheusTimeout. RevertPod must not
 	// inherit that dead deadline (same class as persist confirm).
@@ -13709,10 +13829,9 @@ done437:
 	assert.Equal(t, 2, resizeCalls, "should have 2 UpdateResize calls: original resize + revert")
 }
 
-// --- Issue #441: annotation cleanup conflict retry in checkPendingSafetyObservations ---
+// --- Issue #658: annotation cleanup is a merge patch (no Get, no 409 loop) ---
 
-func TestCheckPendingSafetyObservations_AnnotationCleanupConflictRetry(t *testing.T) {
-	// Verify that annotation cleanup retries on 409 Conflict and succeeds.
+func TestCheckPendingSafetyObservations_AnnotationCleanupPatch(t *testing.T) {
 	resizedAt := time.Now().Add(-10 * time.Minute)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -13742,7 +13861,15 @@ func TestCheckPendingSafetyObservations_AnnotationCleanupConflictRetry(t *testin
 				},
 			},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
 	}
 
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
@@ -13751,11 +13878,8 @@ func TestCheckPendingSafetyObservations_AnnotationCleanupConflictRetry(t *testin
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod).Build()
 	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
 
-	// First annotation cleanup Update returns 409 Conflict, second succeeds.
-	wrappedClient := &conflictThenSucceedClient{Client: fakeClient, conflictsLeft: 1}
-
 	reconciler := NewAttunePolicyReconciler()
-	reconciler.Client = wrappedClient
+	reconciler.Client = fakeClient
 	reconciler.Scheme = scheme
 	reconciler.Clientset = clientset
 
@@ -13763,86 +13887,20 @@ func TestCheckPendingSafetyObservations_AnnotationCleanupConflictRetry(t *testin
 	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
 	policy.Spec.UpdateStrategy.SafetyObservationPeriod = &metav1.Duration{Duration: 5 * time.Minute}
 
-	workloads := []client.Object{deploy}
-	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, &mockCollector{}, workloads)
-
+	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, &mockCollector{}, []client.Object{deploy})
 	assert.False(t, pending, "should not be pending after successful cleanup")
-	assert.Equal(t, 1, wrappedClient.conflictsSeen, "should have retried once on conflict")
 
-	// Verify annotations were removed.
 	var updated corev1.Pod
-	err := wrappedClient.Get(context.Background(), client.ObjectKeyFromObject(pod), &updated)
+	err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), &updated)
 	require.NoError(t, err)
 	_, hasResizedAt := updated.Annotations[annotationResizedAt]
 	assert.False(t, hasResizedAt, "tracking annotations should be removed after cleanup")
-}
+	_, hasTracked := updated.Labels[labelTracked]
+	assert.False(t, hasTracked, "tracked label should be removed after cleanup")
 
-func TestCheckPendingSafetyObservations_AnnotationCleanupConflictExhausted(t *testing.T) {
-	// Verify that exhausting all cleanup retries logs the error but doesn't crash.
-	resizedAt := time.Now().Add(-10 * time.Minute)
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "api-server-abc-1",
-			Namespace: "default",
-			Labels:    map[string]string{"app": "api-server", labelTracked: "true"},
-			Annotations: map[string]string{
-				annotationResizedAt:                     resizedAt.UTC().Format(time.RFC3339),
-				annotationResizedContainers:             "main",
-				annotationOriginalCPUPrefix + "main":    "500m",
-				annotationOriginalMemoryPrefix + "main": "512Mi",
-				annotationPolicy:                        "test-policy",
-				annotationResizedWorkload:               "api-server",
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "main",
-					Image: "nginx",
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("750m"),
-							corev1.ResourceMemory: resource.MustParse("384Mi"),
-						},
-					},
-				},
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	for _, a := range clientset.Actions() {
+		assert.NotEqual(t, "get", a.GetVerb(), "cleanup must not Get the pod")
 	}
-
-	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
-
-	scheme := testScheme()
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod).Build()
-	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
-
-	// All 3 cleanup attempts return 409 Conflict.
-	wrappedClient := &conflictThenSucceedClient{Client: fakeClient, conflictsLeft: 3}
-
-	reconciler := NewAttunePolicyReconciler()
-	reconciler.Client = wrappedClient
-	reconciler.Scheme = scheme
-	reconciler.Clientset = clientset
-
-	policy := newTestPolicy("test-policy", "default")
-	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
-	policy.Spec.UpdateStrategy.SafetyObservationPeriod = &metav1.Duration{Duration: 5 * time.Minute}
-
-	workloads := []client.Object{deploy}
-	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, &mockCollector{}, workloads)
-
-	// Should not crash and should not report pending (annotation cleanup is
-	// best-effort; the annotations will be cleaned on the next reconcile).
-	assert.False(t, pending)
-	assert.Equal(t, 3, wrappedClient.conflictsSeen, "should have exhausted all 3 retries")
-
-	// Annotations should still be present since all updates failed.
-	var updated corev1.Pod
-	err := wrappedClient.Get(context.Background(), client.ObjectKeyFromObject(pod), &updated)
-	require.NoError(t, err)
-	_, hasResizedAt := updated.Annotations[annotationResizedAt]
-	assert.True(t, hasResizedAt, "tracking annotations should still be present after exhausted retries")
 }
 
 // --- Issue #440: startup boost expiry memory regression test ---

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -20,7 +20,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -675,4 +678,112 @@ func TestExecuteResizes_NeighborListError_SkipsIncrease(t *testing.T) {
 		[]client.Object{deploy}, recs, podMap("app", pod), nil, nil)
 	assert.Equal(t, 0, count, "increase must not apply when neighbor list fails")
 	assert.Equal(t, before+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("default", "nb-err", "neighbors")))
+}
+
+func TestNeighborRequestTotals_ExcludesTerminalPhase(t *testing.T) {
+	const nodeName = "node-term"
+	self := newResizePod("app", "500m", "512Mi", "2000m", "2Gi")
+	self.Spec.NodeName = nodeName
+	self.UID = "self-uid"
+	done := neighborPod("finished-job", nodeName, "1500m", "1Gi")
+	done.UID = "job-uid"
+	done.Status.Phase = corev1.PodSucceeded
+	node := neighborTestNode(nodeName, "2000m", "8Gi")
+	deploy := newTestDeployment("app", "default", map[string]string{"app": "app"})
+
+	reconciler, _ := newResizeReconciler(self, deploy, node, done)
+	reconciler.Clientset = kubefake.NewSimpleClientset(self.DeepCopy(), done.DeepCopy(), node.DeepCopy())
+
+	policy := newTestPolicy("nb-term", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("app", "500m", "512Mi", "2000m", "2Gi", "1500m", "512Mi", "2000m", "2Gi"),
+	}
+	count, _ := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy}, recs, podMap("app", self), nil, nil)
+	assert.Equal(t, 1, count, "Succeeded neighbor must not consume allocatable")
+}
+
+func TestNeighborRequestTotals_IncludesTerminating(t *testing.T) {
+	const nodeName = "node-terming"
+	self := newResizePod("app", "500m", "512Mi", "2000m", "2Gi")
+	self.Spec.NodeName = nodeName
+	self.UID = "self-uid"
+	leaving := neighborPod("leaving", nodeName, "1500m", "1Gi")
+	leaving.UID = "leave-uid"
+	now := metav1.Now()
+	leaving.DeletionTimestamp = &now
+	leaving.Finalizers = []string{"attune.io/test"}
+	leaving.Status.Phase = corev1.PodRunning
+	node := neighborTestNode(nodeName, "2000m", "8Gi")
+	deploy := newTestDeployment("app", "default", map[string]string{"app": "app"})
+
+	reconciler, _ := newResizeReconciler(self, deploy, node, leaving)
+	reconciler.Clientset = kubefake.NewSimpleClientset(self.DeepCopy(), leaving.DeepCopy(), node.DeepCopy())
+
+	policy := newTestPolicy("nb-terming", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("app", "500m", "512Mi", "2000m", "2Gi", "1500m", "512Mi", "2000m", "2Gi"),
+	}
+	count, _ := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy}, recs, podMap("app", self), nil, nil)
+	assert.Equal(t, 0, count, "terminating neighbor still holds allocation")
+}
+
+func TestNeighborRequestTotals_IgnoresInformerOnlyNeighbor(t *testing.T) {
+	const nodeName = "node-cache"
+	self := newResizePod("app", "500m", "512Mi", "2000m", "2Gi")
+	self.Spec.NodeName = nodeName
+	self.UID = "self-uid"
+	cachedOnly := neighborPod("other-ns-pod", nodeName, "1500m", "1Gi")
+	cachedOnly.Namespace = "other"
+	cachedOnly.UID = "other-uid"
+	node := neighborTestNode(nodeName, "2000m", "8Gi")
+	deploy := newTestDeployment("app", "default", map[string]string{"app": "app"})
+
+	// Fat neighbor exists only in the informer client, not Clientset.
+	reconciler, _ := newResizeReconciler(self, deploy, node, cachedOnly)
+	reconciler.Clientset = kubefake.NewSimpleClientset(self.DeepCopy(), node.DeepCopy())
+
+	policy := newTestPolicy("nb-cache", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("app", "500m", "512Mi", "2000m", "2Gi", "1500m", "512Mi", "2000m", "2Gi"),
+	}
+	count, _ := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy}, recs, podMap("app", self), nil, nil)
+	assert.Equal(t, 1, count, "informer-only neighbor must not be counted (watch-namespaces fail-open guard)")
+}
+
+func TestNeighborRequestTotals_SingleFlightOneList(t *testing.T) {
+	const nodeName = "node-sf"
+	self := newResizePod("app", "500m", "512Mi", "2000m", "2Gi")
+	self.Spec.NodeName = nodeName
+	self.UID = "self-uid"
+	other := neighborPod("other", nodeName, "100m", "64Mi")
+	other.UID = "other-uid"
+
+	reconciler := NewAttunePolicyReconciler()
+	cs := kubefake.NewSimpleClientset(self.DeepCopy(), other.DeepCopy())
+	var lists atomic.Int32
+	cs.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		lists.Add(1)
+		time.Sleep(40 * time.Millisecond)
+		return false, nil, nil
+	})
+	reconciler.Clientset = cs
+	checks := &resizePreChecks{}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			_, _, err := reconciler.neighborRequestTotals(context.Background(), self, checks)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), lists.Load(), "two workers on one node must share one List")
 }

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -756,6 +756,30 @@ func TestNeighborRequestTotals_IgnoresInformerOnlyNeighbor(t *testing.T) {
 	assert.Equal(t, 1, count, "informer-only neighbor must not be counted (watch-namespaces fail-open guard)")
 }
 
+func TestNeighborRequestTotals_CountsOtherNamespaceOnClientset(t *testing.T) {
+	const nodeName = "node-xns"
+	self := newResizePod("app", "500m", "512Mi", "2000m", "2Gi")
+	self.Spec.NodeName = nodeName
+	self.UID = "self-uid"
+	otherNS := neighborPod("other-ns-pod", nodeName, "1500m", "1Gi")
+	otherNS.Namespace = "other"
+	otherNS.UID = "other-uid"
+	node := neighborTestNode(nodeName, "2000m", "8Gi")
+	deploy := newTestDeployment("app", "default", map[string]string{"app": "app"})
+
+	reconciler, _ := newResizeReconciler(self, deploy, node)
+	reconciler.Clientset = kubefake.NewSimpleClientset(self.DeepCopy(), otherNS.DeepCopy(), node.DeepCopy())
+
+	policy := newTestPolicy("nb-xns", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("app", "500m", "512Mi", "2000m", "2Gi", "1500m", "512Mi", "2000m", "2Gi"),
+	}
+	count, _ := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy}, recs, podMap("app", self), nil, nil)
+	assert.Equal(t, 0, count, "Clientset neighbor in another namespace must still count")
+}
+
 func TestNeighborRequestTotals_SingleFlightOneList(t *testing.T) {
 	const nodeName = "node-sf"
 	self := newResizePod("app", "500m", "512Mi", "2000m", "2Gi")

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -98,6 +99,49 @@ func removeTrackingAnnotations(pod *corev1.Pod) {
 	delete(pod.Annotations, annotationResizedWorkload)
 	delete(pod.Annotations, annotationPolicy)
 	delete(pod.Labels, labelTracked)
+}
+
+// patchRemoveTrackingAnnotations clears tracking keys with a merge patch.
+// Null-valued keys are deleted; missing keys are a no-op. No Get or
+// resourceVersion is required.
+func (r *AttunePolicyReconciler) patchRemoveTrackingAnnotations(ctx context.Context, pod *corev1.Pod) error {
+	if r.Client == nil {
+		return fmt.Errorf("patching tracking annotations on %s/%s: no client", pod.Namespace, pod.Name)
+	}
+	patch, err := trackingCleanupMergePatch(pod)
+	if err != nil {
+		return err
+	}
+	return r.Patch(ctx, pod, client.RawPatch(types.MergePatchType, patch))
+}
+
+func trackingCleanupMergePatch(pod *corev1.Pod) ([]byte, error) {
+	anns := map[string]any{
+		annotationResizedAt:         nil,
+		annotationResizedContainers: nil,
+		annotationResizedWorkload:   nil,
+		annotationPolicy:            nil,
+	}
+	if names, ok := pod.Annotations[annotationResizedContainers]; ok {
+		for _, name := range strings.Split(names, ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			anns[annotationOriginalCPUPrefix+name] = nil
+			anns[annotationOriginalMemoryPrefix+name] = nil
+			anns[annotationOriginalCPULimitPrefix+name] = nil
+			anns[annotationOriginalMemoryLimitPrefix+name] = nil
+			anns[annotationOriginalRestartCountPrefix+name] = nil
+		}
+	}
+	payload := map[string]any{
+		"metadata": map[string]any{
+			"annotations": anns,
+			"labels":      map[string]any{labelTracked: nil},
+		},
+	}
+	return json.Marshal(payload)
 }
 
 // appendResizedContainer adds a container name to the comma-separated

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -1260,14 +1260,24 @@ func earliestSuccessfulInPlaceAfter(history []attunev1alpha1.ResizeHistoryEntry,
 // resizePreChecks holds per-cycle cached data for shouldSkipResize,
 // avoiding redundant API calls when checking many pods in the same namespace.
 // nodeCache uses sync.Map for safe concurrent access when MaxConcurrentResizes > 1.
-type nodePodCache struct {
-	pods []corev1.Pod
-	err  error
+// neighborReq is the compact per-pod request total used for self-exclusion.
+type neighborReq struct {
+	ns, name string
+	cpu, mem int64
+}
+
+// nodeNeighborCache holds per-cycle neighbor request sums for one node.
+// Full pod objects are not retained after the List is reduced.
+type nodeNeighborCache struct {
+	totalCPU, totalMem int64
+	byUID              map[types.UID]neighborReq
+	byName             map[string]neighborReq // namespace/name for empty-UID tests
+	err                error
 }
 
 type resizePreChecks struct {
 	nodeCache         sync.Map // string -> *corev1.Node
-	nodePods          sync.Map // string -> nodePodCache
+	nodePods          sync.Map // string -> nodeNeighborCache
 	limitRanges       []corev1.LimitRange
 	quotas            []corev1.ResourceQuota
 	limitRangeListErr error
@@ -1438,52 +1448,91 @@ func recordCapacitySkip(policy *attunev1alpha1.AttunePolicy, reason string) {
 	}
 }
 
-// podsOnNode lists pods scheduled on nodeName (cached per cycle).
-// The result is filtered by spec.nodeName so fake clientsets that ignore
-// field selectors still behave.
-func (r *AttunePolicyReconciler) podsOnNode(ctx context.Context, nodeName string, checks *resizePreChecks) ([]corev1.Pod, error) {
+const nodeNeighborPageSize = int64(200)
+
+// loadNodeNeighbors returns compact neighbor request totals for nodeName.
+// The List is live (Clientset, not the informer cache) so --watch-namespaces
+// cannot under-count neighbors in unwatched namespaces.
+func (r *AttunePolicyReconciler) loadNodeNeighbors(ctx context.Context, nodeName string, checks *resizePreChecks) (nodeNeighborCache, error) {
 	if nodeName == "" {
-		return nil, nil
+		return nodeNeighborCache{}, nil
 	}
 	if checks != nil {
 		if v, ok := checks.nodePods.Load(nodeName); ok {
-			if cached, ok := v.(nodePodCache); ok {
-				return cached.pods, cached.err
+			if cached, ok := v.(nodeNeighborCache); ok {
+				return cached, cached.err
 			}
 		}
 	}
-	if r.Clientset == nil {
-		// Unit paths without a Clientset keep the this-pod check only.
-		// Production executeResizes always has a Clientset; a live List
-		// error is fail-closed above the caller.
-		return nil, nil
-	}
-	list, err := r.Clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{
-		FieldSelector: "spec.nodeName=" + nodeName,
+	v, _, _ := r.nodeNeighborFlight.Do(nodeName, func() (any, error) {
+		return r.listNodeNeighbors(ctx, nodeName), nil
 	})
-	if err != nil {
-		if checks != nil {
-			checks.nodePods.Store(nodeName, nodePodCache{err: err})
-		}
-		return nil, err
-	}
-	filtered := make([]corev1.Pod, 0, len(list.Items))
-	for i := range list.Items {
-		if list.Items[i].Spec.NodeName == nodeName {
-			filtered = append(filtered, list.Items[i])
-		}
-	}
+	cached, _ := v.(nodeNeighborCache)
 	if checks != nil {
-		checks.nodePods.Store(nodeName, nodePodCache{pods: filtered})
+		checks.nodePods.Store(nodeName, cached)
 	}
-	return filtered, nil
+	return cached, cached.err
 }
 
-func samePod(a, b *corev1.Pod) bool {
-	if a.UID != "" && b.UID != "" {
-		return a.UID == b.UID
+func (r *AttunePolicyReconciler) listNodeNeighbors(ctx context.Context, nodeName string) nodeNeighborCache {
+	if r.Clientset == nil {
+		// Unit paths without a Clientset keep the this-pod check only.
+		return nodeNeighborCache{}
 	}
-	return a.Name == b.Name && a.Namespace == b.Namespace
+	out := nodeNeighborCache{
+		byUID:  make(map[types.UID]neighborReq),
+		byName: make(map[string]neighborReq),
+	}
+	continueToken := ""
+	for {
+		list, err := r.Clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+			FieldSelector:   "spec.nodeName=" + nodeName,
+			ResourceVersion: "0",
+			Limit:           nodeNeighborPageSize,
+			Continue:        continueToken,
+		})
+		if err != nil {
+			out.err = err
+			return out
+		}
+		for i := range list.Items {
+			p := &list.Items[i]
+			if p.Spec.NodeName != nodeName {
+				continue
+			}
+			if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+				continue
+			}
+			req := neighborReq{ns: p.Namespace, name: p.Name}
+			running := append(nativeSidecars(p.Spec.InitContainers), p.Spec.Containers...)
+			for _, c := range running {
+				req.cpu += c.Resources.Requests.Cpu().MilliValue()
+				req.mem += c.Resources.Requests.Memory().Value()
+			}
+			out.totalCPU += req.cpu
+			out.totalMem += req.mem
+			if p.UID != "" {
+				out.byUID[p.UID] = req
+			}
+			out.byName[p.Namespace+"/"+p.Name] = req
+		}
+		if list.Continue == "" {
+			return out
+		}
+		continueToken = list.Continue
+	}
+}
+
+func (c nodeNeighborCache) exclude(pod *corev1.Pod) (cpu, mem int64) {
+	if pod.UID != "" {
+		if e, ok := c.byUID[pod.UID]; ok {
+			return c.totalCPU - e.cpu, c.totalMem - e.mem
+		}
+	}
+	if e, ok := c.byName[pod.Namespace+"/"+pod.Name]; ok {
+		return c.totalCPU - e.cpu, c.totalMem - e.mem
+	}
+	return c.totalCPU, c.totalMem
 }
 
 // neighborRequestTotals sums running-container requests of other pods on
@@ -1493,20 +1542,11 @@ func (r *AttunePolicyReconciler) neighborRequestTotals(ctx context.Context, pod 
 	if pod.Spec.NodeName == "" {
 		return 0, 0, nil
 	}
-	neighbors, err := r.podsOnNode(ctx, pod.Spec.NodeName, checks)
+	cached, err := r.loadNodeNeighbors(ctx, pod.Spec.NodeName, checks)
 	if err != nil {
 		return 0, 0, err
 	}
-	for _, n := range neighbors {
-		if samePod(pod, &n) {
-			continue
-		}
-		running := append(nativeSidecars(n.Spec.InitContainers), n.Spec.Containers...)
-		for _, c := range running {
-			cpu += c.Resources.Requests.Cpu().MilliValue()
-			mem += c.Resources.Requests.Memory().Value()
-		}
-	}
+	cpu, mem = cached.exclude(pod)
 	return cpu, mem, nil
 }
 

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -1374,8 +1374,8 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 				}
 				// Neighbor request budget: skip *increases* that would not
 				// fit after other pods already reserved allocatable.
-				// Decreases stay allowed. Missing nodeName or a failed
-				// neighbor list leaves only the this-pod check above.
+				// Decreases stay allowed. A failed neighbor list is
+				// fail-closed for increases (see nErr below).
 				if targetIncreasesRequests(pod, containerRec.Name, target) {
 					nCPU, nMem, nErr := r.neighborRequestTotals(ctx, pod, checks)
 					if nErr != nil {

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -160,7 +160,8 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 		return
 	}
 
-	monitor := r.newSafetyMonitor(logger, collector, policy.Spec.UpdateStrategy.SLOGuardrails)
+	monitor := r.newSafetyMonitor(logger, collector, policy.Spec.UpdateStrategy.SLOGuardrails).
+		WithSLOQueryMemo()
 	observationPeriod := getObservationPeriod(policy)
 
 	// Revert must not inherit a spent PrometheusTimeout. PromQL/throttle
@@ -263,7 +264,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 
 		var revertFailed, throttlePending bool
 		for _, record := range records {
-			verdict, err := monitor.CheckPod(ctx, record, r.now())
+			verdict, err := monitor.CheckPodObject(ctx, pod, record, r.now())
 			if err != nil {
 				logger.Error(err, "Safety observation check failed", "pod", pod.Name, "container", record.Container)
 				operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
@@ -279,6 +280,19 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 			}
 
 			if !verdict.Safe {
+				confirmed, confirmErr := r.confirmSafetyVerdict(ctx, monitor, pod, record)
+				if confirmErr != nil {
+					logger.Error(confirmErr, "Safety confirm Get failed", "pod", pod.Name, "container", record.Container)
+					operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
+					revertFailed = true
+					continue
+				}
+				if confirmed.Safe {
+					logger.V(1).Info("Cached unsafe verdict not confirmed on live pod",
+						"pod", pod.Name, "container", record.Container, "cachedReason", verdict.Reason)
+					continue
+				}
+				verdict = confirmed
 				logger.Info("Deferred safety violation detected, reverting",
 					"pod", pod.Name, "container", record.Container, "reason", verdict.Reason)
 				if revertErr := revertPod(record); revertErr != nil {
@@ -303,39 +317,34 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 			observationsPending = true
 			continue
 		}
-		// Re-fetch directly from API server (not informer cache) to get
-		// fresh resourceVersion after UpdateResize. The cache may not have
-		// the watch event yet, causing a 409 Conflict on annotation update.
-		// Retry on conflict to handle kubelet status churn.
-		const maxCleanupRetries = 3
-		var cleanupErr error
-		for attempt := range maxCleanupRetries {
-			freshPod, getErr := r.Clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
-			if getErr != nil {
-				logger.Error(getErr, "Failed to re-fetch pod for annotation cleanup", "pod", pod.Name)
-				cleanupErr = getErr
-				break
-			}
-			removeTrackingAnnotations(freshPod)
-			updateErr := r.Update(ctx, freshPod)
-			if updateErr == nil {
-				cleanupErr = nil
-				break
-			}
-			if !apierrors.IsConflict(updateErr) {
-				logger.Error(updateErr, "Failed to remove resize tracking annotations", "pod", pod.Name)
-				cleanupErr = updateErr
-				break
-			}
-			logger.V(1).Info("Annotation cleanup conflict, retrying",
-				"pod", pod.Name, "attempt", attempt+1)
-			cleanupErr = updateErr
-		}
-		if cleanupErr != nil && apierrors.IsConflict(cleanupErr) {
-			logger.Error(cleanupErr, "Exhausted annotation cleanup retries", "pod", pod.Name, "retries", maxCleanupRetries)
+		// Merge-patch nulls tracking keys. No Get and no resourceVersion,
+		// so kubelet status churn cannot 409 the cleanup.
+		if err := r.patchRemoveTrackingAnnotations(ctx, pod); err != nil {
+			logger.Error(err, "Failed to remove resize tracking annotations", "pod", pod.Name)
 		}
 	}
 	return observationsPending
+}
+
+// confirmSafetyVerdict re-Gets the pod and re-evaluates before revert so a
+// flapping Ready=False on the listed snapshot does not undo a now-healthy pod.
+func (r *AttunePolicyReconciler) confirmSafetyVerdict(
+	ctx context.Context,
+	monitor *safety.Monitor,
+	listed *corev1.Pod,
+	record safety.ResizeRecord,
+) (safety.SafetyVerdict, error) {
+	if r.Clientset == nil {
+		return safety.SafetyVerdict{}, fmt.Errorf("confirming safety verdict for %s/%s: no clientset", listed.Namespace, listed.Name)
+	}
+	fresh, err := r.Clientset.CoreV1().Pods(listed.Namespace).Get(ctx, listed.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return safety.SafetyVerdict{Safe: true}, nil
+	}
+	if err != nil {
+		return safety.SafetyVerdict{}, fmt.Errorf("confirming safety verdict for %s/%s: %w", listed.Namespace, listed.Name, err)
+	}
+	return monitor.CheckPodObject(ctx, fresh, record, r.now())
 }
 
 func trackedWorkloadForPolicy(pod *corev1.Pod, policyName string, workloadNames map[string]bool) (string, bool) {

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -235,7 +235,6 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 							confirmed, confirmErr := r.confirmCriticalStatuses(ctx, pod, record)
 							if confirmErr != nil {
 								logger.Error(confirmErr, "Early critical confirm Get failed", "pod", pod.Name)
-								observationsPending = true
 								continue
 							}
 							if confirmed == nil {

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -232,6 +232,18 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 				if earlyRecords, buildErr := buildResizeRecords(pod, observationPeriod); buildErr == nil {
 					for _, record := range earlyRecords {
 						if v := safety.CheckCriticalStatuses(pod, record); v != nil {
+							confirmed, confirmErr := r.confirmCriticalStatuses(ctx, pod, record)
+							if confirmErr != nil {
+								logger.Error(confirmErr, "Early critical confirm Get failed", "pod", pod.Name)
+								observationsPending = true
+								continue
+							}
+							if confirmed == nil {
+								logger.V(1).Info("Cached critical verdict not confirmed on live pod",
+									"pod", pod.Name, "container", record.Container, "cachedReason", v.Reason)
+								continue
+							}
+							v = confirmed
 							logger.Info("Critical safety event detected during observation period, reverting early",
 								"pod", pod.Name, "container", record.Container, "reason", v.Reason)
 							if revertErr := revertPod(record); revertErr != nil {
@@ -345,6 +357,27 @@ func (r *AttunePolicyReconciler) confirmSafetyVerdict(
 		return safety.SafetyVerdict{}, fmt.Errorf("confirming safety verdict for %s/%s: %w", listed.Namespace, listed.Name, err)
 	}
 	return monitor.CheckPodObject(ctx, fresh, record, r.now())
+}
+
+// confirmCriticalStatuses re-Gets and re-runs only OOM/restart checks.
+// Full CheckPodObject is wrong here: observation has not elapsed, so Ready
+// flaps and SLO/throttle must not trigger an early revert.
+func (r *AttunePolicyReconciler) confirmCriticalStatuses(
+	ctx context.Context,
+	listed *corev1.Pod,
+	record safety.ResizeRecord,
+) (*safety.SafetyVerdict, error) {
+	if r.Clientset == nil {
+		return nil, fmt.Errorf("confirming critical verdict for %s/%s: no clientset", listed.Namespace, listed.Name)
+	}
+	fresh, err := r.Clientset.CoreV1().Pods(listed.Namespace).Get(ctx, listed.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("confirming critical verdict for %s/%s: %w", listed.Namespace, listed.Name, err)
+	}
+	return safety.CheckCriticalStatuses(fresh, record), nil
 }
 
 func trackedWorkloadForPolicy(pod *corev1.Pod, policyName string, workloadNames map[string]bool) (string, bool) {

--- a/internal/safety/monitor.go
+++ b/internal/safety/monitor.go
@@ -107,6 +107,15 @@ type Monitor struct {
 	sloQuerier         SLOQuerier
 	sloGuardrails      []attunev1alpha1.SLOGuardrail
 	sloTemplates       map[string]*template.Template // cached parsed templates keyed by query string
+	// sloQueryMemo caches Query results for one observation pass, keyed by
+	// the interpolated PromQL string. A workload-level query then runs once
+	// for every pod that interpolates to the same string.
+	sloQueryMemo map[string]sloMemoEntry
+}
+
+type sloMemoEntry struct {
+	value float64
+	err   error
 }
 
 // NewMonitor creates a Monitor backed by the given Kubernetes client.
@@ -159,6 +168,13 @@ func (m *Monitor) WithSLOChecker(querier SLOQuerier, guardrails []attunev1alpha1
 	return m
 }
 
+// WithSLOQueryMemo enables per-pass memoization of interpolated SLO queries.
+// Call once at the start of an observation pass and drop the Monitor after.
+func (m *Monitor) WithSLOQueryMemo() *Monitor {
+	m.sloQueryMemo = make(map[string]sloMemoEntry)
+	return m
+}
+
 // CheckCriticalStatuses checks a pod's container statuses for critical safety
 // events (OOMKill and excessive restarts) that warrant an immediate revert.
 // Returns a non-nil SafetyVerdict if a critical issue is found.
@@ -208,6 +224,16 @@ func (m *Monitor) CheckPod(ctx context.Context, record ResizeRecord, now time.Ti
 			return SafetyVerdict{Safe: true}, nil
 		}
 		return SafetyVerdict{}, fmt.Errorf("getting pod %s/%s: %w", record.Namespace, record.PodName, err)
+	}
+	return m.CheckPodObject(ctx, pod, record, now)
+}
+
+// CheckPodObject is CheckPod against an already-fetched pod. Observation
+// uses the listed object so a multi-container pod is not re-Gotten per
+// container. Callers that need a live object still use CheckPod.
+func (m *Monitor) CheckPodObject(ctx context.Context, pod *corev1.Pod, record ResizeRecord, now time.Time) (SafetyVerdict, error) {
+	if pod == nil {
+		return SafetyVerdict{Safe: true}, nil
 	}
 
 	// Critical checks: OOMKill and excessive restarts.
@@ -301,7 +327,7 @@ func (m *Monitor) checkSLOGuardrails(ctx context.Context, record ResizeRecord, n
 			continue
 		}
 
-		value, err := m.sloQuerier.Query(ctx, query, now)
+		value, err := m.querySLO(ctx, query, now)
 		if err != nil {
 			m.logger.Error(err, "SLO guardrail query failed, skipping",
 				"guardrail", g.Name, "pod", record.PodName, "namespace", record.Namespace)
@@ -343,6 +369,19 @@ func (m *Monitor) checkSLOGuardrails(ctx context.Context, record ResizeRecord, n
 		}
 	}
 	return nil
+}
+
+func (m *Monitor) querySLO(ctx context.Context, query string, now time.Time) (float64, error) {
+	if m.sloQueryMemo != nil {
+		if e, ok := m.sloQueryMemo[query]; ok {
+			return e.value, e.err
+		}
+	}
+	value, err := m.sloQuerier.Query(ctx, query, now)
+	if m.sloQueryMemo != nil {
+		m.sloQueryMemo[query] = sloMemoEntry{value: value, err: err}
+	}
+	return value, err
 }
 
 // interpolateSLOQuery renders Go template variables in a PromQL query string.

--- a/internal/safety/monitor_test.go
+++ b/internal/safety/monitor_test.go
@@ -19,6 +19,7 @@ package safety
 import (
 	"context"
 	"math"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1789,4 +1790,85 @@ func TestCheckPod_SLONoQuerier(t *testing.T) {
 	verdict, err := monitor.CheckPod(context.Background(), record, time.Now())
 	require.NoError(t, err)
 	assert.True(t, verdict.Safe)
+}
+
+func TestCheckPodObject_UsesListedPodWithoutGet(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-0", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: 0},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	// Nil clientset: CheckPod would fail. CheckPodObject must not Get.
+	monitor := NewMonitor(nil, testr.New(t))
+	record := ResizeRecord{
+		PodName:      "web-0",
+		Namespace:    "default",
+		Container:    "app",
+		ResizedAt:    time.Now().Add(-time.Hour),
+		RestartCount: 0,
+	}
+	verdict, err := monitor.CheckPodObject(context.Background(), pod, record, time.Now())
+	require.NoError(t, err)
+	assert.True(t, verdict.Safe)
+}
+
+type countingSLOQuerier struct {
+	n     atomic.Int32
+	value float64
+}
+
+func (m *countingSLOQuerier) Query(_ context.Context, _ string, _ time.Time) (float64, error) {
+	m.n.Add(1)
+	return m.value, nil
+}
+
+func TestCheckPodObject_SLOMemoOncePerInterpolatedQuery(t *testing.T) {
+	querier := &countingSLOQuerier{value: 0.1}
+	monitor := NewMonitor(nil, testr.New(t))
+	monitor.WithSLOChecker(querier, []attunev1alpha1.SLOGuardrail{
+		{
+			Name:      "availability",
+			Query:     `sum(rate(requests{namespace="{{ .Namespace }}",workload="{{ .WorkloadName }}"}[5m]))`,
+			Threshold: "0.5",
+		},
+	})
+	monitor.WithSLOQueryMemo()
+
+	now := time.Now()
+	resizedAt := now.Add(-6 * time.Minute)
+	healthy := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "app", RestartCount: 0},
+				},
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+	}
+	for _, name := range []string{"web-0", "web-1", "web-2"} {
+		record := ResizeRecord{
+			PodName:      name,
+			Namespace:    "default",
+			Container:    "app",
+			ResizedAt:    resizedAt,
+			RestartCount: 0,
+			WorkloadName: "web",
+		}
+		verdict, err := monitor.CheckPodObject(context.Background(), healthy(name), record, now)
+		require.NoError(t, err)
+		assert.True(t, verdict.Safe, name)
+	}
+	assert.Equal(t, int32(1), querier.n.Load(), "workload-level SLO must query once per pass")
 }


### PR DESCRIPTION
Safety observation and neighbor capacity were doing more live API work than they needed, and the first write-up of #658 had one wrong throttle criterion plus a fail-open neighbor-cache idea.

This implements the revised design from the issue:

**Safety observation**
- Verdicts come from the listed (informer) pod via `CheckPodObject`. No live Get per container on the read path.
- An unsafe verdict re-Gets once and re-evaluates before revert, so a flapping Ready=False does not undo a now-healthy pod.
- Early OOM/restart confirm uses the same live Get but only re-runs critical checks (full `CheckPodObject` would revert on Ready flaps during the observation window).
- Throttle stays per `(pod, container)`.
- SLO queries are memoized on the interpolated PromQL string for one observation pass.
- Tracking annotations are cleared with a merge patch. No Get and no 409 retry loop.

**Neighbor request budget**
- Still a live cluster-scoped Clientset List. The informer cache is namespace-scoped under `--watch-namespaces` and would under-count neighbors.
- Results are reduced to CPU/memory scalars plus UID and namespace/name for self-exclusion. Full pod objects are not kept.
- The first List per node is single-flighted. Pages use `Limit` and `ResourceVersion=0`.
- `Succeeded`/`Failed` pods are excluded. Terminating pods still count.

Closes #658
