### PR TITLE
ci: add zizmor to workflow-sanity without failing the gate

### DIFF
--- a/.github/actions/install-binary-tool/action.yaml
+++ b/.github/actions/install-binary-tool/action.yaml
@@ -30,11 +30,12 @@ runs:
       shell: bash -Eeuo pipefail {0}
       env:
         TOOL_DIR: ${{ runner.temp }}/bin-tool-cache/${{ inputs.name }}
-      run: |
+      run: | # zizmor: ignore[template-injection]
         mkdir -p "$TOOL_DIR"
         export PATH="$TOOL_DIR:$PATH"
         ${{ inputs.install-command }}
 
     - name: Add ${{ inputs.name }} to PATH
       shell: bash -Eeuo pipefail {0}
-      run: echo "${RUNNER_TEMP}/bin-tool-cache/${{ inputs.name }}" >> "$GITHUB_PATH"
+      run: | # zizmor: ignore[template-injection,github-env]
+        echo "${RUNNER_TEMP}/bin-tool-cache/${{ inputs.name }}" >> "$GITHUB_PATH"

--- a/.github/actions/install-go-tool/action.yaml
+++ b/.github/actions/install-go-tool/action.yaml
@@ -37,11 +37,12 @@ runs:
     - name: Install ${{ inputs.name }}
       if: steps.tool-cache.outputs.cache-hit != 'true'
       shell: bash -Eeuo pipefail {0}
-      run: |
+      run: | # zizmor: ignore[template-injection]
         tool_dir="${RUNNER_TEMP}/go-tool-cache/${{ inputs.name }}"
         mkdir -p "$tool_dir"
         GOBIN="$tool_dir" go install "${{ inputs.package }}@${{ inputs.version }}"
 
     - name: Add ${{ inputs.name }} to PATH
       shell: bash -Eeuo pipefail {0}
-      run: echo "${RUNNER_TEMP}/go-tool-cache/${{ inputs.name }}" >> "$GITHUB_PATH"
+      run: | # zizmor: ignore[template-injection,github-env]
+        echo "${RUNNER_TEMP}/go-tool-cache/${{ inputs.name }}" >> "$GITHUB_PATH"

--- a/.github/actions/setup-clean-docker-config/action.yml
+++ b/.github/actions/setup-clean-docker-config/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Configure clean Docker config
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env]
         set -euo pipefail
         docker_config="$(mktemp -d "${RUNNER_TEMP:-/tmp}/docker-ci-config.XXXXXX")"
         printf '{}' > "$docker_config/config.json"

--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -37,7 +37,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ./.github/actions/setup-clean-docker-config
+    - uses: ./.github/actions/setup-clean-docker-config # zizmor: ignore[self-repository]
 
     - name: Verify Docker and buildx
       shell: bash -Eeuo pipefail {0}
@@ -68,7 +68,7 @@ runs:
           /tmp/k3s.tar
         key: e2e-images-${{ runner.os }}-cm${{ inputs.cert-manager-version }}-prom${{ inputs.prometheus-chart-version }}-stress0.20.01-busybox1.37-k3s${{ inputs.k3s-image }}
 
-    - uses: ./.github/actions/install-binary-tool
+    - uses: ./.github/actions/install-binary-tool # zizmor: ignore[self-repository]
       with:
         name: k3d
         version: ${{ inputs.k3d-version }}
@@ -77,7 +77,8 @@ runs:
 
     - name: Prepare isolated kubeconfig
       shell: bash -Eeuo pipefail -x {0}
-      run: printf 'KUBECONFIG=%s\n' "${{ inputs.kubeconfig-path }}" >> "$GITHUB_ENV"
+      run: | # zizmor: ignore[template-injection,github-env]
+        printf 'KUBECONFIG=%s\n' "${{ inputs.kubeconfig-path }}" >> "$GITHUB_ENV"
 
     - name: Cleanup stale k3d clusters and Docker resources
       shell: bash -Eeuo pipefail -x {0}
@@ -96,7 +97,7 @@ runs:
 
     - name: Pre-pull container images
       shell: bash -Eeuo pipefail -x {0}
-      run: |
+      run: | # zizmor: ignore[template-injection]
         # Pull images with docker (parallel layer downloads) and save as
         # tarballs for k3d import. Skip images already restored from cache.
         # Accepts an optional 3rd argument: a fallback image reference to try
@@ -143,7 +144,7 @@ runs:
 
     - name: Create k3d cluster
       shell: bash -Eeuo pipefail -x {0}
-      run: |
+      run: | # zizmor: ignore[template-injection]
         # Load the pre-pulled k3s image into Docker so k3d uses it
         # without pulling from Docker Hub (avoids rate-limit/timeout failures).
         docker load -i /tmp/k3s.tar
@@ -187,7 +188,7 @@ runs:
 
     - name: Load cert-manager images into cluster
       shell: bash -Eeuo pipefail -x {0}
