### PR TITLE
ci: notes-branch releases and cheap release-please ci

### DIFF
--- a/.github/workflows/apply-release-notes.yaml
+++ b/.github/workflows/apply-release-notes.yaml
@@ -1,0 +1,43 @@
+# Cheap apply of curated notes onto a GitHub Release.
+# Reads branch release-note-<semver> or vars RELEASE_NOTES +
+# RELEASE_NOTES_TAG. Deletes the notes branch after a successful
+# apply. Does not compile and does not start GoReleaser.
+name: Apply release notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.1.27)"
+        required: true
+        type: string
+
+concurrency:
+  group: apply-release-notes-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: Apply notes
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      TAG: ${{ inputs.tag }}
+      RELEASE_NOTES: ${{ vars.RELEASE_NOTES }}
+      RELEASE_NOTES_TAG: ${{ vars.RELEASE_NOTES_TAG }}
+    steps:
+      - uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Apply curated notes
+        run: bash hack/apply-release-notes.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,7 @@ jobs:
               - 'scripts/**'
               - 'hack/e2e-install-cert-manager.sh'
               - 'hack/k3d-delete.sh'
+              - 'hack/apply-release-notes.sh'
               - '.github/actions/setup-e2e-cluster/**'
               - '.github/workflows/e2e-nightly.yaml'
             workflows:
@@ -228,7 +229,9 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
     needs: changes
