### PR TITLE
fix: oneshot remaining replicas and restore template on revert

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -658,7 +658,7 @@ To prevent conflicts:
 
 ```
 1. SELECT target pods based on update strategy mode:
-   - OneShot: one eligible pod per cycle
+   - OneShot: one eligible needing pod per cycle
    - Canary: canaryPercentage% of pods (round up to at least 1)
      per app; CREATE sizing, startup boost, and HPA stay off until
      that app's own watch promotes it (`status.canary.workloads`)
@@ -773,7 +773,7 @@ func (r *ResizeEngine) WaitForResize(ctx context.Context, ns, podName,
 |------|----------|------------|
 | `Observe` | Collect metrics and track data-point progress; no recommendations surfaced | None |
 | `Recommend` | Generate recommendations in status, no changes | None |
-| `OneShot` | Resize one pod, monitor, stop | Low |
+| `OneShot` | Resize one eligible needing pod per cycle | Low |
 | `Canary` | Resize canary%, monitor, then remaining | Medium |
 | `Auto` | Full automated canary-then-fleet | Medium-High |
 

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -206,8 +206,13 @@ When a safety violation is detected:
    container resources back to the original values from the `ResizeRecord`.
 2. The revert uses `UpdateResize` (the same in-place mechanism), so no pod
    restart occurs.
-3. The resize history entry is updated to `result: Reverted`.
-4. The `attune_reverts_total` counter is incremented with the
+3. When `templatePersistence.when=AfterSuccessfulResize` is enabled, the
+   controller also restores the Deployment/StatefulSet template for that
+   container from the pre-resize snapshot (`OriginalResources`). Persist
+   already patched the template on Success or Evicted, before the
+   observation window; without this restore, rollouts keep the unsafe size.
+4. The resize history entry is updated to `result: Reverted`.
+5. The `attune_reverts_total` counter is incremented with the
    violation reason as a label.
 
 ```mermaid

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1080,6 +1080,8 @@ spec:
   never fires (webhook warns). Use `when: OnRecommendation` for Recommend.
   A successful memory-only resize still patches the template (CPU can stay
   at the original request). Do not require both resources to change.
+  A later safety revert also restores the template to the pre-resize
+  snapshot so rollouts do not keep the unsafe size.
 - **`OnRecommendation`**: still skipped in **Observe** mode.
 - **Canary**: template patches wait until canary reaches `FullRollout`.
 - **Stale recommendation**: `recommendations[].stale` is true; the template is not patched until fresh Prometheus data.

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -202,7 +202,7 @@ provides a graduated path:
 |------|-------------|------------|
 | **Observe** | Collects metrics and tracks data-point progress; no recommendations surfaced | Zero |
 | **Recommend** | Collects metrics and writes recommendations to the policy status | Zero |
-| **OneShot** | Resizes one pod per reconciliation cycle, then stops | Minimal |
+| **OneShot** | Resizes one pod per cycle until remaining replicas match the recommendation (cooldown between pods) | Minimal |
 | **Canary** | Resizes 10% of pods first, watches them, then auto-promotes to the rest (optional) | Low |
 | **Auto** | Continuously resizes all eligible pods based on observed metrics | Production-ready |
 

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -75,6 +76,47 @@ func TestSelectPodsForResize_OneShot_SelectsExactlyOne(t *testing.T) {
 	pods := makeRunningPods(5)
 	selected := selectPodsForResize(pods, attunev1alpha1.UpdateTypeOneShot, 0)
 	assert.Len(t, selected, 1)
+}
+
+func oneshotResizePod(name, cpuReq, memReq string) corev1.Pod {
+	pod := makeCanaryPod(name, true, false)
+	pod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(cpuReq),
+			corev1.ResourceMemory: resource.MustParse(memReq),
+		},
+	}
+	return pod
+}
+
+func TestFirstOneShotPodNeedingResize_SkipsAlreadyAtTarget(t *testing.T) {
+	pods := []corev1.Pod{
+		oneshotResizePod("pod-0", "200m", "256Mi"),
+		oneshotResizePod("pod-1", "500m", "512Mi"),
+		oneshotResizePod("pod-2", "500m", "512Mi"),
+	}
+	rec := newResizeRecommendation("api", "500m", "512Mi", "0", "0", "200m", "256Mi", "0", "0")
+
+	// Unfixed OneShot is eligible[:1], so it keeps selecting the already-resized pod.
+	selected := selectPodsForResize(pods, attunev1alpha1.UpdateTypeOneShot, 0)
+	require.Len(t, selected, 1)
+	assert.Equal(t, "pod-0", selected[0].Name)
+
+	got := firstOneShotPodNeedingResize(pods, rec)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-1", got[0].Name)
+}
+
+func TestFirstOneShotPodNeedingResize_AllAtTarget(t *testing.T) {
+	pods := []corev1.Pod{
+		oneshotResizePod("pod-0", "200m", "256Mi"),
+		oneshotResizePod("pod-1", "200m", "256Mi"),
+		oneshotResizePod("pod-2", "200m", "256Mi"),
+	}
+	rec := newResizeRecommendation("api", "500m", "512Mi", "0", "0", "200m", "256Mi", "0", "0")
+
+	got := firstOneShotPodNeedingResize(pods, rec)
+	assert.Empty(t, got)
 }
 
 func TestSelectPodsForResize_Canary_10PercentOf20(t *testing.T) {

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -71,6 +71,44 @@ func selectPodsForResize(pods []corev1.Pod, mode attunev1alpha1.UpdateType, cana
 	}
 }
 
