### PR TITLE
fix: persist startup-boost annotation and cap defaults maxallowed

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -325,6 +325,7 @@ Validation is implemented in the admission webhook (`internal/webhook/validation
 not via CEL `x-kubernetes-validations` markers. The webhook enforces:
 
 - `minAllowed <= maxAllowed` for both CPU and memory resource configs
+- `cpu.maxAllowed` must not exceed 256 cores; `memory.maxAllowed` must not exceed 16Ti (AttunePolicy and AttuneDefaults)
 - Canary config required when `updateStrategy.type` is `Canary`
 - `historyWindow` bounded between 1h and 720h (30 days)
 - `burstSensitivity` bounded between 0 and 10.0

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -338,11 +338,14 @@ true recoverability.
 ### Webhook validation
 
 `AttuneDefaults` and `AttuneNamespaceDefaults` both have validating
-webhooks that reject invalid `costPricing`, schedule, and Prometheus
-address values. If `cpuPerCoreHour` or `memoryPerGiBHour` is set, the
-webhook validates that each is a parseable positive float. Invalid values
-(e.g., `"banana"`, `"-0.5"`), invalid schedule settings, and blocked
-Prometheus addresses are rejected at admission time.
+webhooks that reject invalid `costPricing`, schedule, Prometheus
+address values, and resource `maxAllowed` above the same ceilings as
+`AttunePolicy` (`cpu.maxAllowed` greater than 256 cores,
+`memory.maxAllowed` greater than 16Ti). If `cpuPerCoreHour` or
+`memoryPerGiBHour` is set, the webhook validates that each is a
+parseable positive float. Invalid values (e.g., `"banana"`, `"-0.5"`),
+invalid schedule settings, blocked Prometheus addresses, and oversized
+`maxAllowed` are rejected at admission time.
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -218,8 +218,8 @@ CR manually but managed through Helm values.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `defaults.enabled` | bool | `false` | Create an AttuneDefaults resource with the values below |
-| `defaults.cpu.*` | object | | CPU resource defaults (see [Resource Config](#resource-configuration) below) |
-| `defaults.memory.*` | object | | Memory resource defaults (see [Resource Config](#resource-configuration) below) |
+| `defaults.cpu.*` | object | | CPU resource defaults (see [Resource configuration](#resource-configuration) below) |
+| `defaults.memory.*` | object | | Memory resource defaults (see [Resource configuration](#resource-configuration) below) |
 | `defaults.costPricing.cpuPerCoreHour` | string | `"0.031"` | Cost per vCPU-hour for savings estimates |
 | `defaults.costPricing.memoryPerGiBHour` | string | `"0.004"` | Cost per GiB-hour for savings estimates |
 | `defaults.excludeKnownSidecars` | bool | (operator default `true` if unset) | When set on the AttuneDefaults CR, policies that leave the field unset inherit this value. `false` restores exclude-only-via-`excludedContainers`. |
@@ -235,6 +235,28 @@ values; see `values.yaml` for the full set.
 These fields are set on the `AttuneDefaults` cluster-scoped CRD, either
 directly or via the Helm `defaults.*` values above. They apply to all
 `AttunePolicy` resources.
+
+### Resource configuration
+
+`cpu` and `memory` on `AttunePolicy`, `AttuneDefaults`, and
+`AttuneNamespaceDefaults` share the same bound fields. When a bound is
+set, the operator clamps each recommendation to that range. Admission
+also rejects `maxAllowed` above a hard ceiling so cluster or namespace
+defaults cannot merge uncapped bounds onto policies after the policy
+itself was admitted.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cpu.minAllowed` | quantity | (none) | Minimum CPU recommendation (for example `"50m"`). When both bounds are set, must be less than or equal to `cpu.maxAllowed`. |
+| `cpu.maxAllowed` | quantity | (none) | Maximum CPU recommendation (for example `"4000m"`). Must not exceed 256 cores. |
+| `memory.minAllowed` | quantity | (none) | Minimum memory recommendation (for example `"64Mi"`). When both bounds are set, must be less than or equal to `memory.maxAllowed`. |
+| `memory.maxAllowed` | quantity | (none) | Maximum memory recommendation (for example `"8Gi"`). Must not exceed 16Ti. |
+
+The 256-core and 16Ti values are admission caps only. They reject
+oversized `maxAllowed`; they do not inject a default clamp when the
+field is unset. Helm `defaults.cpu.*` and `defaults.memory.*` are
+subject to the same webhook because the chart creates an
+`AttuneDefaults` resource.
 
 ### Cost Pricing
 
@@ -410,6 +432,12 @@ as alternative metrics sources. **At most one** of `prometheus`,
 | `metricsSource.cloudwatch.roleArn` | string | `""` | Optional IAM role ARN for cross-account access (`arn:aws:iam::ACCOUNT:role/NAME`; IRSA/Pod Identity used if empty) |
 
 ## Policy-Level Fields
+
+Bound fields (`minAllowed`, `maxAllowed`) and their admission caps
+(256 cores CPU, 16Ti memory) are documented under
+[Resource configuration](#resource-configuration). The same fields and
+caps apply to `AttunePolicy`, `AttuneDefaults`, and
+`AttuneNamespaceDefaults`.
 
 ### spec.paused
 

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10905,8 +10905,201 @@ func TestApplyStartupBoosts_SkipsWhenAlreadyAtBoostedLevel(t *testing.T) {
 		Name: "my-app-abc", Namespace: "default",
 	}, &updated)
 	require.NoError(t, err)
-	assert.Empty(t, updated.Annotations[annotationStartupBoostAt],
-		"already-at-boosted-level must not persist a startup-boost annotation")
+	assert.Equal(t, now.UTC().Format(time.RFC3339), updated.Annotations[annotationStartupBoostAt],
+		"already-at-boosted inside the window must persist a startup-boost annotation so expiry can run")
+}
+
+func TestApplyStartupBoosts_RetriesAnnotationWhenAlreadyBoosted(t *testing.T) {
+	// After a successful boost resize, if annotation persist fails, the
+	// next reconcile sees current >= boosted and must retry the annotation
+	// without a second /resize.
+	scheme := testScheme()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			CPU: attunev1alpha1.ResourceConfig{
+				StartupBoost: &attunev1alpha1.StartupBoost{
+					Multiplier: "3.0",
+					Duration:   metav1.Duration{Duration: 2 * time.Minute},
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-app-abc",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Second)),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "my-app",
+			Kind:     "Deployment",
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name: "main",
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("200m"),
+					},
+				},
+			},
+		},
+	}
+
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	failClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod.DeepCopy()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+				return fmt.Errorf("simulated persist failure")
+			},
+		}).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = failClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+	r.SetNowFunc(func() time.Time { return now })
+
+	logger := ctrl.Log.WithName("test")
+	resizer := resize.NewPodResizer(clientset, logger)
+	r.applyStartupBoosts(context.Background(), policy, map[string][]corev1.Pod{"my-app": {*pod}}, recs, resizer, nil)
+
+	var foundResize bool
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			foundResize = true
+			break
+		}
+	}
+	require.True(t, foundResize, "first apply must resize to the boosted CPU")
+
+	boosted, err := clientset.CoreV1().Pods("default").Get(context.Background(), "my-app-abc", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.True(t, boosted.Spec.Containers[0].Resources.Requests.Cpu().Cmp(resource.MustParse("100m")) > 0,
+		"clientset pod should already be at boosted CPU after the first apply")
+	assert.Empty(t, boosted.Annotations[annotationStartupBoostAt],
+		"annotation persist failed on the first apply")
+
+	// Second apply: current is already boosted, persist must be retried.
+	clientset2 := kubefake.NewSimpleClientset(boosted.DeepCopy())
+	okClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(boosted.DeepCopy()).Build()
+	r.Client = okClient
+	r.Clientset = clientset2
+	resizer2 := resize.NewPodResizer(clientset2, logger)
+	r.applyStartupBoosts(context.Background(), policy, map[string][]corev1.Pod{"my-app": {*boosted}}, recs, resizer2, nil)
+
+	for _, a := range clientset2.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			t.Fatal("second apply must not resize when current CPU is already boosted")
+		}
+	}
+	var updated corev1.Pod
+	err = okClient.Get(context.Background(), types.NamespacedName{
+		Name: "my-app-abc", Namespace: "default",
+	}, &updated)
+	require.NoError(t, err)
+	assert.Equal(t, now.UTC().Format(time.RFC3339), updated.Annotations[annotationStartupBoostAt],
+		"second apply must retry the startup-boost annotation")
+}
+
+func TestApplyStartupBoosts_SkipsBatchWorkload(t *testing.T) {
+	scheme := testScheme()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			CPU: attunev1alpha1.ResourceConfig{
+				StartupBoost: &attunev1alpha1.StartupBoost{
+					Multiplier: "3.0",
+					Duration:   metav1.Duration{Duration: 2 * time.Minute},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		kind string
+	}{
+		{kind: "Job"},
+		{kind: "CronJob"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "batch-pod",
+					Namespace:         "default",
+					CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Second)),
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+						},
+					},
+				},
+			}
+			clientset := kubefake.NewSimpleClientset(pod)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+			r := NewAttunePolicyReconciler()
+			r.Client = fakeClient
+			r.Scheme = scheme
+			r.Clientset = clientset
+			r.SetNowFunc(func() time.Time { return now })
+
+			recs := []attunev1alpha1.WorkloadRecommendation{
+				{
+					Workload: "batch-job",
+					Kind:     tt.kind,
+					Containers: []attunev1alpha1.ContainerRecommendation{
+						{
+							Name: "main",
+							Recommended: attunev1alpha1.ResourceValues{
+								CPURequest: resource.MustParse("200m"),
+							},
+						},
+					},
+				},
+			}
+			r.applyStartupBoosts(context.Background(), policy, map[string][]corev1.Pod{"batch-job": {*pod}},
+				recs, resize.NewPodResizer(clientset, ctrl.Log.WithName("test")), nil)
+
+			for _, a := range clientset.Actions() {
+				if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+					t.Fatalf("startup boost must not resize %s pods", tt.kind)
+				}
+			}
+			var updated corev1.Pod
+			err := fakeClient.Get(context.Background(), types.NamespacedName{
+				Name: "batch-pod", Namespace: "default",
+			}, &updated)
+			require.NoError(t, err)
+			assert.Empty(t, updated.Annotations[annotationStartupBoostAt],
+				"batch workload must not get a startup-boost annotation")
+		})
+	}
 }
 
 func TestApplyStartupBoosts_NativeSidecars(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10831,6 +10831,84 @@ func TestApplyStartupBoosts_AppliesBoostToNewPod(t *testing.T) {
 	assert.True(t, foundResize, "expected a resize action for startup boost")
 }
 
+func TestApplyStartupBoosts_SkipsWhenAlreadyAtBoostedLevel(t *testing.T) {
+	scheme := testScheme()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			CPU: attunev1alpha1.ResourceConfig{
+				StartupBoost: &attunev1alpha1.StartupBoost{
+					Multiplier: "2.0",
+					Duration:   metav1.Duration{Duration: 2 * time.Minute},
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-app-abc",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Second)),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	clientset := kubefake.NewSimpleClientset(pod)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+	r.SetNowFunc(func() time.Time { return now })
+
+	logger := ctrl.Log.WithName("test")
+	resizer := resize.NewPodResizer(clientset, logger)
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "my-app",
+			Kind:     "Deployment",
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name: "main",
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("50m"),
+					},
+				},
+			},
+		},
+	}
+	podsByWorkload := map[string][]corev1.Pod{"my-app": {*pod}}
+
+	r.applyStartupBoosts(context.Background(), policy, podsByWorkload, recs, resizer, nil)
+
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			t.Fatal("startup boost must not resize when current CPU is already at 2*recommendation")
+		}
+	}
+
+	var updated corev1.Pod
+	err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "my-app-abc", Namespace: "default",
+	}, &updated)
+	require.NoError(t, err)
+	assert.Empty(t, updated.Annotations[annotationStartupBoostAt],
+		"already-at-boosted-level must not persist a startup-boost annotation")
+}
+
 func TestApplyStartupBoosts_NativeSidecars(t *testing.T) {
 	always := corev1.ContainerRestartPolicyAlways
 	now := time.Date(2026, 1, 1, 0, 5, 0, 0, time.UTC)

--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -71,6 +71,13 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 				"workload", rec.Workload)
 			continue
 		}
