### PR TITLE
fix: live-get pod before Infeasible eviction

### DIFF
--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -9100,6 +9100,70 @@ func TestResizeContainer_InfeasiblePodEvictedDirectly(t *testing.T) {
 	assert.Equal(t, 0, resizes, "should NOT have attempted in-place resize on Infeasible pod")
 }
 
+func TestResizeContainer_InfeasibleLiveRecheckAfterStaleCache(t *testing.T) {
+	// Listed/informer pod has no Infeasible; Clientset does. Evict.
+	listed := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	listed.Name = "api-server-abc-1"
+	live := listed.DeepCopy()
+	live.Status.Conditions = append(live.Status.Conditions, corev1.PodCondition{
+		Type:   "PodResizePending",
+		Status: corev1.ConditionTrue,
+		Reason: "Infeasible",
+	})
+	peer := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	peer.Name = "api-server-abc-2"
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(deploy, listed, peer).Build()
+	clientset := kubefake.NewSimpleClientset(live, peer.DeepCopy())
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
+
+	resizer := resize.NewPodResizer(clientset, ctrl.Log)
+	containerRec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("200m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("100m"),
+			MemoryRequest: resource.MustParse("128Mi"),
+		},
+	}
+
+	entries, outcome := r.resizeContainer(context.Background(), resizeParams{
+		Policy:       policy,
+		Pod:          listed,
+		Workload:     deploy,
+		WorkloadName: "api-server",
+		ContainerRec: containerRec,
+		Resizer:      resizer,
+		Monitor:      nil,
+		Now:          metav1.Now(),
+	})
+	assert.Equal(t, resizeOutcomeEvicted, outcome, "live Infeasible must evict even if listed pod is clear")
+	require.Len(t, entries, 1)
+	assert.Equal(t, "Eviction", entries[0].Method)
+	assert.Equal(t, attunev1alpha1.ResizeResultEvicted, entries[0].Result)
+
+	var evictions int
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "create" && a.GetResource().Resource == "pods" && a.GetSubresource() == "eviction" {
+			evictions++
+		}
+	}
+	assert.Equal(t, 1, evictions)
+}
+
 func TestResizeContainer_InfeasiblePodSkippedWithInPlaceOnly(t *testing.T) {
 	// An Infeasible pod with InPlaceOnly should be skipped entirely
 	// (no resize attempt, no eviction).

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -8700,14 +8700,15 @@ func TestExecuteResizes_RevertsOnReFetchFailure(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(allObjects...).Build()
 	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
 
-	// Inject failure on typed clientset Get for pods. ResizePod now does a
-	// pre-resize re-fetch (call 1), then persistResizeAnnotations does a
-	// post-resize re-fetch (call 2). Fail call 2 to test annotation-persist
-	// revert. Subsequent Gets (revert's pod lookup) pass through.
+	// Inject failure on typed clientset Get for pods. resizeContainer now
+	// live-gets before Infeasible (call 1), ResizePod does a pre-resize
+	// re-fetch (call 2), then persistResizeAnnotations does a post-resize
+	// re-fetch (call 3). Fail call 3 to test annotation-persist revert.
+	// Subsequent Gets (revert's pod lookup) pass through.
 	getCount := 0
 	clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		getCount++
-		if getCount == 2 {
+		if getCount == 3 {
 			return true, nil, fmt.Errorf("simulated re-fetch failure")
 		}
 		return false, nil, nil

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -546,6 +546,13 @@ func (r *AttunePolicyReconciler) resizeContainer(
 		}
 	}
 
+	// Live Get before Infeasible: the informer pod can lag kubelet (or an
+	// E2E inject loop) by a watch interval. Same class as the node
+	// pressure re-check above. Get failure keeps the listed object.
+	if live := r.livePodForResize(ctx, pod); live != nil {
+		pod = live
+	}
+
 	// Pods already marked Infeasible cannot be resized in-place on the current node.
 	if resize.IsResizeInfeasible(pod) {
 		if policy.Spec.UpdateStrategy.ResizeMethod == attunev1alpha1.ResizeMethodInPlaceOrRecreate {
@@ -1636,6 +1643,21 @@ func recentMemoryUsage(containerRec attunev1alpha1.ContainerRecommendation) (res
 		return resource.Quantity{}, false
 	}
 	return u, true
+}
+
+// livePodForResize returns the named pod from the typed Clientset when
+// configured. Used immediately before the Infeasible eviction decision so
+// a stale informer snapshot cannot hide a live Infeasible (or keep a
+// cleared one). Returns listed on Get error or when Clientset is unset.
+func (r *AttunePolicyReconciler) livePodForResize(ctx context.Context, listed *corev1.Pod) *corev1.Pod {
+	if r.Clientset == nil || listed == nil {
+		return listed
+	}
+	fresh, err := r.Clientset.CoreV1().Pods(listed.Namespace).Get(ctx, listed.Name, metav1.GetOptions{})
+	if err != nil {
+		return listed
+	}
+	return fresh
 }
 
 // getNodeForResize returns the named node for capacity/pressure checks.

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -1385,7 +1385,8 @@ func TestE2E_EvictionFallback_ResizesWithInPlaceOrRecreate(t *testing.T) {
 	createNamespace(t, ns)
 	// Two replicas so last-replica eviction guard does not block. Keep
 	// requests small so both schedule on the shared k3d node.
-	createDeployment(t, "evict-app", ns, "200m", "128Mi", 2)
+	const startCPU = "200m"
+	createDeployment(t, "evict-app", ns, startCPU, "128Mi", 2)
 	waitForDeploymentReady(t, "evict-app", ns, 90*time.Second)
 
 	deployName := "evict-app"
@@ -1432,12 +1433,12 @@ func TestE2E_EvictionFallback_ResizesWithInPlaceOrRecreate(t *testing.T) {
 		require.NoError(t, tryPatchPodResizePending(t, startPods.Items[i].Name, ns, "Infeasible"))
 	}
 
-	// Kubelet clears injected Infeasible within seconds. Re-apply on a
-	// short ticker so executeResizes still sees it when recs land.
+	// Kubelet clears injected Infeasible within seconds (same class as
+	// MemoryPressure inject). 100ms ticker + live Get in resizeContainer.
 	stopInject := make(chan struct{})
 	defer close(stopInject)
 	go func() {
-		ticker := time.NewTicker(200 * time.Millisecond)
+		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 		for {
 			select {
@@ -1458,10 +1459,25 @@ func TestE2E_EvictionFallback_ResizesWithInPlaceOrRecreate(t *testing.T) {
 		}
 	}()
 
-	// Create the policy after Infeasible is already on the original pods so
-	// the first executeResizes hits eviction instead of a successful in-place.
+	// Do not create the policy until at least one original pod still shows
+	// Infeasible on a live Get. Otherwise the first apply is a guaranteed
+	// in-place and cooldown burns the rest of the wait.
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, 20*time.Second, true, func(ctx context.Context) (bool, error) {
+		for _, name := range origUIDs {
+			pod, err := clientset.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				continue
+			}
+			if resizePendingReason(pod) == "Infeasible" {
+				return true, nil
+			}
+		}
+		return false, nil
+	}), "live Infeasible must be visible before creating the policy")
+
 	require.NoError(t, k8sClient.Create(ctx, policy))
 
+	var lastRestore time.Time
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 1*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var live corev1.PodList
 		if err := k8sClient.List(ctx, &live, client.InNamespace(ns), client.MatchingLabels{"app": "evict-app"}); err != nil {
@@ -1482,16 +1498,35 @@ func TestE2E_EvictionFallback_ResizesWithInPlaceOrRecreate(t *testing.T) {
 
 		replaced := 0
 		stillOrig := 0
+		infeasible := 0
 		for i := range live.Items {
 			if _, ok := origUIDs[live.Items[i].UID]; ok {
 				stillOrig++
+				if resizePendingReason(&live.Items[i]) == "Infeasible" {
+					infeasible++
+				}
 			} else {
 				replaced++
 			}
 		}
-		t.Logf("eviction wait: historyEvicted=%v stillOrig=%d replaced=%d recs=%d resized=%d",
-			historyEvicted, stillOrig, replaced, p.Status.Workloads.WithRecommendations, p.Status.Workloads.Resized)
-		return historyEvicted || replaced >= 1, nil
+		t.Logf("eviction wait: historyEvicted=%v stillOrig=%d replaced=%d infeasible=%d recs=%d resized=%d",
+			historyEvicted, stillOrig, replaced, infeasible, p.Status.Workloads.WithRecommendations, p.Status.Workloads.Resized)
+
+		// In-place won a kubelet-clear window. Restore start CPU so the
+		// next cycle still has a decrease to apply under Infeasible.
+		if !historyEvicted && replaced == 0 && p.Status.Workloads.Resized > 0 &&
+			(lastRestore.IsZero() || time.Since(lastRestore) > 45*time.Second) {
+			lastRestore = time.Now()
+			t.Logf("in-place won the Infeasible race; restoring %s to retry eviction", startCPU)
+			for _, name := range origUIDs {
+				restorePodCPURequest(t, name, ns, startCPU)
+			}
+		}
+
+		if historyEvicted || replaced >= 1 {
+			return true, nil
+		}
+		return false, nil
 	}), "InPlaceOrRecreate must evict an Infeasible pod (history Evicted or original UID replaced)")
 
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
@@ -1502,6 +1537,44 @@ func TestE2E_EvictionFallback_ResizesWithInPlaceOrRecreate(t *testing.T) {
 		t.Logf("post-eviction ReadyReplicas=%d", deploy.Status.ReadyReplicas)
 		return deploy.Status.ReadyReplicas >= 1, nil
 	}), "Deployment must keep at least one ready replica after eviction")
