### PR TITLE
fix: persist template after hold and stale current

### DIFF
--- a/docs/architecture/resize-api.md
+++ b/docs/architecture/resize-api.md
@@ -220,8 +220,11 @@ stateDiagram-v2
   replacement pod from the current PodTemplate. With
   `templatePersistence.when=AfterSuccessfulResize` enabled, Attune patches the
   template after `Evicted` history so the replacement starts at the recommended
-  requests. Without persist, the replacement keeps the old template until a
-  later in-place resize. Evicted pods do not enter the safety observation path.
+  requests. Persist applies the same memory usage floor as live resize: a
+  stale `rec.Current` that is still the old template cannot write a limit
+  below recent usage. Without persist, the replacement keeps the old template
+  until a later in-place resize. Evicted pods do not enter the safety
+  observation path.
 
 - **Fail-open schedule.** If the configured timezone is invalid,
   `isWithinResizeWindow` returns `true` (allows resize) rather than silently

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -289,6 +289,11 @@ The target is then raised if it would fall at or below recent usage
 `(1 + decreaseUsageMarginPercent/100)`. See
 [resize API](resize-api.md).
 
+Template persist uses the same usage floor. After an in-place resize,
+`rec.Current` can still be the old template. Persist raises a recommended
+memory limit that is below recent usage even when that is not a decrease
+versus `rec.Current`. `RequestsOnly` persist does not write limits.
+
 ## Container exclusion
 
 Well-known mesh and sidecar names (for example `istio-proxy`,

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1083,6 +1083,10 @@ spec:
 - **`OnRecommendation`**: still skipped in **Observe** mode.
 - **Canary**: template patches wait until canary reaches `FullRollout`.
 - **Stale recommendation**: `recommendations[].stale` is true; the template is not patched until fresh Prometheus data.
+- **Memory usage floor**: persist will not write a memory limit below
+  recent usage (raw percentile plus `decreaseUsageMarginPercent`), even
+  if `rec.Current` still shows the old template. `RequestsOnly` persist
+  never writes limits.
 
 ### Mid-rollout or no-op
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -28,7 +28,9 @@ container. Check resize history if you see limit-only updates.
 The usage floor compares the target against the live container limit on
 the pod, not the workload template. After an in-place resize the template
 (and `rec.Current`) can lag. Alerts that assume the template limit is
-authoritative should use the live pod instead.
+authoritative should use the live pod instead. Persist applies the same
+floor when writing the template, so a lagged `rec.Current` cannot persist
+a limit below recent usage.
 
 ### Last-replica eviction uses a live Running count
 

--- a/internal/controller/memory_usage_floor_test.go
+++ b/internal/controller/memory_usage_floor_test.go
@@ -220,6 +220,49 @@ func TestApplyMemoryUsageFloor_UsesLiveContainerLimit(t *testing.T) {
 		"got %s want %s (1.5Gi * 1.1)", got.Limits.Memory().String(), want.String())
 }
 