+		// Batch workloads are recommend-only; executeResizes already
+		// skips them. Recs still exist, so skip here too.
+		if rec.Kind == "Job" || rec.Kind == "CronJob" {
+			logger.V(1).Info("Skipping startup boost for batch workload",
+				"workload", rec.Workload, "kind", rec.Kind)
+			continue
+		}
 		pods := podsByWorkload[rec.Workload]
 		// Build per-container recommendation map for this workload.
 		recMap := make(map[string]resource.Quantity, len(rec.Containers))
@@ -94,7 +101,12 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 
 			if boostAtStr == "" && podAge < boostDuration {
 				// New pod within boost window: apply boosted CPU.
-				boostedAny := false
+				// Persist the boost timestamp when we resized or when
+				// current CPU is already at the target. Without this,
+				// a persist miss after a successful resize leaves the
+				// next reconcile with current >= boosted, no persist
+				// retry, and expiry never runs.
+				persistAnnotation := false
 				for _, c := range append(nativeSidecars(pod.Spec.InitContainers), pod.Spec.Containers...) {
 					recCPU, ok := recMap[c.Name]
 					if !ok {
@@ -113,7 +125,11 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 						boostedCPU = cpuLim.DeepCopy()
 					}
 					if c.Resources.Requests.Cpu().Cmp(boostedCPU) >= 0 {
-						continue // already at or above boosted level
+						// Already at/above boosted CPU inside the window.
+						// Persist the annotation so expiry can run later.
+						// Do not /resize again.
+						persistAnnotation = true
+						continue
 					}
 					// Safety check: verify the boosted target does not violate
 					// node allocatable, ResourceQuota, LimitRange, or QoS class.
@@ -155,17 +171,18 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 						}
 						continue
 					}
