### PR TITLE
docs: pin ci badge to push events

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Attune
 
-[![CI](https://github.com/attune-io/attune/actions/workflows/ci.yaml/badge.svg)](https://github.com/attune-io/attune/actions/workflows/ci.yaml)
+[![CI](https://github.com/attune-io/attune/actions/workflows/ci.yaml/badge.svg?event=push)](https://github.com/attune-io/attune/actions/workflows/ci.yaml)
 [![Security](https://github.com/attune-io/attune/actions/workflows/security.yaml/badge.svg)](https://github.com/attune-io/attune/actions/workflows/security.yaml)
 [![Coverage](https://img.shields.io/badge/coverage-90%25%2B-brightgreen)](https://github.com/attune-io/attune/blob/main/docs/contributing/testing.md)
 [![Release](https://img.shields.io/github/v/release/attune-io/attune?logo=github&color=green)](https://github.com/attune-io/attune/releases/latest)


### PR DESCRIPTION
Pin the README CI badge to push-triggered runs so leftover workflow_dispatch flakes stop painting the default branch as failing.

## Problem

GitHub's default workflow badge reports the latest `ci.yaml` run on `main`. After Recipe A, CI no longer runs on push to main. The latest main run is a manual dispatch from 2026-09-05 ([33993681524](https://github.com/attune-io/attune/actions/runs/33993681524)) that failed on a `startup-boost` flake (`signal: killed`). Recent PR CI and E2E Nightly are green.

## Change

Add `?event=push` to the README CI badge URL so it ignores `workflow_dispatch` results. The click-through still opens the CI workflow runs page.

## Validation

Fetched `https://github.com/attune-io/attune/actions/workflows/ci.yaml/badge.svg?event=push`. Title is `CI - passing`.