-      run: |
+      run: | # zizmor: ignore[template-injection]
         k3d image import \
           /tmp/cert-manager-controller.tar \
           /tmp/cert-manager-webhook.tar \
@@ -196,7 +197,7 @@ runs:
 
     - name: Download cert-manager manifest
       shell: bash -Eeuo pipefail -x {0}
-      run: |
+      run: | # zizmor: ignore[template-injection]
         if [[ -f /tmp/cert-manager.yaml ]]; then
           echo "Cached: /tmp/cert-manager.yaml"
         else
@@ -220,13 +221,13 @@ runs:
 
     - name: Load Prometheus and test images into cluster
       shell: bash -Eeuo pipefail -x {0}
-      run: |
+      run: | # zizmor: ignore[template-injection]
         k3d image import /tmp/prometheus.tar /tmp/stress-ng.tar /tmp/busybox.tar -c "${{ inputs.cluster-name }}"
         bash hack/e2e-install-cert-manager.sh --wait-only
 
     - name: Install Prometheus
       shell: bash -Eeuo pipefail -x {0}
-      run: |
+      run: | # zizmor: ignore[template-injection]
         helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
         helm repo update
         # Pre-pull the chart tarball with retry to avoid transient CDN failures
@@ -272,7 +273,7 @@ runs:
           sleep 5
         done
 
-    - uses: ./.github/actions/install-go-tool
+    - uses: ./.github/actions/install-go-tool # zizmor: ignore[self-repository]
       with:
         name: ko
         version: v0.18.0
@@ -280,7 +281,7 @@ runs:
 
     - name: Build and load operator image
       shell: bash -Eeuo pipefail -x {0}
-      run: |
+      run: | # zizmor: ignore[template-injection]
         VERSION=e2e COMMIT=$(git rev-parse --short HEAD) DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
           KO_DOCKER_REPO=attune ko build ./cmd/manager/ \
           --bare --tags=e2e --platform=linux/$(go env GOARCH) \

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -39,6 +41,8 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: pip
     directory: /docs
@@ -59,6 +63,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
@@ -70,3 +76,5 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -48,6 +48,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       # Draft PRs cannot have auto-merge enabled (GitHub API rejects it).
       # Skip cleanly so the required Auto Approve check stays green on drafts.

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -30,6 +30,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ env:
   ENVTEST_K8S_VERSION: "1.35.0"
   HELM_UNITTEST_VERSION: "v0.7.2"
   ACTIONLINT_VERSION: "v1.7.12"
+  ZIZMOR_VERSION: "v1.30.0"
   GOCOVER_COBERTURA_VERSION: "v1.5.0"
   BENCHSTAT_VERSION: "v0.0.0-20260512194132-3cf34090a3db"
   CERT_MANAGER_VERSION: "v1.21.1"
@@ -57,6 +58,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
@@ -158,6 +161,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -229,6 +234,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -269,6 +276,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Check links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
@@ -293,6 +302,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -319,6 +330,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
@@ -342,6 +355,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -443,6 +457,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -498,6 +514,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -567,6 +585,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-e2e-cluster
         with:
@@ -667,6 +687,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -695,6 +717,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -730,6 +754,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
@@ -826,6 +852,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -903,6 +931,33 @@ jobs:
       - name: Run actionlint
         shell: bash -Eeuo pipefail {0}
         run: actionlint -color
+
+      - uses: ./.github/actions/install-binary-tool
+        with:
+          name: zizmor
+          version: ${{ env.ZIZMOR_VERSION }}
+          install-command: |
+            VER="${{ env.ZIZMOR_VERSION }}"
+            case "$(uname -s)" in
+              Linux)  Z_OS=unknown-linux-gnu ;;
+              Darwin) Z_OS=apple-darwin ;;
+              *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+            esac
+            case "$(uname -m)" in
+              x86_64) Z_ARCH=x86_64 ;;
+              aarch64|arm64) Z_ARCH=aarch64 ;;
+              *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+            esac
+            curl -fsSL "https://github.com/zizmorcore/zizmor/releases/download/${VER}/zizmor-${Z_ARCH}-${Z_OS}.tar.gz" \
+              | tar xz -C "$TOOL_DIR" zizmor
+
+      # --offline: GITHUB_TOKEN is always set in Actions and would
+      # otherwise flip zizmor into online mode (API-backed audits).
+      # Offline keeps the gate deterministic and matches the #659
+      # local run. Config is discovered at .github/zizmor.yml.
+      - name: Run zizmor
+        shell: bash -Eeuo pipefail {0}
+        run: zizmor --offline --color=always --strict-collection .
 
       - name: Lock CI build-once triggers
         shell: bash -Eeuo pipefail {0}

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -27,6 +27,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check DCO sign-off
         if: github.event_name == 'pull_request'

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -61,6 +61,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Enable auto-merge
         env:
