### PR TITLE
test: accept memory-only template persist and harden explanation wait

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,6 +498,16 @@ directory. When referencing files elsewhere in the repo (e.g., `charts/`,
   must poll live requests (`waitForNamedContainersCPUDecrease`) instead of
   a one-shot List after `waitForResize`. Read pods via Clientset so the
   informer cache cannot hide a just-written `/resize` spec.
+- Template persistence `AfterSuccessfulResize` E2E must accept a CPU **or**
+  memory template change. A successful memory-only resize (512Mi to 64Mi)
+  still patches the template and writes `TemplatePatched`. Requiring
+  `requests.cpu != 500m` times out when CPU stays at start. Pin
+  `maxAllowed` below the start request so load cannot recommend `1`.
+- Go E2E tests that wait on `explanation.*.finalAdjustment` must warm
+  cAdvisor (`waitForCadvisorMetrics`) before creating the policy and dump
+  recs/explanation on timeout. CPU explanation is missing until CPU
+  samples reach `minimumDataPoints`; memory-only recs are not enough for
+  a CPU `burstSensitivity` assert.
 - Chainsaw assertions must target **stable** operator states, not transient
   ones. With `minimumDataPoints: 1`, the operator can transition from
   `InsufficientData` to `Monitoring` within seconds. A static assert on

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1076,7 +1076,9 @@ spec:
 
 - **`AfterSuccessfulResize`**: only after a successful in-place resize. In
   Recommend/Observe modes this never fires (webhook warns). Use
-  `when: OnRecommendation` for Recommend.
+  `when: OnRecommendation` for Recommend. A successful memory-only resize
+  still patches the template (CPU can stay at the original request). Do
+  not require both resources to change.
 - **`OnRecommendation`**: still skipped in **Observe** mode.
 - **Canary**: template patches wait until canary reaches `FullRollout`.
 - **Stale recommendation**: `recommendations[].stale` is true; the template is not patched until fresh Prometheus data.

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -22,9 +22,11 @@ limitations under the License.
 package e2e_go
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -309,6 +311,97 @@ func podRestartCount(pod corev1.Pod) int32 {
 		total += cs.RestartCount
 	}
 	return total
+}
+
+// waitForCadvisorMetrics polls in-cluster Prometheus until cAdvisor has at
+// least one CPU series for ns. Creating the policy before that lands the
+// first reconcile in InsufficientData and burns the 3m explanation wait
+// under parallel Go E2E load. Same query as the Chainsaw warmup scripts.
+// Missing metrics after 2m logs a warning and returns (do not fail here).
+func waitForCadvisorMetrics(t *testing.T, ns string) {
+	t.Helper()
+	pods, err := clientset.CoreV1().Pods("monitoring").List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server",
+	})
+	if err != nil || len(pods.Items) == 0 {
+		t.Logf("waitForCadvisorMetrics(%s): no prometheus-server pod (%v); proceeding", ns, err)
+		return
+	}
+	pod := pods.Items[0]
+	container := "prometheus-server"
+	if len(pod.Spec.Containers) > 0 {
+		container = pod.Spec.Containers[0].Name
+	}
+	query := url.QueryEscape(fmt.Sprintf(`container_cpu_usage_seconds_total{namespace="%s",container!=""}`, ns))
+	cmd := []string{"wget", "-qO-", "http://localhost:9090/api/v1/query?query=" + query}
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		out, execErr := execPodCommand(ctx, pod.Namespace, pod.Name, container, cmd)
+		if execErr != nil {
+			t.Logf("waitForCadvisorMetrics(%s): exec: %v", ns, execErr)
+			return false, nil
+		}
+		return strings.Contains(out, `"result":[{`), nil
+	})
+	if err != nil {
+		t.Logf("WARNING: no cAdvisor metrics for %s after 2m, proceeding", ns)
+		return
+	}
+	t.Logf("cAdvisor metrics available for namespace %s", ns)
+}
+
+func execPodCommand(ctx context.Context, namespace, pod, container string, command []string) (string, error) {
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(pod).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: container,
+			Command:   command,
+			Stdout:    true,
+			Stderr:    true,
+		}, scheme.ParameterCodec)
+	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		return "", err
+	}
+	var stdout, stderr bytes.Buffer
+	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}); err != nil {
+		return "", fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return stdout.String(), nil
+}
+
+func logPolicyExplanationState(t *testing.T, name, namespace string) {
+	t.Helper()
+	var p attunev1alpha1.AttunePolicy
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &p); err != nil {
+		t.Logf("logPolicyExplanationState(%s/%s): get: %v", namespace, name, err)
+		return
+	}
+	reason := readyReason(p)
+	t.Logf("logPolicyExplanationState(%s/%s): discovered=%d withRecs=%d recs=%d resized=%d ready=%s",
+		namespace, name, p.Status.Workloads.Discovered, p.Status.Workloads.WithRecommendations,
+		len(p.Status.Recommendations), p.Status.Workloads.Resized, reason)
+	for _, c := range p.Status.Conditions {
+		t.Logf("  condition %s=%s reason=%s msg=%s", c.Type, c.Status, c.Reason, c.Message)
+	}
+	for _, rec := range p.Status.Recommendations {
+		for _, c := range rec.Containers {
+			cpuAdj, memAdj := "", ""
+			if c.Explanation != nil && c.Explanation.CPU != nil {
+				cpuAdj = c.Explanation.CPU.FinalAdjustment
+			}
+			if c.Explanation != nil && c.Explanation.Memory != nil {
+				memAdj = c.Explanation.Memory.FinalAdjustment
+			}
+			t.Logf("  container %s cpuRec=%s memRec=%s cpuAdj=%q memAdj=%q",
+				c.Name, c.Recommended.CPURequest.String(), c.Recommended.MemoryRequest.String(), cpuAdj, memAdj)
+		}
+	}
 }
 
 func waitForPolicyDiscovered(t *testing.T, name, namespace string, timeout time.Duration) {
@@ -3796,8 +3889,13 @@ func TestE2E_PodAggregationAndBurstSensitivity_InExplanation(t *testing.T) {
 	t.Parallel()
 	ns := uniqueNS("aggburst")
 	createNamespace(t, ns)
+	// Recommend-only: 250m is inside the pause resize dead zone, but this
+	// test never waits for a resize. Stay at 250m for the shared-node CPU
+	// budget. Failures here are missing CPU explanation text, not a
+	// filtered resize.
 	createDeployment(t, "aggburst-app", ns, "250m", "256Mi", 1)
 	waitForDeploymentReady(t, "aggburst-app", ns, deployReadyTimeout)
+	waitForCadvisorMetrics(t, ns)
 
 	burstOff := "0.5"
 	name := "aggburst-app"
@@ -3838,10 +3936,20 @@ func TestE2E_PodAggregationAndBurstSensitivity_InExplanation(t *testing.T) {
 	require.NoError(t, k8sClient.Create(ctx, policy))
 
 	var note string
-	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+	lastTouch := time.Now()
+	lastDiag := time.Time{}
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		if time.Since(lastTouch) > 45*time.Second {
+			touchPolicySpec(t, "aggburst-policy", ns)
+			lastTouch = time.Now()
+		}
 		var p attunev1alpha1.AttunePolicy
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "aggburst-policy", Namespace: ns}, &p); err != nil {
 			return false, nil
+		}
+		if time.Since(lastDiag) > 30*time.Second {
+			lastDiag = time.Now()
+			logPolicyExplanationState(t, "aggburst-policy", ns)
 		}
 		for _, rec := range p.Status.Recommendations {
 			for _, c := range rec.Containers {
@@ -3856,7 +3964,11 @@ func TestE2E_PodAggregationAndBurstSensitivity_InExplanation(t *testing.T) {
 			}
 		}
 		return false, nil
-	}), "explanation must record Avg aggregation and burstSensitivity=0.5")
+	})
+	if err != nil {
+		logPolicyExplanationState(t, "aggburst-policy", ns)
+	}
+	require.NoError(t, err, "explanation must record Avg aggregation and burstSensitivity=0.5")
 	assert.Contains(t, note, "podAggregation=Avg")
 	assert.Contains(t, note, "burstSensitivity=0.5")
 	assert.NotContains(t, note, "podAggregation=Max")

