### PR TITLE
fix: oneshot walk past blocked first replica

### DIFF
--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -129,19 +129,81 @@ func oneshotResizePodWithLimits(name, cpuReq, memReq, cpuLim, memLim string) cor
 }
 
 func TestFirstOneShotPodNeedingResize_SkipsClampedMemoryLimit(t *testing.T) {
-	// After a 1.33 clamp, live memory limit stays at the start value while
-	// the rec still wants a lower limit. OneShot must treat the clamped
-	// replica as already applied so the remaining set can move.
-	pods := []corev1.Pod{
-		oneshotResizePodWithLimits("pod-0", "200m", "64Mi", "200m", "512Mi"),
-		oneshotResizePodWithLimits("pod-1", "200m", "512Mi", "200m", "512Mi"),
-	}
-	// RequestsAndLimits rec wants 64Mi request and 64Mi limit.
+	// Guaranteed replica already at the post-raise applied state (512/512)
+	// after a 1.33 clamp. Rec still wants 64/64. Without raising the
+	// request to the clamped limit, compare sees live 512 vs target 64
+	// and re-selects pod-0 forever. pod-1 still needs a CPU change.
+	pod0 := oneshotResizePodWithLimits("pod-0", "200m", "512Mi", "200m", "512Mi")
+	pod0.Status.QOSClass = corev1.PodQOSGuaranteed
+	pod1 := oneshotResizePodWithLimits("pod-1", "500m", "512Mi", "500m", "512Mi")
+	pod1.Status.QOSClass = corev1.PodQOSGuaranteed
+	pods := []corev1.Pod{pod0, pod1}
 	rec := newResizeRecommendation("api", "500m", "512Mi", "500m", "512Mi", "200m", "64Mi", "200m", "64Mi")
 
-	r := NewAttunePolicyReconciler()
+	r := newReconcilerWithClient()
 	r.AllowInPlaceMemoryLimitDecrease = false
 	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-1", got[0].Name)
+}
+
+func TestFirstOneShotPodNeedingResize_SkipsMemoryPressureIncrease(t *testing.T) {
+	pod0 := oneshotResizePodWithLimits("pod-0", "500m", "512Mi", "500m", "1Gi")
+	pod0.Spec.NodeName = "pressure-node"
+	pod1 := oneshotResizePodWithLimits("pod-1", "500m", "512Mi", "500m", "1Gi")
+	pod1.Spec.NodeName = "healthy-node"
+	pressureNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "pressure-node"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Conditions: []corev1.NodeCondition{{
+				Type:   corev1.NodeMemoryPressure,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	healthyNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "healthy-node"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Conditions: []corev1.NodeCondition{{
+				Type:   corev1.NodeMemoryPressure,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}
+	// Memory request increase (512Mi -> 1Gi). MemoryPressure blocks pod-0.
+	rec := newResizeRecommendation("api", "500m", "512Mi", "500m", "1Gi", "200m", "1Gi", "200m", "2Gi")
+
+	r := newReconcilerWithClient(pressureNode, healthyNode)
+	r.AllowInPlaceMemoryLimitDecrease = true
+	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), []corev1.Pod{pod0, pod1}, rec)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-1", got[0].Name)
+}
+
+func TestFirstOneShotPodNeedingResize_SkipsInfeasibleInPlaceOnly(t *testing.T) {
+	pod0 := oneshotResizePod("pod-0", "500m", "512Mi")
+	pod0.Status.Conditions = append(pod0.Status.Conditions, corev1.PodCondition{
+		Type:   "PodResizePending",
+		Status: corev1.ConditionTrue,
+		Reason: "Infeasible",
+	})
+	pod1 := oneshotResizePod("pod-1", "500m", "512Mi")
+	rec := newResizeRecommendation("api", "500m", "512Mi", "0", "0", "200m", "256Mi", "0", "0")
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOnly
+
+	r := newReconcilerWithClient()
+	r.AllowInPlaceMemoryLimitDecrease = true
+	got := r.firstOneShotPodNeedingResize(context.Background(), policy, []corev1.Pod{pod0, pod1}, rec)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name)
 }
@@ -163,7 +225,7 @@ func TestFirstOneShotPodNeedingResize_SkipsFlooredGuaranteed(t *testing.T) {
 		},
 	}
 