@@ -129,6 +131,7 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-pull-requests: write
       - name: Ask Dependabot to rebase behind PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install MkDocs
         run: |

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -103,6 +103,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-clean-docker-config
 
@@ -617,6 +619,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -645,6 +649,8 @@ jobs:
     if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Summary
         shell: bash -Eeuo pipefail {0}

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/install-binary-tool
         with:
@@ -54,6 +56,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/install-binary-tool
         with:

--- a/.github/workflows/mirror-e2e-images.yaml
+++ b/.github/workflows/mirror-e2e-images.yaml
@@ -40,6 +40,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           sparse-checkout: .github/workflows/ci.yaml
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
@@ -101,13 +103,14 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ steps.tag.outputs.name }}
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       - name: Check if Docker build is possible
         id: docker-check
@@ -418,6 +421,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Clean up release notes file
         env:
           GH_TOKEN: ${{ steps.cleanup-token.outputs.token }}
@@ -463,6 +468,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ needs.release.outputs.tag }}
 
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
@@ -572,6 +578,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ needs.release.outputs.tag }}
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -586,6 +593,8 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: attune-io
           repositories: community-operators,community-operators-prod
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Generate OLM bundle and create PRs
         id: create-pr
@@ -615,6 +624,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,53 @@
+# zizmor config for Attune (#659).
+# Known false positives and accepted risks are listed here so the
+# workflow-sanity job stays green. Composite-action findings cannot
+# use this file; those use inline `# zizmor: ignore[...]` comments.
+#
+# Do not disable an audit unless a file-level ignore cannot express it.
+# New workflows are still audited; only the files below are skipped.
+
+rules:
+  # First-party interpolations: workflow env, matrix, job/step outputs,
+  # github.repository, secrets, and workflow_dispatch inputs. None of
+  # these are attacker-controlled issue/PR titles. Revisit if a
+  # pull_request_target job starts expanding github.event.issue.* or
+  # github.event.comment.body into a run: script.
+  template-injection:
+    ignore:
+      - dependabot-auto-merge.yaml
+      - e2e-nightly.yaml
+      - release.yaml
+
+  # Workspace-relative `./.github/actions/...` after checkout. The `$/`
+  # self-repo syntax is still new; migrate in one pass later.
+  self-repository:
+    ignore:
+      - bench-baseline.yaml
+      - ci.yaml
+      - e2e-nightly.yaml
+      - fossa.yaml
+      - security.yaml
+
+  # pull_request_target is required so these jobs can write labels,
+  # comments, or auto-merge with secrets. They do not checkout
+  # untrusted PR HEAD into a run: script that expands attacker input.
+  dangerous-triggers:
+    ignore:
+      - backport.yaml
+      - dependabot-auto-merge.yaml
+      - issue-linker.yaml
+      - labeler.yaml
+      - pr-size.yaml
+      - pr-title.yaml
+
+  # auto-approve already gates on pull_request.user.login (not only
+  # github.actor) and never runs Dependabot through this workflow.
+  bot-conditions:
+    ignore:
+      - auto-approve.yaml
+
+  # Informational: attaching install.yaml via gh is already a script
+  # step; the remaining upload action is the documented helper.
+  superfluous-actions:
+    ignore:
+      - release.yaml


### PR DESCRIPTION
## What This PR Does

Adds pinned zizmor v1.30.0 to the `workflow-sanity` job so GitHub Actions
security findings are scanned on every workflow change. A committed
`.github/zizmor.yml` (plus inline comments on composite actions) keeps
`ci-gate` green.

Also lands a few cheap, already-accepted hardenings so those findings
do not need ignores:

- `persist-credentials: false` on remaining `actions/checkout` steps
- Dependabot `cooldown.default-days: 7` on all four ecosystems
- explicit `permission-contents` / `permission-pull-requests` on
  `create-github-app-token` steps
- `cache: false` on the release-job `setup-go` (cache-poisoning)

## Why

Issue #659: a local zizmor run reported a large finding set. Putting
that volume on `ci-gate` without a config would stay red. The path
filter already listed `.github/zizmor.yml`.

## Related Issues

Closes #659

## How to Test

```bash
# same command CI runs (zizmor 1.30.0)
zizmor --offline --strict-collection .
# expected: exit 0, "No findings to report" with ignored/suppressed counts
```

`workflow-sanity` now installs `zizmor-*-unknown-linux-gnu` (or
`apple-darwin`) from `zizmorcore/zizmor` v1.30.0 and runs the same
flags.

## Checklist

- [x] Unit tests added/updated (N/A: CI workflow scan)
- [ ] Integration tests added/updated (if applicable)
- [ ] CRD changes regenerated (`make manifests`)
- [ ] Documentation updated (if user-facing)
- [ ] Helm chart updated (if applicable)
- [x] No breaking API changes (or documented in CHANGELOG)