+// firstOneShotPodNeedingResize returns the first eligible pod whose live
+// requests/limits still differ from rec (at most one). Already-at-target
+// replicas are skipped so OneShot can walk the remaining set across cycles.
+func firstOneShotPodNeedingResize(pods []corev1.Pod, rec attunev1alpha1.WorkloadRecommendation) []corev1.Pod {
+	for i := range pods {
+		p := &pods[i]
+		if !resize.IsEligibleForResize(p) {
+			continue
+		}
+		if oneShotPodAlreadyAtTarget(p, rec) {
+			continue
+		}
+		return []corev1.Pod{*p}
+	}
+	return nil
+}
+
+// oneShotPodAlreadyAtTarget is true when every recommended container already
+// matches buildResizeTarget (same compare as shouldSkipResize).
+func oneShotPodAlreadyAtTarget(pod *corev1.Pod, rec attunev1alpha1.WorkloadRecommendation) bool {
+	if len(rec.Containers) == 0 {
+		return true
+	}
+	for _, containerRec := range rec.Containers {
+		target, _ := buildResizeTarget(containerRec)
+		c := findContainerByName(pod, containerRec.Name)
+		if c == nil {
+			return false
+		}
+		if c.Resources.Requests.Cpu().MilliValue() != target.Requests.Cpu().MilliValue() ||
+			c.Resources.Requests.Memory().Value() != target.Requests.Memory().Value() ||
+			!targetLimitsMatchLive(c.Resources.Limits, target.Limits) {
+			return false
+		}
+	}
+	return true
+}
+
 // budgetIncrease returns the positive live-pod request increase needed to
 // reach the clamped resize target. Decreases do not consume per-cycle budget.
 func budgetIncrease(pod *corev1.Pod, containerName string, target corev1.ResourceRequirements) (cpuMilli int64, memBytes int64) {
@@ -258,6 +296,9 @@ func (r *AttunePolicyReconciler) executeResizes(
 			}
 		}
 		selectedPods := selectPodsForResize(pods, wlMode, canaryPct)
+		if wlMode == attunev1alpha1.UpdateTypeOneShot {
+			selectedPods = firstOneShotPodNeedingResize(pods, rec)
+		}
 		logger.V(1).Info("Pod selection for resize",
 			"workload", rec.Workload, "total", len(pods),
 			"selected", len(selectedPods), "type", wlMode)

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -320,6 +320,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 								logger.Error(revertErr, "Failed to revert pod during early critical check", "pod", pod.Name)
 								continue
 							}
+							r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record)
 							operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, v.Reason).Inc()
 							if r.Recorder != nil {
 								r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",
@@ -382,6 +383,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 					revertFailed = true
 					continue
 				}
