### PR TITLE
fix: prefer live pod state for floor, skip, and last-replica eviction

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,6 +273,18 @@ jobs:
         shell: bash -Eeuo pipefail {0}
         run: bash hack/verify-doc-tool-versions.sh
 
+      - name: Verify PrometheusRule metrics
+        shell: bash -Eeuo pipefail {0}
+        run: bash hack/verify-prometheusrule-metrics.sh
+
+      - name: Verify Helm schema fields
+        shell: bash -Eeuo pipefail {0}
+        run: bash hack/verify-helm-schema-fields.sh
+
+      - name: Verify doc defaults
+        shell: bash -Eeuo pipefail {0}
+        run: bash hack/verify-doc-defaults.sh
+
   link-check:
     name: Link Check
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
@@ -856,6 +868,18 @@ jobs:
       - name: Verify dashboard metrics sync
         shell: bash -Eeuo pipefail {0}
         run: bash hack/verify-dashboard-metrics.sh
+
+      - name: Verify PrometheusRule metrics
+        shell: bash -Eeuo pipefail {0}
+        run: bash hack/verify-prometheusrule-metrics.sh
+
+      - name: Verify Helm schema fields
+        shell: bash -Eeuo pipefail {0}
+        run: bash hack/verify-helm-schema-fields.sh
+
+      - name: Verify doc defaults
+        shell: bash -Eeuo pipefail {0}
+        run: bash hack/verify-doc-defaults.sh
 
   build:
     name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,11 @@ jobs:
               - 'scripts/test_verify_helm_image_tag.sh'
               - 'hack/release-image-tags.sh'
               - 'scripts/test_release_image_tags.sh'
+              # Standalone Grafana JSON is the Helm dashboard source.
+              # Dashboard-only PRs must run verify-dashboard-metrics.sh
+              # without the full Go lint matrix.
+              - 'deploy/grafana/**'
+              - 'hack/verify-dashboard-metrics.sh'
             yaml:
               - 'config/**'
               - '.github/workflows/**'
@@ -847,6 +852,10 @@ jobs:
           bash scripts/test_verify_helm_image_tag.sh
           bash hack/verify-helm-image-tag.sh
           bash scripts/test_release_image_tags.sh
+
+      - name: Verify dashboard metrics sync
+        shell: bash -Eeuo pipefail {0}
+        run: bash hack/verify-dashboard-metrics.sh
 
   build:
     name: Build

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ verify-helm-rbac: ## Verify Helm chart ClusterRole matches kustomize RBAC
 	@bash hack/verify-helm-rbac.sh
 
 .PHONY: verify-dashboard-metrics
-verify-dashboard-metrics: ## Verify Helm dashboard stays synced with the standalone source dashboard
+verify-dashboard-metrics: ## Verify Helm dashboards stay synced with standalone Grafana JSON (overview + fleet)
 	@bash hack/verify-dashboard-metrics.sh
 
 .PHONY: verify-doc-tool-versions
@@ -97,7 +97,7 @@ verify-helm-image-tag: ## Verify Helm default image tag is Chart.appVersion (bar
 	@bash hack/verify-helm-image-tag.sh
 
 .PHONY: verify-release-artifacts