-					boostedAny = true
+					persistAnnotation = true
 					operatormetrics.StartupBoostTotal.WithLabelValues(pod.Namespace, rec.Workload, "applied").Inc()
 					logger.Info("Applied startup CPU boost",
 						"pod", pod.Name, "container", c.Name,
 						"boostedCPU", boostedCPU.String(), "steadyState", recCPU.String())
 					*pod = *refreshed
 				}
-				// Only mark the pod with boost timestamp if at least one
-				// resize succeeded. Without this guard, a failed boost
-				// would trigger a spurious expiry resize on the next reconcile.
-				if boostedAny {
+				// Persist when a resize succeeded or the pod is already
+				// at the boosted target inside the window. Do not persist
+				// from a no-op skip outside the window (this block is
+				// only entered when age < duration).
+				if persistAnnotation {
 					// Re-fetch from API server and retry on conflict to handle
 					// kubelet status churn after resize. Without retry, a 409
 					// leaves the annotation unset and the boost never expires.

--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -215,7 +215,7 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 							"pod", pod.Name, "attempt", attempt+1)
 					}
 					if !annotationPersisted {
-						logger.V(1).Info("Startup boost annotation was not persisted after retries",
+						logger.Info("Startup boost annotation was not persisted after retries",
 							"pod", pod.Name, "retries", maxBoostAnnotationRetries)
 					}
 				}