-    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.helm == 'true'
+    if: >-
+      (needs.changes.outputs.docs == 'true' || needs.changes.outputs.helm == 'true') &&
+      (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please'))
     steps:
       - uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
@@ -296,7 +299,9 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     needs: changes
-    if: needs.changes.outputs.yaml == 'true'
+    if: >-
+      needs.changes.outputs.yaml == 'true' &&
+      (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please'))
     steps:
       - uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
@@ -748,7 +753,9 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
     needs: changes
-    if: needs.changes.outputs.helm == 'true' || needs.changes.outputs.go == 'true'
+    if: >-
+      (needs.changes.outputs.helm == 'true' || needs.changes.outputs.go == 'true') &&
+      (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please'))
     steps:
       - uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -185,17 +185,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Apply custom release notes
+      # Curated notes live on release-note-<semver> or in Actions vars.
+      # After a successful apply the notes branch is deleted. Missing
+      # source leaves the auto changelog. continue-on-error so a notes
+      # miss does not fail GoReleaser uploads.
+      - name: Apply curated release notes
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.name }}
-        run: |
-          if [ -f RELEASE_NOTES.md ]; then
-            echo "Custom release notes found, updating release body..."
-            gh release edit "$TAG" --notes-file RELEASE_NOTES.md
-          else
-            echo "No custom release notes, using auto-generated notes"
-          fi
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_NOTES: ${{ vars.RELEASE_NOTES }}
+          RELEASE_NOTES_TAG: ${{ vars.RELEASE_NOTES_TAG }}
+        run: bash hack/apply-release-notes.sh
 
       - name: Extract legacy .sig and .pem from Sigstore bundle
         shell: bash -Eeuo pipefail {0}
@@ -412,40 +414,6 @@ jobs:
         uses: rajatjindal/krew-release-bot@c970b8a8f6dbc2f2285a26e3ae160903b87002c3 # v0.0.51
         with:
           krew_plugin_release_tag: ${{ steps.tag.outputs.name }}
-
-      # Clean up RELEASE_NOTES.md from main after the release is published.
-      # Branch protection blocks direct pushes, so we create a short-lived PR.
-      # Uses the GitHub App token so the PR triggers CI and auto-approve.
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: cleanup-token
-        with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-      - name: Clean up release notes file
-        env:
-          GH_TOKEN: ${{ steps.cleanup-token.outputs.token }}
-          TAG: ${{ steps.tag.outputs.name }}
-        run: |
-          if git ls-tree HEAD --name-only | grep -q '^RELEASE_NOTES.md$'; then
-            BRANCH="chore/cleanup-release-notes-${TAG}"
-            gh api "repos/${{ github.repository }}/git/refs" \
-              -f ref="refs/heads/$BRANCH" \
-              -f sha="$(git rev-parse HEAD)"
-            FILE_SHA=$(gh api \
-              "repos/${{ github.repository }}/contents/RELEASE_NOTES.md?ref=$BRANCH" \
-              --jq '.sha')
-            gh api --method DELETE \
-              "repos/${{ github.repository }}/contents/RELEASE_NOTES.md" \
-              -f message="chore: remove release notes override" \
-              -f sha="$FILE_SHA" \
-              -f branch="$BRANCH"
-            PR_URL=$(gh pr create --base main --head "$BRANCH" \
-              --title "chore: remove release notes override" \
-              --body "Auto-cleanup after ${TAG} release.")
-            gh pr merge "$PR_URL" --auto --squash
-          fi
 
   helm-release:
     name: Helm Chart Release

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -37,17 +37,31 @@ jobs:
       - uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit
+      - name: Release-please stand-in
+        if: >-
+          github.event_name == 'pull_request' &&
+          startsWith(github.head_ref, 'release-please')
+        run: echo 'version-bump PR; CodeQL already ran on the feature PR'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: >-
+          github.event_name != 'pull_request' ||
+          !startsWith(github.head_ref, 'release-please')
         with:
           persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        if: matrix.language == 'go'
+        if: >-
+          matrix.language == 'go' &&
+          (github.event_name != 'pull_request' ||
+           !startsWith(github.head_ref, 'release-please'))
         with:
           go-version-file: go.mod
           cache: true
 
       - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: >-
+          github.event_name != 'pull_request' ||
+          !startsWith(github.head_ref, 'release-please')
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -55,16 +69,25 @@ jobs:
           dependency-caching: true
 
       - name: Build (Go)
-        if: matrix.build-mode == 'manual'
+        if: >-
+          matrix.build-mode == 'manual' &&
+          (github.event_name != 'pull_request' ||
+           !startsWith(github.head_ref, 'release-please'))
         run: go build ./...
 
       - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: >-
+          github.event_name != 'pull_request' ||
+          !startsWith(github.head_ref, 'release-please')
         with:
           upload: always
           category: "/language:${{ matrix.language }}"
 
   govulncheck:
     name: Govulncheck
+    if: >-
+      github.event_name != 'pull_request' ||
+      !startsWith(github.head_ref, 'release-please')
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -92,6 +115,9 @@ jobs:
 
   trivy:
     name: Trivy
+    if: >-
+      github.event_name != 'pull_request' ||
+      !startsWith(github.head_ref, 'release-please')
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -116,6 +142,9 @@ jobs:
 
   trivy-image:
     name: Trivy Image Scan
+    if: >-
+      github.event_name != 'pull_request' ||
+      !startsWith(github.head_ref, 'release-please')
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ test-fuzz: ## Run fuzz tests (coverage-guided; FUZZTIME=30s default, deadline-fl
 	./scripts/run-fuzz.sh
 
 .PHONY: python-test
-python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync, helm image tag, fleet reports, nightly issue body, k3d-delete, CI triggers)
+python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync, helm image tag, fleet reports, nightly issue body, k3d-delete, CI triggers, apply-release-notes)
 	python3 scripts/test_fossa_filter.py -v
 	bash scripts/test_run_fuzz.sh
 	bash scripts/test_verify_go_version_sync.sh
@@ -251,6 +251,7 @@ python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-v
 	bash scripts/test_nightly_failure_issue_body.sh
 	bash scripts/test_verify_chainsaw_scripts.sh
 	bash scripts/test_ci_build_once.sh