-verify-release-artifacts: kustomize ## Verify release artifacts generate cleanly and, if present, match current sources
+verify-release-artifacts: kustomize ## Verify tracked dist/install.yaml and dist/crds.yaml exist and match current sources
 	@repo_root=$$(pwd); \
 	tmp_dir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmp_dir"' EXIT; \
@@ -106,12 +106,22 @@ verify-release-artifacts: kustomize ## Verify release artifacts generate cleanly
 	$(KUSTOMIZE) build "$$tmp_dir"/config/default > "$$tmp_dir"/install.yaml; \
 	cat "$$repo_root"/charts/attune/crds/*.yaml > "$$tmp_dir"/crds.yaml; \
 	bash "$$repo_root"/hack/verify-doc-defaults.sh "$$tmp_dir"/crds.yaml; \
-	if [ -f "$$repo_root"/dist/install.yaml ] && ! diff -u "$$repo_root"/dist/install.yaml "$$tmp_dir"/install.yaml; then \
+	if [ ! -f "$$repo_root"/dist/install.yaml ]; then \
+		echo ""; \
+		echo "ERROR: dist/install.yaml is missing. Refresh it with: make build-installer IMG=$(IMG)" >&2; \
+		exit 1; \
+	fi; \
+	if ! diff -u "$$repo_root"/dist/install.yaml "$$tmp_dir"/install.yaml; then \
 		echo ""; \
 		echo "ERROR: dist/install.yaml is stale. Refresh it with: make build-installer IMG=$(IMG)" >&2; \
 		exit 1; \
 	fi; \
-	if [ -f "$$repo_root"/dist/crds.yaml ] && ! diff -u "$$repo_root"/dist/crds.yaml "$$tmp_dir"/crds.yaml; then \
+	if [ ! -f "$$repo_root"/dist/crds.yaml ]; then \
+		echo ""; \
+		echo "ERROR: dist/crds.yaml is missing. Refresh it with: make build-crds" >&2; \
+		exit 1; \
+	fi; \
+	if ! diff -u "$$repo_root"/dist/crds.yaml "$$tmp_dir"/crds.yaml; then \
 		echo ""; \
 		echo "ERROR: dist/crds.yaml is stale. Refresh it with: make build-crds" >&2; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,11 @@ test: manifests generate gotestsum ## Run unit tests
 		-covermode=atomic
 	@echo ""
 	@go tool cover -func=coverage.out | grep total:
+	@COVERAGE=$$(go tool cover -func=coverage.out | grep total: | awk '{print $$3}' | tr -d '%'); \
+	if (( $$(echo "$$COVERAGE < 80" | bc -l) )); then \
+		echo "ERROR: Coverage $${COVERAGE}% is below 80% threshold" >&2; \
+		exit 1; \
+	fi
 
 .PHONY: test-integration
 test-integration: manifests generate setup-envtest gotestsum ## Run integration tests
@@ -402,7 +407,7 @@ _deploy-stack:
 		--set alertmanager.enabled=false \
 		--set prometheus-pushgateway.enabled=false \
 		--set server.global.scrape_interval=15s \
-		--wait --timeout 3m 2>/dev/null || true
+		--wait --timeout 3m
 	@echo "Installing operator via Helm..."
 	helm install attune ./charts/attune \
 		--namespace attune-system --create-namespace \

--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -1109,9 +1109,11 @@ type ResizeHistoryEntry struct {
 
 	// Reason explains why the resize was reverted or failed.
 	// Only populated when Result is Reverted or Failed.
-	// Values include: oomkill, restart, notready, throttle,
-	// annotation-conflict, immediate-safety-check, slo:<name>,
-	// infeasible (kubelet Infeasible / InPlaceOnly skip).
+	// This is a free-form string, not a CRD enum. Values include:
+	// oomkill, restart, notready, throttle, annotation-conflict,
+	// immediate-safety-check, slo:<name>, infeasible (kubelet
+	// Infeasible with InPlaceOnly), eviction_last_replica,
+	// eviction_denied, eviction_list_failed, eviction_no_selector.
 	// +optional
 	Reason string `json:"reason,omitempty"`
 }

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -1601,9 +1601,11 @@ spec:
                       description: |-
                         Reason explains why the resize was reverted or failed.
                         Only populated when Result is Reverted or Failed.
-                        Values include: oomkill, restart, notready, throttle,
-                        annotation-conflict, immediate-safety-check, slo:<name>,
-                        infeasible (kubelet Infeasible / InPlaceOnly skip).
+                        This is a free-form string, not a CRD enum. Values include:
+                        oomkill, restart, notready, throttle, annotation-conflict,
+                        immediate-safety-check, slo:<name>, infeasible (kubelet
+                        Infeasible with InPlaceOnly), eviction_last_replica,
+                        eviction_denied, eviction_list_failed, eviction_no_selector.
                       type: string
                     resource:
                       description: |-

--- a/charts/attune/templates/grafana-fleet-dashboard.yaml
+++ b/charts/attune/templates/grafana-fleet-dashboard.yaml
@@ -1,4 +1,6 @@
-{{- /* Fleet multi-cluster dashboard. Source: deploy/grafana/fleet-dashboard.json */ -}}
+{{- /* Fleet multi-cluster dashboard. Source: deploy/grafana/fleet-dashboard.json.
+       Run hack/verify-dashboard-metrics.sh (or make verify-dashboard-metrics)
+       to confirm charts/attune/files/grafana-fleet-dashboard.json is in sync. */ -}}
 {{- if .Values.grafanaFleetDashboard.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -152,6 +152,9 @@ func run(args []string, buildClient dynamicClientFactory) int {
 	}
 	if !isKnownCommand(cmd) {
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", cmd)
+		if suggestion := suggestCommand(cmd); suggestion != "" {
+			fmt.Fprintf(os.Stderr, "Did you mean %q?\n", suggestion)
+		}
 		fs.Usage()
 		return 1
 	}
@@ -176,6 +179,10 @@ func run(args []string, buildClient dynamicClientFactory) int {
 	}
 	if *filter != "" && cmd != "status" {
 		fmt.Fprintf(os.Stderr, "Error: --filter is supported only with the status command\n")
+		return 1
+	}
+	if *sortBy != "" && !validSortBy(*sortBy) {
+		fmt.Fprintf(os.Stderr, "Error: --sort-by must be one of name, namespace, savings, age\n")
 		return 1
 	}
 	if *sortBy != "" && cmd != "status" && cmd != "savings" {
@@ -332,13 +339,95 @@ func buildDynamicClient(kubeconfigPath, contextOverride string) (dynamic.Interfa
 	return dynClient, currentNamespace, nil
 }
 
+var pluginCommands = []string{
+	"status", "savings", "recommendations", "explain", "history",
+	"preview", "version", "wizard", "diff", "export", "doctor",
+}
+
 func isKnownCommand(cmd string) bool {
-	switch cmd {
-	case "status", "savings", "recommendations", "explain", "history", "preview", "version", "wizard", "diff", "export", "doctor":
+	for _, c := range pluginCommands {
+		if cmd == c {
+			return true
+		}
+	}
+	return false
+}
+
+func validSortBy(v string) bool {
+	switch strings.ToLower(v) {
+	case "name", "namespace", "savings", "age":
 		return true
 	default:
 		return false
 	}
+}
+
+func suggestCommand(unknown string) string {
+	lower := strings.ToLower(unknown)
+	var prefixHits []string
+	best := ""
+	bestDist := len(lower) + 8
+	for _, k := range pluginCommands {
+		kl := strings.ToLower(k)
+		if strings.HasPrefix(kl, lower) && lower != kl {
+			prefixHits = append(prefixHits, k)
+		}
+		d := levenshtein(lower, kl)
+		if d < bestDist {
+			bestDist = d
+			best = k
+		}
+	}
+	if len(prefixHits) == 1 {
+		return prefixHits[0]
+	}
+	maxDist := 2
+	if len(lower) <= 4 {
+		maxDist = 1
+	}
+	if best != "" && bestDist <= maxDist {
+		return best
+	}
+	return ""
+}
+
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return len(b)
+	}
+	if b == "" {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			best := del
+			if ins < best {
+				best = ins
+			}
+			if sub < best {
+				best = sub
+			}
+			curr[j] = best
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
 }
 
 func isZeroArgCommand(cmd string) bool {
@@ -1967,7 +2056,7 @@ func filterPolicies(items []unstructured.Unstructured, filterFlag string) []unst
 }
 
 // sortPolicies sorts items in place by the given key. Supported: name,
-// namespace, savings, age. Empty or unrecognized values are no-ops (API order).
+// namespace, savings, age. Empty values are a no-op (API order).
 func sortPolicies(items []unstructured.Unstructured, sortByFlag string) {
 	switch strings.ToLower(sortByFlag) {
 	case "name":

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -1110,6 +1110,19 @@ func TestRun_SortByFlagRejectedForHistory(t *testing.T) {
 	assert.Equal(t, 1, code)
 }
 
+func TestRun_SortByUnknownValue(t *testing.T) {
+	exitCode, _, stderr := captureRun(t, []string{"status", "--sort-by", "bogus"},
+		failingDynamicClientFactory(fmt.Errorf("should not be called")))
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "name, namespace, savings, age")
+}
+
+func TestSuggestCommand(t *testing.T) {
+	assert.Equal(t, "recommendations", suggestCommand("recommend"))
+	assert.Equal(t, "history", suggestCommand("histroy"))
+	assert.Empty(t, suggestCommand("wat"))
+}
+
 // ---------- printStructured ----------
 
 func TestPrintStructured_JSON(t *testing.T) {
@@ -1905,6 +1918,20 @@ func TestRun_MainWiring(t *testing.T) {
 			factory:      failingDynamicClientFactory(fmt.Errorf("should not be called")),
 			wantExitCode: 1,
 			wantStderr:   "Unknown command: wat",
+		},
+		{
+			name:         "unknown command recommend suggests recommendations",
+			args:         []string{"recommend"},
+			factory:      failingDynamicClientFactory(fmt.Errorf("should not be called")),
+			wantExitCode: 1,
+			wantStderr:   `Did you mean "recommendations"`,
+		},
+		{
+			name:         "unknown sort-by value names allowed keys",
+			args:         []string{"status", "--sort-by", "bogus"},
+			factory:      failingDynamicClientFactory(fmt.Errorf("should not be called")),
+			wantExitCode: 1,
+			wantStderr:   "name, namespace, savings, age",
 		},
 		{
 			name:         "watch flag rejected for non-status command",

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -1601,9 +1601,11 @@ spec:
                       description: |-
                         Reason explains why the resize was reverted or failed.
                         Only populated when Result is Reverted or Failed.
-                        Values include: oomkill, restart, notready, throttle,
-                        annotation-conflict, immediate-safety-check, slo:<name>,
-                        infeasible (kubelet Infeasible / InPlaceOnly skip).
+                        This is a free-form string, not a CRD enum. Values include:
+                        oomkill, restart, notready, throttle, annotation-conflict,
+                        immediate-safety-check, slo:<name>, infeasible (kubelet
+                        Infeasible with InPlaceOnly), eviction_last_replica,
+                        eviction_denied, eviction_list_failed, eviction_no_selector.
                       type: string
                     resource:
                       description: |-

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -3388,9 +3388,11 @@ spec:
                       description: |-
                         Reason explains why the resize was reverted or failed.
                         Only populated when Result is Reverted or Failed.
-                        Values include: oomkill, restart, notready, throttle,
-                        annotation-conflict, immediate-safety-check, slo:<name>,
-                        infeasible (kubelet Infeasible / InPlaceOnly skip).
+                        This is a free-form string, not a CRD enum. Values include:
+                        oomkill, restart, notready, throttle, annotation-conflict,
+                        immediate-safety-check, slo:<name>, infeasible (kubelet
+                        Infeasible with InPlaceOnly), eviction_last_replica,
+                        eviction_denied, eviction_list_failed, eviction_no_selector.
                       type: string
                     resource:
                       description: |-

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3387,9 +3387,11 @@ spec:
                       description: |-
                         Reason explains why the resize was reverted or failed.
                         Only populated when Result is Reverted or Failed.
-                        Values include: oomkill, restart, notready, throttle,
-                        annotation-conflict, immediate-safety-check, slo:<name>,
-                        infeasible (kubelet Infeasible / InPlaceOnly skip).
+                        This is a free-form string, not a CRD enum. Values include:
+                        oomkill, restart, notready, throttle, annotation-conflict,
+                        immediate-safety-check, slo:<name>, infeasible (kubelet
+                        Infeasible with InPlaceOnly), eviction_last_replica,
+                        eviction_denied, eviction_list_failed, eviction_no_selector.
                       type: string
                     resource:
                       description: |-

--- a/docs/architecture/resize-api.md
+++ b/docs/architecture/resize-api.md
@@ -210,9 +210,10 @@ stateDiagram-v2
   (`EvictV1`), which enforces PodDisruptionBudgets. If the PDB would be
   violated, the eviction is denied and the pod stays as-is.
 
-- **Last replica protection.** The operator never evicts the last running
-  replica of a workload, even if the PDB would allow it. This prevents
-  complete service outage during resize.
+- **Last replica protection.** The operator never evicts the last live
+  Running replica of a workload, even if the PDB would allow it. The
+  count comes from a live Clientset list (`status.phase=Running` and no
+  deletion timestamp). `spec.replicas` and NotReady pods do not count.
 
 - **Eviction fallback restarts the pod from the current template.** When a pod
   is evicted, the workload controller (Deployment, StatefulSet) creates a
@@ -234,7 +235,7 @@ stateDiagram-v2
   set to `RestartContainer`. If your pod uses `NotRequired` (the default) or
   has no resize policy, the operator will clamp the memory limit to the
   current value and only decrease the memory request. To allow memory limit
-  decreases without a restart, upgrade to Kubernetes 1.34+ where this
+  decreases without a restart, upgrade to Kubernetes 1.35+ where this
   restriction was relaxed.
 - **Memory request decreases**: The kernel only reclaims memory when the
   working set drops below the new limit. If the application holds onto

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -264,6 +264,31 @@ If the node lookup fails (for example node not found), request increases are
 skipped (fail-closed). Decreases still proceed. See
 [Node capacity](node-capacity.md).
 
+## Last-replica eviction
+
+When `resizeMethod` is `InPlaceOrRecreate` and in-place resize cannot
+proceed, the operator may evict the pod. Before calling the Eviction API
+it lists matching pods through the typed Clientset (live API, not the
+informer cache) and counts only pods with `status.phase=Running` and no
+`deletionTimestamp`.
+
+`spec.replicas` and NotReady or Pending pods do not count. A Deployment
+with `replicas: 3` and only one Running pod is treated as a last replica.
+History reason is `eviction_last_replica` and the operator emits
+`EvictionBlocked`. A missing selector or a list failure emits the same
+event with reason `eviction_no_selector` or `eviction_list_failed`. A
+PodDisruptionBudget denial uses `EvictionDenied` / `eviction_denied`.
+
+## Memory usage floor
+
+When decreasing a memory limit, the controller compares the target against
+the live container limit on the pod, not the workload template. The
+template (and `rec.Current` in status) can lag after an in-place resize.
+The target is then raised if it would fall at or below recent usage
+(recommendation raw percentile) times
+`(1 + decreaseUsageMarginPercent/100)`. See
+[resize API](resize-api.md).
+
 ## Container exclusion
 
 Well-known mesh and sidecar names (for example `istio-proxy`,

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -460,7 +460,7 @@ attune_pods_deferred{namespace="...", policy="..."}
 attune_pods_infeasible{namespace="...", policy="..."}
 histogram_quantile(0.95, sum by (le) (rate(attune_deferred_age_seconds_bucket[15m])))
 rate(attune_infeasible_skipped_total[15m])
-rate(attune_eviction_total[15m])
+sum by (result) (rate(attune_eviction_total[15m]))
 ```
 
 **Fix**:

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -451,7 +451,7 @@ kubectl attune history -n <ns>
 | Signal | Meaning | Operator behavior |
 |--------|---------|-------------------|
 | **Deferred** | Kubelet accepted the request but cannot apply it yet (often free request capacity on the node). Pod condition `PodResizePending` reason `Deferred`. | Pod is **not eligible** for a new resize until the condition clears. **Retry**: every reconcile after eligibility returns (no extra config). |
-| **Infeasible** | Kubelet cannot complete the resize in-place on this node. | With default `resizeMethod: InPlaceOnly`, skip + history `Failed`/`infeasible` + event `InfeasibleBlocked`. With `InPlaceOrRecreate`, attempt eviction fallback (subject to PDB / last-replica guards). |
+| **Infeasible** | Kubelet cannot complete the resize in-place on this node. | With default `resizeMethod: InPlaceOnly`, skip + history `Failed`/`infeasible` + event `InfeasibleBlocked`. With `InPlaceOrRecreate`, attempt eviction fallback (PDB / last live Running replica). |
 
 **Metrics** (see [metrics reference](../reference/metrics.md)):
 
@@ -486,7 +486,15 @@ kubectl get pod <pod> -o jsonpath='{range .status.conditions[?(@.type=="PodResiz
 
 - **Deferred**: skip until kubelet clears `PodResizePending`; next reconcile retries. No max deferred age cut-off (watch `attune_deferred_age_seconds` and `ResizeBlocked` message for escalation).
 - **Infeasible + InPlaceOnly**: skip every cycle until the condition clears or you change `resizeMethod` / capacity.
-- **Infeasible + InPlaceOrRecreate**: one eviction attempt per container resize path; if eviction is denied (PDB, last replica), history records `Failed`/`infeasible` and the next cycle may try again.
+- **Infeasible + InPlaceOrRecreate**: one eviction attempt per container resize path. History reason is `eviction_last_replica` when only one live Running replica remains, `eviction_denied` when the Eviction API rejects (PDB), or `eviction_list_failed` / `eviction_no_selector` when the live count cannot be taken. The next cycle may try again.
+
+### InPlaceOrRecreate but no eviction
+
+**Symptom**: `resizeMethod` is `InPlaceOrRecreate`, the pod is Infeasible, but it is not evicted. History shows `Failed` / `eviction_last_replica`. Event `EvictionBlocked`.
+
+**Cause**: Only one live Running replica. The last-replica guard lists pods through the typed Clientset and counts `status.phase=Running` with no deletion timestamp. `spec.replicas` and NotReady or Pending pods do not count.
+
+**Fix**: Scale until at least two pods are Running, or wait for another replica to become Running.
 
 ### QoS class change blocked
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -8,6 +8,53 @@ Maintainers: before publishing a release after multi-version product changes,
 run the full E2E Nightly matrix on tip of `main` (see
 [Releasing: full E2E matrix](../contributing/releasing.md#1b-full-e2e-matrix-required-before-tagging-a-product-release)).
 
+## v0.1.26 to v0.1.27
+
+v0.1.27 tightens last-replica eviction, limit-only resizes, the memory
+usage floor, and kubectl `--sort-by` validation. Existing policy YAML
+keeps working. Read this section if you use `InPlaceOrRecreate`,
+`controlledValues: RequestsAndLimits`, memory limit decreases, eviction
+metrics, or `kubectl attune --sort-by`.
+
+### RequestsAndLimits can apply a limit-only resize
+
+When requests already match the recommendation, `RequestsAndLimits` may
+still apply a resize that only changes limits (for example a missing or
+drifted memory limit). Previously a request match could skip the whole
+container. Check resize history if you see limit-only updates.
+
+### Memory usage floor uses the live container limit
+
+The usage floor compares the target against the live container limit on
+the pod, not the workload template. After an in-place resize the template
+(and `rec.Current`) can lag. Alerts that assume the template limit is
+authoritative should use the live pod instead.
+
+### Last-replica eviction uses a live Running count
+
+Eviction fallback lists pods through the typed Clientset and counts only
+`status.phase=Running` with no deletion timestamp. `spec.replicas` and
+NotReady or Pending pods do not count. The list is paginated and stops
+once two Running pods are visible. Concurrent resizes on the same
+workload serialize that list-plus-evict so two replicas cannot both be
+evicted in one pass. History reasons are `eviction_last_replica`,
+`eviction_denied`, `eviction_list_failed`, and `eviction_no_selector`.
+A failed eviction attempt is not retried for remaining containers on the
+same pod in that cycle.
+
+### kubectl attune --sort-by rejects unknown values
+
+`kubectl attune status` and `kubectl attune savings` now exit 1 when
+`--sort-by` is not `name`, `namespace`, `savings`, or `age`. Scripts that
+passed a typo and got unsorted output now fail closed.
+
+### attune_eviction_total result labels
+
+`attune_eviction_total` now increments for skipped attempts as well as
+successes. The `result` label is `success`, `denied`, `last_replica`,
+`list_failed`, or `no_selector`. Alerts that treated every increment as
+an eviction should filter `result="success"`.
+
 ## v0.1.25 to v0.1.26
 
 v0.1.26 tightens stale-recommendation handling, CloudWatch collection,

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -189,7 +189,7 @@ spec:
 | `resizeHistory[].to` | `string` | New value |
 | `resizeHistory[].method` | `string` | `InPlace`, `Eviction`, or `TemplatePersistence` |
 | `resizeHistory[].result` | `string` | `Success`, `Failed`, `Reverted`, `Evicted`, or `TemplatePatched` |
-| `resizeHistory[].reason` | `string` | Why a resize was reverted or failed (e.g. `oomkill`, `restart`, `notready`, `slo:<name>`, `infeasible`). Empty for successful resizes. |
+| `resizeHistory[].reason` | `string` | Free-form string (not an enum) for why a resize was reverted or failed (e.g. `oomkill`, `restart`, `notready`, `slo:<name>`, `infeasible`, `eviction_last_replica`, `eviction_denied`, `eviction_list_failed`, `eviction_no_selector`). Empty for successful resizes. |
 | `workloadErrors[].workload` | `string` | Workload name that encountered an error during reconciliation |
 | `workloadErrors[].error` | `string` | Human-readable error description |
 | `canary.phase` | `string` | `CanaryInProgress` or `FullRollout`. FullRollout only when every listed app is promoted |
@@ -244,7 +244,9 @@ View them with `kubectl describe attunepolicy <name>` or
 | `ScheduleSkipped` | Normal | Resize was skipped because the current time is outside the configured schedule window |
 | `ResizeFailed` | Warning | An in-place resize API call failed |
 | `BudgetExhausted` | Warning | The per-reconcile resize budget was exhausted before all workloads could be resized |
-| `InfeasibleBlocked` | Warning | A resize was blocked because it would exceed node capacity |
+| `InfeasibleBlocked` | Warning | In-place resize skipped because the kubelet marked the pod Infeasible and `resizeMethod` is `InPlaceOnly` |
+| `EvictionBlocked` | Warning | Eviction fallback skipped (last live Running replica, missing selector, or pod list failure). `spec.replicas` and NotReady pods are not counted |
+| `EvictionDenied` | Warning | Eviction API denied the request (typically a PodDisruptionBudget) |
 | `ResizeSkipped` | Warning | A resize was skipped (e.g. pod in bad state, rolling out) |
 | `Reverted` | Warning | A resize was reverted due to safety observation failure (OOMKill, CPU throttle, restarts, or SLO guardrail breach) |
 | `Evicted` | Warning | A pod was evicted as a fallback when in-place resize was not possible |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,7 +89,7 @@ kubectl attune preview -n production api-services
 | WORKLOAD | Target workload name |
 | CONTAINER | Container name |
 | RESOURCE | `CPU` or `Memory` |
-| CURRENT | Current resource request |
+| CURRENT | Recommendation snapshot of the current request (workload template or last recorded current). This is not necessarily the live container after an in-place resize. |
 | RECOMMENDED | Recommended resource request |
 | CHANGE | Delta description |
 
@@ -220,7 +220,7 @@ kubectl attune history -n production
 | TO | New resource value |
 | METHOD | `InPlace` or `Eviction` |
 | RESULT | `Success`, `Failed`, `Reverted`, or `Evicted` |
-| REASON | Why a resize was reverted or failed (`oomkill`, `restart`, `notready`, `throttle`, `slo:<name>`). Shows `-` for successful resizes. |
+| REASON | Why a resize was reverted or failed (`oomkill`, `restart`, `notready`, `throttle`, `slo:<name>`, `infeasible`, `eviction_last_replica`, `eviction_denied`, `eviction_list_failed`, `eviction_no_selector`). Shows `-` for successful resizes. |
 
 ### wizard
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -112,7 +112,7 @@ to pod eviction after an in-place resize fails or is marked Infeasible.
 |-------|-------------|
 | `namespace` | Workload namespace |
 | `workload` | Workload name |
-| `result` | `success` or `denied` |
+| `result` | `success`, `denied`, `last_replica`, `list_failed`, or `no_selector` |
 
 ### attune_throttle_deferred_total
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -72,7 +72,7 @@ Total number of reconciliation errors by type.
 
 | Label | Description |
 |-------|-------------|
-| `error_type` | `fetch`, `fetch_defaults`, `prometheus_config`, `collector_options`, `collector_create`, `discover_workloads`, `list_policies`, `get_pods`, `compute_recommendations`, `status_update`, or `safety_observation` |
+| `error_type` | `fetch`, `fetch_defaults`, `metrics_source`, `discover_workloads`, `list_policies`, `get_pods`, `compute_recommendations`, `status_update`, or `safety_observation` |
 
 ### attune_webhook_validation_total
 
@@ -80,7 +80,7 @@ Total number of webhook admission decisions.
 
 | Label | Description |
 |-------|-------------|
-| `operation` | `validate_create`, `validate_update`, `defaulting`, `defaults_validate_create`, `defaults_validate_update`, `namespace_defaults_validate_create`, or `namespace_defaults_validate_update` |
+| `operation` | `validate_create`, `validate_update`, `defaulting`, `defaults_validate_create`, `defaults_validate_update`, `namespace_defaults_validate_create`, `namespace_defaults_validate_update`, or `pod-initial-sizing` |
 | `result` | `allowed` or `rejected` |
 
 ### attune_schedule_skipped_total
@@ -453,7 +453,7 @@ Duration of webhook validation and defaulting operations.
 
 | Label | Description |
 |-------|-------------|
-| `operation` | `validate_create`, `validate_update`, `defaulting`, `defaults_validate_create`, `defaults_validate_update`, `namespace_defaults_validate_create`, or `namespace_defaults_validate_update` |
+| `operation` | `validate_create`, `validate_update`, `defaulting`, `defaults_validate_create`, `defaults_validate_update`, `namespace_defaults_validate_create`, `namespace_defaults_validate_update`, or `pod-initial-sizing` |
 
 ## Controller-runtime Workqueue Metrics
 

--- a/hack/verify-dashboard-metrics.sh
+++ b/hack/verify-dashboard-metrics.sh
@@ -2,30 +2,39 @@
 # Copyright 2026 attune-io
 # SPDX-License-Identifier: Apache-2.0
 #
-# The standalone dashboard JSON is the source of truth. The Helm chart uses a
-# generated derivative with datasource-specific fields removed so Grafana
+# Standalone Grafana JSON is the source of truth. The Helm chart uses
+# generated derivatives with datasource-specific fields removed so Grafana
 # sidecar provisioning can consume the same dashboard structure.
+#
+# Pairs:
+#   deploy/grafana/dashboard.json       -> charts/attune/files/grafana-dashboard.json
+#   deploy/grafana/fleet-dashboard.json -> charts/attune/files/grafana-fleet-dashboard.json
 set -euo pipefail
 
 MODE="${1:-check}"
-STANDALONE="deploy/grafana/dashboard.json"
-HELM_TEMPLATE="charts/attune/templates/grafana-dashboard.yaml"
-HELM_DASHBOARD="charts/attune/files/grafana-dashboard.json"
-EXPECTED="$(mktemp)"
-trap 'rm -f "$EXPECTED"' EXIT
 
 if [[ "$MODE" != "check" && "$MODE" != "--write" ]]; then
   echo "Usage: bash hack/verify-dashboard-metrics.sh [--write]" >&2
   exit 2
 fi
 
-python3 - "$STANDALONE" "$EXPECTED" <<'PY'
+EXPECTED_DIR="$(mktemp -d)"
+trap 'rm -rf "$EXPECTED_DIR"' EXIT
+
+# Transform standalone JSON into the Helm sidecar form (strip __inputs and
+# datasource, pin the dashboard uid) and write the result to $3.
+transform_dashboard() {
+  local standalone="$1"
+  local uid="$2"
+  local target="$3"
+  python3 - "$standalone" "$uid" "$target" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 source = Path(sys.argv[1])
-target = Path(sys.argv[2])
+uid = sys.argv[2]
+target = Path(sys.argv[3])
 dashboard = json.loads(source.read_text())
 
 
@@ -43,29 +52,42 @@ def transform(value):
 
 
 dashboard = transform(dashboard)
-dashboard["uid"] = "attune"
+dashboard["uid"] = uid
 target.write_text(json.dumps(dashboard, indent=2) + "\n")
 PY
+}
 
-if ! grep -Fq '.Files.Get "files/grafana-dashboard.json"' "$HELM_TEMPLATE"; then
-  echo "ERROR: $HELM_TEMPLATE must load files/grafana-dashboard.json as the chart dashboard source." >&2
-  exit 1
-fi
+# Verify one standalone -> Helm pair. On --write, refresh the Helm file.
+verify_dashboard() {
+  local standalone="$1"
+  local helm_template="$2"
+  local helm_dashboard="$3"
+  local uid="$4"
+  local files_get="$5"
+  local expected="${EXPECTED_DIR}/${uid}.json"
 
-if [[ "$MODE" == "--write" ]]; then
-  cp "$EXPECTED" "$HELM_DASHBOARD"
-  echo "Wrote $HELM_DASHBOARD from $STANDALONE."
-  exit 0
-fi
+  transform_dashboard "$standalone" "$uid" "$expected"
 
-if ! diff -u "$HELM_DASHBOARD" "$EXPECTED"; then
-  echo ""
-  echo "ERROR: Helm dashboard JSON is stale." >&2
-  echo "Refresh it with: bash hack/verify-dashboard-metrics.sh --write" >&2
-  exit 1
-fi
+  if ! grep -Fq ".Files.Get \"${files_get}\"" "$helm_template"; then
+    echo "ERROR: $helm_template must load ${files_get} as the chart dashboard source." >&2
+    exit 1
+  fi
 
-panel_count=$(python3 - "$STANDALONE" <<'PY'
+  if [[ "$MODE" == "--write" ]]; then
+    cp "$expected" "$helm_dashboard"
+    echo "Wrote $helm_dashboard from $standalone."
+    return 0
+  fi
+
+  if ! diff -u "$helm_dashboard" "$expected"; then
+    echo ""
+    echo "ERROR: Helm dashboard JSON is stale: $helm_dashboard" >&2
+    echo "Refresh it with: bash hack/verify-dashboard-metrics.sh --write" >&2
+    exit 1
+  fi
+
+  local panel_count
+  panel_count=$(python3 - "$standalone" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -75,29 +97,59 @@ print(len(dashboard.get("panels", [])))
 PY
 )
 
-echo "OK: Helm dashboard JSON matches $STANDALONE ($panel_count panels)."
+  echo "OK: Helm dashboard JSON matches $standalone ($panel_count panels)."
+}
 
-# Verify that all attune_* metric names in the dashboard exist in the
+# Verify that all attune_* metric names in a dashboard exist in the
 # operator's metrics registry. This catches typos and stale metric names
 # that would cause Grafana panels to show "No data".
-METRICS_SRC="internal/operatormetrics/metrics.go"
-metrics_in_dashboard=$(grep -oE 'attune_[a-z_]+' "$STANDALONE" | sort -u)
-metrics_in_source=$(grep -oE '"attune_[a-z_]+"' "$METRICS_SRC" | tr -d '"' | sort -u)
+check_metrics() {
+  local standalone="$1"
+  local metrics_src="$2"
+  local metrics_in_dashboard
+  local metrics_in_source
+  local rc=0
+  local m base
 
-rc=0
-for m in $metrics_in_dashboard; do
-  # Strip histogram suffixes (_count, _sum, _bucket) and _total for
-  # counter base-name matching.
-  base="${m%_count}"
-  base="${base%_sum}"
-  base="${base%_bucket}"
-  if ! echo "$metrics_in_source" | grep -qF "$base"; then
-    echo "ERROR: metric '$m' (base '$base') in $STANDALONE not found in $METRICS_SRC" >&2
-    rc=1
+  metrics_in_dashboard=$(grep -oE 'attune_[a-z_]+' "$standalone" | sort -u)
+  metrics_in_source=$(grep -oE '"attune_[a-z_]+"' "$metrics_src" | tr -d '"' | sort -u)
+
+  for m in $metrics_in_dashboard; do
+    # Strip histogram suffixes (_count, _sum, _bucket) for base-name matching.
+    base="${m%_count}"
+    base="${base%_sum}"
+    base="${base%_bucket}"
+    if ! echo "$metrics_in_source" | grep -qF "$base"; then
+      echo "ERROR: metric '$m' (base '$base') in $standalone not found in $metrics_src" >&2
+      rc=1
+    fi
+  done
+
+  if [[ $rc -ne 0 ]]; then
+    exit 1
   fi
-done
+  echo "OK: all metrics in $standalone match registered operator metrics."
+}
 
-if [[ $rc -ne 0 ]]; then
-  exit 1
+verify_dashboard \
+  "deploy/grafana/dashboard.json" \
+  "charts/attune/templates/grafana-dashboard.yaml" \
+  "charts/attune/files/grafana-dashboard.json" \
+  "attune" \
+  "files/grafana-dashboard.json"
+
+verify_dashboard \
+  "deploy/grafana/fleet-dashboard.json" \
+  "charts/attune/templates/grafana-fleet-dashboard.yaml" \
+  "charts/attune/files/grafana-fleet-dashboard.json" \
+  "attune-fleet" \
+  "files/grafana-fleet-dashboard.json"
+
+if [[ "$MODE" == "--write" ]]; then
+  exit 0
 fi
+
+METRICS_SRC="internal/operatormetrics/metrics.go"
+check_metrics "deploy/grafana/dashboard.json" "$METRICS_SRC"
+check_metrics "deploy/grafana/fleet-dashboard.json" "$METRICS_SRC"
 echo "OK: all dashboard metrics match registered operator metrics."

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -213,6 +213,11 @@ type AttunePolicyReconciler struct {
 	// Always initialized by NewAttunePolicyReconciler.
 	eventDedup *eventDedup
 
+	// evictionLocks serializes last-replica List+Evict per workload so two
+	// concurrent resize goroutines cannot both observe running==2 and evict.
+	// Key is namespace+"/"+workloadName. Zero value is an empty sync.Map.
+	evictionLocks sync.Map // map[string]*sync.Mutex
+
 	// nodeNeighborFlight single-flights the live node pod List used for
 	// neighbor request budget. Per-cycle results live in resizePreChecks.
 	nodeNeighborFlight singleflight.Group

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -4722,6 +4722,127 @@ func TestCheckPendingSafetyObservations_EarlyCriticalHealthySkipped(t *testing.T
 	}
 }
 
+func TestCheckPendingSafetyObservations_EarlyNotReadyDoesNotRevert(t *testing.T) {
+	// Ready=False during the observation window is not a critical status.
+	// Early path uses CheckCriticalStatuses only; full CheckPodObject would revert.
+	resizedAt := time.Now().UTC().Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "notready-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "nginx",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", Ready: false, RestartCount: 0},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+
+	reconciler, _ := newSafetyTestReconciler(pod)
+
+	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+	assert.True(t, pending, "should report pending (observation period not elapsed)")
+
+	for _, a := range reconciler.Clientset.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			t.Fatal("Ready=False during observation period should NOT trigger a revert")
+		}
+	}
+}
+
+func TestCheckPendingSafetyObservations_EarlyCriticalConfirmGet500DoesNotRevert(t *testing.T) {
+	resizedAt := time.Now().UTC().Add(-10 * time.Second).Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oom-confirm-500",
+			Namespace: "default",
+			Labels:    map[string]string{"attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:     "OOMKilled",
+							FinishedAt: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+
+	reconciler, _ := newSafetyTestReconciler(pod)
+	cs := reconciler.Clientset.(*kubefake.Clientset)
+	cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(fmt.Errorf("injected confirm Get 500"))
+	})
+
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			t.Fatal("early OOM confirm Get 500 must not revert")
+		}
+	}
+}
+
 // ---------- isCooldownActive parse error ----------
 
 func TestIsCooldownActive_MalformedDate(t *testing.T) {
@@ -6656,6 +6777,127 @@ func TestCheckPendingSafetyObservations_NotReadyFlapConfirmedBeforeRevert(t *tes
 	for _, a := range clientset.Actions() {
 		assert.False(t, a.GetVerb() == "update" && a.GetSubresource() == "resize",
 			"flapping notready must not revert after live confirm")
+	}
+}
+
+func TestCheckPendingSafetyObservations_ConfirmGet500DoesNotRevert(t *testing.T) {
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "confirm-500-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
+	}
+
+	policy := newTestPolicy("test-policy", "default")
+	reconciler, _ := newSafetyTestReconciler(pod)
+	cs := reconciler.Clientset.(*kubefake.Clientset)
+	cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(fmt.Errorf("injected confirm Get 500"))
+	})
+
+	before := promtestutil.ToFloat64(operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation"))
+	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+	after := promtestutil.ToFloat64(operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation"))
+
+	assert.True(t, pending, "confirm Get 500 should keep observation pending")
+	assert.Equal(t, before+1, after, "safety_observation should increment on confirm Get error")
+
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			t.Fatal("confirm Get 500 must not revert")
+		}
+	}
+}
+
+func TestCheckPendingSafetyObservations_ConfirmGetNotFoundDoesNotRevert(t *testing.T) {
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "confirm-404-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
+	}
+
+	policy := newTestPolicy("test-policy", "default")
+	reconciler, _ := newSafetyTestReconciler(pod)
+	cs := reconciler.Clientset.(*kubefake.Clientset)
+	cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ga, ok := action.(k8stesting.GetAction)
+		if !ok {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewNotFound(corev1.Resource("pods"), ga.GetName())
+	})
+
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			t.Fatal("confirm Get 404 must not revert")
+		}
 	}
 }
 
@@ -9163,6 +9405,81 @@ func TestResizeContainer_InfeasibleLiveRecheckAfterStaleCache(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, evictions)
+}
+
+func TestResizeContainer_StaleInfeasibleClearedOnLiveGet(t *testing.T) {
+	// Listed/informer pod is still Infeasible; live Get has cleared it.
+	// Inverse of InfeasibleLiveRecheckAfterStaleCache: stay in-place.
+	listed := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	listed.Name = "api-server-abc-1"
+	listed.Status.Conditions = append(listed.Status.Conditions, corev1.PodCondition{
+		Type:   "PodResizePending",
+		Status: corev1.ConditionTrue,
+		Reason: "Infeasible",
+	})
+	live := listed.DeepCopy()
+	live.Status.Conditions = nil
+	peer := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	peer.Name = "api-server-abc-2"
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(deploy, listed, peer).Build()
+	clientset := kubefake.NewSimpleClientset(live, peer.DeepCopy())
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
+
+	resizer := resize.NewPodResizer(clientset, ctrl.Log)
+	containerRec := attunev1alpha1.ContainerRecommendation{
+		Name: "main",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("200m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("100m"),
+			MemoryRequest: resource.MustParse("128Mi"),
+		},
+	}
+	target, _ := buildResizeTarget(containerRec)
+
+	entries, outcome := r.resizeContainer(context.Background(), resizeParams{
+		Policy:       policy,
+		Pod:          listed,
+		Workload:     deploy,
+		WorkloadName: "api-server",
+		ContainerRec: containerRec,
+		Target:       target,
+		Resizer:      resizer,
+		Monitor:      nil,
+		Now:          metav1.Now(),
+	})
+	assert.Equal(t, resizeOutcomeInPlace, outcome, "cleared live Infeasible must stay in-place")
+	require.NotEmpty(t, entries)
+	assert.NotEqual(t, resizeOutcomeEvicted, outcome)
+	for _, e := range entries {
+		assert.NotEqual(t, "Eviction", e.Method)
+		assert.NotEqual(t, attunev1alpha1.ResizeResultEvicted, e.Result)
+	}
+
+	var evictions, resizes int
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "create" && a.GetResource().Resource == "pods" && a.GetSubresource() == "eviction" {
+			evictions++
+		}
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			resizes++
+		}
+	}
+	assert.Equal(t, 0, evictions, "cleared live Infeasible must not evict")
+	assert.Greater(t, resizes, 0, "cleared live Infeasible must attempt in-place resize")
 }
 
 func TestResizeContainer_InfeasiblePodSkippedWithInPlaceOnly(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -9266,10 +9266,13 @@ func TestTryEvictionFallback_SkipsLastReplica(t *testing.T) {
 	r.Recorder = recorder
 	resizer := resize.NewPodResizer(clientset, ctrl.Log)
 
+	evictionBefore := promtestutil.ToFloat64(operatormetrics.EvictionTotal.WithLabelValues("default", "api-server", "last_replica"))
+
 	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
 		"api-server", "app", resizer)
 	assert.False(t, evicted, "should NOT evict the last replica")
 	assert.Equal(t, reasonEvictionLastReplica, reason)
+	assert.Equal(t, evictionBefore+1, promtestutil.ToFloat64(operatormetrics.EvictionTotal.WithLabelValues("default", "api-server", "last_replica")))
 
 	select {
 	case event := <-recorder.Events:
@@ -10644,10 +10647,13 @@ func TestTryEvictionFallback_ListErrorSkipsEviction(t *testing.T) {
 	r.Recorder = recorder
 	resizer := resize.NewPodResizer(clientset, ctrl.Log)
 
+	evictionBefore := promtestutil.ToFloat64(operatormetrics.EvictionTotal.WithLabelValues("default", "api-server", "list_failed"))
+
 	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
 		"api-server", "app", resizer)
 	assert.False(t, evicted, "should skip eviction when pod list fails")
 	assert.Equal(t, reasonEvictionListFailed, reason)
+	assert.Equal(t, evictionBefore+1, promtestutil.ToFloat64(operatormetrics.EvictionTotal.WithLabelValues("default", "api-server", "list_failed")))
 	select {
 	case event := <-recorder.Events:
 		assert.Contains(t, event, "EvictionBlocked")
@@ -10693,10 +10699,13 @@ func TestTryEvictionFallback_NilSelectorSkipsEviction(t *testing.T) {
 	r.Recorder = recorder
 	resizer := resize.NewPodResizer(clientset, ctrl.Log)
 
+	evictionBefore := promtestutil.ToFloat64(operatormetrics.EvictionTotal.WithLabelValues("default", "api-server", "no_selector"))
+
 	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
 		"api-server", "main", resizer)
 	assert.False(t, evicted, "should skip eviction when workload has nil selector")
 	assert.Equal(t, reasonEvictionNoSelector, reason)
+	assert.Equal(t, evictionBefore+1, promtestutil.ToFloat64(operatormetrics.EvictionTotal.WithLabelValues("default", "api-server", "no_selector")))
 	select {
 	case event := <-recorder.Events:
 		assert.Contains(t, event, "EvictionBlocked")

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -9230,9 +9230,10 @@ func TestTryEvictionFallback_EvictsWhenMultipleReplicas(t *testing.T) {
 	evictionBefore := promtestutil.ToFloat64(operatormetrics.EvictionTotal.WithLabelValues("default", "api-server", "success"))
 	resizeBefore := promtestutil.ToFloat64(operatormetrics.ResizeTotal.WithLabelValues("default", "api-server", "eviction", "success"))
 
-	evicted := r.tryEvictionFallback(context.Background(), policy, pod1, deploy,
+	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod1, deploy,
 		"api-server", "app", resizer)
 	assert.True(t, evicted, "should evict when multiple replicas exist")
+	assert.Empty(t, reason, "successful eviction has no failure reason")
 
 	// Verify eviction was called.
 	var evictions int
@@ -9257,15 +9258,28 @@ func TestTryEvictionFallback_SkipsLastReplica(t *testing.T) {
 	scheme := testScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
 		WithObjects(policy, deploy, pod).Build()
+	recorder := events.NewFakeRecorder(10)
 	r := NewAttunePolicyReconciler()
 	r.Client = fakeClient
 	r.Scheme = scheme
 	r.Clientset = clientset
+	r.Recorder = recorder
 	resizer := resize.NewPodResizer(clientset, ctrl.Log)
 
-	evicted := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
+	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
 		"api-server", "app", resizer)
 	assert.False(t, evicted, "should NOT evict the last replica")
+	assert.Equal(t, reasonEvictionLastReplica, reason)
+
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "EvictionBlocked")
+		assert.Contains(t, event, "1 live Running replica")
+		assert.Contains(t, event, "spec.replicas")
+		assert.Contains(t, event, "NotReady")
+	default:
+		t.Error("expected EvictionBlocked event but none was emitted")
+	}
 }
 
 func TestResizeContainer_InfeasiblePodEvictedDirectly(t *testing.T) {
@@ -9555,6 +9569,75 @@ func TestResizeContainer_InfeasiblePodSkippedWithInPlaceOnly(t *testing.T) {
 		}
 		if a.GetVerb() == "create" && a.GetSubresource() == "eviction" {
 			t.Error("should NOT have attempted eviction with InPlaceOnly")
+		}
+	}
+}
+
+func TestResizeContainer_InfeasibleLastReplicaRecordsReason(t *testing.T) {
+	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod.Name = "api-server-abc-1"
+	pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+		Type:   "PodResizePending",
+		Status: corev1.ConditionTrue,
+		Reason: "Infeasible",
+	})
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(deploy, pod).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	recorder := events.NewFakeRecorder(10)
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+	r.Recorder = recorder
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
+
+	resizer := resize.NewPodResizer(clientset, ctrl.Log)
+	containerRec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("200m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("500m"),
+			MemoryRequest: resource.MustParse("512Mi"),
+		},
+	}
+
+	entries, outcome := r.resizeContainer(context.Background(), resizeParams{
+		Policy:       policy,
+		Pod:          pod,
+		Workload:     deploy,
+		WorkloadName: "api-server",
+		ContainerRec: containerRec,
+		Resizer:      resizer,
+		Monitor:      nil,
+		Now:          metav1.Now(),
+	})
+	assert.Equal(t, resizeOutcomeNone, outcome, "last live Running replica must not be evicted")
+	require.Len(t, entries, 1, "should record a Failed history entry")
+	assert.Equal(t, attunev1alpha1.ResizeResultFailed, entries[0].Result)
+	assert.Equal(t, reasonEvictionLastReplica, entries[0].Reason)
+	assert.NotEqual(t, "infeasible", entries[0].Reason)
+
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "EvictionBlocked")
+		assert.Contains(t, event, "live Running")
+	default:
+		t.Error("expected EvictionBlocked event but none was emitted")
+	}
+
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "create" && a.GetSubresource() == "eviction" {
+			t.Error("should NOT have attempted eviction of the last live Running replica")
 		}
 	}
 }
@@ -10504,9 +10587,10 @@ func TestTryEvictionFallback_EvictionDeniedByPDB(t *testing.T) {
 	r.Clientset = clientset
 	resizer := resize.NewPodResizer(clientset, ctrl.Log)
 
-	evicted := r.tryEvictionFallback(context.Background(), policy, pod1, deploy,
+	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod1, deploy,
 		"api-server", "app", resizer)
 	assert.False(t, evicted, "should return false when eviction is denied by PDB")
+	assert.Equal(t, reasonEvictionDenied, reason)
 }
 
 func TestTryEvictionFallback_StaleCacheDoesNotEvictLastLiveReplica(t *testing.T) {
@@ -10527,9 +10611,10 @@ func TestTryEvictionFallback_StaleCacheDoesNotEvictLastLiveReplica(t *testing.T)
 	r.Clientset = clientset
 	resizer := resize.NewPodResizer(clientset, ctrl.Log)
 
-	evicted := r.tryEvictionFallback(context.Background(), policy, pod1, deploy,
+	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod1, deploy,
 		"api-server", "app", resizer)
 	assert.False(t, evicted, "must not evict when live Clientset has only one running replica")
+	assert.Equal(t, reasonEvictionLastReplica, reason)
 
 	for _, a := range clientset.Actions() {
 		if a.GetVerb() == "create" && a.GetResource().Resource == "pods" && a.GetSubresource() == "eviction" {
@@ -10551,15 +10636,25 @@ func TestTryEvictionFallback_ListErrorSkipsEviction(t *testing.T) {
 	scheme := testScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
 		WithObjects(policy, deploy, pod).Build()
+	recorder := events.NewFakeRecorder(10)
 	r := NewAttunePolicyReconciler()
 	r.Client = fakeClient
 	r.Scheme = scheme
 	r.Clientset = clientset
+	r.Recorder = recorder
 	resizer := resize.NewPodResizer(clientset, ctrl.Log)
 
-	evicted := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
+	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
 		"api-server", "app", resizer)
 	assert.False(t, evicted, "should skip eviction when pod list fails")
+	assert.Equal(t, reasonEvictionListFailed, reason)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "EvictionBlocked")
+		assert.Contains(t, event, "cannot list live Running pods")
+	default:
+		t.Error("expected EvictionBlocked event on list failure")
+	}
 
 	// Verify no eviction was attempted.
 	for _, a := range clientset.Actions() {
@@ -10590,21 +10685,61 @@ func TestTryEvictionFallback_NilSelectorSkipsEviction(t *testing.T) {
 	scheme := testScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
 		WithObjects(policy, deploy, pod).Build()
+	recorder := events.NewFakeRecorder(10)
 	r := NewAttunePolicyReconciler()
 	r.Client = fakeClient
 	r.Scheme = scheme
 	r.Clientset = clientset
+	r.Recorder = recorder
 	resizer := resize.NewPodResizer(clientset, ctrl.Log)
 
-	evicted := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
+	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
 		"api-server", "main", resizer)
 	assert.False(t, evicted, "should skip eviction when workload has nil selector")
+	assert.Equal(t, reasonEvictionNoSelector, reason)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "EvictionBlocked")
+		assert.Contains(t, event, "no pod selector")
+	default:
+		t.Error("expected EvictionBlocked event when selector is nil")
+	}
 
 	// Verify no eviction was attempted.
 	for _, a := range clientset.Actions() {
 		if a.GetVerb() == "create" && a.GetResource().Resource == "pods" && a.GetSubresource() == "eviction" {
 			t.Error("eviction should not be attempted when selector is nil")
 		}
+	}
+}
+
+func TestTryEvictionFallback_NilClientsetSkipsEviction(t *testing.T) {
+	pod := newTestPod("api-server-abc-1", "default", map[string]string{"app": "api-server"})
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
+
+	clientset := kubefake.NewSimpleClientset(pod)
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(policy, deploy, pod).Build()
+	recorder := events.NewFakeRecorder(10)
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Recorder = recorder
+	resizer := resize.NewPodResizer(clientset, ctrl.Log)
+
+	evicted, reason := r.tryEvictionFallback(context.Background(), policy, pod, deploy,
+		"api-server", "app", resizer)
+	assert.False(t, evicted, "should skip eviction when Clientset is nil")
+	assert.Equal(t, reasonEvictionListFailed, reason)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "EvictionBlocked")
+		assert.Contains(t, event, "clientset unavailable")
+	default:
+		t.Error("expected EvictionBlocked event when Clientset is nil")
 	}
 }
 

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10349,6 +10349,143 @@ func TestExecuteResizes_MultiContainerSequential(t *testing.T) {
 	assert.True(t, resizedContainers["sidecar"], "sidecar container should have UpdateResize called")
 }
 
+func TestExecuteResizes_EvictionBlockedKeepsPriorInPlaceSuccess(t *testing.T) {
+	// One Running replica, two containers. Main resizes in-place first.
+	// After that UpdateResize, live Get reports Infeasible so sidecar
+	// attempts eviction, which last-replica blocks. Prior success must
+	// still count the workload as resized.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "api-server-abc-1", Namespace: "default",
+			Labels: map[string]string{"app": "api-server"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "nginx", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}},
+				{Name: "sidecar", Image: "envoy", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+				}},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", Ready: true, RestartCount: 0},
+				{Name: "sidecar", Ready: true, RestartCount: 0},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	deploy.Spec.Replicas = int32Ptr(1)
+	deploy.Status.Replicas = 1
+	deploy.Status.UpdatedReplicas = 1
+	deploy.Status.AvailableReplicas = 1
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+
+	var inPlaceApplied atomic.Bool
+	clientset.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "resize" {
+			return false, nil, nil
+		}
+		inPlaceApplied.Store(true)
+		return false, nil, nil
+	})
+	clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if !inPlaceApplied.Load() {
+			return false, nil, nil
+		}
+		ga, ok := action.(k8stesting.GetAction)
+		if !ok {
+			return false, nil, nil
+		}
+		obj, err := clientset.Tracker().Get(ga.GetResource(), ga.GetNamespace(), ga.GetName())
+		if err != nil {
+			return true, nil, err
+		}
+		live, ok := obj.(*corev1.Pod)
+		if !ok {
+			return false, nil, nil
+		}
+		live = live.DeepCopy()
+		live.Status.Conditions = append(live.Status.Conditions, corev1.PodCondition{
+			Type:   "PodResizePending",
+			Status: corev1.ConditionTrue,
+			Reason: "Infeasible",
+		})
+		return true, live, nil
+	})
+
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
+
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "api-server",
+			Kind:     "Deployment",
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name: "main",
+					Current: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("500m"), MemoryRequest: resource.MustParse("256Mi"),
+					},
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("750m"), MemoryRequest: resource.MustParse("384Mi"),
+					},
+				},
+				{
+					Name: "sidecar",
+					Current: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("100m"), MemoryRequest: resource.MustParse("64Mi"),
+					},
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("200m"), MemoryRequest: resource.MustParse("128Mi"),
+					},
+				},
+			},
+		},
+	}
+
+	count, history := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy}, recommendations,
+		map[string][]corev1.Pod{"api-server": {*pod}}, nil, nil)
+	assert.Equal(t, 1, count, "prior in-place success must still count the workload as resized")
+
+	mainSuccess := false
+	sidecarBlocked := false
+	for _, h := range history {
+		if h.Container == "main" && h.Method == resize.MethodInPlace && h.Result == attunev1alpha1.ResizeResultSuccess {
+			mainSuccess = true
+		}
+		if h.Container == "sidecar" && h.Reason == reasonEvictionLastReplica {
+			sidecarBlocked = true
+		}
+		assert.NotEqual(t, attunev1alpha1.ResizeResultEvicted, h.Result,
+			"last-replica eviction must not evict")
+	}
+	assert.True(t, mainSuccess, "history should keep in-place Success for main")
+	assert.True(t, sidecarBlocked, "history should record eviction_last_replica for sidecar")
+}
+
 func TestExecuteResizes_MultiContainer_BudgetExhaustion(t *testing.T) {
 	// A pod with two containers where the CPU budget is exhausted after the
 	// first container resize. The second container should be skipped (budget

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -9248,6 +9248,95 @@ func TestTryEvictionFallback_EvictsWhenMultipleReplicas(t *testing.T) {
 		"eviction fallback should not increment in-place resize metrics")
 }
 
+func TestTryEvictionFallback_ConcurrentTwoReplicasEvictsAtMostOne(t *testing.T) {
+	// Two executeResizes goroutines can both List running==2 and both Evict
+	// unless List+count+Evict is serialized per workload. Fake clientset
+	// does not remove a pod on Evict, so the reactor deletes it so the
+	// second List sees running==1.
+	pod1 := newTestPod("api-server-abc-1", "default", map[string]string{"app": "api-server"})
+	pod2 := newTestPod("api-server-abc-2", "default", map[string]string{"app": "api-server"})
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
+
+	clientset := kubefake.NewSimpleClientset(pod1, pod2)
+	clientset.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+		create, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		meta, ok := create.GetObject().(metav1.Object)
+		if !ok {
+			return true, nil, fmt.Errorf("eviction object is not metav1.Object")
+		}
+		ns := meta.GetNamespace()
+		if ns == "" {
+			ns = action.GetNamespace()
+		}
+		if err := clientset.Tracker().Delete(corev1.SchemeGroupVersion.WithResource("pods"), ns, meta.GetName()); err != nil {
+			return true, nil, err
+		}
+		return true, create.GetObject(), nil
+	})
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(policy, deploy, pod1, pod2).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+	resizer := resize.NewPodResizer(clientset, ctrl.Log)
+
+	var (
+		start, done     sync.WaitGroup
+		mu              sync.Mutex
+		evictedCount    int
+		lastReplicaHits int
+	)
+	start.Add(2)
+	done.Add(2)
+	run := func(p *corev1.Pod) {
+		defer done.Done()
+		start.Done()
+		start.Wait()
+		evicted, reason := r.tryEvictionFallback(context.Background(), policy, p, deploy,
+			"api-server", "app", resizer)
+		mu.Lock()
+		defer mu.Unlock()
+		if evicted {
+			evictedCount++
+		}
+		if reason == reasonEvictionLastReplica {
+			lastReplicaHits++
+		}
+	}
+	go run(pod1)
+	go run(pod2)
+	done.Wait()
+
+	var evictions int
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "create" && a.GetResource().Resource == "pods" && a.GetSubresource() == "eviction" {
+			evictions++
+		}
+		if a.GetVerb() == "list" {
+			if lo, ok := a.(interface{ GetListOptions() metav1.ListOptions }); ok {
+				opts := lo.GetListOptions()
+				assert.Equal(t, evictionReplicaPageSize, opts.Limit, "last-replica List must paginate")
+				assert.Empty(t, opts.ResourceVersion, "last-replica List must not use ResourceVersion 0")
+			}
+		}
+	}
+	assert.LessOrEqual(t, evictions, 1, "at most one eviction create")
+	assert.LessOrEqual(t, evictedCount, 1, "at most one successful eviction")
+	assert.True(t, lastReplicaHits >= 1 || evictedCount == 1,
+		"at least one call must return last_replica or the second must see running<=1 after the first evicts")
+}
+
 func TestTryEvictionFallback_SkipsLastReplica(t *testing.T) {
 	pod := newTestPod("api-server-abc-1", "default", map[string]string{"app": "api-server"})
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
@@ -9624,7 +9713,7 @@ func TestResizeContainer_InfeasibleLastReplicaRecordsReason(t *testing.T) {
 		Monitor:      nil,
 		Now:          metav1.Now(),
 	})
-	assert.Equal(t, resizeOutcomeNone, outcome, "last live Running replica must not be evicted")
+	assert.Equal(t, resizeOutcomeEvictionBlocked, outcome, "last live Running replica must not be evicted")
 	require.Len(t, entries, 1, "should record a Failed history entry")
 	assert.Equal(t, attunev1alpha1.ResizeResultFailed, entries[0].Result)
 	assert.Equal(t, reasonEvictionLastReplica, entries[0].Reason)

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10509,6 +10509,35 @@ func TestTryEvictionFallback_EvictionDeniedByPDB(t *testing.T) {
 	assert.False(t, evicted, "should return false when eviction is denied by PDB")
 }
 
+func TestTryEvictionFallback_StaleCacheDoesNotEvictLastLiveReplica(t *testing.T) {
+	pod1 := newTestPod("api-server-abc-1", "default", map[string]string{"app": "api-server"})
+	pod2 := newTestPod("api-server-abc-2", "default", map[string]string{"app": "api-server"})
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
+
+	// Informer cache still has two Running pods; the live API has only one.
+	clientset := kubefake.NewSimpleClientset(pod1)
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(policy, deploy, pod1, pod2).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+	resizer := resize.NewPodResizer(clientset, ctrl.Log)
+
+	evicted := r.tryEvictionFallback(context.Background(), policy, pod1, deploy,
+		"api-server", "app", resizer)
+	assert.False(t, evicted, "must not evict when live Clientset has only one running replica")
+
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "create" && a.GetResource().Resource == "pods" && a.GetSubresource() == "eviction" {
+			t.Error("eviction should not be attempted when live replica count is 1")
+		}
+	}
+}
+
 func TestTryEvictionFallback_ListErrorSkipsEviction(t *testing.T) {
 	pod := newTestPod("api-server-abc-1", "default", map[string]string{"app": "api-server"})
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
@@ -10516,15 +10545,12 @@ func TestTryEvictionFallback_ListErrorSkipsEviction(t *testing.T) {
 	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
 
 	clientset := kubefake.NewSimpleClientset(pod)
+	clientset.PrependReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("connection refused")
+	})
 	scheme := testScheme()
-	// Use an interceptor to make List fail, simulating API server unreachable.
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(policy, deploy, pod).
-		WithInterceptorFuncs(interceptor.Funcs{
-			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
-				return fmt.Errorf("connection refused")
-			},
-		}).Build()
+		WithObjects(policy, deploy, pod).Build()
 	r := NewAttunePolicyReconciler()
 	r.Client = fakeClient
 	r.Scheme = scheme
@@ -13425,6 +13451,48 @@ func TestShouldSkipResize_AlreadyAtTarget(t *testing.T) {
 	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
 	assert.True(t, skip, "should skip when pod already matches target")
 	assert.Empty(t, reason, "reason should be empty for already-at-target skip")
+}
+
+func TestShouldSkipResize_RequestMatchLimitDriftDoesNotSkip(t *testing.T) {
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+
+	policy := &attunev1alpha1.AttunePolicy{}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}},
+			},
+		},
+	}
+	containerRec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("500m"),
+			MemoryRequest: resource.MustParse("256Mi"),
+		},
+	}
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	skip, _ := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	assert.False(t, skip, "must not skip when requests match but target sets a missing live limit")
 }
 
 func TestShouldSkipResize_PreChecksLimitRange(t *testing.T) {

--- a/internal/controller/memory_usage_floor_test.go
+++ b/internal/controller/memory_usage_floor_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
@@ -158,6 +159,65 @@ func TestApplyMemoryUsageFloor_SafeDecreaseUnchanged(t *testing.T) {
 
 	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
 	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("800Mi")))
+}
+
+func TestApplyMemoryUsageFloor_UsesLiveContainerLimit(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	margin := int32(10)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-live", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			Memory: attunev1alpha1.ResourceConfig{
+				DecreaseUsageMarginPercent: &margin,
+			},
+		},
+	}
+	r := NewAttunePolicyReconciler()
+	r.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Template Current is stale after in-place resize (512Mi). Live pod is 2Gi.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "app",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+			}},
+		},
+	}
+	rec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			MemoryLimit: resource.MustParse("512Mi"),
+		},
+		Explanation: &attunev1alpha1.ContainerRecommendationExplanation{
+			Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+				RawPercentile: resource.MustParse("1.5Gi"),
+			},
+		},
+	}
+	target := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+	}
+
+	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
+	// Stale 512Mi would treat 1Gi as an increase and leave it unchanged.
+	assert.False(t, got.Limits.Memory().Equal(resource.MustParse("1Gi")),
+		"must not keep 1Gi when live limit is 2Gi and usage floor applies (got %s)",
+		got.Limits.Memory().String())
+	// 1.5Gi * 1.1, rounded up to whole bytes.
+	usage := resource.MustParse("1.5Gi")
+	want := *resource.NewQuantity(int64(math.Ceil(float64(usage.Value())*1.1)), resource.BinarySI)
+	assert.True(t, got.Limits.Memory().Equal(want),
+		"got %s want %s (1.5Gi * 1.1)", got.Limits.Memory().String(), want.String())
 }
 
 func TestRecentMemoryUsage(t *testing.T) {

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -343,6 +343,14 @@ func (r *AttunePolicyReconciler) executeResizes(
 						podResized = false
 						break
 					}
+					if outcome == resizeOutcomeEvictionBlocked {
+						// Eviction was attempted and failed. Do not retry the
+						// same List+Evict for remaining containers on this pod.
+						refundBudget(cpuIncrease, memIncrease)
+						podHistory = append(podHistory, entries...)
+						podResized = false
+						break
+					}
 					podHistory = append(podHistory, entries...)
 					podReservedCPU += cpuIncrease
 					podReservedMem += memIncrease
@@ -396,6 +404,9 @@ const (
 	resizeOutcomeNone resizeOutcome = iota
 	resizeOutcomeInPlace
 	resizeOutcomeEvicted
+	// resizeOutcomeEvictionBlocked means eviction fallback ran and did not
+	// evict (last replica, list failure, no selector, or PDB denial).
+	resizeOutcomeEvictionBlocked
 )
 
 // resizeContainer performs a single container resize on a pod, including
@@ -569,7 +580,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 				Timestamp: now, Workload: workloadName, Container: containerRec.Name,
 				Resource: "cpu+memory", Method: resize.MethodInPlace,
 				Result: attunev1alpha1.ResizeResultFailed, Reason: reason,
-			}}, resizeOutcomeNone
+			}}, resizeOutcomeEvictionBlocked
 		}
 		logger.Info("Pod resize is Infeasible and resizeMethod is InPlaceOnly, skipping",
 			"pod", pod.Name, "container", containerRec.Name)
@@ -625,6 +636,9 @@ func (r *AttunePolicyReconciler) resizeContainer(
 				r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, "ResizeFailed", "resize",
 					"Failed to resize pod %s container %s: %v", pod.Name, containerRec.Name, err)
 			}
+		}
+		if evictionFailReason != "" {
+			return entries, resizeOutcomeEvictionBlocked
 		}
 		return entries, resizeOutcomeNone
 	}

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -1314,6 +1314,20 @@ func (r *AttunePolicyReconciler) buildResizePreChecks(ctx context.Context, polic
 	return checks
 }
 
+// targetLimitsMatchLive reports whether every resource in targetLimits is
+// present on the live container at the same quantity. An empty target
+// limits map always matches (request-only already-at-target). A missing
+// live limit is not a match.
+func targetLimitsMatchLive(live, target corev1.ResourceList) bool {
+	for res, targetQty := range target {
+		liveQty, ok := live[res]
+		if !ok || liveQty.Cmp(targetQty) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // shouldSkipResize runs pre-checks and returns whether to skip the resize
 // and an optional reason string. An empty reason with skip=true means the
 // pod already matches the recommendation (no log needed).
@@ -1329,7 +1343,8 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 	// so requests clamped to limits are correctly detected as no-ops).
 	if c := findContainerByName(pod, containerRec.Name); c != nil {
 		if c.Resources.Requests.Cpu().MilliValue() == target.Requests.Cpu().MilliValue() &&
-			c.Resources.Requests.Memory().Value() == target.Requests.Memory().Value() {
+			c.Resources.Requests.Memory().Value() == target.Requests.Memory().Value() &&
+			targetLimitsMatchLive(c.Resources.Limits, target.Limits) {
 			return true, ""
 		}
 	}
@@ -1584,14 +1599,7 @@ func (r *AttunePolicyReconciler) applyMemoryUsageFloor(
 	if !ok {
 		return target
 	}
-	currentLim := containerRec.Current.MemoryLimit
-	if currentLim.IsZero() {
-		if c := findContainerByName(pod, containerRec.Name); c != nil {
-			if lim, lok := c.Resources.Limits[corev1.ResourceMemory]; lok {
-				currentLim = lim
-			}
-		}
-	}
+	currentLim := liveContainerCurrent(pod, containerRec).MemoryLimit
 	if currentLim.IsZero() || targetLim.Cmp(currentLim) >= 0 {
 		return target
 	}

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -558,14 +558,17 @@ func (r *AttunePolicyReconciler) resizeContainer(
 		if policy.Spec.UpdateStrategy.ResizeMethod == attunev1alpha1.ResizeMethodInPlaceOrRecreate {
 			logger.Info("Pod resize is Infeasible, attempting eviction fallback",
 				"pod", pod.Name, "container", containerRec.Name)
-			if evicted := r.tryEvictionFallback(ctx, policy, pod, workload, workloadName, containerRec.Name, resizer); evicted {
+			evicted, reason := r.tryEvictionFallback(ctx, policy, pod, workload, workloadName, containerRec.Name, resizer)
+			if evicted {
 				return evictionHistory(), resizeOutcomeEvicted
 			}
-			// Eviction denied or blocked: record failure with actionable reason.
+			if reason == "" {
+				reason = "infeasible"
+			}
 			return []attunev1alpha1.ResizeHistoryEntry{{
 				Timestamp: now, Workload: workloadName, Container: containerRec.Name,
 				Resource: "cpu+memory", Method: resize.MethodInPlace,
-				Result: attunev1alpha1.ResizeResultFailed, Reason: "infeasible",
+				Result: attunev1alpha1.ResizeResultFailed, Reason: reason,
 			}}, resizeOutcomeNone
 		}
 		logger.Info("Pod resize is Infeasible and resizeMethod is InPlaceOnly, skipping",
@@ -593,23 +596,35 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	resizeStart := r.now()
 	results, err := resizer.ResizePod(ctx, pod, containerRec.Name, target)
 	if err != nil {
-		// Attempt eviction fallback if configured.
+		evictionFailReason := ""
 		if policy.Spec.UpdateStrategy.ResizeMethod == attunev1alpha1.ResizeMethodInPlaceOrRecreate {
-			if evicted := r.tryEvictionFallback(ctx, policy, pod, workload, workloadName, containerRec.Name, resizer); evicted {
+			evicted, reason := r.tryEvictionFallback(ctx, policy, pod, workload, workloadName, containerRec.Name, resizer)
+			if evicted {
 				return evictionHistory(), resizeOutcomeEvicted
 			}
+			evictionFailReason = reason
 		}
 
 		logger.Error(err, "Failed to resize pod",
-			"pod", pod.Name, "container", containerRec.Name)
+			"pod", pod.Name, "container", containerRec.Name, "evictionReason", evictionFailReason)
 		var entries []attunev1alpha1.ResizeHistoryEntry
 		for _, res := range results {
-			entries = append(entries, newHistoryEntry(now, workloadName, containerRec.Name, res, attunev1alpha1.ResizeResultFailed))
+			entry := newHistoryEntry(now, workloadName, containerRec.Name, res, attunev1alpha1.ResizeResultFailed)
+			if evictionFailReason != "" {
+				entry.Reason = evictionFailReason
+			}
+			entries = append(entries, entry)
 			operatormetrics.ResizeTotal.WithLabelValues(pod.Namespace, workloadName, res.Resource, "failed").Inc()
 		}
 		if r.Recorder != nil {
-			r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, "ResizeFailed", "resize",
-				"Failed to resize pod %s container %s: %v", pod.Name, containerRec.Name, err)
+			if evictionFailReason != "" {
+				r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, "ResizeFailed", "resize",
+					"Failed to resize pod %s container %s: %v (eviction fallback: %s)",
+					pod.Name, containerRec.Name, err, evictionFailReason)
+			} else {
+				r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, "ResizeFailed", "resize",
+					"Failed to resize pod %s container %s: %v", pod.Name, containerRec.Name, err)
+			}
 		}
 		return entries, resizeOutcomeNone
 	}

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -346,9 +346,10 @@ func (r *AttunePolicyReconciler) executeResizes(
 					if outcome == resizeOutcomeEvictionBlocked {
 						// Eviction was attempted and failed. Do not retry the
 						// same List+Evict for remaining containers on this pod.
+						// Leave podResized as-is so a prior in-place success
+						// still counts (unlike Evicted, which clears it).
 						refundBudget(cpuIncrease, memIncrease)
 						podHistory = append(podHistory, entries...)
-						podResized = false
 						break
 					}
 					podHistory = append(podHistory, entries...)

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -75,6 +76,10 @@ const (
 	reasonEvictionListFailed  = "eviction_list_failed"
 	reasonEvictionNoSelector  = "eviction_no_selector"
 	reasonEvictionDenied      = "eviction_denied"
+
+	// evictionReplicaPageSize is the live last-replica List page size.
+	// Count stops as soon as two Running pods are visible.
+	evictionReplicaPageSize = int64(50)
 )
 
 // tryEvictionFallback attempts to evict a pod as a fallback when in-place
@@ -115,9 +120,16 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 			pod.Name, workloadName)
 		return false, reasonEvictionListFailed
 	}
-	podList, err := r.Clientset.CoreV1().Pods(pod.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(selectorLabels).String(),
-	})
+
+	// Serialize List + count + Evict per workload so two resize goroutines
+	// cannot both observe running==2 and take the Deployment to zero.
+	lockKey := pod.Namespace + "/" + workloadName
+	v, _ := r.evictionLocks.LoadOrStore(lockKey, &sync.Mutex{})
+	mu := v.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+
+	running, err := r.countLiveRunningReplicas(ctx, pod.Namespace, selectorLabels)
 	if err != nil {
 		logger.Error(err, "Cannot list pods for eviction safety check, skipping eviction")
 		operatormetrics.EvictionTotal.WithLabelValues(pod.Namespace, workloadName, "list_failed").Inc()
@@ -125,12 +137,6 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 			"Eviction fallback blocked for pod %s in workload %s: cannot list live Running pods: %v",
 			pod.Name, workloadName, err)
 		return false, reasonEvictionListFailed
-	}
-	running := 0
-	for _, p := range podList.Items {
-		if p.Status.Phase == corev1.PodRunning && p.DeletionTimestamp == nil {
-			running++
-		}
 	}
 	if running <= 1 {
 		logger.Info("Skipping eviction fallback: would evict the last running replica",
@@ -163,6 +169,44 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	logger.Info("Eviction fallback successful",
 		"pod", pod.Name, "workload", workloadName, "container", containerName)
 	return true, ""
+}
+
+// countLiveRunningReplicas lists matching pods through the typed Clientset
+// (live API, not the informer cache) and counts Running pods with no
+// deletion timestamp. Pages with Limit and returns as soon as running>1.
+// ResourceVersion is left empty (not "0") so the list is consistent.
+// A list error is returned so the caller can fail closed.
+func (r *AttunePolicyReconciler) countLiveRunningReplicas(
+	ctx context.Context,
+	namespace string,
+	selectorLabels map[string]string,
+) (int, error) {
+	selector := labels.SelectorFromSet(selectorLabels).String()
+	continueToken := ""
+	running := 0
+	for {
+		podList, err := r.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: selector,
+			Limit:         evictionReplicaPageSize,
+			Continue:      continueToken,
+		})
+		if err != nil {
+			return 0, err
+		}
+		for i := range podList.Items {
+			p := &podList.Items[i]
+			if p.Status.Phase == corev1.PodRunning && p.DeletionTimestamp == nil {
+				running++
+				if running > 1 {
+					return running, nil
+				}
+			}
+		}
+		if podList.Continue == "" {
+			return running, nil
+		}
+		continueToken = podList.Continue
+	}
 }
 
 // checkPendingSafetyObservations checks pods that were previously resized and

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -100,6 +100,7 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	if len(selectorLabels) == 0 {
 		logger.Info("Skipping eviction fallback: workload has no pod selector labels",
 			"pod", pod.Name, "workload", workloadName)
+		operatormetrics.EvictionTotal.WithLabelValues(pod.Namespace, workloadName, "no_selector").Inc()
 		r.emitEventOnce(policy, corev1.EventTypeWarning, "EvictionBlocked", "resize",
 			"Eviction fallback blocked for pod %s in workload %s: workload has no pod selector",
 			pod.Name, workloadName)
@@ -108,6 +109,7 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	if r.Clientset == nil {
 		logger.Info("Cannot list pods for eviction safety check, skipping eviction",
 			"reason", "clientset is nil")
+		operatormetrics.EvictionTotal.WithLabelValues(pod.Namespace, workloadName, "list_failed").Inc()
 		r.emitEventOnce(policy, corev1.EventTypeWarning, "EvictionBlocked", "resize",
 			"Eviction fallback blocked for pod %s in workload %s: cannot list live Running pods (clientset unavailable)",
 			pod.Name, workloadName)
@@ -118,6 +120,7 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	})
 	if err != nil {
 		logger.Error(err, "Cannot list pods for eviction safety check, skipping eviction")
+		operatormetrics.EvictionTotal.WithLabelValues(pod.Namespace, workloadName, "list_failed").Inc()
 		r.emitEventOnce(policy, corev1.EventTypeWarning, "EvictionBlocked", "resize",
 			"Eviction fallback blocked for pod %s in workload %s: cannot list live Running pods: %v",
 			pod.Name, workloadName, err)
@@ -132,6 +135,7 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	if running <= 1 {
 		logger.Info("Skipping eviction fallback: would evict the last running replica",
 			"pod", pod.Name, "workload", workloadName, "liveRunning", running)
+		operatormetrics.EvictionTotal.WithLabelValues(pod.Namespace, workloadName, "last_replica").Inc()
 		r.emitEventOnce(policy, corev1.EventTypeWarning, "EvictionBlocked", "resize",
 			"Eviction fallback blocked for pod %s in workload %s: %d live Running replica(s); spec.replicas and NotReady pods do not count",
 			pod.Name, workloadName, running)

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -92,11 +93,15 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 			"pod", pod.Name, "workload", workloadName)
 		return false
 	}
-	var podList corev1.PodList
-	if err := r.List(ctx, &podList,
-		client.InNamespace(pod.Namespace),
-		client.MatchingLabels(selectorLabels),
-	); err != nil {
+	if r.Clientset == nil {
+		logger.Info("Cannot list pods for eviction safety check, skipping eviction",
+			"reason", "clientset is nil")
+		return false
+	}
+	podList, err := r.Clientset.CoreV1().Pods(pod.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(selectorLabels).String(),
+	})
+	if err != nil {
 		logger.Error(err, "Cannot list pods for eviction safety check, skipping eviction")
 		return false
 	}

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -70,12 +70,21 @@ func (r *AttunePolicyReconciler) runImmediateSafetyCheck(
 	return "", nil
 }
 
+const (
+	reasonEvictionLastReplica = "eviction_last_replica"
+	reasonEvictionListFailed  = "eviction_list_failed"
+	reasonEvictionNoSelector  = "eviction_no_selector"
+	reasonEvictionDenied      = "eviction_denied"
+)
+
 // tryEvictionFallback attempts to evict a pod as a fallback when in-place
 // resize fails. It checks safety guards before evicting:
 //   - Never evict the last replica of a workload
 //   - The Eviction API itself enforces PodDisruptionBudgets
 //
-// Returns true if the eviction was submitted successfully.
+// Returns evicted=true when the eviction was submitted. When evicted is
+// false, reason is a free-form history token: eviction_last_replica,
+// eviction_list_failed, eviction_no_selector, or eviction_denied.
 func (r *AttunePolicyReconciler) tryEvictionFallback(
 	ctx context.Context,
 	policy *attunev1alpha1.AttunePolicy,
@@ -83,27 +92,36 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	workload client.Object,
 	workloadName, containerName string,
 	resizer *resize.PodResizer,
-) bool {
+) (evicted bool, reason string) {
 	logger := log.FromContext(ctx)
 
-	// Safety: never evict the last replica. Count running pods for this workload.
+	// Safety: never evict the last replica. Count live Running pods.
 	selectorLabels := r.getPodSelectorLabels(workload)
 	if len(selectorLabels) == 0 {
 		logger.Info("Skipping eviction fallback: workload has no pod selector labels",
 			"pod", pod.Name, "workload", workloadName)
-		return false
+		r.emitEventOnce(policy, corev1.EventTypeWarning, "EvictionBlocked", "resize",
+			"Eviction fallback blocked for pod %s in workload %s: workload has no pod selector",
+			pod.Name, workloadName)
+		return false, reasonEvictionNoSelector
 	}
 	if r.Clientset == nil {
 		logger.Info("Cannot list pods for eviction safety check, skipping eviction",
 			"reason", "clientset is nil")
-		return false
+		r.emitEventOnce(policy, corev1.EventTypeWarning, "EvictionBlocked", "resize",
+			"Eviction fallback blocked for pod %s in workload %s: cannot list live Running pods (clientset unavailable)",
+			pod.Name, workloadName)
+		return false, reasonEvictionListFailed
 	}
 	podList, err := r.Clientset.CoreV1().Pods(pod.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(selectorLabels).String(),
 	})
 	if err != nil {
 		logger.Error(err, "Cannot list pods for eviction safety check, skipping eviction")
-		return false
+		r.emitEventOnce(policy, corev1.EventTypeWarning, "EvictionBlocked", "resize",
+			"Eviction fallback blocked for pod %s in workload %s: cannot list live Running pods: %v",
+			pod.Name, workloadName, err)
+		return false, reasonEvictionListFailed
 	}
 	running := 0
 	for _, p := range podList.Items {
@@ -113,11 +131,11 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	}
 	if running <= 1 {
 		logger.Info("Skipping eviction fallback: would evict the last running replica",
-			"pod", pod.Name, "workload", workloadName)
+			"pod", pod.Name, "workload", workloadName, "liveRunning", running)
 		r.emitEventOnce(policy, corev1.EventTypeWarning, "EvictionBlocked", "resize",
-			"Eviction fallback blocked for pod %s in workload %s: would evict the only running replica",
-			pod.Name, workloadName)
-		return false
+			"Eviction fallback blocked for pod %s in workload %s: %d live Running replica(s); spec.replicas and NotReady pods do not count",
+			pod.Name, workloadName, running)
+		return false, reasonEvictionLastReplica
 	}
 
 	// The Eviction API respects PDBs. If the eviction is denied, the error
@@ -129,7 +147,7 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 		r.emitEventOnce(policy, corev1.EventTypeWarning, "EvictionDenied", "resize",
 			"Eviction fallback denied for pod %s in workload %s: %v (check PodDisruptionBudgets)",
 			pod.Name, workloadName, err)
-		return false
+		return false, reasonEvictionDenied
 	}
 
 	operatormetrics.EvictionTotal.WithLabelValues(pod.Namespace, workloadName, "success").Inc()
@@ -140,7 +158,7 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	}
 	logger.Info("Eviction fallback successful",
 		"pod", pod.Name, "workload", workloadName, "container", containerName)
-	return true
+	return true, ""
 }
 
 // checkPendingSafetyObservations checks pods that were previously resized and

--- a/internal/operatormetrics/metrics.go
+++ b/internal/operatormetrics/metrics.go
@@ -177,7 +177,7 @@ var (
 	EvictionTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "attune_eviction_total",
-			Help: "Total eviction attempts (InPlaceOrRecreate fallback)",
+			Help: "Total eviction attempts and skip results (InPlaceOrRecreate fallback)",
 		},
 		[]string{"namespace", "workload", "result"},
 	)


### PR DESCRIPTION
Live resize decisions used to trust the workload template, the informer cache, or request-only equality. After an in-place resize those snapshots go stale, so Auto could skip a needed limit change, drop a memory limit below live usage, or evict the last Running replica.

This MPI cycle makes those paths read the live pod and fail closed.

## Resize and eviction

- Memory usage floor compares the live container limit (`liveContainerCurrent`), not stale `rec.Current`.
- `shouldSkipResize` treats request-only equality as already-at-target only when every target limit also matches the live container.
- Last-replica eviction counts live Running pods via Clientset List (paginated, stop at two).
- Per-workload mutex around List plus Evict so `maxConcurrentResizes > 1` cannot evict two peers at once.
- Failed eviction stops remaining containers on the same pod (`resizeOutcomeEvictionBlocked`).
- History reasons: `eviction_last_replica`, `eviction_denied`, `eviction_list_failed`, `eviction_no_selector`.
- `attune_eviction_total` now increments `last_replica`, `list_failed`, and `no_selector` (success and denied unchanged).

## kubectl attune

- Unknown commands suggest the closest match (`recommend` -> `recommendations`).
- Unknown `--sort-by` values exit 1 instead of silently keeping API order.

## CI and local gates

- Helm Lint runs dashboard (including fleet) sync on `deploy/grafana/**` changes.
- Helm Lint and Docs Check run prometheusrule, schema, and doc-defaults scripts.
- `verify-release-artifacts` fails if `dist/install.yaml` or `dist/crds.yaml` is missing.
- `make test` fails below 80% coverage (same as CI).
- Local `_deploy-stack` no longer swallows a failed Prometheus install.

## Docs

- `CURRENT` in preview is the recommendation snapshot, not necessarily the live container.
- Memory limit decrease caveat is Kubernetes 1.35+ (was 1.34+).
- `upgrading.md` has a v0.1.26 to v0.1.27 section.
- CRD description and `metrics.md` `error_type` / webhook `operation` lists match the code.

## Tests

- Observation Ready=False does not revert; confirm Get 500/404 does not revert.
- Inverse Infeasible: listed pending, live cleared, stays in-place.
- Live memory floor, limit-drift skip, stale-cache last replica, concurrent two-replica evicts at most one.
- kubectl unknown command and `--sort-by` parse tests.

Release PR #670 stays user-gated. This PR does not merge it.