+func TestApplyMemoryUsageFloor_ZeroMargin(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	margin := int32(0)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-zero", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			Memory: attunev1alpha1.ResourceConfig{
+				DecreaseUsageMarginPercent: &margin,
+			},
+		},
+	}
+	r := NewAttunePolicyReconciler()
+	r.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"}}
+	rec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			MemoryLimit: resource.MustParse("512Mi"),
+		},
+		Explanation: &attunev1alpha1.ContainerRecommendationExplanation{
+			Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+				RawPercentile: resource.MustParse("200Mi"),
+			},
+		},
+	}
+	target := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("64Mi")},
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("64Mi")},
+	}
+
+	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
+	gotLim := got.Limits.Memory()
+	assert.True(t, gotLim.Cmp(resource.MustParse("200Mi")) > 0,
+		"zero-margin floor must exceed usage 200Mi, got %s", gotLim.String())
+	assert.True(t, gotLim.Cmp(resource.MustParse("220Mi")) < 0,
+		"zero-margin floor %s must be < default 10%% floor 220Mi", gotLim.String())
+}
+
 func TestRecentMemoryUsage(t *testing.T) {
 	t.Parallel()
 	_, ok := recentMemoryUsage(attunev1alpha1.ContainerRecommendation{})

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -19,10 +19,12 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,14 +114,20 @@ func materializeContainerResources(
 	// Match resize path: requests must not exceed limits when both are set.
 	_ = clampRequestsToLimits(&out)
 
-	if memLim, ok := out.Limits[corev1.ResourceMemory]; ok &&
-		!c.Current.MemoryLimit.IsZero() && memLim.Cmp(c.Current.MemoryLimit) < 0 {
+	if _, ok := out.Limits[corev1.ResourceMemory]; ok {
 		if usage, hasUsage := recentMemoryUsage(c); hasUsage {
 			margin := float64(attunev1alpha1.DefaultDecreaseUsageMarginPercent)
 			if policy.Spec.Memory.DecreaseUsageMarginPercent != nil {
 				margin = float64(*policy.Spec.Memory.DecreaseUsageMarginPercent)
 			}
-			floored, applied := resize.FloorMemoryLimitForUsage(out, c.Current.MemoryLimit, usage, margin)
+			// rec.Current may be the stale template; max with usageFloor so
+			// an increase vs Current still cannot land below usage.
+			currentLimit := c.Current.MemoryLimit.DeepCopy()
+			usageFloor := memoryUsageFloorQuantity(usage, margin)
+			if !usageFloor.IsZero() && usageFloor.Cmp(currentLimit) > 0 {
+				currentLimit = usageFloor
+			}
+			floored, applied := resize.FloorMemoryLimitForUsage(out, currentLimit, usage, margin)
 			if applied {
 				out = floored
 			}
@@ -142,6 +150,36 @@ func materializeContainerResources(
 		}
 	}
 	return out
+}
+
+// memoryUsageFloorQuantity is ceil(usage * (1 + margin/100)). Margin 0 is
+// strictly above usage, matching resize.FloorMemoryLimitForUsage.
+func memoryUsageFloorQuantity(usage resource.Quantity, marginPercent float64) resource.Quantity {
+	if usage.IsZero() || usage.Sign() <= 0 {
+		return resource.Quantity{}
+	}
+	if math.IsNaN(marginPercent) || math.IsInf(marginPercent, 0) {
+		marginPercent = 0
+	}
+	if marginPercent < 0 {
+		marginPercent = 0
+	}
+	if marginPercent > 100 {
+		marginPercent = 100
+	}
+	floorBytes := float64(usage.Value()) * (1.0 + marginPercent/100.0)
+	if floorBytes <= 0 || math.IsNaN(floorBytes) || math.IsInf(floorBytes, 0) {
+		return resource.Quantity{}
+	}
+	floorInt := int64(math.Ceil(floorBytes))
+	if floorInt <= 0 {
+		return resource.Quantity{}
+	}
+	floor := *resource.NewQuantity(floorInt, resource.BinarySI)
+	if marginPercent == 0 && floor.Cmp(usage) <= 0 {
+		floor = *resource.NewQuantity(usage.Value()+1, resource.BinarySI)
+	}
+	return floor
 }
 
 // canaryBlocksTemplatePersistence returns true while a canary rollout is
@@ -259,13 +297,6 @@ func (r *AttunePolicyReconciler) applyTemplatePersistence(
 		desired := make(map[string]corev1.ResourceRequirements)
 		for _, c := range rec.Containers {
 			if excludeSet[c.Name] {
-				continue
-			}
-			// Skip if recommendation equals current (no real change).
-			if c.Recommended.CPURequest.Equal(c.Current.CPURequest) &&
-				c.Recommended.MemoryRequest.Equal(c.Current.MemoryRequest) &&
-				c.Recommended.CPULimit.Equal(c.Current.CPULimit) &&
-				c.Recommended.MemoryLimit.Equal(c.Current.MemoryLimit) {
 				continue
 			}
 			want := materializeContainerResources(policy, c)

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -380,11 +380,12 @@ func applyResourcesToPodSpec(spec *corev1.PodSpec, desired map[string]corev1.Res
 		if !ok {
 			continue
 		}
-		if resourcesEqual(c.Resources, want) {
+		// Merge first so RequestsOnly (Limits=nil) does not treat leftover
+		// template limits as a change when requests already match.
+		merged := mergeTemplateResources(c.Resources, want)
+		if resourcesEqual(c.Resources, merged) {
 			continue
 		}
-		// Preserve uncontrolled limit fields when only requests are set.
-		merged := mergeTemplateResources(c.Resources, want)
 		c.Resources = merged
 		modified = true
 	}
@@ -397,10 +398,11 @@ func applyResourcesToPodSpec(spec *corev1.PodSpec, desired map[string]corev1.Res
 		if !ok {
 			continue
 		}
-		if resourcesEqual(c.Resources, want) {
+		merged := mergeTemplateResources(c.Resources, want)
+		if resourcesEqual(c.Resources, merged) {
 			continue
 		}
-		c.Resources = mergeTemplateResources(c.Resources, want)
+		c.Resources = merged
 		modified = true
 	}
 	return modified

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -191,6 +191,97 @@ func TestApplyResourcesToPodSpec_NativeSidecarInitContainer(t *testing.T) {
 		"non-native init container must not be modified")
 }
 
+func TestApplyResourcesToPodSpec_RequestsOnlyKeepsLimitsAndNoOps(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name: "app",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		}},
+		InitContainers: []corev1.Container{{
+			Name:          "mesh",
+			RestartPolicy: &always,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		}},
+	}
+	desired := map[string]corev1.ResourceRequirements{
+		"app": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+		"mesh": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+	}
+
+	assert.False(t, applyResourcesToPodSpec(spec, desired),
+		"RequestsOnly with matching requests must not treat leftover limits as a change")
+	assert.Equal(t, int64(200), spec.Containers[0].Resources.Requests.Cpu().MilliValue())
+	assert.True(t, spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("256Mi")))
+	require.NotNil(t, spec.Containers[0].Resources.Limits)
+	assert.Equal(t, int64(1000), spec.Containers[0].Resources.Limits.Cpu().MilliValue())
+	assert.True(t, spec.Containers[0].Resources.Limits.Memory().Equal(resource.MustParse("1Gi")))
+	require.NotNil(t, spec.InitContainers[0].Resources.Limits)
+	assert.Equal(t, int64(1000), spec.InitContainers[0].Resources.Limits.Cpu().MilliValue())
+	assert.True(t, spec.InitContainers[0].Resources.Limits.Memory().Equal(resource.MustParse("1Gi")))
+}
+
+func TestApplyResourcesToPodSpec_RequestsOnlyUpdatesRequestsKeepsLimits(t *testing.T) {
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name: "app",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		}},
+	}
+	desired := map[string]corev1.ResourceRequirements{
+		"app": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+	}
+
+	assert.True(t, applyResourcesToPodSpec(spec, desired))
+	assert.Equal(t, int64(200), spec.Containers[0].Resources.Requests.Cpu().MilliValue())
+	assert.True(t, spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("256Mi")))
+	require.NotNil(t, spec.Containers[0].Resources.Limits)
+	assert.Equal(t, int64(1000), spec.Containers[0].Resources.Limits.Cpu().MilliValue())
+	assert.True(t, spec.Containers[0].Resources.Limits.Memory().Equal(resource.MustParse("1Gi")))
+}
+
 func TestMergeTemplateResources_PreservesUncontrolledLimits(t *testing.T) {
 	current := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -645,6 +736,45 @@ func TestMaterializeContainerResources_MemoryUsageFloor(t *testing.T) {
 	assert.Nil(t, gotRO.Limits, "RequestsOnly must still leave Limits nil")
 }
 
+func TestMaterializeContainerResources_MemoryUsageFloor_ZeroMargin(t *testing.T) {
+	policy := &attunev1alpha1.AttunePolicy{}
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.Memory.ControlledValues = &cv
+	memDec := true
+	policy.Spec.Memory.AllowDecrease = &memDec
+	zeroMargin := int32(0)
+	policy.Spec.Memory.DecreaseUsageMarginPercent = &zeroMargin
+	c := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			MemoryRequest: resource.MustParse("64Mi"),
+			MemoryLimit:   resource.MustParse("512Mi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			MemoryRequest: resource.MustParse("64Mi"),
+			MemoryLimit:   resource.MustParse("64Mi"),
+		},
+		Explanation: &attunev1alpha1.ContainerRecommendationExplanation{
+			Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+				RawPercentile: resource.MustParse("200Mi"),
+			},
+		},
+	}
+	got := materializeContainerResources(policy, c)
+	require.NotNil(t, got.Limits)
+	gotLim := got.Limits[corev1.ResourceMemory]
+	assert.True(t, gotLim.Cmp(resource.MustParse("200Mi")) > 0,
+		"zero-margin floor must exceed usage 200Mi, got %s", gotLim.String())
+	assert.True(t, gotLim.Cmp(resource.MustParse("220Mi")) < 0,
+		"zero-margin floor %s must be < default 10%% floor 220Mi", gotLim.String())
+
+	reqOnly := &attunev1alpha1.AttunePolicy{}
+	reqOnly.Spec.Memory.AllowDecrease = &memDec
+	reqOnly.Spec.Memory.DecreaseUsageMarginPercent = &zeroMargin
+	gotRO := materializeContainerResources(reqOnly, c)
+	assert.Nil(t, gotRO.Limits, "RequestsOnly must still leave Limits nil")
+}
+
 func TestMaterializeContainerResources_ClampsRequestsAndLimits(t *testing.T) {
 	policy := &attunev1alpha1.AttunePolicy{}
 	cv := attunev1alpha1.ControlledRequestsAndLimits
@@ -936,6 +1066,75 @@ func TestApplyTemplatePersistence_SkipsStale(t *testing.T) {
 		"stale rec must leave template memory request unchanged")
 }
 