+	python3 scripts/test_apply_release_notes.py
 
 .PHONY: test-bench
 test-bench: ## Run benchmark tests

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1020,7 +1020,11 @@ Validate compatibility with Kubernetes API conventions:
 Product tests do not run again on `push` to `main`. The branch ruleset
 requires an up-to-date PR, so a squash of a green PR is the same tree.
 `push` to `main` still runs cheap promote jobs (release-please, Docs
-deploy, Scorecard).
+deploy, Scorecard). Curated GitHub Release notes live on
+`release-note-<semver>` (or Actions vars), not on `main`. The Release
+job applies them and deletes the notes branch. Version-bump
+`release-please*` PRs skip Helm/Docs/YAML lint and CodeQL analyze
+(required `CodeQL (go)` / `CodeQL (actions)` still report a stand-in).
 
 ```
 Jobs:

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -45,8 +45,37 @@ gh workflow run "E2E Nightly" --repo attune-io/attune
 3. Do not ship until all four K8s matrix cells and Fuzz are green on that SHA.
 
 If the release-please PR is **BEHIND** main, update/rebase it (or let
-release-please refresh) so the release notes and version bump include the
-latest commits.
+release-please refresh) so the version bump includes the latest commits.
+
+### 1c. Curated GitHub Release notes (optional)
+
+Do **not** commit `RELEASE_NOTES.md` to `main`. That path used to
+need a notes PR plus a cleanup PR after every cut.
+
+Push a one-file orphan branch named for the version. The Release job
+(or `Apply release notes`) copies it onto the GitHub Release and
+deletes the branch. Skip this for a thin patch; the auto changelog
+is enough.
+
+```bash
+# tag v0.1.27 -> branch release-note-0.1.27
+git checkout --orphan release-note-0.1.27
+git rm -rf --cached .
+# write RELEASE_NOTES.md at the repo root, then:
+git add RELEASE_NOTES.md
+git commit -s -m "docs: notes for 0.1.27"
+git push -u origin release-note-0.1.27
+```
+
+Do not open a PR for that branch. Re-apply without rebuilding:
+
+```bash
+gh workflow run "Apply release notes" -f tag=v0.1.27
+```
+
+Or skip git: set Actions variables `RELEASE_NOTES` (markdown) and
+`RELEASE_NOTES_TAG` (`v0.1.27` or `0.1.27`). The tag pin stops leftover
+text applying to a later cut.
 
 ### 2. Tag the release
 

--- a/hack/apply-release-notes.sh
+++ b/hack/apply-release-notes.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Apply curated notes to an existing GitHub Release, then delete the
+# notes branch. Notes are not on main.
+#
+# Sources, first match:
+#   1. NOTES_FILE (tests)
+#   2. RELEASE_NOTES.md on branch release-note-<semver> (tag v0.1.2
+#      -> release-note-0.1.2)
+#   3. Actions vars RELEASE_NOTES + RELEASE_NOTES_TAG (tag must match)
+#
+# Missing source is a no-op (auto changelog stays). After a successful
+# apply from the notes branch, that branch is deleted. Variables are
+# left in place; the tag pin stops them applying to a later cut.
+set -euo pipefail
+
+TAG="${TAG:-}"
+REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+DRY_RUN="${DRY_RUN:-0}"
+DELETE_BRANCH="${DELETE_BRANCH:-1}"
+NOTES_FILE="${NOTES_FILE:-}"
+RELEASE_NOTES="${RELEASE_NOTES:-}"
+RELEASE_NOTES_TAG="${RELEASE_NOTES_TAG:-}"
+
+if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "TAG must look like vX.Y.Z: ${TAG}" >&2
+  exit 1
+fi
+
+if [ -z "${REPO}" ]; then
+  echo "GH_REPO or GITHUB_REPOSITORY required" >&2
+  exit 1
+fi
+
+semver="${TAG#v}"
+branch="${NOTES_BRANCH:-release-note-${semver}}"
+loaded_from_branch=0
+source_label=""
+
+tmp="$(mktemp)"
+cleanup() { rm -f "${tmp}"; }
+trap cleanup EXIT
+
+tag_matches_pin() {
+  local pin="$1"
+  if [ -z "${pin}" ]; then
+    return 1
+  fi
+  if [ "${pin}" = "${TAG}" ] || [ "${pin}" = "${semver}" ]; then
+    return 0
+  fi
+  return 1
+}
+
+if [ -n "${NOTES_FILE}" ] && [ -f "${NOTES_FILE}" ]; then
+  echo "PLAN: file ${NOTES_FILE}"
+  cp "${NOTES_FILE}" "${tmp}"
+  source_label="file:${NOTES_FILE}"
+elif [ -n "${GH_TOKEN:-}" ]; then
+  echo "PLAN: fetch RELEASE_NOTES.md from ${branch}"
+  if gh api "repos/${REPO}/contents/RELEASE_NOTES.md?ref=${branch}" \
+    -H "Accept: application/vnd.github.raw" >"${tmp}"; then
+    loaded_from_branch=1
+    source_label="branch:${branch}"
+  else
+    : >"${tmp}"
+    echo "PLAN: no notes branch ${branch}"
+  fi
+fi
+
+if [ ! -s "${tmp}" ] && [ -n "${RELEASE_NOTES}" ] \
+  && tag_matches_pin "${RELEASE_NOTES_TAG}"; then
+  echo "PLAN: Actions variable RELEASE_NOTES (pin ${RELEASE_NOTES_TAG})"
+  printf '%s\n' "${RELEASE_NOTES}" >"${tmp}"
+  source_label="variable"
+fi
+
+if [ ! -s "${tmp}" ]; then
+  echo "OK: no curated notes for ${TAG}; leaving auto notes"
+  exit 0
+fi
+
+if [ "${DRY_RUN}" = "1" ]; then
+  echo "DRY_RUN: would apply ${source_label} to ${TAG}"
+  echo "BYTES: $(wc -c <"${tmp}" | tr -d ' ')"
+  if [ "${loaded_from_branch}" = "1" ] && [ "${DELETE_BRANCH}" = "1" ]; then
+    echo "DRY_RUN: would delete branch ${branch}"
+  fi
+  exit 0
+fi
+
+if ! gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+  echo "FAIL: release ${TAG} does not exist" >&2
+  exit 1
+fi
+
+echo "DO: gh release edit ${TAG} from ${source_label}"
+gh release edit "${TAG}" --repo "${REPO}" --notes-file "${tmp}"
+echo "OK: applied notes to ${TAG}"
+
+if [ "${loaded_from_branch}" = "1" ] && [ "${DELETE_BRANCH}" = "1" ]; then
+  echo "DO: delete ${branch}"
+  if gh api -X DELETE "repos/${REPO}/git/refs/heads/${branch}"; then
+    echo "DONE: deleted ${branch}"
+  else
+    echo "WARN: could not delete ${branch}; delete it by hand" >&2
+  fi
+fi

--- a/scripts/test_apply_release_notes.py
+++ b/scripts/test_apply_release_notes.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Tests for hack/apply-release-notes.sh."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "hack" / "apply-release-notes.sh"
+
+
+def run_script(
+    env: dict[str, str], cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    merged.pop("GH_TOKEN", None)
+    merged.pop("GITHUB_TOKEN", None)
+    merged.pop("RELEASE_NOTES", None)
+    merged.pop("RELEASE_NOTES_TAG", None)
+    merged.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=merged,
+        cwd=cwd,
+        check=False,
+    )
+
+
+class ApplyReleaseNotesTests(unittest.TestCase):
+    def test_rejects_bad_tag(self) -> None:
+        r = run_script({"TAG": "canact-v0.1.2", "GH_REPO": "attune-io/attune"})
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("vX.Y.Z", r.stderr)
+
+    def test_missing_source_is_noop(self) -> None:
+        r = run_script(
+            {"TAG": "v0.1.2", "GH_REPO": "attune-io/attune", "DRY_RUN": "1"}
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("leaving auto notes", r.stdout)
+
+    def test_notes_file_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            notes = Path(td) / "RELEASE_NOTES.md"
+            notes.write_text("attune 0.1.27 notes\n", encoding="utf-8")
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "attune-io/attune",
+                    "DRY_RUN": "1",
+                    "NOTES_FILE": str(notes),
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("DRY_RUN: would apply file:", r.stdout)
+            self.assertIn("BYTES: 20", r.stdout)
+            self.assertNotIn("would delete branch", r.stdout)
+
+    def test_empty_file_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            notes = Path(td) / "RELEASE_NOTES.md"
+            notes.write_text("", encoding="utf-8")
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "attune-io/attune",
+                    "DRY_RUN": "1",
+                    "NOTES_FILE": str(notes),
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("leaving auto notes", r.stdout)
+
+    def test_variable_requires_matching_tag(self) -> None:
+        r = run_script(
+            {
+                "TAG": "v0.1.2",
+                "GH_REPO": "attune-io/attune",
+                "DRY_RUN": "1",
+                "RELEASE_NOTES": "stale notes",
+                "RELEASE_NOTES_TAG": "v0.1.1",
+            }
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("leaving auto notes", r.stdout)
+
+    def test_variable_applies_when_tag_matches(self) -> None:
+        r = run_script(
+            {
+                "TAG": "v0.1.2",
+                "GH_REPO": "attune-io/attune",
+                "DRY_RUN": "1",
+                "RELEASE_NOTES": "from var",
+                "RELEASE_NOTES_TAG": "0.1.2",
+            }
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("Actions variable", r.stdout)
+        self.assertIn("DRY_RUN: would apply variable to v0.1.2", r.stdout)
+        self.assertNotIn("would delete branch", r.stdout)
+
+    def test_branch_fetch_dry_run_deletes_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            fake_bin = Path(td) / "bin"
+            fake_bin.mkdir()
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  printf '%s\\n' 'from branch'\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "attune-io/attune",
+                    "DRY_RUN": "1",
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            self.assertIn("release-note-0.1.2", r.stdout)
+            self.assertIn("DRY_RUN: would delete branch release-note-0.1.2", r.stdout)
+
+    def test_release_view_fail_skips_edit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            notes = td_path / "RELEASE_NOTES.md"
+            notes.write_text("curated notes\n", encoding="utf-8")
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            log = td_path / "gh.log"
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> '{log}'\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = view ]; then\n"
+                "  exit 1\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "attune-io/attune",
+                    "NOTES_FILE": str(notes),
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 1, r.stderr + r.stdout)
+            self.assertIn("does not exist", r.stderr)
+            logged = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertIn("release view", logged)
+            self.assertNotIn("release edit", logged)
+
+    def test_delete_fail_warns_and_exits_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            log = td_path / "gh.log"
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> '{log}'\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  printf '%s\\n' 'from branch'\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = view ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = edit ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = api ] && [ \"$2\" = -X ] && [ \"$3\" = DELETE ]; then\n"
+                "  exit 1\n"
+                "fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "attune-io/attune",
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            combined = f"{r.stderr}\n{r.stdout}"
+            self.assertIn("WARN", combined)
+            self.assertIn("could not delete", combined)
+            logged = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertIn("release view", logged)
+            self.assertIn("release edit", logged)
+            self.assertIn("DELETE", logged)
+
+    def test_failed_branch_fetch_applies_matching_variable(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            log = td_path / "gh.log"
+            notes_seen = td_path / "notes_seen.txt"
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> '{log}'\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  printf '%s\\n' "
+                "'{\"message\":\"Not Found\","
+                "\"documentation_url\":\"https://docs.github.com\"}'\n"
+                "  exit 1\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = view ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = edit ]; then\n"
+                "  while [ $# -gt 0 ]; do\n"
+                "    if [ \"$1\" = --notes-file ]; then\n"
+                f"      cat \"$2\" > '{notes_seen}'\n"
+                "      break\n"
+                "    fi\n"
+                "    shift\n"
+                "  done\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "attune-io/attune",
+                    "GH_TOKEN": "test",
+                    "RELEASE_NOTES": "from var after failed fetch",
+                    "RELEASE_NOTES_TAG": "v0.1.2",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            self.assertIn("variable", r.stdout)
+            self.assertTrue(notes_seen.is_file(), r.stderr + r.stdout)
+            seen = notes_seen.read_text(encoding="utf-8")
+            self.assertIn("from var after failed fetch", seen)
+            self.assertNotIn("Not Found", seen)
+            self.assertNotIn("documentation_url", seen)
+            logged = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertIn("release edit", logged)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_build_once.sh
+++ b/scripts/test_ci_build_once.sh
@@ -66,6 +66,30 @@ if grep -nE 'go test|make test|cargo test|cargo nextest' "${RELEASE}"; then
 fi
 echo "OK: release.yaml has no test matrix"
 
+echo "DO: curated notes use apply-release-notes.sh, not a main-file cleanup PR"
+APPLY="${ROOT}/.github/workflows/apply-release-notes.yaml"
+[[ -f "${APPLY}" ]] || fail "missing ${APPLY}"
+apply_on="$(extract_on "${APPLY}")"
+grep -q '^  workflow_dispatch:' <<<"${apply_on}" || fail "apply-release-notes.yaml: missing workflow_dispatch"
+if grep -q '^  push:' <<<"${apply_on}"; then
+  fail "apply-release-notes.yaml: push trigger is not needed"
+fi
+if grep -nE 'go test|go build|make test|docker build' "${APPLY}"; then
+  fail "apply-release-notes.yaml must not compile"
+fi
+grep -q 'hack/apply-release-notes.sh' "${RELEASE}" || fail "release.yaml must call hack/apply-release-notes.sh"
+if grep -n 'cleanup-release-notes' "${RELEASE}"; then
+  fail "release.yaml still opens a notes cleanup PR"
+fi
+echo "OK: notes-branch apply, no cleanup PR"
+
+echo "DO: release-please heads skip product compile (Recipe G)"
+grep -q "startsWith(github.head_ref, 'release-please')" "${CI}" || \
+  fail "ci.yaml missing release-please skip"
+grep -q "Release-please stand-in" "${SECURITY}" || \
+  fail "security.yaml missing CodeQL stand-in for release-please heads"
+echo "OK: Recipe G stand-in and skips present"
+
 echo "DO: PR CI restores bench baselines; main bench-baseline.yaml writes them"
 if grep -n 'actions/cache/save' "${CI}"; then
   fail "ci.yaml must not cache/save (PR cache is not visible to other PRs)"


### PR DESCRIPTION
Stop committing curated notes to `main`, and stop re-running Helm/Docs/CodeQL analyze on every release-please rewrite.

## Problem

Attune still used the old notes path: land `RELEASE_NOTES.md` on `main`, then open a cleanup PR after publish. That is two extra PRs and a dual-token dance every cut.

Every `feat:` / `fix:` merge also rewrites the open release-please PR. Path filters already skip unit/E2E, but Helm Lint, Docs Check, YAML Lint, and full CodeQL still ran on a Chart.yaml + CHANGELOG bump. Required names are `CI Gate`, `DCO`, `CodeQL (go)`, and `CodeQL (actions)`.

## Change

Match canact:

- Curated notes live on `release-note-<semver>` (or Actions vars). `hack/apply-release-notes.sh` applies them after GoReleaser and deletes the notes branch. Missing source leaves the auto changelog.
- New `Apply release notes` workflow for a cheap re-apply without rebuilding.
- Removed the main-file cleanup PR from `release.yaml`.
- On `release-please*` heads: skip Helm/Docs/YAML lint; CodeQL keeps the required job names and prints a stand-in instead of `go build` + analyze. Optional Security jobs that compile or scan images also skip.

Release still compiles once at `release_created` (GoReleaser + signed image). That is the provenance boundary, not a second test matrix.

## Validation

```
python3 scripts/test_apply_release_notes.py
bash scripts/test_ci_build_once.sh
```

Both passed locally (10 apply tests; Recipe A + notes-branch + Recipe G locks).