--- a/internal/webhook/defaults_validation.go
+++ b/internal/webhook/defaults_validation.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
@@ -261,6 +262,9 @@ func validateResourceConfigFields(prefix string, rc *attunev1alpha1.ResourceConf
 				prefix, rc.MinAllowed.String(), prefix, rc.MaxAllowed.String())
 		}
 	}
+	if err := validateResourceMaxAllowedCap(prefix, rc); err != nil {
+		return err
+	}
 
 	// StartupBoost (only valid for CPU, but validate format for both)
 	if sb := rc.StartupBoost; sb != nil {
@@ -285,6 +289,33 @@ func validateResourceConfigFields(prefix string, rc *attunev1alpha1.ResourceConf
 		}
 	}
 
+	return nil
+}
+
+// validateResourceMaxAllowedCap enforces the same absolute ceilings used
+// by AttunePolicy admission (256 cores CPU, 16Ti memory) so AttuneDefaults
+// cannot merge uncapped maxAllowed onto policies after admission.
+func validateResourceMaxAllowedCap(prefix string, rc *attunev1alpha1.ResourceConfig) error {
+	if rc == nil || rc.MaxAllowed == nil {
+		return nil
+	}
+	var capStr, human string
+	switch prefix {
+	case "cpu":
+		capStr, human = "256", "256 cores"
+	case "memory":
+		capStr, human = "16Ti", "16Ti"
+	default:
+		return nil
+	}
+	cap, err := resource.ParseQuantity(capStr)
+	if err != nil {
+		return fmt.Errorf("%s.maxAllowed cap %q: %w", prefix, capStr, err)
+	}
+	if rc.MaxAllowed.Cmp(cap) > 0 {
+		return fmt.Errorf("%s.maxAllowed (%s) exceeds the maximum allowed value of %s",
+			prefix, rc.MaxAllowed.String(), human)
+	}
 	return nil
 }
 

