### PR TITLE
test: assert persist template fields and exact usage floors

### DIFF
--- a/internal/controller/memory_usage_floor_test.go
+++ b/internal/controller/memory_usage_floor_test.go
@@ -257,10 +257,9 @@ func TestApplyMemoryUsageFloor_ZeroMargin(t *testing.T) {
 
 	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
 	gotLim := got.Limits.Memory()
-	assert.True(t, gotLim.Cmp(resource.MustParse("200Mi")) > 0,
-		"zero-margin floor must exceed usage 200Mi, got %s", gotLim.String())
-	assert.True(t, gotLim.Cmp(resource.MustParse("220Mi")) < 0,
-		"zero-margin floor %s must be < default 10%% floor 220Mi", gotLim.String())
+	usage := resource.MustParse("200Mi")
+	want := *resource.NewQuantity(usage.Value()+1, resource.BinarySI)
+	assert.True(t, gotLim.Equal(want), "zero-margin floor must be usage+1 byte, got %s want %s", gotLim.String(), want.String())
 }
 
 func TestRecentMemoryUsage(t *testing.T) {

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -457,6 +458,12 @@ func TestApplyTemplatePersistence_AfterSuccessfulResize_OnlyResizedWorkloads(t *
 		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, map[string]bool{"api": true})
 	require.Len(t, history, 1)
 	assert.Equal(t, attunev1alpha1.ResizeResultTemplatePatched, history[0].Result)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.Equal(t, int64(200), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"default AllowDecrease=false keeps template memory 512Mi")
 }
 
 func TestApplyTemplatePersistence_StatefulSet(t *testing.T) {
@@ -763,10 +770,9 @@ func TestMaterializeContainerResources_MemoryUsageFloor_ZeroMargin(t *testing.T)
 	got := materializeContainerResources(policy, c)
 	require.NotNil(t, got.Limits)
 	gotLim := got.Limits[corev1.ResourceMemory]
-	assert.True(t, gotLim.Cmp(resource.MustParse("200Mi")) > 0,
-		"zero-margin floor must exceed usage 200Mi, got %s", gotLim.String())
-	assert.True(t, gotLim.Cmp(resource.MustParse("220Mi")) < 0,
-		"zero-margin floor %s must be < default 10%% floor 220Mi", gotLim.String())
+	usage := resource.MustParse("200Mi")
+	want := *resource.NewQuantity(usage.Value()+1, resource.BinarySI)
+	assert.True(t, gotLim.Equal(want), "zero-margin floor must be usage+1 byte, got %s want %s", gotLim.String(), want.String())
 
 	reqOnly := &attunev1alpha1.AttunePolicy{}
 	reqOnly.Spec.Memory.AllowDecrease = &memDec
@@ -799,11 +805,12 @@ func TestMaterializeContainerResources_FloorsAgainstUsageWhenNotDecreaseVsCurren
 	require.NotNil(t, got.Limits)
 	gotLim := got.Limits[corev1.ResourceMemory]
 	// Recommended 1Gi is an increase vs stale Current 512Mi, but still
-	// below usage 1.5Gi + 10% (~1689Mi). Persist must not write 1Gi.
+	// below usage 1.5Gi + 10%. Persist must not write 1Gi.
 	assert.True(t, gotLim.Cmp(resource.MustParse("1Gi")) > 0,
 		"limit %s must exceed recommended 1Gi", gotLim.String())
-	assert.True(t, gotLim.Cmp(resource.MustParse("1689Mi")) >= 0,
-		"limit %s must be >= usage floor 1.5Gi * 1.10 (~1689Mi)", gotLim.String())
+	usage := resource.MustParse("1536Mi")
+	want := *resource.NewQuantity(int64(math.Ceil(float64(usage.Value())*1.1)), resource.BinarySI)
+	assert.True(t, gotLim.Equal(want), "got %s want %s (1536Mi * 1.1)", gotLim.String(), want.String())
 
 	reqOnly := &attunev1alpha1.AttunePolicy{}
 	reqOnly.Spec.Memory.AllowDecrease = &memDec
@@ -964,12 +971,24 @@ func TestApplyTemplatePersistence_SkipsCanaryInProgress(t *testing.T) {
 		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, map[string]bool{"api": true})
 	assert.Empty(t, history, "canary InProgress must not patch templates")
 
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.Equal(t, int64(500), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(),
+		"canary InProgress must leave template CPU request unchanged")
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"canary InProgress must leave template memory request unchanged")
+
 	// FullRollout allows patch.
 	policy.Status.Canary.Phase = attunev1alpha1.CanaryPhaseFullRollout
 	history = r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
 		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, map[string]bool{"api": true})
 	require.Len(t, history, 1)
 	assert.Equal(t, attunev1alpha1.ResizeResultTemplatePatched, history[0].Result)