+}
+
+func resizePendingReason(pod *corev1.Pod) string {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodResizePending && c.Status == corev1.ConditionTrue {
+			return c.Reason
+		}
+	}
+	return ""
+}
+
+func restorePodCPURequest(t *testing.T, podName, namespace, cpu string) {
+	t.Helper()
+	qty, err := resource.ParseQuantity(cpu)
+	if err != nil {
+		t.Logf("restore %s/%s: parse %s: %v", namespace, podName, cpu, err)
+		return
+	}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pod, getErr := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		for i := range pod.Spec.Containers {
+			if pod.Spec.Containers[i].Name != "app" {
+				continue
+			}
+			if pod.Spec.Containers[i].Resources.Requests == nil {
+				pod.Spec.Containers[i].Resources.Requests = corev1.ResourceList{}
+			}
+			pod.Spec.Containers[i].Resources.Requests[corev1.ResourceCPU] = qty
+		}
+		_, updErr := clientset.CoreV1().Pods(namespace).UpdateResize(ctx, pod.Name, pod, metav1.UpdateOptions{})
+		return updErr
+	})
+	if err != nil {
+		t.Logf("restore %s/%s CPU %s: %v", namespace, podName, cpu, err)
+	}
 }
 
 func TestE2E_RecommendMode_KeepsRecommendationsWithoutLivePods(t *testing.T) {


### PR DESCRIPTION
## Why

Dependabot [#671](https://github.com/attune-io/attune/pull/671) failed `TestE2E_EvictionFallback_ResizesWithInPlaceOrRecreate` at 242s, then passed on rebase. Logs were `resized=1` with `historyEvicted=false stillOrig=2`. Recs landed. In-place won because kubelet cleared injected `Infeasible`.

## Change

- Live Clientset Get immediately before the Infeasible eviction decision (same class as the node MemoryPressure re-check).
- Unit: listed pod clear, live pod Infeasible, evict.
- E2E: 100ms inject, wait until live Infeasible is visible before creating the policy, restore start CPU if in-place wins so another decrease can still evict.

## Checks

- `go test ./internal/controller/ -race -count=1 -run TestResizeContainer_Infeasible`
- `go test -tags=e2e -c ./test/e2e-go/`
- `make lint`