--- a/test/e2e/template-persistence-after-resize/chainsaw-test.yaml
+++ b/test/e2e/template-persistence-after-resize/chainsaw-test.yaml
@@ -105,14 +105,17 @@ spec:
                   percentile: 95
                   overhead: "20"
                   minAllowed: 50m
-                  maxAllowed: "2"
+                  # Below the 500m start so parallel-load spikes cannot
+                  # recommend 1 (1000m) and skip the in-place CPU change.
+                  maxAllowed: 400m
                   maxChangePercent: 100
                   allowDecrease: true
                 memory:
                   percentile: 99
                   overhead: "30"
                   minAllowed: 64Mi
-                  maxAllowed: 2Gi
+                  # Below the 512Mi start so memory must decrease.
+                  maxAllowed: 256Mi
                   maxChangePercent: 100
                   allowDecrease: true
                 updateStrategy:
@@ -158,17 +161,18 @@ spec:
                 exit 1
               fi
 
-              # 2) Template must change from original 500m after successful resize.
-              # AfterSuccessfulResize is the only writer; OnRecommendation is not configured.
+              # 2) Template must leave the original 500m/512Mi after a
+              # successful resize. AfterSuccessfulResize is the only writer.
+              # Memory-only persist is valid: pause CPU rec can stay at 500m
+              # (or be skipped) while memory decreases 512Mi -> 64Mi.
               for i in $(seq 1 36); do
                 CPU=$(kubectl get deploy "$DEPLOY" -n "$NS" \
                   -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}' 2>/dev/null || true)
                 MEM=$(kubectl get deploy "$DEPLOY" -n "$NS" \
                   -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}' 2>/dev/null || true)