+
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.Equal(t, int64(200), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"default AllowDecrease=false keeps template memory 512Mi")
 }
 
 func TestApplyTemplatePersistence_SkipsMidRollout(t *testing.T) {
@@ -1031,6 +1050,13 @@ func TestApplyTemplatePersistence_SkipsMidRollout(t *testing.T) {
 	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
 		attunev1alpha1.TemplatePersistenceOnRecommendation, nil)
 	assert.Empty(t, history, "mid-rollout must not patch")
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.Equal(t, int64(500), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(),
+		"mid-rollout must leave template CPU request unchanged")
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"mid-rollout must leave template memory request unchanged")
 }
 
 func TestApplyTemplatePersistence_SkipsStale(t *testing.T) {

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -790,9 +790,9 @@ func TestE2E_OneShotMode_ResizesOnePod(t *testing.T) {
 			Memory: attunev1alpha1.ResourceConfig{
 				Percentile:       99,
 				Overhead:         "30",
-				AllowDecrease:    boolPtr(true),
-				MinAllowed:       quantityPtr("64Mi"),
-				MaxAllowed:       quantityPtr("8Gi"),
+				AllowDecrease:    boolPtr(false),
+				MinAllowed:       quantityPtr("256Mi"),
+				MaxAllowed:       quantityPtr("256Mi"),
 				MaxChangePercent: int32Ptr(100),
 			},
 			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
@@ -804,34 +804,67 @@ func TestE2E_OneShotMode_ResizesOnePod(t *testing.T) {
 	}
 	require.NoError(t, k8sClient.Create(ctx, policy))
 
-	waitForResize(t, "oneshot-policy", ns, 3*time.Minute)
-
-	// Workloads.Resized is per-workload; count live replica CPUs instead.
-	pods, err := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
-		LabelSelector: "app=oneshot-app",
-	})
-	require.NoError(t, err)
-	decreased := 0
-	stillAtStart := 0
-	for i := range pods.Items {
-		pod := &pods.Items[i]
-		if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
-			continue
+	// waitForResize returns on Workloads.Resized after any one resource.
+	// Memory-only Success under parallel PromQL made a one-shot CPU count
+	// see 0 decreases. Pin memory min=max and poll live replica CPUs.
+	lastTouch := time.Now()
+	lastDiag := time.Time{}
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		if time.Since(lastTouch) > 45*time.Second {
+			touchPolicySpec(t, "oneshot-policy", ns)
+			lastTouch = time.Now()
 		}
-		for _, c := range pod.Spec.Containers {
-			if c.Name != "app" {
+		pods, err := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=oneshot-app",
+		})
+		if err != nil {
+			return false, nil
+		}
+		decreased := 0
+		stillAtStart := 0
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
 				continue
 			}
-			cpu := c.Resources.Requests.Cpu()
-			if cpu != nil && cpu.MilliValue() < 500 {
-				decreased++
-			} else if cpu != nil && cpu.MilliValue() >= 500 {
-				stillAtStart++
+			for _, c := range pod.Spec.Containers {
+				if c.Name != "app" {
+					continue
+				}
+				cpu := c.Resources.Requests.Cpu()
+				if cpu != nil && cpu.MilliValue() < 500 {
+					decreased++
+				} else if cpu != nil && cpu.MilliValue() >= 500 {
+					stillAtStart++
+				}
 			}
 		}
-	}
-	require.Equal(t, 1, decreased, "OneShot should decrease exactly one replica below start")
-	require.Equal(t, 1, stillAtStart, "OneShot should leave exactly one replica at start")
+		if decreased == 1 && stillAtStart == 1 {
+			return true, nil
+		}
+		if time.Since(lastDiag) > 30*time.Second {
+			lastDiag = time.Now()
+			var p attunev1alpha1.AttunePolicy
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: "oneshot-policy", Namespace: ns}, &p); err == nil {
+				t.Logf("oneshot: decreased=%d stillAtStart=%d discovered=%d recs=%d resized=%d",
+					decreased, stillAtStart, p.Status.Workloads.Discovered,
+					p.Status.Workloads.WithRecommendations, p.Status.Workloads.Resized)
+			}
+			for i := range pods.Items {
+				pod := &pods.Items[i]
+				for _, c := range pod.Spec.Containers {
+					if c.Name != "app" {
+						continue
+					}
+					t.Logf("  pod %s phase=%s cpu=%s mem=%s",
+						pod.Name, pod.Status.Phase,
+						c.Resources.Requests.Cpu().String(),
+						c.Resources.Requests.Memory().String())
+				}
+			}
+		}
+		return false, nil
+	}), "OneShot should decrease exactly one replica CPU below start")
 
 	var updated attunev1alpha1.AttunePolicy
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "oneshot-policy", Namespace: ns}, &updated))


### PR DESCRIPTION
## Summary

Test Auditor pass after #680. Persist tests treated `TemplatePatched` history as proof the template changed, and usage-floor tests only used a range.

- AfterSuccessfulResize, canary InProgress/FullRollout, and mid-rollout now `Get` the Deployment and assert CPU and memory.
- Zero-margin floors are pinned to usage+1 byte (not any value in `(200Mi, 220Mi)`).
- Persist floor versus a stale `rec.Current` is exact `ceil(usage * 1.1)`.

No production change.

Local `make verify-quick` on this branch. Release PR #670 stays user-gated.


## Follow-up

CI E2E `TestE2E_OneShotMode_ResizesOnePod` failed in 11s: `waitForResize` returned after a memory-only Success, then a one-shot CPU count saw 0 decreases. Poll live replica CPUs and pin memory min=max.