-	r := NewAttunePolicyReconciler()
+	r := newReconcilerWithClient()
 	r.AllowInPlaceMemoryLimitDecrease = true
 	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec)
 	require.Len(t, got, 1)
@@ -172,7 +234,7 @@ func TestFirstOneShotPodNeedingResize_SkipsFlooredGuaranteed(t *testing.T) {
 
 // firstOneShotNeeding wraps firstOneShotPodNeedingResize for request-only tests.
 func firstOneShotNeeding(pods []corev1.Pod, rec attunev1alpha1.WorkloadRecommendation) []corev1.Pod {
-	r := NewAttunePolicyReconciler()
+	r := newReconcilerWithClient()
 	return r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec)
 }
 

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -73,7 +73,8 @@ func selectPodsForResize(pods []corev1.Pod, mode attunev1alpha1.UpdateType, cana
 
 // firstOneShotPodNeedingResize returns the first eligible pod whose live
 // requests/limits still differ from the post-clamp post-floor target (at
-// most one). Already-at-target replicas are skipped so OneShot can walk
+// most one) and that is not blocked from applying that change. Already-at-
+// target and permanently blocked replicas are skipped so OneShot can walk
 // the remaining set across cycles.
 func (r *AttunePolicyReconciler) firstOneShotPodNeedingResize(
 	ctx context.Context,
@@ -89,9 +90,42 @@ func (r *AttunePolicyReconciler) firstOneShotPodNeedingResize(
 		if r.oneShotPodAlreadyAtTarget(ctx, policy, p, rec) {
 			continue
 		}
+		if r.oneShotPodAllNeedingContainersBlocked(ctx, policy, p, rec) {
+			continue
+		}
 		return []corev1.Pod{*p}
 	}
 	return nil
+}
+
+// appliedResizeTarget is the clamp + Guaranteed QoS raise + usage floor that
+// resizeContainer applies before shouldSkipResize. OneShot selection must
+// compare and skip against this same applied target.
+func (r *AttunePolicyReconciler) appliedResizeTarget(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	pod *corev1.Pod,
+	containerRec attunev1alpha1.ContainerRecommendation,
+) corev1.ResourceRequirements {
+	target, _ := buildResizeTarget(containerRec)
+	preClamped := target.DeepCopy()
+	target = resize.ClampMemoryLimitForPolicy(pod, containerRec.Name, target, r.AllowInPlaceMemoryLimitDecrease)
+	platformClamped := false
+	if memLim, ok := preClamped.Limits[corev1.ResourceMemory]; ok {
+		if clampedLim, cok := target.Limits[corev1.ResourceMemory]; cok && !memLim.Equal(clampedLim) {
+			platformClamped = true
+			if pod.Status.QOSClass == corev1.PodQOSGuaranteed {
+				if memReq, rok := target.Requests[corev1.ResourceMemory]; rok && memReq.Cmp(clampedLim) < 0 {
+					target.Requests[corev1.ResourceMemory] = clampedLim.DeepCopy()
+				}
+			}
+		}
+	}
+	if !platformClamped {
+		target = r.applyMemoryUsageFloor(ctx, policy, pod, containerRec, target)
+		target = resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
+	}
+	return target
 }
 
 // oneShotPodAlreadyAtTarget is true when every recommended container already
@@ -110,37 +144,59 @@ func (r *AttunePolicyReconciler) oneShotPodAlreadyAtTarget(
 		return true
 	}
 	for _, containerRec := range rec.Containers {
-		target, _ := buildResizeTarget(containerRec)
-		// Same clamp + Guaranteed QoS raise + usage floor as resizeContainer
-		// so selection and shouldSkipResize see the same numbers.
-		preClamped := target.DeepCopy()
-		target = resize.ClampMemoryLimitForPolicy(pod, containerRec.Name, target, r.AllowInPlaceMemoryLimitDecrease)
-		platformClamped := false
-		if memLim, ok := preClamped.Limits[corev1.ResourceMemory]; ok {
-			if clampedLim, cok := target.Limits[corev1.ResourceMemory]; cok && !memLim.Equal(clampedLim) {
-				platformClamped = true
-				if pod.Status.QOSClass == corev1.PodQOSGuaranteed {
-					if memReq, rok := target.Requests[corev1.ResourceMemory]; rok && memReq.Cmp(clampedLim) < 0 {
-						target.Requests[corev1.ResourceMemory] = clampedLim.DeepCopy()
-					}
-				}
-			}
-		}
-		if !platformClamped {
-			target = r.applyMemoryUsageFloor(ctx, policy, pod, containerRec, target)
-			target = resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
-		}
+		target := r.appliedResizeTarget(ctx, policy, pod, containerRec)
 		c := findContainerByName(pod, containerRec.Name)
-		if c == nil {
-			return false
-		}
-		if c.Resources.Requests.Cpu().MilliValue() != target.Requests.Cpu().MilliValue() ||
-			c.Resources.Requests.Memory().Value() != target.Requests.Memory().Value() ||
-			!targetLimitsMatchLive(c.Resources.Limits, target.Limits) {
+		if c == nil || !containerMatchesAppliedTarget(c, target) {
 			return false
 		}
 	}
 	return true
+}
+
+func resizeMethodIsInPlaceOnly(policy *attunev1alpha1.AttunePolicy) bool {
+	if policy == nil || policy.Spec.UpdateStrategy == nil {
+		return true
+	}
+	m := policy.Spec.UpdateStrategy.ResizeMethod
+	return m == "" || m == attunev1alpha1.ResizeMethodInPlaceOnly
+}
+
+func containerMatchesAppliedTarget(c *corev1.Container, target corev1.ResourceRequirements) bool {
+	return c.Resources.Requests.Cpu().MilliValue() == target.Requests.Cpu().MilliValue() &&
+		c.Resources.Requests.Memory().Value() == target.Requests.Memory().Value() &&
+		targetLimitsMatchLive(c.Resources.Limits, target.Limits)
+}
+
+// oneShotPodAllNeedingContainersBlocked is true when every container that
+// still differs from the applied target would no-op in resizeContainer
+// (Infeasible+InPlaceOnly, or shouldSkipResize with a non-empty reason).
+// A pod with any unblocked needing container is still selected.
+func (r *AttunePolicyReconciler) oneShotPodAllNeedingContainersBlocked(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	pod *corev1.Pod,
+	rec attunev1alpha1.WorkloadRecommendation,
+) bool {
+	infeasibleBlocked := resize.IsResizeInfeasible(pod) && resizeMethodIsInPlaceOnly(policy)
+	needing := 0
+	blocked := 0
+	for _, containerRec := range rec.Containers {
+		target := r.appliedResizeTarget(ctx, policy, pod, containerRec)
+		c := findContainerByName(pod, containerRec.Name)
+		if c != nil && containerMatchesAppliedTarget(c, target) {
+			continue
+		}
+		needing++
+		if infeasibleBlocked {
+			blocked++
+			continue
+		}
+		skip, reason := r.shouldSkipResize(ctx, policy, pod, containerRec, target, nil)
+		if skip && reason != "" {
+			blocked++
+		}
+	}
+	return needing > 0 && blocked == needing
 }
 
 // budgetIncrease returns the positive live-pod request increase needed to


### PR DESCRIPTION
## Summary

OneShot now skips a first replica that cannot apply (MemoryPressure, Infeasible plus InPlaceOnly, quota, QoS) and selects the next needing pod.

## Problem

After [#683](https://github.com/attune-io/attune/pull/683), OneShot only walked past replicas already at the applied target. A first replica blocked by node pressure, Infeasible with InPlaceOnly, quota, or QoS was re-selected every cycle. Later replicas never moved.

## Change

- Shared `appliedResizeTarget` (clamp, Guaranteed raise, usage floor).
- `oneShotPodAllNeedingContainersBlocked` continues when every needing container would skip.
- `TestFirstOneShotPodNeedingResize_SkipsMemoryPressureIncrease`
- `TestFirstOneShotPodNeedingResize_SkipsInfeasibleInPlaceOnly`
- Clamp test is now Guaranteed 512Mi/512Mi so dropping the request raise fails.

## Validation

- Red: those two tests selected pod-0 on unfixed code.
- Green: `go test ./internal/controller/ -count=1 -run TestFirstOneShot` (6 passed).

## Issue reference

Follow-up to [#683](https://github.com/attune-io/attune/pull/683). No open issue to close.