+func TestApplyTemplatePersistence_SkipsStale_AfterSuccessfulResize(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api",
+		Kind:     "Deployment",
+		Stale:    true,
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("512Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("200m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+			},
+		}},
+	}}
+
+	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
+		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, map[string]bool{"api": true})
+	assert.Empty(t, history, "stale rec must not patch after a successful resize")
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.Equal(t, int64(500), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(),
+		"stale rec must leave template CPU request unchanged")
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"stale rec must leave template memory request unchanged")
+}
+
 func TestApplyTemplatePersistence_NoOpWhenTemplateMatches(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, appsv1.AddToScheme(scheme))
@@ -998,6 +1197,84 @@ func TestApplyTemplatePersistence_NoOpWhenTemplateMatches(t *testing.T) {
 	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
 		attunev1alpha1.TemplatePersistenceOnRecommendation, nil)
 	assert.Empty(t, history, "template already matches desired; no history entry")
+}
+
+func TestApplyTemplatePersistence_RequestsOnlyPreservesTemplateLimits(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	memDec := true
+	policy.Spec.Memory.AllowDecrease = &memDec
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("512Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("200m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+			},
+		}},
+	}}
+
+	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
+		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, map[string]bool{"api": true})
+	require.Len(t, history, 1)
+	assert.Equal(t, attunev1alpha1.ResizeResultTemplatePatched, history[0].Result)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	res := updated.Spec.Template.Spec.Containers[0].Resources
+	assert.Equal(t, int64(200), res.Requests.Cpu().MilliValue())
+	assert.True(t, res.Requests.Memory().Equal(resource.MustParse("256Mi")))
+	require.NotNil(t, res.Limits)
+	assert.Equal(t, int64(1000), res.Limits.Cpu().MilliValue())
+	assert.True(t, res.Limits.Memory().Equal(resource.MustParse("1Gi")))
 }
 
 func TestApplyTemplatePersistence_DisabledByDefault(t *testing.T) {

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -775,6 +775,42 @@ func TestMaterializeContainerResources_MemoryUsageFloor_ZeroMargin(t *testing.T)
 	assert.Nil(t, gotRO.Limits, "RequestsOnly must still leave Limits nil")
 }
 