+				r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record)
 				operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, verdict.Reason).Inc()
 				if r.Recorder != nil {
 					r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -33,6 +33,7 @@ import (
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/attune-io/attune/internal/operatormetrics"
 	"github.com/attune-io/attune/internal/resize"
+	"github.com/attune-io/attune/internal/safety"
 	pkgdefaults "github.com/attune-io/attune/pkg/defaults"
 )
 
@@ -222,6 +223,55 @@ func quantityEqual(a, b corev1.ResourceList, name corev1.ResourceName) bool {
 		return false
 	}
 	return qa.Equal(qb)
+}
+
+// restoreTemplateAfterSafetyRevert writes the pre-resize snapshot back onto
+// the Deployment/StatefulSet template after a successful live-pod revert.
+// AfterSuccessfulResize already patched the unsafe rec before observation;
+// without this restore, new pods and rollouts start at the size that just
+// failed safety.
+func (r *AttunePolicyReconciler) restoreTemplateAfterSafetyRevert(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	workloads []client.Object,
+	record safety.ResizeRecord,
+) {
+	logger := log.FromContext(ctx)
+	if !templatePersistenceEnabled(policy.Spec.UpdateStrategy) {
+		return
+	}
+	if templatePersistenceWhen(policy.Spec.UpdateStrategy) != attunev1alpha1.TemplatePersistenceAfterSuccessfulResize {
+		return
+	}
+
+	var workload client.Object
+	for _, w := range workloads {
+		if w.GetName() != record.WorkloadName {
+			continue
+		}
+		switch workloadKindName(w) {
+		case "Deployment", "StatefulSet":
+			workload = w
+		}
+		break
+	}
+	if workload == nil {
+		return
+	}
+
+	desired := map[string]corev1.ResourceRequirements{
+		record.Container: record.OriginalResources,
+	}
+	changed, err := r.patchWorkloadTemplateResources(ctx, workload, desired)
+	if err != nil {
+		logger.Error(err, "Failed to restore template after safety revert",
+			"workload", record.WorkloadName, "container", record.Container)
+		return
+	}
+	if changed {
+		logger.Info("Restored template after safety revert",
+			"workload", record.WorkloadName, "container", record.Container)
+	}
 }
 
 // applyTemplatePersistence patches Deployment/StatefulSet pod templates for

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/safety"
 )
 
 func TestTemplatePersistenceEnabled(t *testing.T) {
@@ -1505,4 +1506,99 @@ func TestWorkloadKindName(t *testing.T) {
 	assert.Equal(t, "CronJob", workloadKindName(&batchv1.CronJob{}))
 	// Unknown object falls back to GVK kind (empty when unset).
 	assert.Equal(t, "", workloadKindName(&corev1.Pod{}))
+}
+
+func persistAtRec64MiDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("200m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+}
+
+func original256MiRecord() safety.ResizeRecord {
+	return safety.ResizeRecord{
+		PodName:      "api-abc",
+		Namespace:    "default",
+		Container:    "app",
+		WorkloadName: "api",
+		OriginalResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+	}
+}
+
+func TestRestoreTemplateAfterSafetyRevert_AfterSuccessfulResize(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := persistAtRec64MiDeployment()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	r.restoreTemplateAfterSafetyRevert(context.Background(), policy, []client.Object{deploy}, original256MiRecord())
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("256Mi")),
+		"template memory request must restore to the pre-resize snapshot")
+}
+
+func TestRestoreTemplateAfterSafetyRevert_DisabledNoOp(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := persistAtRec64MiDeployment()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(false),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	r.restoreTemplateAfterSafetyRevert(context.Background(), policy, []client.Object{deploy}, original256MiRecord())
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("64Mi")),
+		"disabled persist must leave the template at the recommended size")
 }


### PR DESCRIPTION
## Summary

Two live product holes on the resize/persist path.

- **OneShot:** selection was the first Running pod every cycle. After that replica succeeded, the next cycle no-oped it and later replicas never resized. OneShot now picks the first eligible pod that still differs from the recommendation.
- **Safety revert:** AfterSuccessfulResize already patches the template on Success. Revert only `UpdateResize`d the live pod, so rollouts and new pods kept the unsafe rec. A successful safety revert now restores the Deployment/StatefulSet template from the pre-resize snapshot. Persist is not delayed (Evicted replacements still need the new template immediately).

## Tests

- `TestFirstOneShotPodNeedingResize_SkipsAlreadyAtTarget`
- `TestFirstOneShotPodNeedingResize_AllAtTarget`
- `TestRestoreTemplateAfterSafetyRevert_AfterSuccessfulResize`
- `TestRestoreTemplateAfterSafetyRevert_DisabledNoOp`

Local `make verify-quick`: 2374 tests, 93.2% coverage.

Release PR #670 stays user-gated.
