### PR TITLE
fix: persist template after eviction and harden e2e contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,6 +498,11 @@ directory. When referencing files elsewhere in the repo (e.g., `charts/`,
   must poll live requests (`waitForNamedContainersCPUDecrease`) instead of
   a one-shot List after `waitForResize`. Read pods via Clientset so the
   informer cache cannot hide a just-written `/resize` spec.
+- OneShot, ScaleUp, and Paused must count live Clientset CPU decreases
+  (strictly below start; pin MaxAllowed below start). Do not treat
+  `Workloads.Resized` or `cpu != start` as proof. Paused asserts Ready
+  reason only; a post-pause sleep cannot prove no further resizes when
+  cooldown is 1m and CPU is already at MaxAllowed.
 - Template persistence `AfterSuccessfulResize` E2E must accept a CPU **or**
   memory template change. A successful memory-only resize (512Mi to 64Mi)
   still patches the template and writes `TemplatePatched`. Requiring

--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -63,8 +63,9 @@ const (
 type TemplatePersistenceWhen string
 
 const (
-	// TemplatePersistenceAfterSuccessfulResize patches the template only after
-	// an in-place resize succeeds for the workload.
+	// TemplatePersistenceAfterSuccessfulResize patches the template after
+	// a successful in-place resize or a successful Eviction (InPlaceOrRecreate)
+	// so replacement pods start from the recommended requests.
 	TemplatePersistenceAfterSuccessfulResize TemplatePersistenceWhen = "AfterSuccessfulResize"
 	// TemplatePersistenceOnRecommendation patches the template when a
 	// recommendation is accepted (change filter / bounds passed), without
@@ -589,7 +590,8 @@ type TemplatePersistence struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// When selects the trigger. Defaults to AfterSuccessfulResize when
-	// Enabled is true and When is empty.
+	// Enabled is true and When is empty. AfterSuccessfulResize also
+	// patches after Eviction+Evicted (InPlaceOrRecreate).
 	// +kubebuilder:validation:Enum=AfterSuccessfulResize;OnRecommendation
 	// +optional
 	When TemplatePersistenceWhen `json:"when,omitempty"`

--- a/charts/attune/crds/attune.io_attunedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunedefaults.yaml
@@ -861,7 +861,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation

--- a/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
@@ -862,7 +862,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -954,7 +954,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -512,6 +512,25 @@ func isNoResourceMatch(err error) bool {
 		strings.Contains(msg, "no matches for kind")
 }
 
+// policyGetErrorMessage is the stderr text for explain/preview Get failures.
+func policyGetErrorMessage(namespace, policyName string, err error) string {
+	if isNoResourceMatch(err) {
+		return "Error: Attune CRDs are not installed in this cluster.\n" +
+			"Install the operator first:\n" +
+			"  helm install attune oci://ghcr.io/attune-io/charts/attune"
+	}
+	if apierrors.IsNotFound(err) {
+		return fmt.Sprintf("Error: policy %s/%s not found.\nList policies with: kubectl attune status -n %s",
+			namespace, policyName, namespace)
+	}
+	return fmt.Sprintf("Error fetching policy %s/%s: %v", namespace, policyName, err)
+}
+
+func exitPolicyGet(namespace, policyName string, err error) {
+	fmt.Fprintln(os.Stderr, policyGetErrorMessage(namespace, policyName, err))
+	os.Exit(1)
+}
+
 func printStatus(ctx context.Context, dynClient dynamic.Interface, namespace, sortByFlag, filterFlag string) {
 	list := fetchPolicies(ctx, dynClient, namespace)
 	printStatusItems(list.Items, sortByFlag, filterFlag)
@@ -1125,8 +1144,7 @@ func printExplain(ctx context.Context, dynClient dynamic.Interface, namespace, p
 
 	item, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, policyName, metav1.GetOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error fetching policy %s/%s: %v\n", namespace, policyName, err)
-		os.Exit(1)
+		exitPolicyGet(namespace, policyName, err)
 	}
 
 	selected, err := fetchSelectedDefaults(ctx, dynClient, namespace)
@@ -2226,8 +2244,7 @@ func printPreview(ctx context.Context, dynClient dynamic.Interface, namespace, p
 
 	item, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, policyName, metav1.GetOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error fetching policy %s/%s: %v\n", namespace, policyName, err)
-		os.Exit(1)
+		exitPolicyGet(namespace, policyName, err)
 	}
 
 	mode := getNestedString(*item, "spec", "updateStrategy", "type")

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -3855,6 +3856,21 @@ func TestIsNoResourceMatch(t *testing.T) {
 			assert.Equal(t, tt.expected, isNoResourceMatch(tt.err))
 		})
 	}
+}
+
+func TestPolicyGetErrorMessage(t *testing.T) {
+	t.Parallel()
+	crd := policyGetErrorMessage("ns", "web", fmt.Errorf("the server could not find the requested resource"))
+	assert.Contains(t, crd, "Attune CRDs are not installed")
+	assert.Contains(t, crd, "helm install attune")
+	assert.NotContains(t, crd, "Error fetching policy")
+
+	missing := policyGetErrorMessage("ns", "web", apierrors.NewNotFound(schema.GroupResource{Resource: "attunepolicies"}, "web"))
+	assert.Contains(t, missing, "policy ns/web not found")
+	assert.Contains(t, missing, "kubectl attune status -n ns")
+
+	other := policyGetErrorMessage("ns", "web", fmt.Errorf("connection refused"))
+	assert.Contains(t, other, "Error fetching policy ns/web: connection refused")
 }
 
 func ptrInt32(v int32) *int32 { return &v }

--- a/config/crd/bases/attune.io_attunedefaults.yaml
+++ b/config/crd/bases/attune.io_attunedefaults.yaml
@@ -861,7 +861,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation

--- a/config/crd/bases/attune.io_attunenamespacedefaults.yaml
+++ b/config/crd/bases/attune.io_attunenamespacedefaults.yaml
@@ -862,7 +862,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -954,7 +954,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -861,7 +861,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation
@@ -1755,7 +1756,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation
@@ -2741,7 +2743,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -860,7 +860,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation
@@ -1754,7 +1755,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation
@@ -2740,7 +2742,8 @@ spec:
                       when:
                         description: |-
                           When selects the trigger. Defaults to AfterSuccessfulResize when
-                          Enabled is true and When is empty.
+                          Enabled is true and When is empty. AfterSuccessfulResize also
+                          patches after Eviction+Evicted (InPlaceOrRecreate).
                         enum:
                         - AfterSuccessfulResize
                         - OnRecommendation

--- a/docs/architecture/resize-api.md
+++ b/docs/architecture/resize-api.md
@@ -217,11 +217,11 @@ stateDiagram-v2
 
 - **Eviction fallback restarts the pod from the current template.** When a pod
   is evicted, the workload controller (Deployment, StatefulSet) creates a
-  replacement pod from the current PodTemplate. Attune does not patch
-  workload templates as part of eviction fallback, so the replacement pod may
-  come back with the original resources until a later in-place resize succeeds.
-  Evicted pods are recorded separately from successful in-place resizes and do
-  not enter the safety observation path.
+  replacement pod from the current PodTemplate. With
+  `templatePersistence.when=AfterSuccessfulResize` enabled, Attune patches the
+  template after `Evicted` history so the replacement starts at the recommended
+  requests. Without persist, the replacement keeps the old template until a
+  later in-place resize. Evicted pods do not enter the safety observation path.
 
 - **Fail-open schedule.** If the configured timezone is invalid,
   `isWithinResizeWindow` returns `true` (allows resize) rather than silently

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -486,7 +486,7 @@ kubectl get pod <pod> -o jsonpath='{range .status.conditions[?(@.type=="PodResiz
 
 - **Deferred**: skip until kubelet clears `PodResizePending`; next reconcile retries. No max deferred age cut-off (watch `attune_deferred_age_seconds` and `ResizeBlocked` message for escalation).
 - **Infeasible + InPlaceOnly**: skip every cycle until the condition clears or you change `resizeMethod` / capacity.
-- **Infeasible + InPlaceOrRecreate**: one eviction attempt per container resize path. History reason is `eviction_last_replica` when only one live Running replica remains, `eviction_denied` when the Eviction API rejects (PDB), or `eviction_list_failed` / `eviction_no_selector` when the live count cannot be taken. The next cycle may try again.
+- **Infeasible + InPlaceOrRecreate**: one eviction attempt per container resize path. History reason is `eviction_last_replica` when only one live Running replica remains, `eviction_denied` when the Eviction API rejects (PDB), or `eviction_list_failed` / `eviction_no_selector` when the live count cannot be taken. The next cycle may try again. If `templatePersistence.when=AfterSuccessfulResize` is enabled, a successful Eviction also patches the template so the replacement is not supposed to boot at the old request.
 
 ### InPlaceOrRecreate but no eviction
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1074,11 +1074,12 @@ spec:
       when: AfterSuccessfulResize # default when enabled
 ```
 
-- **`AfterSuccessfulResize`**: only after a successful in-place resize. In
-  Recommend/Observe modes this never fires (webhook warns). Use
-  `when: OnRecommendation` for Recommend. A successful memory-only resize
-  still patches the template (CPU can stay at the original request). Do
-  not require both resources to change.
+- **`AfterSuccessfulResize`**: after a successful in-place resize, and
+  also after a successful Eviction (InPlaceOrRecreate) so the owner
+  recreates from the updated template. In Recommend/Observe modes this
+  never fires (webhook warns). Use `when: OnRecommendation` for Recommend.
+  A successful memory-only resize still patches the template (CPU can stay
+  at the original request). Do not require both resources to change.
 - **`OnRecommendation`**: still skipped in **Observe** mode.
 - **Canary**: template patches wait until canary reaches `FullRollout`.
 - **Stale recommendation**: `recommendations[].stale` is true; the template is not patched until fresh Prometheus data.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -461,7 +461,7 @@ Built-in known names include `istio-proxy`, `linkerd-proxy`, `consul-dataplane`,
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `updateStrategy.templatePersistence.enabled` | bool | `false` | When true, write recommended resources into Deployment/StatefulSet pod templates so new pods start correctly sized. **Opt-in only.** Do not enable under unmanaged GitOps without adopting recommendations in Git; prefer `export` or `initialSizing` instead. |
-| `updateStrategy.templatePersistence.when` | string | `AfterSuccessfulResize` | `AfterSuccessfulResize`: patch template only after a successful in-place resize. `OnRecommendation`: patch when a recommendation is accepted (works in Recommend mode). |
+| `updateStrategy.templatePersistence.when` | string | `AfterSuccessfulResize` | `AfterSuccessfulResize`: patch template after a successful in-place resize or a successful Eviction (`InPlaceOrRecreate`) so replacement pods start from the new requests. `OnRecommendation`: patch when a recommendation is accepted (works in Recommend mode). |
 
 Template changes trigger a rolling update. The operator no-ops when the template already matches and skips patches mid-rollout. **Observe mode never patches.** **Canary** defers template writes until `FullRollout` so a partial canary resize does not roll the whole fleet via the template. Requests are clamped to limits the same way as live resize.
 

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -30,6 +30,7 @@ import (
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/attune-io/attune/internal/operatormetrics"
+	"github.com/attune-io/attune/internal/resize"
 	pkgdefaults "github.com/attune-io/attune/pkg/defaults"
 )
 
@@ -110,6 +111,20 @@ func materializeContainerResources(
 	}
 	// Match resize path: requests must not exceed limits when both are set.
 	_ = clampRequestsToLimits(&out)
+
+	if memLim, ok := out.Limits[corev1.ResourceMemory]; ok &&
+		!c.Current.MemoryLimit.IsZero() && memLim.Cmp(c.Current.MemoryLimit) < 0 {
+		if usage, hasUsage := recentMemoryUsage(c); hasUsage {
+			margin := float64(attunev1alpha1.DefaultDecreaseUsageMarginPercent)
+			if policy.Spec.Memory.DecreaseUsageMarginPercent != nil {
+				margin = float64(*policy.Spec.Memory.DecreaseUsageMarginPercent)
+			}
+			floored, applied := resize.FloorMemoryLimitForUsage(out, c.Current.MemoryLimit, usage, margin)
+			if applied {
+				out = floored
+			}
+		}
+	}
 
 	// Only write limits into the template when ControlledValues says so.
 	// RequestsOnly must leave existing template limits untouched (merge keeps them).
@@ -421,12 +436,23 @@ func workloadKindName(w client.Object) string {
 	}
 }
 
+// isSuccessfulResizeForPersist reports whether history should trigger
+// AfterSuccessfulResize template persistence. Includes in-place Success
+// and Eviction+Evicted (InPlaceOrRecreate) so replacement pods pick up
+// the updated template.
+func isSuccessfulResizeForPersist(h attunev1alpha1.ResizeHistoryEntry) bool {
+	if isSuccessfulInPlaceHistory(h) {
+		return true
+	}
+	return resizeHistoryMethod(h) == "Eviction" && h.Result == attunev1alpha1.ResizeResultEvicted
+}
+
 // successfulResizeWorkloads returns workload names that had a successful
-// in-place resize in the given history batch.
+// in-place resize or eviction in the given history batch.
 func successfulResizeWorkloads(history []attunev1alpha1.ResizeHistoryEntry) map[string]bool {
 	out := make(map[string]bool)
 	for _, h := range history {
-		if isSuccessfulInPlaceHistory(h) {
+		if isSuccessfulResizeForPersist(h) {
 			out[h.Workload] = true
 		}
 	}
@@ -434,11 +460,12 @@ func successfulResizeWorkloads(history []attunev1alpha1.ResizeHistoryEntry) map[
 }
 
 // laggingAfterResizeWorkloads returns workloads that should (re)try template
-// persistence after a successful in-place resize. Includes this-cycle
-// successes always. From status history, only includes a workload when its
-// latest InPlace Success is not followed by a TemplatePatched entry (failed
-// patch, mid-rollout skip, or never attempted). This avoids turning
-// AfterSuccessfulResize into permanent OnRecommendation after one success.
+// persistence after a successful in-place resize or eviction. Includes
+// this-cycle successes always. From status history, only includes a workload
+// when its latest persist-trigger success is not followed by a
+// TemplatePatched entry (failed patch, mid-rollout skip, or never
+// attempted). This avoids turning AfterSuccessfulResize into permanent
+// OnRecommendation after one success.
 func laggingAfterResizeWorkloads(
 	cycleHistory []attunev1alpha1.ResizeHistoryEntry,
 	statusHistory []attunev1alpha1.ResizeHistoryEntry,
@@ -458,7 +485,7 @@ func laggingAfterResizeWorkloads(
 			st = &wlState{}
 			byWL[h.Workload] = st
 		}
-		if isSuccessfulInPlaceHistory(h) {
+		if isSuccessfulResizeForPersist(h) {
 			if !st.hasSuccess || h.Timestamp.After(st.lastSuccess.Time) {
 				st.hasSuccess = true
 				st.lastSuccess = h.Timestamp

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -268,7 +268,15 @@ func (r *AttunePolicyReconciler) applyTemplatePersistence(
 				c.Recommended.MemoryLimit.Equal(c.Current.MemoryLimit) {
 				continue
 			}
-			desired[c.Name] = materializeContainerResources(policy, c)
+			want := materializeContainerResources(policy, c)
+			if recLim, ok := want.Limits[corev1.ResourceMemory]; ok &&
+				!c.Recommended.MemoryLimit.IsZero() && recLim.Cmp(c.Recommended.MemoryLimit) > 0 {
+				logger.V(1).Info("Template persist memory limit floored above usage",
+					"workload", rec.Workload, "container", c.Name,
+					"recommendedLimit", c.Recommended.MemoryLimit.String(),
+					"flooredLimit", recLim.String())
+			}
+			desired[c.Name] = want
 		}
 		if len(desired) == 0 {
 			logger.V(1).Info("Template persistence no-op: no container changes",

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -520,10 +520,12 @@ func TestSuccessfulResizeWorkloads(t *testing.T) {
 		{Workload: "a", Method: "InPlace", Result: attunev1alpha1.ResizeResultSuccess},
 		{Workload: "b", Method: "InPlace", Result: attunev1alpha1.ResizeResultFailed},
 		{Workload: "c", Method: "TemplatePersistence", Result: attunev1alpha1.ResizeResultTemplatePatched},
+		{Workload: "d", Method: "Eviction", Result: attunev1alpha1.ResizeResultEvicted},
 	})
 	assert.True(t, got["a"])
 	assert.False(t, got["b"])
 	assert.False(t, got["c"])
+	assert.True(t, got["d"], "Evicted InPlaceOrRecreate must trigger AfterSuccessfulResize persist")
 }
 
 func TestLaggingAfterResizeWorkloads(t *testing.T) {
@@ -548,6 +550,11 @@ func TestLaggingAfterResizeWorkloads(t *testing.T) {
 			{Workload: "retry", Method: "InPlace", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: t0},
 			{Workload: "retry", Method: "TemplatePersistence", Result: attunev1alpha1.ResizeResultTemplatePatched, Timestamp: t1},
 			{Workload: "retry", Method: "InPlace", Result: attunev1alpha1.ResizeResultSuccess, Timestamp: t2},
+			// prior Evicted without later TemplatePatched → lagging
+			{Workload: "evicted-prior", Method: "Eviction", Result: attunev1alpha1.ResizeResultEvicted, Timestamp: t0},
+			// Evicted then TemplatePatched → not lagging
+			{Workload: "evicted-done", Method: "Eviction", Result: attunev1alpha1.ResizeResultEvicted, Timestamp: t0},
+			{Workload: "evicted-done", Method: "TemplatePersistence", Result: attunev1alpha1.ResizeResultTemplatePatched, Timestamp: t1},
 		},
 	)
 	assert.True(t, got["cycle"])
@@ -555,6 +562,8 @@ func TestLaggingAfterResizeWorkloads(t *testing.T) {
 	assert.False(t, got["failed"])
 	assert.False(t, got["done"])
 	assert.True(t, got["retry"])
+	assert.True(t, got["evicted-prior"], "Evicted without later TemplatePatched must lag")
+	assert.False(t, got["evicted-done"], "Evicted then TemplatePatched must not lag")
 }
 
 func TestCanaryBlocksTemplatePersistence(t *testing.T) {
@@ -597,6 +606,43 @@ func TestMaterializeContainerResources_ClampsRequestsOnlyDefault(t *testing.T) {
 	assert.Equal(t, int64(200), got.Requests.Cpu().MilliValue(), "CPU request clamped to current limit")
 	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("256Mi")), "memory request clamped to current limit")
 	assert.Nil(t, got.Limits, "RequestsOnly must not write limits into the template payload")
+}
+
+func TestMaterializeContainerResources_MemoryUsageFloor(t *testing.T) {
+	policy := &attunev1alpha1.AttunePolicy{}
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.Memory.ControlledValues = &cv
+	memDec := true
+	policy.Spec.Memory.AllowDecrease = &memDec
+	c := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			MemoryRequest: resource.MustParse("64Mi"),
+			MemoryLimit:   resource.MustParse("512Mi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			MemoryRequest: resource.MustParse("64Mi"),
+			MemoryLimit:   resource.MustParse("64Mi"),
+		},
+		Explanation: &attunev1alpha1.ContainerRecommendationExplanation{
+			Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+				RawPercentile: resource.MustParse("200Mi"),
+			},
+		},
+	}
+	got := materializeContainerResources(policy, c)
+	require.NotNil(t, got.Limits)
+	gotLim := got.Limits[corev1.ResourceMemory]
+	assert.True(t, gotLim.Cmp(resource.MustParse("64Mi")) > 0,
+		"floored limit must exceed raw recommended 64Mi, got %s", gotLim.String())
+	// Default 10% margin: 200Mi * 1.10 = 220Mi
+	assert.True(t, gotLim.Cmp(resource.MustParse("220Mi")) >= 0,
+		"limit %s must be >= usage floor 220Mi", gotLim.String())
+
+	reqOnly := &attunev1alpha1.AttunePolicy{}
+	reqOnly.Spec.Memory.AllowDecrease = &memDec
+	gotRO := materializeContainerResources(reqOnly, c)
+	assert.Nil(t, gotRO.Limits, "RequestsOnly must still leave Limits nil")
 }
 
 func TestMaterializeContainerResources_ClampsRequestsAndLimits(t *testing.T) {

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -764,17 +764,78 @@ func TestE2E_OneShotMode_ResizesOnePod(t *testing.T) {
 	t.Parallel()
 	ns := uniqueNS("oneshot")
 	createNamespace(t, ns)
-	createDeployment(t, "oneshot-app", ns, "250m", "256Mi", 2)
+	createDeployment(t, "oneshot-app", ns, "500m", "256Mi", 2)
 	waitForDeploymentReady(t, "oneshot-app", ns, deployReadyTimeout)
 
-	createPolicy(t, "oneshot-policy", ns, "oneshot-app", attunev1alpha1.UpdateTypeOneShot)
+	// Pin MaxAllowed below start so a load spike cannot count as a resize.
+	deployName := "oneshot-app"
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "oneshot-policy", Namespace: ns},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			TargetRef: attunev1alpha1.TargetRef{Kind: "Deployment", Name: &deployName},
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Prometheus:        &attunev1alpha1.PrometheusConfig{Address: promAddr},
+				MinimumDataPoints: int32Ptr(1),
+				HistoryWindow:     &metav1.Duration{Duration: time.Hour},
+				QueryStep:         &metav1.Duration{Duration: 30 * time.Second},
+				RateWindow:        &metav1.Duration{Duration: 5 * time.Minute},
+			},
+			CPU: attunev1alpha1.ResourceConfig{
+				Percentile:       95,
+				Overhead:         "20",
+				MinAllowed:       quantityPtr("50m"),
+				MaxAllowed:       quantityPtr("250m"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			Memory: attunev1alpha1.ResourceConfig{
+				Percentile:       99,
+				Overhead:         "30",
+				AllowDecrease:    boolPtr(true),
+				MinAllowed:       quantityPtr("64Mi"),
+				MaxAllowed:       quantityPtr("8Gi"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type:       attunev1alpha1.UpdateTypeOneShot,
+				Cooldown:   &metav1.Duration{Duration: time.Minute},
+				AutoRevert: boolPtr(true),
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, policy))
 
 	waitForResize(t, "oneshot-policy", ns, 3*time.Minute)
 
-	// OneShot should resize exactly 1 pod.
-	var policy attunev1alpha1.AttunePolicy
-	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "oneshot-policy", Namespace: ns}, &policy))
-	assert.Equal(t, int32(1), policy.Status.Workloads.Resized,
+	// Workloads.Resized is per-workload; count live replica CPUs instead.
+	pods, err := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=oneshot-app",
+	})
+	require.NoError(t, err)
+	decreased := 0
+	stillAtStart := 0
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+			continue
+		}
+		for _, c := range pod.Spec.Containers {
+			if c.Name != "app" {
+				continue
+			}
+			cpu := c.Resources.Requests.Cpu()
+			if cpu != nil && cpu.MilliValue() < 500 {
+				decreased++
+			} else if cpu != nil && cpu.MilliValue() >= 500 {
+				stillAtStart++
+			}
+		}
+	}
+	require.Equal(t, 1, decreased, "OneShot should decrease exactly one replica below start")
+	require.Equal(t, 1, stillAtStart, "OneShot should leave exactly one replica at start")
+
+	var updated attunev1alpha1.AttunePolicy
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "oneshot-policy", Namespace: ns}, &updated))
+	assert.Equal(t, int32(1), updated.Status.Workloads.Resized,
 		"OneShot mode should resize exactly 1 workload")
 }
 
@@ -2403,10 +2464,45 @@ func TestE2E_ScaleUp_NewReplicasGetResized(t *testing.T) {
 	t.Parallel()
 	ns := uniqueNS("scaleup")
 	createNamespace(t, ns)
-	createDeployment(t, "scaleup-app", ns, "250m", "256Mi", 1)
+	createDeployment(t, "scaleup-app", ns, "500m", "256Mi", 1)
 	waitForDeploymentReady(t, "scaleup-app", ns, deployReadyTimeout)
 
-	createPolicy(t, "scaleup-policy", ns, "scaleup-app", attunev1alpha1.UpdateTypeAuto)
+	// Pin MaxAllowed below start so a load spike to 1 cannot count as resized.
+	deployName := "scaleup-app"
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "scaleup-policy", Namespace: ns},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			TargetRef: attunev1alpha1.TargetRef{Kind: "Deployment", Name: &deployName},
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Prometheus:        &attunev1alpha1.PrometheusConfig{Address: promAddr},
+				MinimumDataPoints: int32Ptr(1),
+				HistoryWindow:     &metav1.Duration{Duration: time.Hour},
+				QueryStep:         &metav1.Duration{Duration: 30 * time.Second},
+				RateWindow:        &metav1.Duration{Duration: 5 * time.Minute},
+			},
+			CPU: attunev1alpha1.ResourceConfig{
+				Percentile:       95,
+				Overhead:         "20",
+				MinAllowed:       quantityPtr("50m"),
+				MaxAllowed:       quantityPtr("250m"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			Memory: attunev1alpha1.ResourceConfig{
+				Percentile:       99,
+				Overhead:         "30",
+				AllowDecrease:    boolPtr(true),
+				MinAllowed:       quantityPtr("64Mi"),
+				MaxAllowed:       quantityPtr("8Gi"),
+				MaxChangePercent: int32Ptr(100),
+			},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type:       attunev1alpha1.UpdateTypeAuto,
+				Cooldown:   &metav1.Duration{Duration: time.Minute},
+				AutoRevert: boolPtr(true),
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, policy))
 	waitForResize(t, "scaleup-policy", ns, 5*time.Minute)
 
 	// Scale up to 2 replicas.
@@ -2423,9 +2519,10 @@ func TestE2E_ScaleUp_NewReplicasGetResized(t *testing.T) {
 	// Force a reconcile so the operator sees the new pod.
 	forcePolicyReconcile(t, "scaleup-policy", ns, 2*time.Minute)
 
-	// Wait for the second pod to be resized. Re-bump the policy periodically:
-	// under parallel E2E load the new replica can miss a single reconcile
-	// window (cooldown / InsufficientData), which flaked nightly on v1.33.
+	// Wait for both replicas to decrease below start. Re-bump the policy
+	// periodically: under parallel E2E load the new replica can miss a
+	// single reconcile window (cooldown / InsufficientData).
+	origCPU := resource.MustParse("500m")
 	lastForce := time.Now()
 	lastDiag := time.Time{}
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
@@ -2433,27 +2530,33 @@ func TestE2E_ScaleUp_NewReplicasGetResized(t *testing.T) {
 			touchPolicySpec(t, "scaleup-policy", ns)
 			lastForce = time.Now()
 		}
-		var podList corev1.PodList
-		if err := k8sClient.List(ctx, &podList, client.InNamespace(ns), client.MatchingLabels{"app": "scaleup-app"}); err != nil {
+		pods, err := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=scaleup-app",
+		})
+		if err != nil {
 			return false, nil
 		}
 		resizedCount := 0
 		running := 0
-		origCPU := resource.MustParse("250m")
-		for _, pod := range podList.Items {
-			if pod.Status.Phase != corev1.PodRunning {
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
 				continue
 			}
 			running++
 			for _, c := range pod.Spec.Containers {
-				if c.Name == "app" && c.Resources.Requests.Cpu().Cmp(origCPU) != 0 {
+				if c.Name != "app" {
+					continue
+				}
+				cpu := c.Resources.Requests.Cpu()
+				if cpu != nil && cpu.Cmp(origCPU) < 0 {
 					resizedCount++
 				}
 			}
 		}
 		if time.Since(lastDiag) > 30*time.Second {
 			lastDiag = time.Now()
-			for _, pod := range podList.Items {
+			for _, pod := range pods.Items {
 				for _, c := range pod.Spec.Containers {
 					if c.Name == "app" {
 						t.Logf("scaleup pod %s phase=%s cpu=%s", pod.Name, pod.Status.Phase, c.Resources.Requests.Cpu().String())
@@ -2463,7 +2566,7 @@ func TestE2E_ScaleUp_NewReplicasGetResized(t *testing.T) {
 			t.Logf("scaleup progress: running=%d resized=%d", running, resizedCount)
 		}
 		return running >= 2 && resizedCount >= 2, nil
-	}), "both replicas should eventually be resized")
+	}), "both replicas should eventually decrease below start")
 }
 
 func TestE2E_ConcurrentPolicies_SameNamespace(t *testing.T) {
@@ -3611,7 +3714,6 @@ func TestE2E_Paused_StopsAfterResize(t *testing.T) {
 	waitForLiveCPUDecrease(t, "paused-policy", ns, "paused-app", resource.MustParse("500m"), 4*time.Minute,
 		"need a resize before pause")
 
-	cpuBefore := liveAppCPU(t, ns, "paused-app")
 	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var p attunev1alpha1.AttunePolicy
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "paused-policy", Namespace: ns}, &p); err != nil {
@@ -3633,14 +3735,6 @@ func TestE2E_Paused_StopsAfterResize(t *testing.T) {
 		}
 		return false, nil
 	}), "Ready reason should become Paused")
-
-	deadline := time.Now().Add(45 * time.Second)
-	for time.Now().Before(deadline) {
-		live := liveAppCPU(t, ns, "paused-app")
-		assert.Equal(t, cpuBefore.MilliValue(), live.MilliValue(),
-			"paused policy must not keep changing live CPU")
-		time.Sleep(5 * time.Second)
-	}
 }
 
 func TestE2E_StatefulSet_AutoDecreasesCPU(t *testing.T) {
@@ -4103,23 +4197,4 @@ func readyReason(p attunev1alpha1.AttunePolicy) string {
 		}
 	}
 	return ""
-}
-
-func liveAppCPU(t *testing.T, namespace, app string) resource.Quantity {
-	t.Helper()
-	var pods corev1.PodList
-	require.NoError(t, k8sClient.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{"app": app}))
-	require.NotEmpty(t, pods.Items)
-	for _, pod := range pods.Items {
-		if pod.Status.Phase != corev1.PodRunning {
-			continue
-		}
-		for _, c := range pod.Spec.Containers {
-			if c.Name == "app" && c.Resources.Requests.Cpu() != nil {
-				return *c.Resources.Requests.Cpu()
-			}
-		}
-	}
-	t.Fatalf("no running app container CPU in %s/%s", namespace, app)
-	return resource.Quantity{}
 }


### PR DESCRIPTION
## Why

`AfterSuccessfulResize` ignored `Evicted` history. `InPlaceOrRecreate` then recreated pods from the old template. Persist also wrote raw recommended memory limits, skipping the live usage floor.

Three Go E2E tests could pass without proving their names: OneShot counted per-workload `Resized`, ScaleUp treated any CPU != 250m as resized, and Paused slept 45s inside a 1m cooldown.

## What changed

- Persist treats Eviction+Evicted as a trigger (`isSuccessfulResizeForPersist`). `isSuccessfulInPlaceHistory` is unchanged (cooldown/canary).
- `materializeContainerResources` applies `FloorMemoryLimitForUsage` from explanation RawPercentile. V(1) when the template limit is raised.
- CRD `When` text, configuration, troubleshooting, and resize-api docs match.
- OneShot/ScaleUp pin MaxAllowed and count live Clientset CPU decreases. Paused keeps `ReasonPaused` only.
- `kubectl attune explain` / `preview` print the same CRD-missing Helm hint as `status`, plus a NotFound list hint.

## Test plan

- [x] `go test ./internal/controller/ ./internal/resize/ ./cmd/kubectl-attune/ -race -count=1`
- [x] `make verify-quick` (2362 tests, 93.3% coverage, helm-unittest 118)
- [ ] PR E2E on this HEAD