+func TestMaterializeContainerResources_FloorsAgainstUsageWhenNotDecreaseVsCurrent(t *testing.T) {
+	policy := &attunev1alpha1.AttunePolicy{}
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.Memory.ControlledValues = &cv
+	memDec := true
+	policy.Spec.Memory.AllowDecrease = &memDec
+	c := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			MemoryLimit: resource.MustParse("512Mi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			MemoryLimit: resource.MustParse("1Gi"),
+		},
+		Explanation: &attunev1alpha1.ContainerRecommendationExplanation{
+			Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+				RawPercentile: resource.MustParse("1536Mi"),
+			},
+		},
+	}
+	got := materializeContainerResources(policy, c)
+	require.NotNil(t, got.Limits)
+	gotLim := got.Limits[corev1.ResourceMemory]
+	// Recommended 1Gi is an increase vs stale Current 512Mi, but still
+	// below usage 1.5Gi + 10% (~1689Mi). Persist must not write 1Gi.
+	assert.True(t, gotLim.Cmp(resource.MustParse("1Gi")) > 0,
+		"limit %s must exceed recommended 1Gi", gotLim.String())
+	assert.True(t, gotLim.Cmp(resource.MustParse("1689Mi")) >= 0,
+		"limit %s must be >= usage floor 1.5Gi * 1.10 (~1689Mi)", gotLim.String())
+
+	reqOnly := &attunev1alpha1.AttunePolicy{}
+	reqOnly.Spec.Memory.AllowDecrease = &memDec
+	gotRO := materializeContainerResources(reqOnly, c)
+	assert.Nil(t, gotRO.Limits, "RequestsOnly must not invent limits")
+}
+
 func TestMaterializeContainerResources_ClampsRequestsAndLimits(t *testing.T) {
 	policy := &attunev1alpha1.AttunePolicy{}
 	cv := attunev1alpha1.ControlledRequestsAndLimits
@@ -1133,6 +1169,76 @@ func TestApplyTemplatePersistence_SkipsStale_AfterSuccessfulResize(t *testing.T)
 		"stale rec must leave template CPU request unchanged")
 	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("512Mi")),
 		"stale rec must leave template memory request unchanged")