--- a/internal/webhook/defaults_validation_test.go
+++ b/internal/webhook/defaults_validation_test.go
@@ -633,6 +633,47 @@ func TestDefaultsValidate_BoundsMinExceedsMax(t *testing.T) {
 	}
 }
 
+func TestDefaultsValidate_MaxAllowedCaps(t *testing.T) {
+	tests := []struct {
+		name    string
+		cpuMax  string
+		memMax  string
+		wantErr string
+	}{
+		{name: "CPU 257 rejected", cpuMax: "257", wantErr: "cpu.maxAllowed"},
+		{name: "memory 17Ti rejected", memMax: "17Ti", wantErr: "memory.maxAllowed"},
+		{name: "CPU 256 accepted", cpuMax: "256"},
+		{name: "memory 16Ti accepted", memMax: "16Ti"},
+		{name: "CPU 256 and memory 16Ti accepted", cpuMax: "256", memMax: "16Ti"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &AttuneDefaultsValidator{}
+			defaults := &attunev1alpha1.AttuneDefaults{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       attunev1alpha1.AttuneDefaultsSpec{},
+			}
+			if tc.cpuMax != "" {
+				q := resource.MustParse(tc.cpuMax)
+				defaults.Spec.CPU = &attunev1alpha1.ResourceConfig{MaxAllowed: &q}
+			}
+			if tc.memMax != "" {
+				q := resource.MustParse(tc.memMax)
+				defaults.Spec.Memory = &attunev1alpha1.ResourceConfig{MaxAllowed: &q}
+			}
+
+			_, err := v.ValidateCreate(context.Background(), defaults)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			assert.Contains(t, err.Error(), "exceeds the maximum allowed value")
+		})
+	}
+}
+
 func TestDefaultsValidate_BurstSensitivityInvalid(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/webhook/defaults_validation_test.go
+++ b/internal/webhook/defaults_validation_test.go
@@ -643,6 +643,8 @@ func TestDefaultsValidate_MaxAllowedCaps(t *testing.T) {
 		{name: "CPU 257 rejected", cpuMax: "257", wantErr: "cpu.maxAllowed"},
 		{name: "memory 17Ti rejected", memMax: "17Ti", wantErr: "memory.maxAllowed"},
 		{name: "CPU 256 accepted", cpuMax: "256"},
+		{name: "CPU 256000m accepted", cpuMax: "256000m"},
+		{name: "CPU 256001m rejected", cpuMax: "256001m", wantErr: "cpu.maxAllowed"},
 		{name: "memory 16Ti accepted", memMax: "16Ti"},
 		{name: "CPU 256 and memory 16Ti accepted", cpuMax: "256", memMax: "16Ti"},
 	}

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
@@ -76,23 +75,6 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 	}
 	if err := validateResourceConfigFields("memory", &policy.Spec.Memory); err != nil {
 		return warnings, err
-	}
-
-	// Policy-specific caps beyond what ResourceConfig validates:
-	// CPU maxAllowed capped at 256 cores, memory maxAllowed capped at 16Ti.
-	if policy.Spec.CPU.MaxAllowed != nil {
-		maxCPU := resource.MustParse("256")
-		if policy.Spec.CPU.MaxAllowed.Cmp(maxCPU) > 0 {
-			return warnings, fmt.Errorf("cpu.maxAllowed (%s) exceeds the maximum allowed value of 256 cores",
-				policy.Spec.CPU.MaxAllowed.String())
-		}
-	}
-	if policy.Spec.Memory.MaxAllowed != nil {
-		maxMemory := resource.MustParse("16Ti")
-		if policy.Spec.Memory.MaxAllowed.Cmp(maxMemory) > 0 {
-			return warnings, fmt.Errorf("memory.maxAllowed (%s) exceeds the maximum allowed value of 16Ti",
-				policy.Spec.Memory.MaxAllowed.String())
-		}
 	}
 
 	// Warn if memory startup boost is set (only CPU boost is implemented).

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -198,6 +198,35 @@ func TestValidate_CPUBoundsMaxExceedsUpperLimit(t *testing.T) {
 	assert.Empty(t, warnings)
 }
 
