### PR TITLE
fix: oneshot treat clamped memory as already at target

### DIFF
--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -102,7 +102,7 @@ func TestFirstOneShotPodNeedingResize_SkipsAlreadyAtTarget(t *testing.T) {
 	require.Len(t, selected, 1)
 	assert.Equal(t, "pod-0", selected[0].Name)
 
-	got := firstOneShotPodNeedingResize(pods, rec)
+	got := firstOneShotNeeding(pods, rec)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name)
 }
@@ -115,8 +115,41 @@ func TestFirstOneShotPodNeedingResize_AllAtTarget(t *testing.T) {
 	}
 	rec := newResizeRecommendation("api", "500m", "512Mi", "0", "0", "200m", "256Mi", "0", "0")
 
-	got := firstOneShotPodNeedingResize(pods, rec)
+	got := firstOneShotNeeding(pods, rec)
 	assert.Empty(t, got)
+}
+
+func oneshotResizePodWithLimits(name, cpuReq, memReq, cpuLim, memLim string) corev1.Pod {
+	pod := oneshotResizePod(name, cpuReq, memReq)
+	pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(cpuLim),
+		corev1.ResourceMemory: resource.MustParse(memLim),
+	}
+	return pod
+}
+
+func TestFirstOneShotPodNeedingResize_SkipsClampedMemoryLimit(t *testing.T) {
+	// After a 1.33 clamp, live memory limit stays at the start value while
+	// the rec still wants a lower limit. OneShot must treat the clamped
+	// replica as already applied so the remaining set can move.
+	pods := []corev1.Pod{
+		oneshotResizePodWithLimits("pod-0", "200m", "64Mi", "200m", "512Mi"),
+		oneshotResizePodWithLimits("pod-1", "200m", "512Mi", "200m", "512Mi"),
+	}
+	// RequestsAndLimits rec wants 64Mi request and 64Mi limit.
+	rec := newResizeRecommendation("api", "500m", "512Mi", "500m", "512Mi", "200m", "64Mi", "200m", "64Mi")
+
+	r := NewAttunePolicyReconciler()
+	r.AllowInPlaceMemoryLimitDecrease = false
+	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-1", got[0].Name)
+}
+
+// firstOneShotNeeding wraps firstOneShotPodNeedingResize for request-only tests.
+func firstOneShotNeeding(pods []corev1.Pod, rec attunev1alpha1.WorkloadRecommendation) []corev1.Pod {
+	r := NewAttunePolicyReconciler()
+	return r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec)
 }
 
 func TestSelectPodsForResize_Canary_10PercentOf20(t *testing.T) {

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -146,6 +146,30 @@ func TestFirstOneShotPodNeedingResize_SkipsClampedMemoryLimit(t *testing.T) {
 	assert.Equal(t, "pod-1", got[0].Name)
 }
 
+func TestFirstOneShotPodNeedingResize_SkipsFlooredGuaranteed(t *testing.T) {
+	// After the usage floor, a Guaranteed replica already at the floored
+	// pair (550/550) must count as applied. Without raising the request
+	// after the floor, compare sees live 550/550 vs target 200/550.
+	pod0 := oneshotResizePodWithLimits("pod-0", "200m", "550Mi", "200m", "550Mi")
+	pod0.Status.QOSClass = corev1.PodQOSGuaranteed
+	pod1 := oneshotResizePodWithLimits("pod-1", "200m", "1Gi", "200m", "1Gi")
+	pod1.Status.QOSClass = corev1.PodQOSGuaranteed
+	pods := []corev1.Pod{pod0, pod1}
+
+	rec := newResizeRecommendation("api", "200m", "1Gi", "200m", "1Gi", "200m", "200Mi", "200m", "200Mi")
+	rec.Containers[0].Explanation = &attunev1alpha1.ContainerRecommendationExplanation{
+		Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+			RawPercentile: resource.MustParse("500Mi"),
+		},
+	}
+
+	r := NewAttunePolicyReconciler()
+	r.AllowInPlaceMemoryLimitDecrease = true
+	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-1", got[0].Name)
+}
+
 // firstOneShotNeeding wraps firstOneShotPodNeedingResize for request-only tests.
 func firstOneShotNeeding(pods []corev1.Pod, rec attunev1alpha1.WorkloadRecommendation) []corev1.Pod {
 	r := NewAttunePolicyReconciler()

--- a/internal/controller/memory_usage_floor_test.go
+++ b/internal/controller/memory_usage_floor_test.go
@@ -32,7 +32,75 @@ import (
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/attune-io/attune/internal/operatormetrics"
+	"github.com/attune-io/attune/internal/resize"
 )
+
+func TestApplyMemoryUsageFloor_GuaranteedRaisesRequestToFlooredLimit(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	margin := int32(10)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-qos", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			Memory: attunev1alpha1.ResourceConfig{
+				DecreaseUsageMarginPercent: &margin,
+			},
+		},
+	}
+	r := NewAttunePolicyReconciler()
+	r.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "app",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{QOSClass: corev1.PodQOSGuaranteed},
+	}
+	rec := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("200m"),
+			CPULimit:      resource.MustParse("200m"),
+			MemoryRequest: resource.MustParse("1Gi"),
+			MemoryLimit:   resource.MustParse("1Gi"),
+		},
+		Explanation: &attunev1alpha1.ContainerRecommendationExplanation{
+			Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+				RawPercentile: resource.MustParse("500Mi"),
+			},
+		},
+	}
+	target := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
+	}
+
+	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
+	got = resize.RaiseGuaranteedMemoryRequestToLimit(pod, got)
+	want := resource.MustParse("550Mi")
+	require.NotNil(t, got.Limits)
+	assert.True(t, got.Limits.Memory().Equal(want),
+		"limit %s want %s", got.Limits.Memory().String(), want.String())
+	assert.True(t, got.Requests.Memory().Equal(want),
+		"request %s want %s (Guaranteed must match floored limit)",
+		got.Requests.Memory().String(), want.String())
+}
 
 func TestApplyMemoryUsageFloor_RaisesUnsafeLimit(t *testing.T) {
 	t.Parallel()

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -72,15 +72,21 @@ func selectPodsForResize(pods []corev1.Pod, mode attunev1alpha1.UpdateType, cana
 }
 
 // firstOneShotPodNeedingResize returns the first eligible pod whose live
-// requests/limits still differ from rec (at most one). Already-at-target
-// replicas are skipped so OneShot can walk the remaining set across cycles.
-func firstOneShotPodNeedingResize(pods []corev1.Pod, rec attunev1alpha1.WorkloadRecommendation) []corev1.Pod {
+// requests/limits still differ from the post-clamp post-floor target (at
+// most one). Already-at-target replicas are skipped so OneShot can walk
+// the remaining set across cycles.
+func (r *AttunePolicyReconciler) firstOneShotPodNeedingResize(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	pods []corev1.Pod,
+	rec attunev1alpha1.WorkloadRecommendation,
+) []corev1.Pod {
 	for i := range pods {
 		p := &pods[i]
 		if !resize.IsEligibleForResize(p) {
 			continue
 		}
-		if oneShotPodAlreadyAtTarget(p, rec) {
+		if r.oneShotPodAlreadyAtTarget(ctx, policy, p, rec) {
 			continue
 		}
 		return []corev1.Pod{*p}
@@ -89,13 +95,40 @@ func firstOneShotPodNeedingResize(pods []corev1.Pod, rec attunev1alpha1.Workload
 }
 
 // oneShotPodAlreadyAtTarget is true when every recommended container already
-// matches buildResizeTarget (same compare as shouldSkipResize).
-func oneShotPodAlreadyAtTarget(pod *corev1.Pod, rec attunev1alpha1.WorkloadRecommendation) bool {
+// matches the applied (clamped/floored) target. resizeContainer applies
+// ClampMemoryLimitForPolicy and applyMemoryUsageFloor before shouldSkipResize,
+// so OneShot must compare against that same applied target. Otherwise a
+// replica whose live limit stayed at the clamped/floored value is re-selected
+// every cycle and later replicas never move.
+func (r *AttunePolicyReconciler) oneShotPodAlreadyAtTarget(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	pod *corev1.Pod,
+	rec attunev1alpha1.WorkloadRecommendation,
+) bool {
 	if len(rec.Containers) == 0 {
 		return true
 	}
 	for _, containerRec := range rec.Containers {
 		target, _ := buildResizeTarget(containerRec)
+		// Same clamp + Guaranteed QoS raise + usage floor as resizeContainer
+		// so selection and shouldSkipResize see the same numbers.
+		preClamped := target.DeepCopy()
+		target = resize.ClampMemoryLimitForPolicy(pod, containerRec.Name, target, r.AllowInPlaceMemoryLimitDecrease)
+		platformClamped := false
+		if memLim, ok := preClamped.Limits[corev1.ResourceMemory]; ok {
+			if clampedLim, cok := target.Limits[corev1.ResourceMemory]; cok && !memLim.Equal(clampedLim) {
+				platformClamped = true
+				if pod.Status.QOSClass == corev1.PodQOSGuaranteed {
+					if memReq, rok := target.Requests[corev1.ResourceMemory]; rok && memReq.Cmp(clampedLim) < 0 {
+						target.Requests[corev1.ResourceMemory] = clampedLim.DeepCopy()
+					}
+				}
+			}
+		}
+		if !platformClamped {
+			target = r.applyMemoryUsageFloor(ctx, policy, pod, containerRec, target)
+		}
 		c := findContainerByName(pod, containerRec.Name)
 		if c == nil {
 			return false
@@ -297,7 +330,7 @@ func (r *AttunePolicyReconciler) executeResizes(
 		}
 		selectedPods := selectPodsForResize(pods, wlMode, canaryPct)
 		if wlMode == attunev1alpha1.UpdateTypeOneShot {
-			selectedPods = firstOneShotPodNeedingResize(pods, rec)
+			selectedPods = r.firstOneShotPodNeedingResize(ctx, policy, pods, rec)
 		}
 		logger.V(1).Info("Pod selection for resize",
 			"workload", rec.Workload, "total", len(pods),

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -128,6 +128,7 @@ func (r *AttunePolicyReconciler) oneShotPodAlreadyAtTarget(
 		}
 		if !platformClamped {
 			target = r.applyMemoryUsageFloor(ctx, policy, pod, containerRec, target)
+			target = resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
 		}
 		c := findContainerByName(pod, containerRec.Name)
 		if c == nil {
@@ -538,6 +539,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	// recent usage from the metrics window (#444 / #428).
 	if !platformClamped {
 		target = r.applyMemoryUsageFloor(ctx, policy, pod, containerRec, target)
+		target = resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
 	}
 
 	skip, reason := r.shouldSkipResize(ctx, policy, pod, containerRec, target, p.Checks)

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -19,12 +19,10 @@ package controller
 import (
 	"context"
 	"fmt"
-	"math"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -124,7 +122,7 @@ func materializeContainerResources(
 			// rec.Current may be the stale template; max with usageFloor so
 			// an increase vs Current still cannot land below usage.
 			currentLimit := c.Current.MemoryLimit.DeepCopy()
-			usageFloor := memoryUsageFloorQuantity(usage, margin)
+			usageFloor := resize.MemoryUsageFloorQuantity(usage, margin)
 			if !usageFloor.IsZero() && usageFloor.Cmp(currentLimit) > 0 {
 				currentLimit = usageFloor
 			}
@@ -150,37 +148,13 @@ func materializeContainerResources(
 			out.Limits = nil
 		}
 	}
+	// After RequestsOnly strips limits, raise is a no-op. Guaranteed is
+	// detected from current request==limit (no live pod QoS on a template).
+	guaranteed := resize.CurrentResourcesAreGuaranteed(
+		c.Current.CPURequest, c.Current.CPULimit,
+		c.Current.MemoryRequest, c.Current.MemoryLimit)
+	out = resize.RaiseMemoryRequestToLimitIfGuaranteed(out, guaranteed)
 	return out
-}
-
-// memoryUsageFloorQuantity is ceil(usage * (1 + margin/100)). Margin 0 is
-// strictly above usage, matching resize.FloorMemoryLimitForUsage.
-func memoryUsageFloorQuantity(usage resource.Quantity, marginPercent float64) resource.Quantity {
-	if usage.IsZero() || usage.Sign() <= 0 {
-		return resource.Quantity{}
-	}
-	if math.IsNaN(marginPercent) || math.IsInf(marginPercent, 0) {
-		marginPercent = 0
-	}
-	if marginPercent < 0 {
-		marginPercent = 0
-	}
-	if marginPercent > 100 {
-		marginPercent = 100
-	}
-	floorBytes := float64(usage.Value()) * (1.0 + marginPercent/100.0)
-	if floorBytes <= 0 || math.IsNaN(floorBytes) || math.IsInf(floorBytes, 0) {
-		return resource.Quantity{}
-	}
-	floorInt := int64(math.Ceil(floorBytes))
-	if floorInt <= 0 {
-		return resource.Quantity{}
-	}
-	floor := *resource.NewQuantity(floorInt, resource.BinarySI)
-	if marginPercent == 0 && floor.Cmp(usage) <= 0 {
-		floor = *resource.NewQuantity(usage.Value()+1, resource.BinarySI)
-	}
-	return floor
 }
 
 // canaryBlocksTemplatePersistence returns true while a canary rollout is

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -744,6 +744,53 @@ func TestMaterializeContainerResources_MemoryUsageFloor(t *testing.T) {
 	assert.Nil(t, gotRO.Limits, "RequestsOnly must still leave Limits nil")
 }
 
+func TestMaterializeContainerResources_MemoryUsageFloor_GuaranteedRaisesRequest(t *testing.T) {
+	policy := &attunev1alpha1.AttunePolicy{}
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.CPU.ControlledValues = &cv
+	policy.Spec.Memory.ControlledValues = &cv
+	memDec := true
+	policy.Spec.Memory.AllowDecrease = &memDec
+	c := attunev1alpha1.ContainerRecommendation{
+		Name: "app",
+		Current: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("200m"),
+			CPULimit:      resource.MustParse("200m"),
+			MemoryRequest: resource.MustParse("1Gi"),
+			MemoryLimit:   resource.MustParse("1Gi"),
+		},
+		Recommended: attunev1alpha1.ResourceValues{
+			CPURequest:    resource.MustParse("200m"),
+			CPULimit:      resource.MustParse("200m"),
+			MemoryRequest: resource.MustParse("200Mi"),
+			MemoryLimit:   resource.MustParse("200Mi"),
+		},
+		Explanation: &attunev1alpha1.ContainerRecommendationExplanation{
+			Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+				RawPercentile: resource.MustParse("500Mi"),
+			},
+		},
+	}
+	got := materializeContainerResources(policy, c)
+	require.NotNil(t, got.Limits)
+	want := resource.MustParse("550Mi")
+	gotLim := got.Limits[corev1.ResourceMemory]
+	gotReq := got.Requests[corev1.ResourceMemory]
+	assert.True(t, gotLim.Equal(want), "limit %s want %s", gotLim.String(), want.String())
+	assert.True(t, gotReq.Equal(want),
+		"Guaranteed request %s want %s (not 200/550 Burstable)",
+		gotReq.String(), want.String())
+
+	reqOnly := &attunev1alpha1.AttunePolicy{}
+	reqOnly.Spec.Memory.AllowDecrease = &memDec
+	gotRO := materializeContainerResources(reqOnly, c)
+	assert.Nil(t, gotRO.Limits, "RequestsOnly must still leave Limits nil")
+	gotROReq := gotRO.Requests[corev1.ResourceMemory]
+	assert.True(t, gotROReq.Equal(resource.MustParse("200Mi")),
+		"RequestsOnly must not raise request without a memory limit, got %s",
+		gotROReq.String())
+}
+
 func TestMaterializeContainerResources_MemoryUsageFloor_ZeroMargin(t *testing.T) {
 	policy := &attunev1alpha1.AttunePolicy{}
 	cv := attunev1alpha1.ControlledRequestsAndLimits

--- a/internal/resize/usage_floor.go
+++ b/internal/resize/usage_floor.go
@@ -99,3 +99,80 @@ func FloorMemoryLimitForUsage(
 	}
 	return *adjusted, true
 }
+
+// RaiseGuaranteedMemoryRequestToLimit sets memory request equal to memory
+// limit when the pod is Guaranteed and request is below the (possibly
+// floored) limit. No-op when target has no memory limit (RequestsOnly).
+func RaiseGuaranteedMemoryRequestToLimit(pod *corev1.Pod, target corev1.ResourceRequirements) corev1.ResourceRequirements {
+	if pod == nil || pod.Status.QOSClass != corev1.PodQOSGuaranteed {
+		return target
+	}
+	return raiseMemoryRequestToLimit(target)
+}
+
+// RaiseMemoryRequestToLimitIfGuaranteed is the persist and CREATE-webhook
+// path: there is no live pod QoS. guaranteed is true when current
+// request equals limit for memory and CPU (all set, non-zero).
+func RaiseMemoryRequestToLimitIfGuaranteed(target corev1.ResourceRequirements, guaranteed bool) corev1.ResourceRequirements {
+	if !guaranteed {
+		return target
+	}
+	return raiseMemoryRequestToLimit(target)
+}
+
+// CurrentResourcesAreGuaranteed reports whether current request and limit
+// match for memory and CPU (all set, non-zero). Used when no live pod QoS
+// is available (template persist, CREATE initial sizing).
+func CurrentResourcesAreGuaranteed(cpuReq, cpuLim, memReq, memLim resource.Quantity) bool {
+	if cpuReq.IsZero() || cpuLim.IsZero() || memReq.IsZero() || memLim.IsZero() {
+		return false
+	}
+	return cpuReq.Equal(cpuLim) && memReq.Equal(memLim)
+}
+
+// MemoryUsageFloorQuantity is ceil(usage * (1 + margin/100)). Margin 0 is
+// strictly above usage, matching FloorMemoryLimitForUsage.
+func MemoryUsageFloorQuantity(usage resource.Quantity, marginPercent float64) resource.Quantity {
+	if usage.IsZero() || usage.Sign() <= 0 {
+		return resource.Quantity{}
+	}
+	if math.IsNaN(marginPercent) || math.IsInf(marginPercent, 0) {
+		marginPercent = 0
+	}
+	if marginPercent < 0 {
+		marginPercent = 0
+	}
+	if marginPercent > 100 {
+		marginPercent = 100
+	}
+	floorBytes := float64(usage.Value()) * (1.0 + marginPercent/100.0)
+	if floorBytes <= 0 || math.IsNaN(floorBytes) || math.IsInf(floorBytes, 0) {
+		return resource.Quantity{}
+	}
+	floorInt := int64(math.Ceil(floorBytes))
+	if floorInt <= 0 {
+		return resource.Quantity{}
+	}
+	floor := *resource.NewQuantity(floorInt, resource.BinarySI)
+	if marginPercent == 0 && floor.Cmp(usage) <= 0 {
+		floor = *resource.NewQuantity(usage.Value()+1, resource.BinarySI)
+	}
+	return floor
+}
+
+func raiseMemoryRequestToLimit(target corev1.ResourceRequirements) corev1.ResourceRequirements {
+	memLim, ok := target.Limits[corev1.ResourceMemory]
+	if !ok || memLim.IsZero() {
+		return target
+	}
+	memReq, rok := target.Requests[corev1.ResourceMemory]
+	if !rok || memReq.Cmp(memLim) >= 0 {
+		return target
+	}
+	adjusted := target.DeepCopy()
+	if adjusted.Requests == nil {
+		adjusted.Requests = corev1.ResourceList{}
+	}
+	adjusted.Requests[corev1.ResourceMemory] = memLim.DeepCopy()
+	return *adjusted
+}

--- a/internal/resize/usage_floor_test.go
+++ b/internal/resize/usage_floor_test.go
@@ -152,6 +152,63 @@ func TestFloorMemoryLimitForUsage(t *testing.T) {
 	}
 }
 
+func TestRaiseGuaranteedMemoryRequestToLimit(t *testing.T) {
+	t.Parallel()
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("550Mi")},
+	}
+	guaranteed := &corev1.Pod{Status: corev1.PodStatus{QOSClass: corev1.PodQOSGuaranteed}}
+	got := RaiseGuaranteedMemoryRequestToLimit(guaranteed, target)
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("550Mi")),
+		"got request %s", got.Requests.Memory().String())
+
+	burstable := &corev1.Pod{Status: corev1.PodStatus{QOSClass: corev1.PodQOSBurstable}}
+	got = RaiseGuaranteedMemoryRequestToLimit(burstable, target)
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("200Mi")),
+		"Burstable request must stay %s", got.Requests.Memory().String())
+
+	reqOnly := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
+	}
+	got = RaiseGuaranteedMemoryRequestToLimit(guaranteed, reqOnly)
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("200Mi")),
+		"no limit: request must stay %s", got.Requests.Memory().String())
+	assert.Empty(t, got.Limits)
+}
+
+func TestCurrentResourcesAreGuaranteed(t *testing.T) {
+	t.Parallel()
+	must := resource.MustParse
+	assert.True(t, CurrentResourcesAreGuaranteed(must("200m"), must("200m"), must("1Gi"), must("1Gi")))
+	assert.False(t, CurrentResourcesAreGuaranteed(must("200m"), must("400m"), must("1Gi"), must("1Gi")))
+	assert.False(t, CurrentResourcesAreGuaranteed(must("200m"), must("200m"), must("64Mi"), must("1Gi")))
+	assert.False(t, CurrentResourcesAreGuaranteed(resource.Quantity{}, must("200m"), must("1Gi"), must("1Gi")))
+}
+
+func TestRaiseMemoryRequestToLimitIfGuaranteed(t *testing.T) {
+	t.Parallel()
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("550Mi")},
+	}
+	got := RaiseMemoryRequestToLimitIfGuaranteed(target, true)
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("550Mi")))
+	got = RaiseMemoryRequestToLimitIfGuaranteed(target, false)
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("200Mi")))
+}
+
+func TestMemoryUsageFloorQuantity(t *testing.T) {
+	t.Parallel()
+	usage := resource.MustParse("500Mi")
+	got := MemoryUsageFloorQuantity(usage, 10)
+	assert.True(t, got.Equal(resource.MustParse("550Mi")), "got %s", got.String())
+	got = MemoryUsageFloorQuantity(usage, 0)
+	assert.Equal(t, usage.Value()+1, got.Value())
+	zeroFloor := MemoryUsageFloorQuantity(resource.Quantity{}, 10)
+	assert.True(t, zeroFloor.IsZero())
+}
+
 func TestFloorMemoryLimitForUsage_NaNMargin(t *testing.T) {
 	t.Parallel()
 	target := corev1.ResourceRequirements{

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -34,6 +34,7 @@ import (
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/attune-io/attune/internal/operatormetrics"
+	"github.com/attune-io/attune/internal/resize"
 )
 
 const (
@@ -294,13 +295,62 @@ func (h *PodMutatingHandler) mutateContainer(
 				if container.Resources.Limits == nil {
 					container.Resources.Limits = corev1.ResourceList{}
 				}
-				container.Resources.Limits[corev1.ResourceMemory] = cr.Recommended.MemoryLimit
+				memTarget := applyCreateMemoryUsageFloor(container.Resources, cr, policy)
+				container.Resources.Limits[corev1.ResourceMemory] = memTarget.Limits[corev1.ResourceMemory]
+				if req, ok := memTarget.Requests[corev1.ResourceMemory]; ok {
+					container.Resources.Requests[corev1.ResourceMemory] = req
+				}
 			}
 		}
 
 		return mutated
 	}
 	return false
+}
+
+// applyCreateMemoryUsageFloor floors a CREATE memory limit the same way
+// persist does (max currentLimit with usageFloor) and raises a Guaranteed
+// request to the floored limit. CREATE is not /resize, so no 1.33 clamp.
+func applyCreateMemoryUsageFloor(
+	live corev1.ResourceRequirements,
+	cr attunev1alpha1.ContainerRecommendation,
+	policy *attunev1alpha1.AttunePolicy,
+) corev1.ResourceRequirements {
+	target := corev1.ResourceRequirements{
+		Requests: live.Requests.DeepCopy(),
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: cr.Recommended.MemoryLimit.DeepCopy()},
+	}
+	if req, ok := live.Requests[corev1.ResourceMemory]; !ok || req.IsZero() {
+		if !cr.Recommended.MemoryRequest.IsZero() {
+			if target.Requests == nil {
+				target.Requests = corev1.ResourceList{}
+			}
+			target.Requests[corev1.ResourceMemory] = cr.Recommended.MemoryRequest.DeepCopy()
+		}
+	}
+
+	if cr.Explanation != nil && cr.Explanation.Memory != nil {
+		usage := cr.Explanation.Memory.RawPercentile
+		if !usage.IsZero() && usage.Sign() > 0 {
+			margin := float64(attunev1alpha1.DefaultDecreaseUsageMarginPercent)
+			if policy != nil && policy.Spec.Memory.DecreaseUsageMarginPercent != nil {
+				margin = float64(*policy.Spec.Memory.DecreaseUsageMarginPercent)
+			}
+			currentLimit := cr.Current.MemoryLimit.DeepCopy()
+			usageFloor := resize.MemoryUsageFloorQuantity(usage, margin)
+			if !usageFloor.IsZero() && usageFloor.Cmp(currentLimit) > 0 {
+				currentLimit = usageFloor
+			}
+			if floored, applied := resize.FloorMemoryLimitForUsage(target, currentLimit, usage, margin); applied {
+				target = floored
+			}
+		}
+	}
+
+	guaranteed := resize.CurrentResourcesAreGuaranteed(
+		cr.Current.CPURequest, cr.Current.CPULimit,
+		cr.Current.MemoryRequest, cr.Current.MemoryLimit)
+	return resize.RaiseMemoryRequestToLimitIfGuaranteed(target, guaranteed)
 }
 
 // resolveOwner walks the ownerReferences to find the top-level workload kind.

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -524,6 +524,48 @@ func TestPodMutatingHandler_RequestsAndLimits(t *testing.T) {
 	assert.Equal(t, resource.MustParse("512Mi"), mutatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
 }
 
+func TestPodMutatingHandler_RequestsAndLimits_UsageFloorGuaranteed(t *testing.T) {
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.CPU.ControlledValues = &cv
+	policy.Spec.Memory.ControlledValues = &cv
+	cr := &policy.Status.Recommendations[0].Containers[0]
+	cr.Current = attunev1alpha1.ResourceValues{
+		CPURequest:    resource.MustParse("200m"),
+		CPULimit:      resource.MustParse("200m"),
+		MemoryRequest: resource.MustParse("1Gi"),
+		MemoryLimit:   resource.MustParse("1Gi"),
+	}
+	cr.Recommended.CPURequest = resource.MustParse("200m")
+	cr.Recommended.CPULimit = resource.MustParse("200m")
+	cr.Recommended.MemoryRequest = resource.MustParse("200Mi")
+	cr.Recommended.MemoryLimit = resource.MustParse("200Mi")
+	cr.Explanation = &attunev1alpha1.ContainerRecommendationExplanation{
+		Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+			RawPercentile: resource.MustParse("500Mi"),
+		},
+	}
+
+	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	req := makeAdmissionRequest(t, pod, "default")
+	resp := handler.Handle(context.Background(), req)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches, "expected patches")
+
+	mutatedPod := patchedPod(t, req.Object.Raw, resp)
+	want := resource.MustParse("550Mi")
+	gotLim := mutatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
+	gotReq := mutatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
+	assert.True(t, gotLim.Equal(want),
+		"CREATE must not write a limit below the usage floor, got %s want %s",
+		gotLim.String(), want.String())
+	assert.True(t, gotReq.Equal(want),
+		"Guaranteed CREATE request %s want %s", gotReq.String(), want.String())
+}
+
 func TestPodMutatingHandler_WrongNamespace(t *testing.T) {
 	policy := testPolicy("my-policy", "production", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")


### PR DESCRIPTION
## Summary

OneShot now treats a replica as already at target when its live resources match the post-clamp, post-floor values that `resizeContainer` would actually apply.

## Problem

[#682](https://github.com/attune-io/attune/pull/682) made OneShot skip replicas that already match the recommendation so later pods can move. That compare used the raw `buildResizeTarget` rec.

On Kubernetes 1.33 (`NotRequired` memory-limit clamp) or when the usage floor raises a recommended limit, `resizeContainer` applies a higher limit than the raw rec, then `shouldSkipResize` no-ops. OneShot still selected that first replica every cycle. Remaining replicas never resized.

The shipped OneShot example is RequestsOnly, so this hole is narrower than the first OneShot stuck-replica bug. It is still product-red for RequestsAndLimits plus a memory-limit decrease.

## Change

- `firstOneShotPodNeedingResize` / `oneShotPodAlreadyAtTarget` run the same clamp, Guaranteed request raise, and usage floor as `resizeContainer` before comparing live resources.
- After the usage floor lifts a memory limit above the recommended request, raise the Guaranteed request to that limit (live resize, OneShot compare, persist rematerialize, CREATE initial sizing). Without this, `PreservesQoS` skips the replica forever and persist writes Burstable.
- `TestFirstOneShotPodNeedingResize_SkipsClampedMemoryLimit`: pod-0 already at the clamped 512Mi limit, rec wants 64Mi; expect pod-1.
- `TestApplyMemoryUsageFloor_GuaranteedRaisesRequestToFlooredLimit`, `TestFirstOneShotPodNeedingResize_SkipsFlooredGuaranteed`, persist and CREATE floor tests.

## Validation

- `go test ./internal/controller/ ./internal/resize/ ./internal/webhook/ -count=1` (1493 passed)
- Red-green: new tests failed on unfixed code (request stayed 200Mi / selected pod-0 / CREATE limit 200Mi), then passed after the raise.

## Issue reference

Follow-up to [#682](https://github.com/attune-io/attune/pull/682). No open issue to close.