-                HIST=$(kubectl get attunepolicy "$POLICY" -n "$NS" \
-                  -o json 2>/dev/null || true)
-                if [ -n "$CPU" ] && [ "$CPU" != "500m" ]; then
-                  echo "Template CPU updated from 500m to $CPU (memory=$MEM)"
+                if { [ -n "$CPU" ] && [ "$CPU" != "500m" ]; } || \
+                   { [ -n "$MEM" ] && [ "$MEM" != "512Mi" ]; }; then
+                  echo "Template updated: cpu=$CPU memory=$MEM"
                   # Prove AfterSuccessfulResize wrote history (not only a template field change).
                   # kubectl -o json may space after colons; match result/method values loosely.
                   RESULTS=$(kubectl get attunepolicy "$POLICY" -n "$NS" \
@@ -184,7 +188,7 @@ spec:
                 fi
                 sleep 5
               done
-              echo "FAIL: expected template CPU change + TemplatePatched history after successful resize"
+              echo "FAIL: expected template CPU or memory change + TemplatePatched history after successful resize"
               kubectl get deploy "$DEPLOY" -n "$NS" -o yaml
               kubectl get attunepolicy "$POLICY" -n "$NS" -o yaml
               exit 1


### PR DESCRIPTION
## Why

PR #677 E2E went red twice on the same SHA, then green on a third `--failed`. Those were not infra flakes.

1. `chainsaw/template-persistence-after-resize` timed out after a real memory-only Success (`512Mi` to `64Mi`) plus `TemplatePatched`. History also had a CPU `500m` to `500m` InPlace row (resize always records both resources). The script only accepted template CPU leaving `500m`.
2. `TestE2E_PodAggregationAndBurstSensitivity_InExplanation` hit the 3m poll with no CPU `finalAdjustment` dump. Recommend-only. CPU `rate()` samples can lag under parallel PromQL while memory recs still land.

## What changed

- AfterSuccessfulResize Chainsaw now accepts template CPU **or** memory change, same as the OnRecommendation sibling, and still requires `TemplatePersistence` / `TemplatePatched`.
- Pin `cpu.maxAllowed=400m` and `memory.maxAllowed=256Mi` so load cannot recommend `1` / keep 512Mi.
- Aggburst: warm cAdvisor before Create, `touchPolicySpec` every 45s, dump recs/explanation every 30s and on timeout.

No product persist or explanation-stamp change. Persist already writes whichever rec fields differ. `recordQuerySettings` already stamps `podAggregation` / `burstSensitivity` once a CPU rec exists.

## Test plan

- [x] `gofmt` + `go test -c -tags e2e ./test/e2e-go/`
- [x] `hack/verify-chainsaw-scripts.sh`
- [ ] PR E2E (Chainsaw + Go) on this HEAD