+func TestValidate_CPUBoundsMaxAllowedMillicores(t *testing.T) {
+	tests := []struct {
+		name    string
+		cpuMax  string
+		wantErr bool
+	}{
+		{name: "256000m accepted", cpuMax: "256000m"},
+		{name: "256001m rejected", cpuMax: "256001m", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			validator := &AttunePolicyValidator{}
+			policy := validPolicy()
+			cpuMax := resource.MustParse(tc.cpuMax)
+			policy.Spec.CPU.MaxAllowed = &cpuMax
+
+			warnings, err := validator.ValidateCreate(context.Background(), policy)
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "cpu.maxAllowed")
+				assert.Contains(t, err.Error(), "exceeds the maximum allowed value of 256 cores")
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Empty(t, warnings)
+		})
+	}
+}
+
 func TestValidate_MemoryBoundsMaxExceedsUpperLimit(t *testing.T) {
 	validator := &AttunePolicyValidator{}
 	policy := validPolicy()

--- a/test/e2e/startup-boost/chainsaw-test.yaml
+++ b/test/e2e/startup-boost/chainsaw-test.yaml
@@ -44,7 +44,7 @@ spec:
                             restartPolicy: NotRequired
                         resources:
                           requests:
-                            cpu: 100m
+                            cpu: 50m
                             memory: 128Mi
                           limits:
                             cpu: 500m
@@ -129,9 +129,9 @@ spec:
     - name: verify-startup-boost-annotation
       try:
         - script:
-            timeout: 3m
+            timeout: 4m
             content: |
-              for i in $(seq 1 36); do
+              for i in $(seq 1 42); do
                 ANNOTATION=$(kubectl get pods -n e2e-startup-boost -l app=boost-app \
                   -o jsonpath='{.items[0].metadata.annotations.attune\.io/startup-boost-at}' 2>/dev/null)
                 if [ -n "$ANNOTATION" ]; then


### PR DESCRIPTION
Startup boost E2E was a no-op (100m start, 2x of 50m rec), so the annotation wait died with `signal: killed`. Defaults could also inherit a `maxAllowed` above the policy webhook cap.

## Problem

Pause recs clamp to `minAllowed` 50m. Boost target `2 * 50m` equals the old 100m request, so `applyStartupBoosts` skipped. CI dispatch 33993681524 failed on Chainsaw `startup-boost`. A persist miss after a successful boost left the pod boosted with no expiry. `AttuneDefaults` did not enforce the 256-core / 16Ti `maxAllowed` caps that `AttunePolicy` already had.

## Change

- Start the boost E2E pod at 50m and give the annotation script 4m so a real miss prints YAML.
- Retry `attune.io/startup-boost-at` when the pod is already at the boost target and still inside the window.
- Skip Job/CronJob recommendations on the boost path (same as `executeResizes`).
- Log persist exhaustion at Info.
- Share `validateResourceMaxAllowedCap` for Policy and Defaults (including millicore equivalents).
- Document the caps in configuration, API, and SPEC.

## Validation

```
go test ./internal/controller/ ./internal/webhook/ -race -count=1 \
  -run 'TestApplyStartupBoosts_|TestDefaultsValidate_|TestValidate_CPUBounds|TestValidate_MemoryBounds'
```

Both packages passed. `gofmt -l` clean on touched Go files.

No issue `Closes` (community inbox is human-blocked).
