### PR TITLE
ci: skip product rebuild on push to main

### DIFF
--- a/.github/workflows/bench-baseline.yaml
+++ b/.github/workflows/bench-baseline.yaml
@@ -1,0 +1,76 @@
+name: Bench Baseline
+
+# Cheap main-only job: write the shared Actions cache that PR benches
+# restore. PR jobs cannot update default-branch cache scope.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "go.sum"
+      - "internal/controller/**"
+      - "internal/metrics/**"
+      - "internal/recommendation/**"
+      - ".github/workflows/bench-baseline.yaml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-baseline-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test-bench:
+    name: Benchmark Baseline (${{ matrix.pkg }})
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkg: controller-core
+            path: ./internal/controller/...
+            bench: '^Benchmark(BuildPrometheusQuery|Reconcile$|ComputeRecommendations)'
+          - pkg: controller-workloads
+            path: ./internal/controller/...
+            bench: '^BenchmarkReconcile_ManyWorkloads'
+          - pkg: controller-policies
+            path: ./internal/controller/...
+            bench: '^BenchmarkReconcile_(ManyPolicies|Concurrent)'
+          - pkg: metrics
+            path: ./internal/metrics/...
+            bench: '.'
+          - pkg: recommendation
+            path: ./internal/recommendation/...
+            bench: '.'
+    steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: ./.github/actions/install-go-tool
+        with:
+          name: benchstat
+          version: v0.0.0-20260512194132-3cf34090a3db
+          package: golang.org/x/perf/cmd/benchstat
+
+      - name: Run benchmarks
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          go test ${{ matrix.path }} -bench='${{ matrix.bench }}' -benchmem -run='^$' \
+            -count=5 -timeout=10m | tee bench-baseline.txt
+
+      - name: Save baseline
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: bench-baseline.txt
+          key: bench-baseline-${{ matrix.pkg }}-${{ runner.os }}-${{ hashFiles('go.sum') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
+  # Product tests run on PRs (and merge_group if a queue is added).
+  # Do not add push to main: the ruleset requires an up-to-date branch,
+  # so a squash of a green PR is the same tree.
   pull_request:
     branches: [main]
   merge_group: {}
@@ -417,9 +418,7 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 15
     needs: changes
-    if: >
-      needs.changes.outputs.bench == 'true' ||
-      (github.ref == 'refs/heads/main' && needs.changes.outputs.go == 'true')
+    if: needs.changes.outputs.bench == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -483,22 +482,10 @@ jobs:
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "No baseline found; comparison will be available after the first main push."
+            echo "No baseline found; comparison will be available after the next main bench-baseline run."
             echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
-            echo "No baseline yet. One will be established on the next merge to main." >> "$GITHUB_STEP_SUMMARY"
+            echo "No baseline yet. One is written on push to main by bench-baseline.yaml." >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      - name: Promote current run as baseline (main only)
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        shell: bash -Eeuo pipefail {0}
-        run: cp bench-current.txt bench-baseline.txt
-
-      - name: Save baseline (main only)
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: bench-baseline.txt
-          key: bench-baseline-${{ matrix.pkg }}-${{ runner.os }}-${{ hashFiles('go.sum') }}
 
   test-integration:
     name: Integration Tests
@@ -916,6 +903,10 @@ jobs:
       - name: Run actionlint
         shell: bash -Eeuo pipefail {0}
         run: actionlint -color
+
+      - name: Lock CI build-once triggers
+        shell: bash -Eeuo pipefail {0}
+        run: bash scripts/test_ci_build_once.sh
 
   # Gate job: always runs, aggregates all conditional job results.
   # This is the ONLY required status check for branch protection,

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,8 +1,7 @@
 name: Security
 
 on:
-  push:
-    branches: [main]
+  # PR + weekly schedule. Do not add push to main (same tree as the last PR).
   pull_request:
     branches: [main]
   merge_group: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,7 +367,7 @@ Dependabot PRs (#348, #349 etc.) are important for **Dependency-Update-Tool (10)
    `--auto --squash` with the release App token for all semver types
    (patch, minor, and major). The App token is required so the squash
    merge to main is not a `GITHUB_TOKEN` push (those do not re-trigger
-   CI/Security/Docs on main). `auto-approve.yaml` (`pull_request`)
+   Docs, Scorecard, or Release Please on main). `auto-approve.yaml` (`pull_request`)
    excludes `dependabot[bot]` because secrets are unavailable in that context.
 6. After a merge to main, `dependabot-auto-merge.yaml` comments
    `@dependabot rebase` on open Dependabot PRs. It lists Dependabot PRs
@@ -378,8 +378,12 @@ Dependabot PRs (#348, #349 etc.) are important for **Dependency-Update-Tool (10)
    `rebase-strategy: auto` can lag for hours. To hurry one PR,
    `gh pr comment N --body "@dependabot rebase"` or run
    `scripts/rebase-dependabot.sh N`.
-7. After a Dependabot merge, if main has no CI/Security runs for the merge
-   SHA, dispatch them: `gh workflow run CI --ref main` (and Security/Docs).
+7. After a Dependabot merge, do **not** `gh workflow run CI --ref main`
+   (or Security). The PR already ran the test matrix on an up-to-date
+   branch. A dispatch is a second compile of the same tree. Docs deploy
+   still runs on `push` to main. If that push was a `GITHUB_TOKEN` squash
+   and Docs did not start, dispatch **Docs** only:
+   `gh workflow run Docs --ref main`.
 
 **Grouped updates and semver classification:** `dependabot/fetch-metadata`
 classifies grouped updates by the **highest** semver type in the group. If

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ test-fuzz: ## Run fuzz tests (coverage-guided; FUZZTIME=30s default, deadline-fl
 	./scripts/run-fuzz.sh
 
 .PHONY: python-test
-python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync, helm image tag, fleet reports, nightly issue body, k3d-delete)
+python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync, helm image tag, fleet reports, nightly issue body, k3d-delete, CI triggers)
 	python3 scripts/test_fossa_filter.py -v
 	bash scripts/test_run_fuzz.sh
 	bash scripts/test_verify_go_version_sync.sh
@@ -250,6 +250,7 @@ python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-v
 	bash scripts/test_collect_fleet_reports.sh
 	bash scripts/test_nightly_failure_issue_body.sh
 	bash scripts/test_verify_chainsaw_scripts.sh
+	bash scripts/test_ci_build_once.sh
 
 .PHONY: test-bench
 test-bench: ## Run benchmark tests

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1014,7 +1014,12 @@ Validate compatibility with Kubernetes API conventions:
 
 ### 10.1 GitHub Actions Workflows
 
-#### `ci.yaml` - Continuous Integration (on every PR and push to main)
+#### `ci.yaml` - Continuous Integration (PRs, merge_group, and dispatch)
+
+Product tests do not run again on `push` to `main`. The branch ruleset
+requires an up-to-date PR, so a squash of a green PR is the same tree.
+`push` to `main` still runs cheap promote jobs (release-please, Docs
+deploy, Scorecard).
 
 ```
 Jobs:
@@ -1107,7 +1112,12 @@ Jobs:
     - Sign the published chart with cosign
 ```
 
-#### `security.yaml` - Security Scanning (on PR, push, weekly schedule)
+#### `bench-baseline.yaml` - Shared bench cache (push to main, path-filtered)
+
+Writes the default-branch Actions cache that PR `test-bench` jobs restore.
+PR jobs cannot update that cache scope.
+
+#### `security.yaml` - Security Scanning (on PR, weekly schedule, dispatch)
 
 ```
 Jobs:
@@ -1345,6 +1355,7 @@ attune/
 ├── .github/
 │   ├── workflows/
 │   │   ├── ci.yaml
+│   │   ├── bench-baseline.yaml
 │   │   ├── release.yaml
 │   │   ├── security.yaml
 │   │   └── docs.yaml

--- a/scripts/test_ci_build_once.sh
+++ b/scripts/test_ci_build_once.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Lock Recipe A: product test/security compile workflows must not
+# retrigger on push to main. Promote/release workflows may.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CI="${ROOT}/.github/workflows/ci.yaml"
+SECURITY="${ROOT}/.github/workflows/security.yaml"
+RELEASE="${ROOT}/.github/workflows/release.yaml"
+DOCS="${ROOT}/.github/workflows/docs.yaml"
+BENCH="${ROOT}/.github/workflows/bench-baseline.yaml"
+
+echo "PLAN: lock CI/Security triggers off push to main"
+
+fail() {
+  echo "FAIL: $*"
+  echo "DONE: ok=false"
+  exit 1
+}
+
+extract_on() {
+  awk '
+    /^on:/ {p=1; next}
+    p && /^[A-Za-z]/ {exit}
+    p {print}
+  ' "$1"
+}
+
+[[ -f "${CI}" ]] || fail "missing ${CI}"
+[[ -f "${SECURITY}" ]] || fail "missing ${SECURITY}"
+[[ -f "${RELEASE}" ]] || fail "missing ${RELEASE}"
+[[ -f "${DOCS}" ]] || fail "missing ${DOCS}"
+[[ -f "${BENCH}" ]] || fail "missing ${BENCH}"
+
+echo "DO: ci.yaml and security.yaml keep PR + dispatch, no push"
+for f in "${CI}" "${SECURITY}"; do
+  on_block="$(extract_on "${f}")"
+  grep -q '^  pull_request:' <<<"${on_block}" || fail "${f}: missing pull_request"
+  grep -q '^  workflow_dispatch:' <<<"${on_block}" || fail "${f}: missing workflow_dispatch"
+  if grep -q '^  push:' <<<"${on_block}"; then
+    fail "${f}: push trigger would recompile the same tree on main"
+  fi
+  if grep -q '^  tags:' <<<"${on_block}"; then
+    fail "${f}: tag trigger would compile again on release"
+  fi
+  echo "OK: $(basename "${f}") on-block has no push/tags"
+done
+
+echo "DO: security.yaml keeps a schedule (weekly scan, not a third compile)"
+sec_on="$(extract_on "${SECURITY}")"
+grep -q '^  schedule:' <<<"${sec_on}" || fail "security.yaml: missing schedule"
+
+echo "DO: release.yaml and docs.yaml still run on push to main (promote)"
+rel_on="$(extract_on "${RELEASE}")"
+docs_on="$(extract_on "${DOCS}")"
+grep -q '^  push:' <<<"${rel_on}" || fail "release.yaml: missing push (release-please)"
+grep -q '^  push:' <<<"${docs_on}" || fail "docs.yaml: missing push (Pages deploy)"
+
+echo "DO: release.yaml must not run the test matrix"
+if grep -nE 'go test|make test|cargo test|cargo nextest' "${RELEASE}"; then
+  fail "release.yaml contains a test-matrix command"
+fi
+echo "OK: release.yaml has no test matrix"
+
+echo "DO: PR CI restores bench baselines; main bench-baseline.yaml writes them"
+if grep -n 'actions/cache/save' "${CI}"; then
+  fail "ci.yaml must not cache/save (PR cache is not visible to other PRs)"
+fi
+grep -q 'actions/cache/restore' "${CI}" || fail "ci.yaml must restore bench baselines"
+bench_on="$(extract_on "${BENCH}")"
+grep -q '^  push:' <<<"${bench_on}" || fail "bench-baseline.yaml: missing push (shared cache scope)"
+grep -q 'actions/cache/save' "${BENCH}" || fail "bench-baseline.yaml must cache/save on main"
+echo "OK: bench restore on PR, save on main"
+
+echo "DO: lock predicate fails closed when push: is injected"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+awk '
+  /^on:/ {print; print "  push:"; print "    branches: [main]"; next}
+  {print}
+' "${CI}" > "${tmpdir}/ci-with-push.yaml"
+mut_on="$(extract_on "${tmpdir}/ci-with-push.yaml")"
+grep -q '^  push:' <<<"${mut_on}" || fail "mutation did not add push: to on-block"
+echo "OK: extract_on detects an injected push trigger"
+
+echo "DONE: ok=true"


### PR DESCRIPTION
Product CI and Security no longer rebuild the same tree after a squash to main.

## Problem

Every up-to-date PR already ran lint, unit, integration, E2E, image build, CodeQL, and Trivy. The branch ruleset requires the branch to be current with main, so a squash of that green PR is the same file tree. `ci.yaml` and `security.yaml` still listened to `push` to `main`, so each code merge paid a second ~23 minute matrix.

## Change

- `ci.yaml` and `security.yaml` run on pull_request, merge_group, and workflow_dispatch (Security also keeps the weekly schedule).
- `push` to `main` still runs cheap promote jobs: Release Please, Docs deploy, Scorecard, FOSSA, and a new path-filtered `bench-baseline.yaml` that writes the shared Actions cache PR benches restore (PR jobs cannot update default-branch cache).
- Lock test `scripts/test_ci_build_once.sh` fails if product CI/Security regain a `push` trigger. Workflow sanity runs it when workflow files change.
- `AGENTS.md` no longer tells agents to `gh workflow run CI --ref main` after a green squash. Dispatch Docs only if a `GITHUB_TOKEN` squash skipped the Pages deploy.

## Validation

- `bash scripts/test_ci_build_once.sh`
- `actionlint` on `ci.yaml`, `security.yaml`, and `bench-baseline.yaml`

After this merges, `gh run list --commit MERGE_SHA --workflow CI` should be empty (or only a manual dispatch). That is expected.