+}
+
+func TestApplyTemplatePersistence_PatchesTemplateWhenRecCurrentEqualsRecommended(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	memDec := true
+	policy.Spec.Memory.AllowDecrease = &memDec
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	// holdMissing copies live/prior into both Current and Recommended.
+	// Rec equality must not skip persist when the template is still stale.
+	held := attunev1alpha1.ResourceValues{
+		CPURequest:    resource.MustParse("200m"),
+		MemoryRequest: resource.MustParse("256Mi"),
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name:        "app",
+			Current:     held,
+			Recommended: held,
+		}},
+	}}
+
+	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
+		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, map[string]bool{"api": true})
+	require.Len(t, history, 1)
+	assert.Equal(t, attunev1alpha1.ResizeResultTemplatePatched, history[0].Result)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.Equal(t, int64(200), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("256Mi")))
 }
 
 func TestApplyTemplatePersistence_NoOpWhenTemplateMatches(t *testing.T) {


### PR DESCRIPTION
## Summary

Template persist could skip a real write, or write an unsafe memory limit, after a successful resize.

- **RequestsOnly no-op:** leftover template limits no longer force `TemplatePatched` when requests already match. Merge first, then compare.
- **Hold / prior rec:** AfterSuccessfulResize no longer skips when `rec.Current` equals `rec.Recommended`. `holdMissingResourceRequest` copies live or prior into both fields, so that equality is not "template already matches."
- **Usage floor:** persist raises a recommended memory limit that is below recent usage even when `rec.Current` is still the old template. `RequestsOnly` still writes no limits.

## Tests

Red-green on:

- `TestApplyResourcesToPodSpec_RequestsOnlyKeepsLimitsAndNoOps`
- `TestApplyTemplatePersistence_RequestsOnlyPreservesTemplateLimits`
- `TestApplyTemplatePersistence_PatchesTemplateWhenRecCurrentEqualsRecommended`
- `TestMaterializeContainerResources_FloorsAgainstUsageWhenNotDecreaseVsCurrent`

Local `make verify-quick`: 2370 tests, 93.2% coverage, helm-unittest 118.

## Docs

`resize-api.md`, `safety.md`, `upgrading.md`, and troubleshooting persist notes now describe the persist usage floor versus a lagged `rec.Current`.

Release PR #670 (`chore(main): release 0.1.27`) stays user-gated.
