### PR TITLE
feat: namespace freeze kill-switch and oneshot apply safety

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -257,21 +257,7 @@ runs:
 
     - name: Wait for cAdvisor metrics in Prometheus
       shell: bash -Eeuo pipefail -x {0}
-      run: |
-        echo "Waiting for Prometheus to scrape cAdvisor metrics..."
-        PROM_POD=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server -o name | head -1)
-        for i in $(seq 1 30); do
-          result=$(kubectl exec -n monitoring "$PROM_POD" -- \
-            wget -qO- 'http://localhost:9090/api/v1/query?query=container_cpu_usage_seconds_total' 2>/dev/null || true)
-          if echo "$result" | grep -q '"result":\[{'; then
-            echo "cAdvisor metrics available after ${i}x5s"
-            break
-          fi
-          if [ "$i" -eq 30 ]; then
-            echo "WARNING: cAdvisor metrics not found after 150s, proceeding anyway"
-          fi
-          sleep 5
-        done
+      run: bash hack/e2e-wait-cadvisor.sh
 
     - uses: ./.github/actions/install-go-tool # zizmor: ignore[self-repository]
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,12 @@ jobs:
               - 'charts/attune/README.md.gotmpl'
             e2e:
               - 'test/e2e/**'
+              - 'test/e2e-go/**'
               - '.chainsaw.yaml'
+              - '.github/actions/setup-e2e-cluster/**'
+              - 'hack/e2e-install-cert-manager.sh'
+              - 'hack/e2e-wait-cadvisor.sh'
+              - 'hack/k3d-delete.sh'
             # CRDs, kustomize, and tracked release manifests (dist/).
             # Used by crd-freshness so dist/ cannot lag without a CI failure.
             manifests:
@@ -129,6 +134,7 @@ jobs:
             scripts:
               - 'scripts/**'
               - 'hack/e2e-install-cert-manager.sh'
+              - 'hack/e2e-wait-cadvisor.sh'
               - 'hack/k3d-delete.sh'
               - 'hack/apply-release-notes.sh'
               - '.github/actions/setup-e2e-cluster/**'
@@ -567,7 +573,7 @@ jobs:
             --junitfile test-results/integration.xml \
             --rerun-fails --rerun-fails-max-failures=3 \
             --packages="./test/integration/..." \
-            -- -race -timeout=15m \
+            -- -race -count=1 -timeout=15m \
             -tags=integration
 
       - name: Upload test results
@@ -592,7 +598,7 @@ jobs:
   test-e2e:
     name: E2E
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs: [changes, lint, test-unit]
     if: |
       always()
@@ -650,26 +656,19 @@ jobs:
             echo "::error::Failed to download Chainsaw after 3 attempts"
             exit 1
 
-      - name: Run Chainsaw and Go E2E concurrently
+      # Sequential like nightly. Go E2E patches node MemoryPressure;
+      # concurrent Chainsaw would resize on that same node.
+      - name: Run Chainsaw suite
         shell: bash -Eeuo pipefail -x {0}
         run: |
           mkdir -p test-results
+          chainsaw test test/e2e/ --config .chainsaw.yaml 2>&1 | tee test-results/chainsaw.log
 
-          chainsaw test test/e2e/ --config .chainsaw.yaml 2>&1 | tee test-results/chainsaw.log &
-          chainsaw_pid=$!
-
-          go test -tags=e2e ./test/e2e-go/... -race -count=1 -timeout=15m -v 2>&1 | tee test-results/go-e2e.log &
-          go_pid=$!
-
-          chainsaw_rc=0
-          go_rc=0
-          wait $chainsaw_pid || chainsaw_rc=$?
-          wait $go_pid || go_rc=$?
-
-          echo "Chainsaw exit=$chainsaw_rc, Go E2E exit=$go_rc"
-          if (( chainsaw_rc != 0 || go_rc != 0 )); then
-            exit 1
-          fi
+      - name: Run Go E2E tests
+        shell: bash -Eeuo pipefail -x {0}
+        run: |
+          mkdir -p test-results
+          go test -tags=e2e ./test/e2e-go/... -race -count=1 -timeout=15m -v 2>&1 | tee test-results/go-e2e.log
 
       - name: Collect debug info on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ YAMLLINT_VERSION ?= 1.37.1
 K3D_VERSION ?= v5.8.3
 GITLEAKS_VERSION ?= 8.30.1
 CERT_MANAGER_VERSION ?= v1.21.1
+PROMETHEUS_CHART_VERSION ?= 27.22.0
+PROMETHEUS_IMAGE ?= quay.io/prometheus/prometheus:v3.4.1
 KO_VERSION ?= v0.18.0
 HELM_UNITTEST_VERSION ?= v0.7.2
 
@@ -254,13 +256,14 @@ test-fuzz: ## Run fuzz tests (coverage-guided; FUZZTIME=30s default, deadline-fl
 	./scripts/run-fuzz.sh
 
 .PHONY: python-test
-python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync, helm image tag, fleet reports, nightly issue body, k3d-delete, CI triggers, apply-release-notes)
+python-test: ## Run helper script tests (fossa-filter, run-fuzz classifier, go-version sync, helm image tag, fleet reports, nightly issue body, k3d-delete, cadvisor wait, CI triggers, apply-release-notes)
 	python3 scripts/test_fossa_filter.py -v
 	bash scripts/test_run_fuzz.sh
 	bash scripts/test_verify_go_version_sync.sh
 	bash scripts/test_verify_helm_image_tag.sh
 	bash scripts/test_release_image_tags.sh
 	bash scripts/test_e2e_install_cert_manager.sh
+	bash scripts/test_e2e_wait_cadvisor.sh
 	bash scripts/test_k3d_delete.sh
 	bash scripts/test_collect_fleet_reports.sh
 	bash scripts/test_nightly_failure_issue_body.sh
@@ -401,13 +404,17 @@ _deploy-stack:
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts 2>/dev/null || true
 	helm repo update
 	helm install prometheus prometheus-community/prometheus \
-		--version 27.22.0 \
+		--version $(PROMETHEUS_CHART_VERSION) \
 		--namespace monitoring --create-namespace \
+		--set server.image.repository=$(firstword $(subst :, ,$(PROMETHEUS_IMAGE))) \
+		--set server.image.tag=$(lastword $(subst :, ,$(PROMETHEUS_IMAGE))) \
 		--set server.persistentVolume.enabled=false \
 		--set alertmanager.enabled=false \
 		--set prometheus-pushgateway.enabled=false \
 		--set server.global.scrape_interval=15s \
-		--wait --timeout 3m
+		--wait --timeout 5m
+	@echo "Waiting for cAdvisor metrics..."
+	bash hack/e2e-wait-cadvisor.sh
 	@echo "Installing operator via Helm..."
 	helm install attune ./charts/attune \
 		--namespace attune-system --create-namespace \

--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -459,7 +459,7 @@ type ResourceBounds struct {
 type UpdateStrategy struct {
 	// Mode determines the update behavior, graduated from safe to automated:
 	//   Recommend: collects metrics and writes recommendations to status, no pod changes.
-	//   OneShot: resizes one pod per reconcile cycle.
+	//   OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
 	//   Canary: resizes a percentage of pods first, then the rest after observation.
 	//   Auto: resizes all eligible pods each cycle.
 	//   Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -459,7 +459,7 @@ type ResourceBounds struct {
 type UpdateStrategy struct {
 	// Mode determines the update behavior, graduated from safe to automated:
 	//   Recommend: collects metrics and writes recommendations to status, no pod changes.
-	//   OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+	//   OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
 	//   Canary: resizes a percentage of pods first, then the rest after observation.
 	//   Auto: resizes all eligible pods each cycle.
 	//   Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -62,7 +62,8 @@ const (
 	// ResizeBlocked condition reasons.
 	// ReasonNamespaceFrozen is set when the policy namespace has
 	// attune.io/freeze=true, or the namespace cannot be read (fail closed).
-	// Apply is skipped; recommendations still compute.
+	// Apply (resize, persist, CREATE initial sizing) is skipped;
+	// recommendations still compute.
 	ReasonNamespaceFrozen           = "NamespaceFrozen"
 	ReasonPodsDeferred              = "PodsDeferred"
 	ReasonPodsInfeasible            = "PodsInfeasible"

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -60,6 +60,10 @@ const (
 	ReasonInsideWindow        = "InsideWindow"
 	ReasonPaused              = "Paused"
 	// ResizeBlocked condition reasons.
+	// ReasonNamespaceFrozen is set when the policy namespace has
+	// attune.io/freeze=true, or the namespace cannot be read (fail closed).
+	// Apply is skipped; recommendations still compute.
+	ReasonNamespaceFrozen           = "NamespaceFrozen"
 	ReasonPodsDeferred              = "PodsDeferred"
 	ReasonPodsInfeasible            = "PodsInfeasible"
 	ReasonPodsDeferredAndInfeasible = "PodsDeferredAndInfeasible"

--- a/charts/attune/crds/attune.io_attunedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunedefaults.yaml
@@ -872,7 +872,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/charts/attune/crds/attune.io_attunedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunedefaults.yaml
@@ -872,7 +872,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
@@ -873,7 +873,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
@@ -873,7 +873,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -965,7 +965,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -965,7 +965,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/charts/attune/templates/clusterrole.yaml
+++ b/charts/attune/templates/clusterrole.yaml
@@ -194,3 +194,12 @@ rules:
       - get
       - list
       - watch
+  # Namespaces: read attune.io/freeze kill-switch (list/watch for cache)
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch

--- a/charts/attune/tests/rbac_test.yaml
+++ b/charts/attune/tests/rbac_test.yaml
@@ -222,6 +222,20 @@ tests:
               - get
               - list
               - watch
+
+  - it: should include namespace read permissions for attune.io/freeze
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - namespaces
+            verbs:
+              - get
+              - list
+              - watch
   - it: should include deployment and statefulset patch for template persistence
     asserts:
       - contains:

--- a/cmd/kubectl-attune/doctor.go
+++ b/cmd/kubectl-attune/doctor.go
@@ -462,6 +462,7 @@ func runDoctor(ctx context.Context, stdout, stderr io.Writer, disc doctorDiscove
 	}
 	results := runDoctorChecks(ctx, disc, objects, err, ping)
 	printDoctorResults(stdout, results)
+	fmt.Fprintln(stdout, "Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.")
 	if doctorFailed(results) {
 		fmt.Fprintln(stderr, "doctor: one or more checks failed")
 		return 1

--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -535,6 +535,7 @@ func TestRunDoctor_ExitCodes(t *testing.T) {
 	assert.Contains(t, stdout.String(), "Kubernetes version     ok   [required]")
 	assert.Contains(t, stdout.String(), "Prometheus             WARN [optional] skipped (no address on policies or defaults)")
 	assert.Contains(t, stdout.String(), "AttunePolicies         WARN [optional] no AttunePolicies in scope")
+	assert.Contains(t, stdout.String(), "Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.")
 	assert.NotContains(t, stdout.String(), "Prometheus             ok")
 	assert.Empty(t, stderr.String())
 

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1500,6 +1500,8 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	printEffectiveField("  Decrease usage margin", formatPercentInt64Ptr(rawInt64Field(item, "spec", "memory", "decreaseUsageMarginPercent")), formatPercentPtr(effective.Spec.Memory.DecreaseUsageMarginPercent), selected, memDefaults != nil && memDefaults.DecreaseUsageMarginPercent != nil)
 	printEffectiveField("  Memory from CPU ratio", getNestedString(item, "spec", "memory", "memoryFromCpuRatio"), formatStringPtr(effective.Spec.Memory.MemoryFromCPURatio), selected, memDefaults != nil && memDefaults.MemoryFromCPURatio != nil)
 
+	fmt.Println("  Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.")
+
 	// Pure export / GitOps mode note (makes the recommended workflow first-class in CLI)
 	if effective.Spec.UpdateStrategy.Export != nil && effective.Spec.UpdateStrategy.Export.ConfigMap {
 		mode := effective.Spec.UpdateStrategy.Type

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -2837,6 +2837,27 @@ func TestPrintEffectivePolicySummary_DoesNotPanic(t *testing.T) {
 	printEffectivePolicySummary(item, policy, selectedDefaults{defaults: defaults, source: "cluster"})
 }
 
+func TestPrintEffectivePolicySummary_NamespaceFreezeHelp(t *testing.T) {
+	policy := &attunev1alpha1.AttunePolicy{
+		Spec: attunev1alpha1.AttunePolicySpec{
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{Type: attunev1alpha1.UpdateTypeAuto},
+		},
+	}
+	item := unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{},
+	}}
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	old := os.Stdout
+	os.Stdout = w
+	printEffectivePolicySummary(item, policy, selectedDefaults{})
+	_ = w.Close()
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.")
+}
+
 func TestPrintEffectivePolicySummary_CostPricing(t *testing.T) {
 	policy := &attunev1alpha1.AttunePolicy{
 		Spec: attunev1alpha1.AttunePolicySpec{

--- a/config/crd/bases/attune.io_attunedefaults.yaml
+++ b/config/crd/bases/attune.io_attunedefaults.yaml
@@ -872,7 +872,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/config/crd/bases/attune.io_attunedefaults.yaml
+++ b/config/crd/bases/attune.io_attunedefaults.yaml
@@ -872,7 +872,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/config/crd/bases/attune.io_attunenamespacedefaults.yaml
+++ b/config/crd/bases/attune.io_attunenamespacedefaults.yaml
@@ -873,7 +873,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/config/crd/bases/attune.io_attunenamespacedefaults.yaml
+++ b/config/crd/bases/attune.io_attunenamespacedefaults.yaml
@@ -873,7 +873,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -965,7 +965,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -965,7 +965,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,7 @@ rules:
   - ""
   resources:
   - limitranges
+  - namespaces
   - nodes
   - resourcequotas
   - services

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -872,7 +872,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.
@@ -1767,7 +1767,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.
@@ -2754,7 +2754,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -872,7 +872,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.
@@ -1767,7 +1767,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.
@@ -2754,7 +2754,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -871,7 +871,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.
@@ -1766,7 +1766,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.
@@ -2753,7 +2753,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
+                        OneShot: at most one needing pod per cycle. Skips already-at-target and blocked replicas (QoS, pressure, quota, Infeasible+InPlaceOnly).
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -871,7 +871,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.
@@ -1766,7 +1766,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.
@@ -2753,7 +2753,7 @@ spec:
                     description: |-
                       Mode determines the update behavior, graduated from safe to automated:
                         Recommend: collects metrics and writes recommendations to status, no pod changes.
-                        OneShot: resizes one pod per reconcile cycle.
+                        OneShot: applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
                         Canary: resizes a percentage of pods first, then the rest after observation.
                         Auto: resizes all eligible pods each cycle.
                         Observe: collects metrics and tracks data points but does not surface recommendations or savings.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3626,6 +3626,7 @@ rules:
   - ""
   resources:
   - limitranges
+  - namespaces
   - nodes
   - resourcequotas
   - services

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -803,8 +803,10 @@ Before any resize:
 - Check for other AttunePolicy with higher weight
 - Check for `attune.io/skip: "true"` annotation on workload (opt-out)
 - Check for `attune.io/freeze: "true"` on the policy namespace (skip apply
-  only: resize, eviction, startup boost; recommendations still compute;
-  fail closed if the namespace cannot be read)
+  only: resize, eviction, startup boost, template persist, CREATE initial
+  sizing; recommendations still compute; fail closed if the namespace
+  cannot be read). Freeze is re-checked immediately before apply so a
+  flag set during PromQL still skips persist and resize.
 - Check for active rollout on the parent Deployment (don't resize during rollouts)
 
 ---
@@ -1562,7 +1564,7 @@ attune/
 | Unified vertical CRD (not VPA+HPA) | Datadog | Single AttunePolicy instead of separate VPA + HPA objects |
 | Cron-style scheduling | Oblik | `schedule.windows` + `daysOfWeek` (Oblik uses `cron` + `cronAddRandomMax`) |
 | Annotation-based opt-out | CAST AI, Oblik | `attune.io/skip: "true"` for workload exclusion |
-| Namespace freeze kill-switch | Kilter | `attune.io/freeze: "true"` on the namespace skips apply |
+| Namespace freeze kill-switch | Kilter | `attune.io/freeze: "true"` on the namespace skips apply (resize, persist, CREATE initial sizing) |
 
 ### Anti-Patterns Avoided
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -402,6 +402,7 @@ spec:
 | `Resizing` | `InProgress`, `Idle`, `CooldownActive` | Active resize operation |
 | `Degraded` | `HighRevertRate` | Some resizes failing |
 | `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Whether the current time is within the configured resize schedule window |
+| `ResizeBlocked` | `NamespaceFrozen`, `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Namespace freeze, or pods stuck Deferred or Infeasible |
 
 Status conditions use `meta.SetStatusCondition()` from `k8s.io/apimachinery/pkg/api/meta`
 (the Kyverno pattern) with `observedGeneration` on every condition.
@@ -801,6 +802,9 @@ Before any resize:
 - Check for existing HPA (adjust behavior, don't block)
 - Check for other AttunePolicy with higher weight
 - Check for `attune.io/skip: "true"` annotation on workload (opt-out)
+- Check for `attune.io/freeze: "true"` on the policy namespace (skip apply
+  only: resize, eviction, startup boost; recommendations still compute;
+  fail closed if the namespace cannot be read)
 - Check for active rollout on the parent Deployment (don't resize during rollouts)
 
 ---
@@ -1558,6 +1562,7 @@ attune/
 | Unified vertical CRD (not VPA+HPA) | Datadog | Single AttunePolicy instead of separate VPA + HPA objects |
 | Cron-style scheduling | Oblik | `schedule.windows` + `daysOfWeek` (Oblik uses `cron` + `cronAddRandomMax`) |
 | Annotation-based opt-out | CAST AI, Oblik | `attune.io/skip: "true"` for workload exclusion |
+| Namespace freeze kill-switch | Kilter | `attune.io/freeze: "true"` on the namespace skips apply |
 
 ### Anti-Patterns Avoided
 

--- a/docs/architecture/design.md
+++ b/docs/architecture/design.md
@@ -90,6 +90,8 @@ Located in `internal/conflict/`. Detects potential conflicts:
 - **HPA**: identifies HPAs targeting the same workload.
 - **VPA**: warns about active VPA objects targeting the same workload.
 - **Opt-out**: checks for the `attune.io/skip: "true"` annotation.
+- **Namespace freeze**: `attune.io/freeze=true` on the policy namespace
+  blocks apply (resize, eviction, boost) while recommendations continue.
 - **Active rollout**: detects in-progress deployments.
 
 ### Status Reporter

--- a/docs/architecture/design.md
+++ b/docs/architecture/design.md
@@ -91,7 +91,8 @@ Located in `internal/conflict/`. Detects potential conflicts:
 - **VPA**: warns about active VPA objects targeting the same workload.
 - **Opt-out**: checks for the `attune.io/skip: "true"` annotation.
 - **Namespace freeze**: `attune.io/freeze=true` on the policy namespace
-  blocks apply (resize, eviction, boost) while recommendations continue.
+  blocks apply (resize, eviction, boost, persist, CREATE initial sizing)
+  while recommendations continue.
 - **Active rollout**: detects in-progress deployments.
 
 ### Status Reporter

--- a/docs/architecture/resize-api.md
+++ b/docs/architecture/resize-api.md
@@ -206,6 +206,11 @@ stateDiagram-v2
   skipping") to avoid wasting an UpdateResize API call that would fail
   on every reconcile cycle.
 
+- **OneShot walks past blocked replicas.** OneShot applies at most one
+  needing pod per cycle. Replicas that are already at the applied target,
+  or that are blocked by QoS, node pressure, quota, or Infeasible plus
+  InPlaceOnly, are skipped so another replica can still resize.
+
 - **Eviction respects PDBs.** The operator uses the Kubernetes Eviction API
   (`EvictV1`), which enforces PodDisruptionBudgets. If the PDB would be
   violated, the eviction is denied and the pod stays as-is.

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -316,6 +316,9 @@ Before resizing, the controller checks for potential conflicts:
   mid-rollout and resizing is deferred.
 - **Opt-out annotation**: workloads with `attune.io/skip: "true"` are
   skipped entirely.
+- **Namespace freeze**: `attune.io/freeze=true` on the namespace skips
+  in-place resize, eviction, and startup boost. Recommendations still
+  compute. If the namespace cannot be read, apply is skipped (fail closed).
 - **QoS preservation**: for Guaranteed-class pods, the resize is blocked if
   it would cause requests to differ from limits.
 - **HPA coexistence**: an informational notice is logged but resizing proceeds.

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -317,8 +317,9 @@ Before resizing, the controller checks for potential conflicts:
 - **Opt-out annotation**: workloads with `attune.io/skip: "true"` are
   skipped entirely.
 - **Namespace freeze**: `attune.io/freeze=true` on the namespace skips
-  in-place resize, eviction, and startup boost. Recommendations still
-  compute. If the namespace cannot be read, apply is skipped (fail closed).
+  in-place resize, eviction, startup boost, template persist, and CREATE
+  initial sizing. Recommendations still compute. If the namespace cannot
+  be read, apply is skipped (fail closed).
 - **QoS preservation**: for Guaranteed-class pods, the resize is blocked if
   it would cause requests to differ from limits.
 - **HPA coexistence**: an informational notice is logged but resizing proceeds.

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -17,7 +17,7 @@ flowchart LR
 | Mode | Risk | What happens |
 |------|------|-------------|
 | Recommend | None | Metrics collected, recommendations computed and written to status |
-| OneShot | Low | One pod resized per cycle |
+| OneShot | Low | OneShot applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize. |
 | Canary | Medium | Percentage-based rollout with observation |
 | Auto | Higher | All eligible pods resized |
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -28,7 +28,7 @@ Modes are graduated from safe observation to full automation:
 |------|:---:|:---:|:---:|
 | **Observe** | Yes | No (data collection only) | No |
 | **Recommend** | Yes | Yes (status only) | No |
-| **OneShot** | Yes | Yes | One pod per cycle |
+| **OneShot** | Yes | Yes | OneShot applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize. |
 | **Canary** | Yes | Yes | A percentage of pods, then the rest after observation |
 | **Auto** | Yes | Yes | All eligible pods |
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -176,4 +176,5 @@ The operator detects:
 - **Active rollouts**: skips resizing during an in-progress deployment rollout.
 - **Opt-out annotation**: workloads with `attune.io/skip: "true"` are ignored.
 - **Namespace freeze**: `attune.io/freeze=true` on the namespace skips
-  resizes, evictions, and startup boosts. Recommendations still update.
+  resizes, evictions, startup boosts, template persist, and CREATE
+  initial sizing. Recommendations still update.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -175,3 +175,5 @@ The operator detects:
   AttunePolicies match the same workload.
 - **Active rollouts**: skips resizing during an in-progress deployment rollout.
 - **Opt-out annotation**: workloads with `attune.io/skip: "true"` are ignored.
+- **Namespace freeze**: `attune.io/freeze=true` on the namespace skips
+  resizes, evictions, and startup boosts. Recommendations still update.

--- a/docs/guides/recommend-mode.md
+++ b/docs/guides/recommend-mode.md
@@ -143,7 +143,7 @@ cost savings.
 When you are satisfied with the recommendations, change the mode:
 
 - Use [Canary](canary-rollout.md) to resize a subset first.
-- Use **OneShot** to resize a single pod per reconciliation cycle.
+- **OneShot** applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.
 - Use **Auto** to resize all eligible pods (best for non-critical workloads).
 
 ```bash

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -309,6 +309,26 @@ Existing resizes are not reverted.
 **Fix**: Set `spec.paused: false` or remove the field entirely. The operator
 will resume reconciliation on the next cycle.
 
+### NamespaceFrozen
+
+**Symptom**: ResizeBlocked is `True` with reason `NamespaceFrozen`. Events
+say `namespace has attune.io/freeze=true; resizes skipped`. Recommendations
+still appear in status.
+
+**Cause**: The policy namespace has `attune.io/freeze=true`, or the operator
+could not read the namespace (fail closed). In-place resizes, evictions, and
+startup boosts are skipped. Metrics collection and recommendations continue
+so `kubectl attune recommendations` still works.
+
+**Fix**: Remove the annotation or set it to any value other than `true`:
+
+```bash
+kubectl annotate namespace <ns> attune.io/freeze-
+```
+
+If the condition message says the namespace could not be read, check RBAC
+for `namespaces` get/list/watch on the operator ServiceAccount.
+
 ### CooldownActive
 
 **Symptom**: The operator logs "Cooldown active, skipping resize" and no

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -496,6 +496,21 @@ kubectl get pod <pod> -o jsonpath='{range .status.conditions[?(@.type=="PodResiz
 
 **Fix**: Scale until at least two pods are Running, or wait for another replica to become Running.
 
+### OneShot skipped the first replica but others still need a resize
+
+**Symptom**: OneShot did not resize the first listed replica, but other
+replicas still need a resize. Events show `ResizeSkipped` for QoS, node
+pressure, quota, or Infeasible plus InPlaceOnly.
+
+**Cause**: OneShot applies at most one needing pod per cycle. Replicas
+that are already at the applied target, or that are blocked by QoS, node
+pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another
+replica can still resize.
+
+**Fix**: Check events on the skipped replica. The next needing replica
+in the same cycle should still resize. Remaining needing replicas wait
+for later cycles and cooldown.
+
 ### QoS class change blocked
 
 **Symptom**: Operator logs `Skipping resize: would change QoS class`.
@@ -504,8 +519,10 @@ kubectl get pod <pod> -o jsonpath='{range .status.conditions[?(@.type=="PodResiz
 policy would set different values for requests and limits, the resize is
 skipped.
 
-**Fix**: Set `controlledValues: RequestsAndLimits` so both are updated
-together, or switch to `RequestsOnly` if the pod should be Burstable.
+**Fix**: Use controlledValues: RequestsAndLimits so requests stay equal
+to limits. Attune will not change QoS from Guaranteed to Burstable. On
+Kubernetes 1.33, a memory limit decrease may also need resizePolicy:
+RestartContainer.
 
 ### ResourceQuota exceeded
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -316,9 +316,10 @@ say `namespace has attune.io/freeze=true; resizes skipped`. Recommendations
 still appear in status.
 
 **Cause**: The policy namespace has `attune.io/freeze=true`, or the operator
-could not read the namespace (fail closed). In-place resizes, evictions, and
-startup boosts are skipped. Metrics collection and recommendations continue
-so `kubectl attune recommendations` still works.
+could not read the namespace (fail closed). In-place resizes, evictions,
+startup boosts, template persistence, and CREATE initial sizing are skipped.
+Metrics collection and recommendations continue so `kubectl attune
+recommendations` still works.
 
 **Fix**: Remove the annotation or set it to any value other than `true`:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -216,7 +216,7 @@ the estimator chain: `rawPercentile`, `overhead`, `afterOverhead`,
 | `Resizing` | `InProgress`, `Idle`, `CooldownActive` | Active resize operation state. `CooldownActive` only when every matched app is still cooling |
 | `Degraded` | `HighRevertRate` | High revert rate detected (3+ of last 5 reverted) |
 | `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Whether the current time is within the configured resize schedule window |
-| `ResizeBlocked` | `NamespaceFrozen`, `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Namespace freeze kill-switch (`attune.io/freeze=true`), or one or more target pods stuck Deferred (kubelet pending) or Infeasible; message includes sample pod names and next actions |
+| `ResizeBlocked` | `NamespaceFrozen`, `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Namespace freeze kill-switch (`attune.io/freeze=true` skips resize, persist, and CREATE initial sizing), or one or more target pods stuck Deferred (kubelet pending) or Infeasible; message includes sample pod names and next actions |
 
 ### Print columns
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -216,7 +216,7 @@ the estimator chain: `rawPercentile`, `overhead`, `afterOverhead`,
 | `Resizing` | `InProgress`, `Idle`, `CooldownActive` | Active resize operation state. `CooldownActive` only when every matched app is still cooling |
 | `Degraded` | `HighRevertRate` | High revert rate detected (3+ of last 5 reverted) |
 | `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Whether the current time is within the configured resize schedule window |
-| `ResizeBlocked` | `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | One or more target pods stuck Deferred (kubelet pending) or Infeasible; message includes sample pod names and next actions |
+| `ResizeBlocked` | `NamespaceFrozen`, `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Namespace freeze kill-switch (`attune.io/freeze=true`), or one or more target pods stuck Deferred (kubelet pending) or Infeasible; message includes sample pod names and next actions |
 
 ### Print columns
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -446,6 +446,25 @@ caps apply to `AttunePolicy`, `AttuneDefaults`, and
 | `runtimeProfile` | string | (none) | Optional language/runtime profile (`generic`, `java`, `python`, `golang`, `nodejs`). Applies safe memory defaults and admission warnings. See [runtime profiles](../guides/runtime-profiles.md). |
 | `paused` | bool | `false` | Halts all reconciliation for this policy: no metrics collection, no recommendations, no resizes. Existing resizes are not reverted. The operator sets `Ready=False` with `reason=Paused`. |
 
+### Namespace freeze (`attune.io/freeze`)
+
+Annotate a namespace to stop apply during an incident without pausing
+recommendation computation. The value must be exactly `true`, the same
+parser as `attune.io/skip` (`True`, `1`, and `yes` do not freeze).
+
+```bash
+kubectl annotate namespace <ns> attune.io/freeze=true
+```
+
+| Annotation | Scope | Effect |
+|------------|-------|--------|
+| `attune.io/freeze=true` | Namespace | Skip in-place resize, eviction, and startup boost. Metrics, recommendations, status, and export still update. `ResizeBlocked=True` with `reason=NamespaceFrozen`. |
+| `attune.io/skip=true` | Workload | Skip that workload entirely (no recommendations). Independent of freeze. |
+
+If the operator cannot read the namespace, apply is skipped (fail closed)
+and the same `NamespaceFrozen` reason is set. Existing resizes are not
+reverted. Remove the annotation to resume apply on the next reconcile.
+
 ### Container exclusion
 
 | Field | Type | Default | Description |
@@ -605,7 +624,7 @@ The controller sets these conditions on each `AttunePolicy`:
 | `Resizing` | `InProgress`, `Idle`, `CooldownActive` | Active resize operation state (only in resize modes). `CooldownActive` is set only when every matched workload is still cooling down. |
 | `Degraded` | `HighRevertRate` | Set when 3+ of the last 5 resizes were reverted |
 | `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Set when `updateStrategy.schedule` is configured; indicates whether the current time is within an allowed resize window |
-| `ResizeBlocked` | `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Pods stuck Deferred or Infeasible; see troubleshooting "Deferred or Infeasible resize" |
+| `ResizeBlocked` | `NamespaceFrozen`, `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Namespace freeze kill-switch, or pods stuck Deferred or Infeasible; see troubleshooting "NamespaceFrozen" and "Deferred or Infeasible resize" |
 | `GitOpsPullRequest` | `PullRequestOpen`, `PullRequestFailed`, `GitOpsEndpointBlocked`, `NoDrift`, `PullRequestUnchanged`, `PullRequestCooldown`, `PullRequestDryRun`, `PullRequestDisabled` | Opt-in `export.pullRequest` automation status (see [GitOps integration](../guides/gitops-integration.md)) |
 
 ### Status fields (GitOps PR)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -282,7 +282,7 @@ that do not set them explicitly. Policy-level values always take precedence.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `type` | string | `Recommend` | `Observe`, `Recommend`, `OneShot`, `Canary`, `Auto` |
+| `type` | string | `Recommend` | `Observe`, `Recommend`, `OneShot`, `Canary`, `Auto`. OneShot applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize. |
 | `cooldown` | duration | `1h` | Minimum time between resizes of the same workload. Other apps on the same policy are not locked. When every matched app is still cooling, the next reconcile waits only until the soonest per-app window expires (a watch event does not restart a full cooldown). |
 | `autoRevert` | bool | `true` | Revert unsafe resizes automatically |
 | `resizeMethod` | string | `InPlaceOnly` | `InPlaceOnly` or `InPlaceOrRecreate` |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -458,7 +458,7 @@ kubectl annotate namespace <ns> attune.io/freeze=true
 
 | Annotation | Scope | Effect |
 |------------|-------|--------|
-| `attune.io/freeze=true` | Namespace | Skip in-place resize, eviction, and startup boost. Metrics, recommendations, status, and export still update. `ResizeBlocked=True` with `reason=NamespaceFrozen`. |
+| `attune.io/freeze=true` | Namespace | Skip in-place resize, eviction, startup boost, template persist, and CREATE initial sizing. Metrics, recommendations, status, and export still update. `ResizeBlocked=True` with `reason=NamespaceFrozen`. |
 | `attune.io/skip=true` | Workload | Skip that workload entirely (no recommendations). Independent of freeze. |
 
 If the operator cannot read the namespace, apply is skipped (fail closed)

--- a/docs/why-attune.md
+++ b/docs/why-attune.md
@@ -202,7 +202,7 @@ provides a graduated path:
 |------|-------------|------------|
 | **Observe** | Collects metrics and tracks data-point progress; no recommendations surfaced | Zero |
 | **Recommend** | Collects metrics and writes recommendations to the policy status | Zero |
-| **OneShot** | Resizes one pod per cycle until remaining replicas match the recommendation (cooldown between pods) | Minimal |
+| **OneShot** | OneShot applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize. | Minimal |
 | **Canary** | Resizes 10% of pods first, watches them, then auto-promotes to the rest (optional) | Low |
 | **Auto** | Continuously resizes all eligible pods based on observed metrics | Production-ready |
 

--- a/examples/09-oneshot-mode.yaml
+++ b/examples/09-oneshot-mode.yaml
@@ -1,8 +1,11 @@
 ---
-# OneShot Mode: resize exactly one pod per reconcile cycle.
-# The safest automated mode. Each cycle resizes at most one pod,
-# then waits for the cooldown before touching another. Ideal for
-# StatefulSets or workloads where you want human-speed rollout.
+# OneShot Mode: OneShot applies at most one needing pod per cycle.
+# Replicas that are already at the applied target, or that are blocked
+# by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are
+# skipped so another replica can still resize.
+# The safest automated mode. Each cycle waits for the cooldown before
+# touching another needing replica. Ideal for StatefulSets or
+# workloads where you want human-speed rollout.
 #
 # Apply:
 #   kubectl apply -f examples/09-oneshot-mode.yaml

--- a/hack/e2e-wait-cadvisor.sh
+++ b/hack/e2e-wait-cadvisor.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Wait until Prometheus has scraped cAdvisor series
+# (container_cpu_usage_seconds_total). Used by setup-e2e-cluster and
+# make _deploy-stack so the two paths cannot drift.
+# Soft-fails after CADVISOR_ATTEMPTS so local/CI can proceed.
+#
+# Overrides for tests: KUBECTL, CADVISOR_NAMESPACE, CADVISOR_ATTEMPTS,
+# CADVISOR_SLEEP, CADVISOR_QUERY.
+
+set -euo pipefail
+
+KUBECTL="${KUBECTL:-kubectl}"
+NAMESPACE="${CADVISOR_NAMESPACE:-monitoring}"
+ATTEMPTS="${CADVISOR_ATTEMPTS:-30}"
+SLEEP="${CADVISOR_SLEEP:-5}"
+QUERY="${CADVISOR_QUERY:-container_cpu_usage_seconds_total}"
+
+echo "PLAN: wait for cAdvisor metrics in Prometheus (${ATTEMPTS}x${SLEEP}s)"
+
+prom_pods="$("${KUBECTL}" get pods -n "${NAMESPACE}" \
+  -l app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server \
+  -o name || true)"
+PROM_POD=""
+while IFS= read -r line; do
+  if [[ -n "${line}" ]]; then
+    PROM_POD="${line}"
+    break
+  fi
+done <<< "${prom_pods}"
+
+if [[ -z "${PROM_POD}" ]]; then
+  echo "WARNING: no Prometheus server pod in ${NAMESPACE}, proceeding anyway"
+  echo "DONE: ok=true found=false"
+  echo "NEXT: none"
+  exit 0
+fi
+
+echo "DO: query ${QUERY} via ${PROM_POD}"
+
+i=0
+while (( i < ATTEMPTS )); do
+  i=$((i + 1))
+  result="$("${KUBECTL}" exec -n "${NAMESPACE}" "${PROM_POD}" -- \
+    wget -qO- "http://localhost:9090/api/v1/query?query=${QUERY}" 2>/dev/null || true)"
+  if echo "${result}" | grep -q '"result":\[{'; then
+    echo "OK: cAdvisor metrics available after ${i}x${SLEEP}s"
+    echo "DONE: ok=true found=true"
+    echo "NEXT: none"
+    exit 0
+  fi
+  if (( i == ATTEMPTS )); then
+    elapsed=$((ATTEMPTS * SLEEP))
+    echo "WARNING: cAdvisor metrics not found after ${elapsed}s, proceeding anyway"
+    echo "DONE: ok=true found=false"
+    echo "NEXT: none"
+    exit 0
+  fi
+  echo "WAIT: no cAdvisor series yet (${i}/${ATTEMPTS})"
+  sleep "${SLEEP}"
+done

--- a/internal/conflict/detector.go
+++ b/internal/conflict/detector.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -40,8 +41,9 @@ type ConflictType string
 const AnnotationSkip = "attune.io/skip"
 
 // AnnotationFreeze is the namespace annotation that blocks apply
-// (in-place resize, eviction, startup boost) for every policy in that
-// namespace. Recommendations, status, and export still update.
+// (in-place resize, eviction, startup boost, template persist, and
+// CREATE initial sizing) for every policy in that namespace.
+// Recommendations, status, and export still update.
 const AnnotationFreeze = "attune.io/freeze"
 
 // annotationEnabledValue is the only accepted value for skip and freeze.
@@ -102,6 +104,17 @@ func (d *Detector) CheckAnnotationFreeze(obj metav1.ObjectMeta) bool {
 // IsFreezeAnnotation reports whether annotations contain attune.io/freeze=true.
 func IsFreezeAnnotation(annotations map[string]string) bool {
 	return annotationExactTrue(annotations, AnnotationFreeze)
+}
+
+// NamespaceApplyFrozen reports whether apply must be skipped for this
+// namespace. Get errors fail closed (frozen=true) so a missing RBAC
+// grant or API outage cannot resume apply during an incident.
+func NamespaceApplyFrozen(ctx context.Context, c client.Client, namespace string) (bool, error) {
+	var ns corev1.Namespace
+	if err := c.Get(ctx, client.ObjectKey{Name: namespace}, &ns); err != nil {
+		return true, err
+	}
+	return IsFreezeAnnotation(ns.Annotations), nil
 }
 
 // CheckActiveRollout returns true if the deployment has an active rollout in

--- a/internal/conflict/detector.go
+++ b/internal/conflict/detector.go
@@ -39,6 +39,15 @@ type ConflictType string
 // AnnotationSkip is the annotation key for opting a workload out of right-sizing.
 const AnnotationSkip = "attune.io/skip"
 
+// AnnotationFreeze is the namespace annotation that blocks apply
+// (in-place resize, eviction, startup boost) for every policy in that
+// namespace. Recommendations, status, and export still update.
+const AnnotationFreeze = "attune.io/freeze"
+
+// annotationEnabledValue is the only accepted value for skip and freeze.
+// Match this exact string; do not treat "True", "1", or "yes" as set.
+const annotationEnabledValue = "true"
+
 const (
 	// ConflictVPA indicates a VerticalPodAutoscaler targets the same workload.
 	ConflictVPA ConflictType = "VPA"
@@ -67,14 +76,32 @@ func NewDetector(logger logr.Logger) *Detector {
 	}
 }
 
+// annotationExactTrue reports whether annotations[key] is exactly "true".
+// Shared by skip and freeze so both parsers stay identical.
+func annotationExactTrue(annotations map[string]string, key string) bool {
+	if annotations == nil {
+		return false
+	}
+	return annotations[key] == annotationEnabledValue
+}
+
 // CheckAnnotationOptOut returns true if the object carries the annotation
 // "attune.io/skip" set to "true", indicating that the workload has opted
 // out of automatic right-sizing.
 func (d *Detector) CheckAnnotationOptOut(obj metav1.ObjectMeta) bool {
-	if obj.Annotations == nil {
-		return false
-	}
-	return obj.Annotations[AnnotationSkip] == "true"
+	return annotationExactTrue(obj.Annotations, AnnotationSkip)
+}
+
+// CheckAnnotationFreeze returns true if the object carries the annotation
+// "attune.io/freeze" set to "true". Same parser as CheckAnnotationOptOut
+// (exact "true" only). Used on Namespace objects as an incident kill-switch.
+func (d *Detector) CheckAnnotationFreeze(obj metav1.ObjectMeta) bool {
+	return IsFreezeAnnotation(obj.Annotations)
+}
+
+// IsFreezeAnnotation reports whether annotations contain attune.io/freeze=true.
+func IsFreezeAnnotation(annotations map[string]string) bool {
+	return annotationExactTrue(annotations, AnnotationFreeze)
 }
 
 // CheckActiveRollout returns true if the deployment has an active rollout in

--- a/internal/conflict/detector_test.go
+++ b/internal/conflict/detector_test.go
@@ -91,6 +91,90 @@ func TestCheckAnnotationOptOut(t *testing.T) {
 	}
 }
 
+func TestCheckAnnotationFreeze(t *testing.T) {
+	detector := NewDetector(testr.New(t))
+
+	tests := []struct {
+		name string
+		obj  metav1.ObjectMeta
+		want bool
+	}{
+		{
+			name: "annotation present with value true",
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationFreeze: "true",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "annotation absent",
+			obj:  metav1.ObjectMeta{},
+			want: false,
+		},
+		{
+			name: "annotation present with value false",
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationFreeze: "false",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "True is not accepted (same parser as skip)",
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationFreeze: "True",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "1 is not accepted (same parser as skip)",
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationFreeze: "1",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "yes is not accepted (same parser as skip)",
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationFreeze: "yes",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "skip annotation does not freeze",
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					AnnotationSkip: "true",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty annotations map",
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detector.CheckAnnotationFreeze(tt.obj)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestCheckActiveRollout(t *testing.T) {
 	detector := NewDetector(testr.New(t))
 

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -141,6 +141,7 @@ const (
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=resourcequotas;limitranges,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list
 
 // AttunePolicyReconciler reconciles an AttunePolicy object.
@@ -352,6 +353,14 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	// Namespace freeze is an incident kill-switch: still recommend, do not apply.
+	applyFrozen, freezeErr := r.namespaceApplyFrozen(ctx, policy.Namespace)
+	if freezeErr != nil {
+		logger.Error(freezeErr, "Failed to read namespace for attune.io/freeze; skipping apply")
+	} else if applyFrozen {
+		logger.Info("Namespace is frozen, skipping apply", "annotation", conflict.AnnotationFreeze)
+	}
+
 	// Step 2: Resolve metrics source, create collector, and select query builder.
 	collector, queryBuilder, err := r.resolveMetricsCollector(ctx, &policy, defaults)
 	if err != nil {
@@ -384,7 +393,7 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Check pending safety observations from previous resizes before computing
 	// new recommendations. Uses already-discovered workloads for provenance.
 	var safetyObservationsPending bool
-	if autoRevertEnabled(policy.Spec.UpdateStrategy) {
+	if !applyFrozen && autoRevertEnabled(policy.Spec.UpdateStrategy) {
 		safetyObservationsPending = r.checkPendingSafetyObservations(workloadCtx, &policy, collector, workloads)
 	}
 
@@ -532,7 +541,7 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	var cycleResizeHistory []attunev1alpha1.ResizeHistoryEntry
-	if isResizeMode(mode) && !allCooling && withinWindow {
+	if !applyFrozen && isResizeMode(mode) && !allCooling && withinWindow {
 		resizedCount, history := r.executeResizes(ctx, &policy, workloads, recommendations, podsByWorkload, collector, preChecks)
 		newResizedCount = resizedCount
 		cycleResizeHistory = history
@@ -592,7 +601,7 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Apply startup CPU boosts for newly created pods if configured.
 	// Only in resize modes (Auto, OneShot, Canary); Observe and Recommend
 	// modes must not modify pod resources.
-	if isResizeMode(mode) && policy.Spec.CPU.StartupBoost != nil && r.Clientset != nil && len(recommendations) > 0 {
+	if !applyFrozen && isResizeMode(mode) && policy.Spec.CPU.StartupBoost != nil && r.Clientset != nil && len(recommendations) > 0 {
 		resizer := resize.NewPodResizer(r.Clientset, logger)
 		resizer.AllowInPlaceMemoryLimitDecrease = r.AllowInPlaceMemoryLimitDecrease
 		r.applyStartupBoosts(ctx, &policy, podsByWorkload, recommendations, resizer, preChecks)
@@ -669,6 +678,10 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		operatormetrics.PodsDeferred.WithLabelValues(policy.Namespace, policy.Name).Set(0)
 		operatormetrics.PodsInfeasible.WithLabelValues(policy.Namespace, policy.Name).Set(0)
 		meta.RemoveStatusCondition(&policy.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+	}
+
+	if applyFrozen {
+		r.markNamespaceFrozen(&policy, freezeErr)
 	}
 
 	// Set Ready condition (surface series cap as degraded data quality note).
@@ -867,6 +880,39 @@ func absInt64(v int64) int64 {
 		return -v
 	}
 	return v
+}
+
+// namespaceApplyFrozen reports whether apply (resize, eviction, startup
+// boost) must be skipped for this namespace. Get errors fail closed
+// (frozen=true) so a missing RBAC grant or API outage cannot resume
+// resizes during an incident.
+func (r *AttunePolicyReconciler) namespaceApplyFrozen(ctx context.Context, namespace string) (bool, error) {
+	var ns corev1.Namespace
+	if err := r.Get(ctx, client.ObjectKey{Name: namespace}, &ns); err != nil {
+		return true, err
+	}
+	return conflict.IsFreezeAnnotation(ns.Annotations), nil
+}
+
+// markNamespaceFrozen records ResizeBlocked=NamespaceFrozen and emits a
+// single Warning. Recommendations remain in status; only apply is skipped.
+func (r *AttunePolicyReconciler) markNamespaceFrozen(policy *attunev1alpha1.AttunePolicy, freezeErr error) {
+	msg := "namespace has attune.io/freeze=true; resizes skipped"
+	if freezeErr != nil {
+		msg = "cannot read namespace for attune.io/freeze; resizes skipped"
+		r.emitEventOnce(policy, corev1.EventTypeWarning, attunev1alpha1.ReasonNamespaceFrozen, "resize",
+			"cannot read namespace for attune.io/freeze; resizes skipped")
+	} else {
+		r.emitEventOnce(policy, corev1.EventTypeWarning, attunev1alpha1.ReasonNamespaceFrozen, "resize",
+			"namespace has attune.io/freeze=true; resizes skipped")
+	}
+	meta.SetStatusCondition(&policy.Status.Conditions, metav1.Condition{
+		Type:               attunev1alpha1.ConditionResizeBlocked,
+		Status:             metav1.ConditionTrue,
+		Reason:             attunev1alpha1.ReasonNamespaceFrozen,
+		Message:            msg,
+		ObservedGeneration: policy.Generation,
+	})
 }
 
 // processWorkloads processes discovered workloads in parallel, checking for

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -494,10 +494,12 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Template persistence (OnRecommendation): write accepted recs into templates.
 	// Observe mode is gated inside applyTemplatePersistence; Canary InProgress too.
+	// Re-check freeze immediately before persist (PromQL may have taken minutes).
 	if templatePersistenceEnabled(policy.Spec.UpdateStrategy) &&
 		templatePersistenceWhen(policy.Spec.UpdateStrategy) == attunev1alpha1.TemplatePersistenceOnRecommendation &&
 		policy.Spec.UpdateStrategy.Type != attunev1alpha1.UpdateTypeObserve &&
-		len(recommendations) > 0 {
+		len(recommendations) > 0 &&
+		r.applyNotFrozen(ctx, policy.Namespace, &applyFrozen, &freezeErr) {
 		tplHistory := r.applyTemplatePersistence(ctx, &policy, workloads, recommendations,
 			attunev1alpha1.TemplatePersistenceOnRecommendation, nil)
 		if len(tplHistory) > 0 {
@@ -541,7 +543,11 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	var cycleResizeHistory []attunev1alpha1.ResizeHistoryEntry
-	if !applyFrozen && isResizeMode(mode) && !allCooling && withinWindow {
+	// Re-check freeze immediately before apply. processWorkloads can run
+	// until prometheusTimeout; a freeze set during that window must still
+	// skip resize. Do not abort mid-PromQL.
+	if isResizeMode(mode) && !allCooling && withinWindow &&
+		r.applyNotFrozen(ctx, policy.Namespace, &applyFrozen, &freezeErr) {
 		resizedCount, history := r.executeResizes(ctx, &policy, workloads, recommendations, podsByWorkload, collector, preChecks)
 		newResizedCount = resizedCount
 		cycleResizeHistory = history
@@ -588,7 +594,8 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// template patch can still be retried while resize is cooling down.
 	if templatePersistenceEnabled(policy.Spec.UpdateStrategy) &&
 		templatePersistenceWhen(policy.Spec.UpdateStrategy) == attunev1alpha1.TemplatePersistenceAfterSuccessfulResize &&
-		len(recommendations) > 0 {
+		len(recommendations) > 0 &&
+		r.applyNotFrozen(ctx, policy.Namespace, &applyFrozen, &freezeErr) {
 		resizedWLs := laggingAfterResizeWorkloads(cycleResizeHistory, policy.Status.ResizeHistory)
 		if len(resizedWLs) > 0 {
 			tplHistory := r.applyTemplatePersistence(ctx, &policy, workloads, recommendations,
@@ -601,7 +608,8 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Apply startup CPU boosts for newly created pods if configured.
 	// Only in resize modes (Auto, OneShot, Canary); Observe and Recommend
 	// modes must not modify pod resources.
-	if !applyFrozen && isResizeMode(mode) && policy.Spec.CPU.StartupBoost != nil && r.Clientset != nil && len(recommendations) > 0 {
+	if isResizeMode(mode) && policy.Spec.CPU.StartupBoost != nil && r.Clientset != nil && len(recommendations) > 0 &&
+		r.applyNotFrozen(ctx, policy.Namespace, &applyFrozen, &freezeErr) {
 		resizer := resize.NewPodResizer(r.Clientset, logger)
 		resizer.AllowInPlaceMemoryLimitDecrease = r.AllowInPlaceMemoryLimitDecrease
 		r.applyStartupBoosts(ctx, &policy, podsByWorkload, recommendations, resizer, preChecks)
@@ -883,15 +891,38 @@ func absInt64(v int64) int64 {
 }
 
 // namespaceApplyFrozen reports whether apply (resize, eviction, startup
-// boost) must be skipped for this namespace. Get errors fail closed
-// (frozen=true) so a missing RBAC grant or API outage cannot resume
-// resizes during an incident.
+// boost, template persist, CREATE initial sizing) must be skipped for
+// this namespace. Get errors fail closed (frozen=true) so a missing
+// RBAC grant or API outage cannot resume apply during an incident.
 func (r *AttunePolicyReconciler) namespaceApplyFrozen(ctx context.Context, namespace string) (bool, error) {
-	var ns corev1.Namespace
-	if err := r.Get(ctx, client.ObjectKey{Name: namespace}, &ns); err != nil {
-		return true, err
+	return conflict.NamespaceApplyFrozen(ctx, r.Client, namespace)
+}
+
+// refreshApplyFrozen re-reads attune.io/freeze immediately before an
+// apply path. A freeze set during PromQL or processWorkloads must still
+// skip apply. Once frozen in this reconcile, stay frozen.
+func (r *AttunePolicyReconciler) refreshApplyFrozen(ctx context.Context, namespace string, applyFrozen *bool, freezeErr *error) {
+	if applyFrozen == nil || freezeErr == nil || *applyFrozen {
+		return
 	}
-	return conflict.IsFreezeAnnotation(ns.Annotations), nil
+	frozen, err := r.namespaceApplyFrozen(ctx, namespace)
+	if err != nil {
+		*applyFrozen = true
+		*freezeErr = err
+		log.FromContext(ctx).Error(err, "Failed to read namespace for attune.io/freeze; skipping apply")
+		return
+	}
+	if frozen {
+		*applyFrozen = true
+		*freezeErr = nil
+		log.FromContext(ctx).Info("Namespace is frozen, skipping apply", "annotation", conflict.AnnotationFreeze)
+	}
+}
+
+// applyNotFrozen re-checks freeze and reports whether apply may proceed.
+func (r *AttunePolicyReconciler) applyNotFrozen(ctx context.Context, namespace string, applyFrozen *bool, freezeErr *error) bool {
+	r.refreshApplyFrozen(ctx, namespace, applyFrozen, freezeErr)
+	return applyFrozen != nil && !*applyFrozen
 }
 
 // markNamespaceFrozen records ResizeBlocked=NamespaceFrozen and emits a

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -13687,7 +13687,7 @@ func TestShouldSkipResize_LimitRangeViolation(t *testing.T) {
 		},
 	}
 
-	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, containerRec, target, nil)
 	assert.True(t, skip)
 	assert.Contains(t, reason, "quota/limitrange violation")
 	assert.Contains(t, reason, "below LimitRange minimum")
@@ -13740,7 +13740,7 @@ func TestShouldSkipResize_QuotaHeadroomExceeded(t *testing.T) {
 		},
 	}
 
-	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, containerRec, target, nil)
 	assert.True(t, skip)
 	assert.Contains(t, reason, "quota/limitrange violation")
 	assert.Contains(t, reason, "would exceed ResourceQuota")
@@ -13803,7 +13803,7 @@ func TestShouldSkipResize_NodeAllocatableExceeded(t *testing.T) {
 		},
 	}
 
-	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, containerRec, target, nil)
 	assert.True(t, skip)
 	assert.Contains(t, reason, "exceed node allocatable")
 }
@@ -13858,7 +13858,7 @@ func TestShouldSkipResize_NodeAllocatableNotExceeded(t *testing.T) {
 		},
 	}
 
-	skip, _ := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	skip, _ := r.shouldSkipResize(context.Background(), pod, containerRec, target, nil)
 	assert.False(t, skip)
 }
 
@@ -13898,7 +13898,7 @@ func TestShouldSkipResize_AlreadyAtTarget(t *testing.T) {
 		},
 	}
 
-	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, containerRec, target, nil)
 	assert.True(t, skip, "should skip when pod already matches target")
 	assert.Empty(t, reason, "reason should be empty for already-at-target skip")
 }
@@ -13941,7 +13941,7 @@ func TestShouldSkipResize_RequestMatchLimitDriftDoesNotSkip(t *testing.T) {
 		},
 	}
 
-	skip, _ := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	skip, _ := r.shouldSkipResize(context.Background(), pod, containerRec, target, nil)
 	assert.False(t, skip, "must not skip when requests match but target sets a missing live limit")
 }
 
@@ -13992,7 +13992,7 @@ func TestShouldSkipResize_PreChecksLimitRange(t *testing.T) {
 		},
 	}
 
-	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, checks)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, containerRec, target, checks)
 	assert.True(t, skip, "should skip when target violates pre-fetched LimitRange")
 	assert.Contains(t, reason, "quota/limitrange violation")
 }
@@ -14046,7 +14046,7 @@ func TestShouldSkipResize_NodeCacheHit(t *testing.T) {
 	}
 	checks.nodeCache.Store("test-node", cachedNode)
 
-	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, checks)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, containerRec, target, checks)
 	assert.True(t, skip, "should skip when target exceeds cached node allocatable")
 	assert.Contains(t, reason, "exceed node allocatable")
 }
@@ -14099,7 +14099,7 @@ func TestShouldSkipResize_NodeCacheMiss(t *testing.T) {
 	// Empty cache; node should be fetched and stored.
 	checks := &resizePreChecks{}
 
-	skip, _ := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, checks)
+	skip, _ := r.shouldSkipResize(context.Background(), pod, containerRec, target, checks)
 	assert.False(t, skip, "should not skip when target fits in node allocatable")
 
 	// Verify the node was cached.
@@ -14169,7 +14169,7 @@ func TestShouldSkipResize_ClientsetPrefersLivePressure(t *testing.T) {
 		},
 	}
 
-	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, containerRec, target, nil)
 	assert.True(t, skip, "live Clientset MemoryPressure must block memory increase")
 	assert.Contains(t, reason, "MemoryPressure")
 }
@@ -14222,7 +14222,7 @@ func TestShouldSkipResize_QoSClassChange(t *testing.T) {
 
 	recorder := events.NewFakeRecorder(10)
 	r.Recorder = recorder
-	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, containerRec, target, nil)
 	assert.True(t, skip, "should skip when resize would change QoS class")
 	assert.Contains(t, reason, "QoS class")
 	select {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -328,13 +328,41 @@ func newReconcilerWithClient(objects ...client.Object) *AttunePolicyReconciler {
 	return r
 }
 
+// ensureTestNamespaces adds a Namespace object for every namespaced object
+// so Reconcile can Get the policy namespace (attune.io/freeze). Explicit
+// Namespace objects in objects are left unchanged.
+func ensureTestNamespaces(objects []client.Object) []client.Object {
+	have := make(map[string]struct{})
+	for _, o := range objects {
+		if ns, ok := o.(*corev1.Namespace); ok {
+			have[ns.Name] = struct{}{}
+		}
+	}
+	var extra []client.Object
+	for _, o := range objects {
+		name := o.GetNamespace()
+		if name == "" {
+			continue
+		}
+		if _, ok := have[name]; ok {
+			continue
+		}
+		have[name] = struct{}{}
+		extra = append(extra, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	}
+	if len(extra) == 0 {
+		return objects
+	}
+	return append(extra, objects...)
+}
+
 // newReconcilerForReconcile creates a reconciler with status subresource
 // support and a mock metrics factory, ready for Reconcile tests.
 func newReconcilerForReconcile(mc rsmetrics.MetricsCollector, objects ...client.Object) (*AttunePolicyReconciler, client.Client) {
 	scheme := testScheme()
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(objects...).
+		WithObjects(ensureTestNamespaces(objects)...).
 		WithStatusSubresource(&attunev1alpha1.AttunePolicy{}).
 		Build()
 	r := NewAttunePolicyReconciler()

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -13655,7 +13655,6 @@ func TestShouldSkipResize_LimitRangeViolation(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -13708,7 +13707,6 @@ func TestShouldSkipResize_QuotaHeadroomExceeded(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -13763,7 +13761,6 @@ func TestShouldSkipResize_NodeAllocatableExceeded(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -13824,7 +13821,6 @@ func TestShouldSkipResize_NodeAllocatableNotExceeded(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -13869,7 +13865,6 @@ func TestShouldSkipResize_AlreadyAtTarget(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -13910,7 +13905,6 @@ func TestShouldSkipResize_RequestMatchLimitDriftDoesNotSkip(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -13953,7 +13947,6 @@ func TestShouldSkipResize_PreChecksLimitRange(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -14004,7 +13997,6 @@ func TestShouldSkipResize_NodeCacheHit(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -14067,7 +14059,6 @@ func TestShouldSkipResize_NodeCacheMiss(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -14139,7 +14130,6 @@ func TestShouldSkipResize_ClientsetPrefersLivePressure(t *testing.T) {
 	r.Scheme = scheme
 	r.Clientset = kubefake.NewSimpleClientset(liveNode)
 
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{
@@ -14181,9 +14171,6 @@ func TestShouldSkipResize_QoSClassChange(t *testing.T) {
 	r.Client = fakeClient
 	r.Scheme = scheme
 
-	policy := &attunev1alpha1.AttunePolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
-	}
 	// Guaranteed pod: requests == limits for all resources.
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -6255,12 +6255,19 @@ func TestExecuteResizes_QoSBlocked_EmitsResizeSkippedEvent(t *testing.T) {
 	count, _ := reconciler.executeResizes(context.Background(), policy, workloads, recommendations, podMap("api-server", pod), nil, nil)
 	assert.Equal(t, 0, count)
 
-	select {
-	case event := <-recorder.Events:
-		assert.Contains(t, event, "ResizeSkipped")
-		assert.Contains(t, event, "controlledValues")
-	default:
-		t.Fatal("expected a ResizeSkipped event but channel was empty")
+	var got []string
+	for {
+		select {
+		case event := <-recorder.Events:
+			got = append(got, event)
+		default:
+			require.Len(t, got, 1, "QoS skip must emit exactly one user-visible event")
+			assert.Contains(t, got[0], "ResizeSkipped")
+			assert.Contains(t, got[0], "controlledValues")
+			assert.Contains(t, got[0], "would change QoS class")
+			assert.NotContains(t, got[0], "Skipping resize")
+			return
+		}
 	}
 }
 
@@ -8986,15 +8993,16 @@ func TestExecuteResizes_RevertsOnReFetchFailure(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(allObjects...).Build()
 	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
 
-	// Inject failure on typed clientset Get for pods. resizeContainer now
-	// live-gets before Infeasible (call 1), ResizePod does a pre-resize
-	// re-fetch (call 2), then persistResizeAnnotations does a post-resize
-	// re-fetch (call 3). Fail call 3 to test annotation-persist revert.
-	// Subsequent Gets (revert's pod lookup) pass through.
+	// Inject failure on typed clientset Get for pods. OneShot selection
+	// live-gets before Infeasible (call 1), resizeContainer live-gets
+	// again (call 2), ResizePod does a pre-resize re-fetch (call 3),
+	// then persistResizeAnnotations does a post-resize re-fetch (call 4).
+	// Fail call 4 to test annotation-persist revert. Subsequent Gets
+	// (revert's pod lookup) pass through.
 	getCount := 0
 	clientset.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		getCount++
-		if getCount == 3 {
+		if getCount == 4 {
 			return true, nil, fmt.Errorf("simulated re-fetch failure")
 		}
 		return false, nil, nil
@@ -14184,9 +14192,84 @@ func TestShouldSkipResize_QoSClassChange(t *testing.T) {
 		},
 	}
 
+	recorder := events.NewFakeRecorder(10)
+	r.Recorder = recorder
 	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, nil)
 	assert.True(t, skip, "should skip when resize would change QoS class")
 	assert.Contains(t, reason, "QoS class")
+	select {
+	case ev := <-recorder.Events:
+		t.Fatalf("shouldSkipResize must not Eventf; callers emit ResizeSkipped, got %s", ev)
+	default:
+	}
+}
+
+func TestApplyStartupBoosts_QoSSkipDoesNotEmitResizeSkipped(t *testing.T) {
+	// Guaranteed QoS with request-only boost target fails PreservesQoS.
+	// shouldSkipResize must stay a predicate so boost does not inherit a
+	// "Skipping resize ... QoS" event.
+	scheme := testScheme()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			CPU: attunev1alpha1.ResourceConfig{
+				StartupBoost: &attunev1alpha1.StartupBoost{
+					Multiplier: "3.0",
+					Duration:   metav1.Duration{Duration: 2 * time.Minute},
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-app-qos",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Second)),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, QOSClass: corev1.PodQOSGuaranteed},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "main",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
+			}},
+		},
+	}
+	clientset := kubefake.NewSimpleClientset(pod)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+	r.SetNowFunc(func() time.Time { return now })
+	recorder := events.NewFakeRecorder(10)
+	r.Recorder = recorder
+
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "my-app",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name:        "main",
+			Recommended: attunev1alpha1.ResourceValues{CPURequest: resource.MustParse("200m")},
+		}},
+	}}
+	r.applyStartupBoosts(context.Background(), policy, map[string][]corev1.Pod{"my-app": {*pod}}, recs, resize.NewPodResizer(clientset, ctrl.Log.WithName("test")), nil)
+
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			t.Fatal("Guaranteed request-only boost must be skipped by PreservesQoS")
+		}
+	}
+	select {
+	case ev := <-recorder.Events:
+		t.Fatalf("startup boost QoS skip must not emit resize events, got %s", ev)
+	default:
+	}
 }
 
 func TestFindContainerByName_RegularContainer(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -4888,6 +4888,50 @@ func TestExecuteResizes_SuccessfulResize(t *testing.T) {
 	assert.Equal(t, attunev1alpha1.ResizeResultSuccess, history[1].Result, "memory resize should succeed")
 }
 
+func TestExecuteResizes_OneShot_WalksPastBlockedFirstReplica(t *testing.T) {
+	// Replica 0 is already at the applied target. Replica 1 still needs
+	// the resize. OneShot must walk past pod-0; eligible[:1] would pick
+	// it and no-op.
+	pod0 := newResizePod("api-server", "200m", "256Mi", "400m", "512Mi")
+	pod0.Name = "pod-0"
+	pod1 := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+	pod1.Name = "pod-1"
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod0, pod1).Build()
+	clientset := kubefake.NewSimpleClientset(pod0.DeepCopy(), pod1.DeepCopy())
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeOneShot
+
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("api-server", "500m", "512Mi", "1000m", "1Gi", "200m", "256Mi", "400m", "512Mi"),
+	}
+
+	count, history := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy}, recommendations,
+		map[string][]corev1.Pod{"api-server": {*pod0, *pod1}}, nil, nil)
+	assert.Equal(t, 1, count)
+	require.NotEmpty(t, history)
+
+	var resized []string
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			updated := a.(k8stesting.UpdateAction).GetObject().(*corev1.Pod)
+			resized = append(resized, updated.Name)
+		}
+	}
+	require.NotEmpty(t, resized, "UpdateResize must run on the still-needing replica")
+	for _, name := range resized {
+		assert.Equal(t, "pod-1", name)
+	}
+}
+
 func TestExecuteResizes_ContextCancelledAbortsRemaining(t *testing.T) {
 	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -26,10 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
@@ -292,6 +294,29 @@ func TestFirstOneShotPodNeedingResize_UsesLivePodForInfeasible(t *testing.T) {
 	got := r.firstOneShotPodNeedingResize(context.Background(), policy, []corev1.Pod{listed0, pod1}, rec, nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name, "live Infeasible on pod-0 must walk to pod-1")
+}
+
+func TestFirstOneShotPodNeedingResize_LiveGetErrorWalksPast(t *testing.T) {
+	pod0 := oneshotResizePod("pod-0", "500m", "512Mi")
+	pod1 := oneshotResizePod("pod-1", "500m", "512Mi")
+	rec := newResizeRecommendation("api", "500m", "512Mi", "0", "0", "200m", "256Mi", "0", "0")
+	policy := newTestPolicy("test-policy", "default")
+
+	r := newReconcilerWithClient()
+	r.AllowInPlaceMemoryLimitDecrease = true
+	cs := kubefake.NewSimpleClientset(pod0.DeepCopy(), pod1.DeepCopy())
+	cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		get := action.(k8stesting.GetAction)
+		if get.GetName() == "pod-0" {
+			return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), "pod-0", fmt.Errorf("injected live Get 403"))
+		}
+		return false, nil, nil
+	})
+	r.Clientset = cs
+
+	got := r.firstOneShotPodNeedingResize(context.Background(), policy, []corev1.Pod{pod0, pod1}, rec, nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-1", got[0].Name, "live Get error on pod-0 must walk past, not apply the listed snapshot")
 }
 
 // firstOneShotNeeding wraps firstOneShotPodNeedingResize for request-only tests.

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -188,6 +188,23 @@ func TestFirstOneShotPodNeedingResize_SkipsMemoryPressureIncrease(t *testing.T) 
 	assert.Equal(t, "pod-1", got[0].Name)
 }
 
+func TestFirstOneShotPodNeedingResize_SkipsQoSChange(t *testing.T) {
+	// pod-0 is Guaranteed (500/500). Rec lowers memory request only, so
+	// PreservesQoS is false and shouldSkipResize blocks it. pod-1 is
+	// Burstable request-only and can take the same rec.
+	pod0 := oneshotResizePodWithLimits("pod-0", "500m", "512Mi", "500m", "512Mi")
+	pod0.Status.QOSClass = corev1.PodQOSGuaranteed
+	pod1 := oneshotResizePod("pod-1", "500m", "512Mi")
+	pod1.Status.QOSClass = corev1.PodQOSBurstable
+	rec := newResizeRecommendation("api", "500m", "512Mi", "0", "0", "500m", "256Mi", "0", "0")
+
+	r := newReconcilerWithClient()
+	r.AllowInPlaceMemoryLimitDecrease = true
+	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), []corev1.Pod{pod0, pod1}, rec)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-1", got[0].Name)
+}
+
 func TestFirstOneShotPodNeedingResize_SkipsInfeasibleInPlaceOnly(t *testing.T) {
 	pod0 := oneshotResizePod("pod-0", "500m", "512Mi")
 	pod0.Status.Conditions = append(pod0.Status.Conditions, corev1.PodCondition{

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -142,7 +142,7 @@ func TestFirstOneShotPodNeedingResize_SkipsClampedMemoryLimit(t *testing.T) {
 
 	r := newReconcilerWithClient()
 	r.AllowInPlaceMemoryLimitDecrease = false
-	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec)
+	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec, nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name)
 }
@@ -183,7 +183,7 @@ func TestFirstOneShotPodNeedingResize_SkipsMemoryPressureIncrease(t *testing.T) 
 
 	r := newReconcilerWithClient(pressureNode, healthyNode)
 	r.AllowInPlaceMemoryLimitDecrease = true
-	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), []corev1.Pod{pod0, pod1}, rec)
+	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), []corev1.Pod{pod0, pod1}, rec, nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name)
 }
@@ -200,7 +200,7 @@ func TestFirstOneShotPodNeedingResize_SkipsQoSChange(t *testing.T) {
 
 	r := newReconcilerWithClient()
 	r.AllowInPlaceMemoryLimitDecrease = true
-	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), []corev1.Pod{pod0, pod1}, rec)
+	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), []corev1.Pod{pod0, pod1}, rec, nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name)
 }
@@ -220,7 +220,7 @@ func TestFirstOneShotPodNeedingResize_SkipsInfeasibleInPlaceOnly(t *testing.T) {
 
 	r := newReconcilerWithClient()
 	r.AllowInPlaceMemoryLimitDecrease = true
-	got := r.firstOneShotPodNeedingResize(context.Background(), policy, []corev1.Pod{pod0, pod1}, rec)
+	got := r.firstOneShotPodNeedingResize(context.Background(), policy, []corev1.Pod{pod0, pod1}, rec, nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name)
 }
@@ -244,15 +244,60 @@ func TestFirstOneShotPodNeedingResize_SkipsFlooredGuaranteed(t *testing.T) {
 
 	r := newReconcilerWithClient()
 	r.AllowInPlaceMemoryLimitDecrease = true
-	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec)
+	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec, nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name)
+}
+
+func TestFirstOneShotPodNeedingResize_PrefetchQuotaFailClosedWalksPast(t *testing.T) {
+	// pod-0 needs a request increase; pod-1 needs a decrease to the same rec.
+	// checks.quotaListErr fail-closes increases only. If checks is still nil,
+	// live quota list on an empty client succeeds and pod-0 is selected.
+	pod0 := oneshotResizePod("pod-0", "200m", "256Mi")
+	pod1 := oneshotResizePod("pod-1", "800m", "1Gi")
+	rec := newResizeRecommendation("api", "200m", "256Mi", "0", "0", "500m", "512Mi", "0", "0")
+	policy := newTestPolicy("test-policy", "default")
+
+	r := newReconcilerWithClient()
+	r.AllowInPlaceMemoryLimitDecrease = true
+
+	got := r.firstOneShotPodNeedingResize(context.Background(), policy, []corev1.Pod{pod0, pod1}, rec, nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-0", got[0].Name, "nil checks uses live list success and must pick the first needing replica")
+
+	checks := &resizePreChecks{quotaListErr: fmt.Errorf("list forbidden")}
+	got = r.firstOneShotPodNeedingResize(context.Background(), policy, []corev1.Pod{pod0, pod1}, rec, checks)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-1", got[0].Name, "prefetch fail-closed must walk past the increase replica")
+}
+
+func TestFirstOneShotPodNeedingResize_UsesLivePodForInfeasible(t *testing.T) {
+	listed0 := oneshotResizePod("pod-0", "500m", "512Mi")
+	live0 := listed0.DeepCopy()
+	live0.Status.Conditions = append(live0.Status.Conditions, corev1.PodCondition{
+		Type:   "PodResizePending",
+		Status: corev1.ConditionTrue,
+		Reason: "Infeasible",
+	})
+	pod1 := oneshotResizePod("pod-1", "500m", "512Mi")
+	rec := newResizeRecommendation("api", "500m", "512Mi", "0", "0", "200m", "256Mi", "0", "0")
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOnly
+
+	r := newReconcilerWithClient()
+	r.AllowInPlaceMemoryLimitDecrease = true
+	r.Clientset = kubefake.NewSimpleClientset(live0, pod1.DeepCopy())
+
+	got := r.firstOneShotPodNeedingResize(context.Background(), policy, []corev1.Pod{listed0, pod1}, rec, nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pod-1", got[0].Name, "live Infeasible on pod-0 must walk to pod-1")
 }
 
 // firstOneShotNeeding wraps firstOneShotPodNeedingResize for request-only tests.
 func firstOneShotNeeding(pods []corev1.Pod, rec attunev1alpha1.WorkloadRecommendation) []corev1.Pod {
 	r := newReconcilerWithClient()
-	return r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec)
+	return r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec, nil)
 }
 
 func TestSelectPodsForResize_Canary_10PercentOf20(t *testing.T) {

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -59,6 +59,7 @@ func TestRecordCapacitySkip(t *testing.T) {
 	recordCapacitySkip(policy, "node has DiskPressure; skipping resource request increase (every increase is blocked; all decreases still apply; retry when the node condition clears)")
 	recordCapacitySkip(policy, "node has PIDPressure; skipping resource request increase (every increase is blocked; all decreases still apply; retry when the node condition clears)")
 	recordCapacitySkip(policy, "node status unavailable; skipping request increase")
+	recordCapacitySkip(policy, "pod status unavailable; skipping resize")
 	recordCapacitySkip(policy, "node free request budget exceeded by neighbors")
 	recordCapacitySkip(policy, "node neighbor list unavailable; skipping request increase")
 	recordCapacitySkip(policy, "quota/limitrange violation: too large")                                                                                                      // no metric
@@ -67,7 +68,7 @@ func TestRecordCapacitySkip(t *testing.T) {
 
 	assert.Equal(t, beforeAlloc+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "allocatable")))
 	assert.Equal(t, beforePress+3, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "pressure")))
-	assert.Equal(t, beforeUnavail+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "unavailable")))
+	assert.Equal(t, beforeUnavail+2, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "unavailable")))
 	assert.Equal(t, beforeNeighbors+2, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "neighbors")))
 }
 
@@ -723,6 +724,7 @@ func TestExecuteResizes_LiveGetFail_SkipsRequestIncrease(t *testing.T) {
 			"500m", "200Mi", "1000m", "1Gi"),
 	}
 
+	beforeUnavail := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable"))
 	count, history := reconciler.executeResizes(
 		context.Background(),
 		policy,
@@ -735,6 +737,8 @@ func TestExecuteResizes_LiveGetFail_SkipsRequestIncrease(t *testing.T) {
 	assert.Equal(t, 0, count)
 	assert.Empty(t, history)
 	assert.Equal(t, 0, resizeSubresourceCount(reconciler.Clientset.(*kubefake.Clientset)))
+	assert.Equal(t, beforeUnavail+1,
+		testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable")))
 
 	found := false
 	for {
@@ -775,6 +779,7 @@ func TestExecuteResizes_LiveGetFail_SkipsMemoryLimitDecrease(t *testing.T) {
 			"200m", "64Mi", "200m", "64Mi"),
 	}
 
+	beforeUnavail := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable"))
 	count, history := reconciler.executeResizes(
 		context.Background(),
 		policy,
@@ -787,6 +792,8 @@ func TestExecuteResizes_LiveGetFail_SkipsMemoryLimitDecrease(t *testing.T) {
 	assert.Equal(t, 0, count)
 	assert.Empty(t, history)
 	assert.Equal(t, 0, resizeSubresourceCount(reconciler.Clientset.(*kubefake.Clientset)))
+	assert.Equal(t, beforeUnavail+1,
+		testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable")))
 
 	found := false
 	for {
@@ -829,6 +836,7 @@ func TestExecuteResizes_LiveGetFail_SkipsRequestOnlyDecrease(t *testing.T) {
 			"200m", "256Mi", "1000m", "1Gi"),
 	}
 
+	beforeUnavail := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable"))
 	count, history := reconciler.executeResizes(
 		context.Background(),
 		policy,
@@ -841,6 +849,8 @@ func TestExecuteResizes_LiveGetFail_SkipsRequestOnlyDecrease(t *testing.T) {
 	assert.Equal(t, 0, count, "live Get error must not apply from a listed snapshot")
 	assert.Empty(t, history)
 	assert.Equal(t, 0, resizeSubresourceCount(cs))
+	assert.Equal(t, beforeUnavail+1,
+		testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "unavailable")))
 
 	found := false
 	for {

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -792,7 +792,7 @@ func TestExecuteResizes_LiveGetFail_SkipsMemoryLimitDecrease(t *testing.T) {
 	for {
 		select {
 		case event := <-recorder.Events:
-			if strings.Contains(event, "ResizeSkipped") && strings.Contains(event, "memory limit decrease") {
+			if strings.Contains(event, "ResizeSkipped") && strings.Contains(event, "pod status unavailable") {
 				found = true
 			}
 		default:
@@ -802,10 +802,9 @@ func TestExecuteResizes_LiveGetFail_SkipsMemoryLimitDecrease(t *testing.T) {
 	}
 }
 
-// TestExecuteResizes_LiveGetFail_AllowsRequestOnlyDecrease: request
-// decreases that are not memory-limit decreases still proceed when live
-// Get fails (same as node-unavailable decreases).
-func TestExecuteResizes_LiveGetFail_AllowsRequestOnlyDecrease(t *testing.T) {
+// TestExecuteResizes_LiveGetFail_SkipsRequestOnlyDecrease: a listed
+// snapshot that looks like a decrease is still stale; fail closed.
+func TestExecuteResizes_LiveGetFail_SkipsRequestOnlyDecrease(t *testing.T) {
 	const (
 		policyNS   = "default"
 		policyName = "live-get-fail-dec-policy"
@@ -815,7 +814,12 @@ func TestExecuteResizes_LiveGetFail_AllowsRequestOnlyDecrease(t *testing.T) {
 	pod := newResizePod(appName, "500m", "512Mi", "1000m", "1Gi")
 	deploy := newTestDeployment(appName, policyNS, map[string]string{"app": appName})
 	reconciler, _ := newResizeReconciler(pod, deploy)
-	failFirstPodGet(reconciler.Clientset.(*kubefake.Clientset))
+	cs := reconciler.Clientset.(*kubefake.Clientset)
+	cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(corev1.Resource("pods"), appName+"-abc-1", fmt.Errorf("injected live Get 403"))
+	})
+	recorder := events.NewFakeRecorder(10)
+	reconciler.Recorder = recorder
 
 	policy := newTestPolicy(policyName, policyNS)
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
@@ -834,9 +838,22 @@ func TestExecuteResizes_LiveGetFail_AllowsRequestOnlyDecrease(t *testing.T) {
 		nil,
 		nil,
 	)
-	assert.Equal(t, 1, count, "request-only decrease may proceed when live Get fails")
-	require.NotEmpty(t, history)
-	assert.Greater(t, resizeSubresourceCount(reconciler.Clientset.(*kubefake.Clientset)), 0)
+	assert.Equal(t, 0, count, "live Get error must not apply from a listed snapshot")
+	assert.Empty(t, history)
+	assert.Equal(t, 0, resizeSubresourceCount(cs))
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "ResizeSkipped") && strings.Contains(event, "pod status unavailable") {
+				found = true
+			}
+		default:
+			require.True(t, found, "expected ResizeSkipped when live Get fails on a request-only decrease")
+			return
+		}
+	}
 }
 
 func TestComputeSavings_ReclaimedAliases(t *testing.T) {

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -386,11 +386,11 @@ func TestShouldSkipResize_NilNodeBlocksIncrease(t *testing.T) {
 		},
 	}
 
-	skip, reason := r.shouldSkipResize(context.Background(), &attunev1alpha1.AttunePolicy{}, pod, rec, higherMem, nil)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, rec, higherMem, nil)
 	assert.True(t, skip)
 	assert.Contains(t, reason, "node status unavailable")
 
-	skip, reason = r.shouldSkipResize(context.Background(), &attunev1alpha1.AttunePolicy{}, pod, rec, lowerMem, nil)
+	skip, reason = r.shouldSkipResize(context.Background(), pod, rec, lowerMem, nil)
 	assert.False(t, skip, "decreases must not be blocked when node is unavailable: %s", reason)
 }
 

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -53,15 +53,15 @@ func TestRecordCapacitySkip(t *testing.T) {
 
 	// Exact producer strings from shouldSkipResize / nodePressureBlocksIncrease.
 	recordCapacitySkip(policy, "total pod requests would exceed node allocatable")
-	recordCapacitySkip(policy, "node has MemoryPressure; skipping memory request increase")
-	recordCapacitySkip(policy, "node has DiskPressure; skipping resource request increase")
-	recordCapacitySkip(policy, "node has PIDPressure; skipping resource request increase")
+	recordCapacitySkip(policy, "node has MemoryPressure; skipping memory request increase (CPU increases and all decreases still apply; retry when the node condition clears)")
+	recordCapacitySkip(policy, "node has DiskPressure; skipping resource request increase (every increase is blocked; all decreases still apply; retry when the node condition clears)")
+	recordCapacitySkip(policy, "node has PIDPressure; skipping resource request increase (every increase is blocked; all decreases still apply; retry when the node condition clears)")
 	recordCapacitySkip(policy, "node status unavailable; skipping request increase")
 	recordCapacitySkip(policy, "node free request budget exceeded by neighbors")
 	recordCapacitySkip(policy, "node neighbor list unavailable; skipping request increase")
-	recordCapacitySkip(policy, "quota/limitrange violation: too large")                  // no metric
-	recordCapacitySkip(policy, "")                                                       // no metric
-	recordCapacitySkip(nil, "node has MemoryPressure; skipping memory request increase") // no metric
+	recordCapacitySkip(policy, "quota/limitrange violation: too large")                                                                                                      // no metric
+	recordCapacitySkip(policy, "")                                                                                                                                           // no metric
+	recordCapacitySkip(nil, "node has MemoryPressure; skipping memory request increase (CPU increases and all decreases still apply; retry when the node condition clears)") // no metric
 
 	assert.Equal(t, beforeAlloc+1, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "allocatable")))
 	assert.Equal(t, beforePress+3, testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues("ns-cap", "cap-test", "pressure")))

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -29,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -523,6 +525,318 @@ func TestExecuteResizes_NilNode_LiveRecheckBlocksIncrease(t *testing.T) {
 			return
 		}
 	}
+}
+
+// TestExecuteResizes_UsageFloorUsesLiveLimitNotStaleInformer: informer still
+// has 512Mi after live rose to 2Gi. Floor must use the live limit so usage
+// ~1.5Gi is not clipped to the stale 512Mi before UpdateResize.
+func TestExecuteResizes_UsageFloorUsesLiveLimitNotStaleInformer(t *testing.T) {
+	const (
+		policyNS   = "default"
+		policyName = "floor-live-limit-policy"
+		appName    = "floor-live-app"
+	)
+
+	listed := newResizePod(appName, "200m", "512Mi", "200m", "512Mi")
+	live := listed.DeepCopy()
+	mem2Gi, err := resource.ParseQuantity("2Gi")
+	require.NoError(t, err)
+	live.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = mem2Gi
+	live.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = mem2Gi
+
+	deploy := newTestDeployment(appName, policyNS, map[string]string{"app": appName})
+	reconciler, _ := newResizeReconciler(listed, deploy)
+	reconciler.AllowInPlaceMemoryLimitDecrease = true
+	reconciler.Clientset = kubefake.NewSimpleClientset(live)
+
+	policy := newTestPolicy(policyName, policyNS)
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation(appName,
+			"200m", "512Mi", "200m", "512Mi",
+			"200m", "64Mi", "200m", "64Mi"),
+	}
+	usage, err := resource.ParseQuantity("1536Mi")
+	require.NoError(t, err)
+	recommendations[0].Containers[0].Explanation = &attunev1alpha1.ContainerRecommendationExplanation{
+		Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+			RawPercentile: usage,
+		},
+	}
+
+	_, _ = reconciler.executeResizes(
+		context.Background(),
+		policy,
+		[]client.Object{deploy},
+		recommendations,
+		podMap(appName, listed),
+		nil,
+		nil,
+	)
+
+	staleLimit, err := resource.ParseQuantity("512Mi")
+	require.NoError(t, err)
+	wantFloor := *resource.NewQuantity(int64(math.Ceil(float64(usage.Value())*1.1)), resource.BinarySI)
+
+	var gotLimit resource.Quantity
+	var found bool
+	for _, a := range reconciler.Clientset.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			updated := a.(k8stesting.UpdateAction).GetObject().(*corev1.Pod)
+			gotLimit = updated.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "UpdateResize must run so the floored limit can be inspected")
+	assert.False(t, gotLimit.Equal(staleLimit),
+		"floor must not clip to stale informer 512Mi, got %s", gotLimit.String())
+	assert.True(t, gotLimit.Equal(wantFloor),
+		"got limit %s want %s (1.5Gi * 1.1 vs live 2Gi)", gotLimit.String(), wantFloor.String())
+}
+
+// TestExecuteResizes_MemoryPressure_StaleHighInformerDoesNotAuthorizeIncrease:
+// informer still has 500Mi after live dropped to 100Mi. Target 200Mi is an
+// increase vs live and must skip under MemoryPressure (not a decrease vs
+// the stale-high cache).
+func TestExecuteResizes_MemoryPressure_StaleHighInformerDoesNotAuthorizeIncrease(t *testing.T) {
+	const (
+		policyNS   = "default"
+		policyName = "stale-high-pressure-policy"
+		nodeName   = "stale-high-node"
+		appName    = "stale-high-app"
+	)
+
+	listed := newResizePod(appName, "500m", "500Mi", "1000m", "1Gi")
+	listed.Spec.NodeName = nodeName
+	live := listed.DeepCopy()
+	liveMem, err := resource.ParseQuantity("100Mi")
+	require.NoError(t, err)
+	live.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = liveMem
+
+	deploy := newTestDeployment(appName, policyNS, map[string]string{"app": appName})
+	pressureNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Conditions: []corev1.NodeCondition{{
+				Type:   corev1.NodeMemoryPressure,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+
+	reconciler, _ := newResizeReconciler(listed, deploy, pressureNode)
+	reconciler.Clientset = kubefake.NewSimpleClientset(live, pressureNode.DeepCopy())
+	recorder := events.NewFakeRecorder(10)
+	reconciler.Recorder = recorder
+
+	policy := newTestPolicy(policyName, policyNS)
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation(appName,
+			"500m", "500Mi", "1000m", "1Gi",
+			"500m", "200Mi", "1000m", "1Gi"),
+	}
+
+	beforePress := testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "pressure"))
+	count, history := reconciler.executeResizes(
+		context.Background(),
+		policy,
+		[]client.Object{deploy},
+		recommendations,
+		podMap(appName, listed),
+		nil,
+		nil,
+	)
+	assert.Equal(t, 0, count, "increase vs live under MemoryPressure must not resize")
+	assert.Empty(t, history)
+	assert.Equal(t, beforePress+1,
+		testutil.ToFloat64(operatormetrics.CapacitySkipTotal.WithLabelValues(policyNS, policyName, "pressure")))
+
+	var resizes int
+	for _, a := range reconciler.Clientset.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			resizes++
+		}
+	}
+	assert.Equal(t, 0, resizes, "UpdateResize must not apply a live increase under MemoryPressure")
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "ResizeSkipped") && strings.Contains(event, "MemoryPressure") {
+				found = true
+			}
+		default:
+			require.True(t, found, "expected ResizeSkipped from live increase under MemoryPressure")
+			return
+		}
+	}
+}
+
+func failFirstPodGet(cs *kubefake.Clientset) {
+	var gets atomic.Int32
+	cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if gets.Add(1) == 1 {
+			return true, nil, apierrors.NewInternalError(fmt.Errorf("injected live pod Get"))
+		}
+		return false, nil, nil
+	})
+}
+
+func resizeSubresourceCount(cs *kubefake.Clientset) int {
+	var n int
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestExecuteResizes_LiveGetFail_SkipsRequestIncrease: live Get failure is
+// fail-closed for request increases (same philosophy as node unavailable).
+func TestExecuteResizes_LiveGetFail_SkipsRequestIncrease(t *testing.T) {
+	const (
+		policyNS   = "default"
+		policyName = "live-get-fail-inc-policy"
+		appName    = "live-get-fail-inc"
+	)
+
+	pod := newResizePod(appName, "500m", "100Mi", "1000m", "1Gi")
+	deploy := newTestDeployment(appName, policyNS, map[string]string{"app": appName})
+	reconciler, _ := newResizeReconciler(pod, deploy)
+	failFirstPodGet(reconciler.Clientset.(*kubefake.Clientset))
+	recorder := events.NewFakeRecorder(10)
+	reconciler.Recorder = recorder
+
+	policy := newTestPolicy(policyName, policyNS)
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation(appName,
+			"500m", "100Mi", "1000m", "1Gi",
+			"500m", "200Mi", "1000m", "1Gi"),
+	}
+
+	count, history := reconciler.executeResizes(
+		context.Background(),
+		policy,
+		[]client.Object{deploy},
+		recommendations,
+		podMap(appName, pod),
+		nil,
+		nil,
+	)
+	assert.Equal(t, 0, count)
+	assert.Empty(t, history)
+	assert.Equal(t, 0, resizeSubresourceCount(reconciler.Clientset.(*kubefake.Clientset)))
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "ResizeSkipped") && strings.Contains(event, "pod status unavailable") {
+				found = true
+			}
+		default:
+			require.True(t, found, "expected ResizeSkipped when live Get fails on a request increase")
+			return
+		}
+	}
+}
+
+// TestExecuteResizes_LiveGetFail_SkipsMemoryLimitDecrease: cannot floor
+// against a live limit we failed to read.
+func TestExecuteResizes_LiveGetFail_SkipsMemoryLimitDecrease(t *testing.T) {
+	const (
+		policyNS   = "default"
+		policyName = "live-get-fail-lim-policy"
+		appName    = "live-get-fail-lim"
+	)
+
+	pod := newResizePod(appName, "200m", "512Mi", "200m", "512Mi")
+	deploy := newTestDeployment(appName, policyNS, map[string]string{"app": appName})
+	reconciler, _ := newResizeReconciler(pod, deploy)
+	reconciler.AllowInPlaceMemoryLimitDecrease = true
+	failFirstPodGet(reconciler.Clientset.(*kubefake.Clientset))
+	recorder := events.NewFakeRecorder(10)
+	reconciler.Recorder = recorder
+
+	policy := newTestPolicy(policyName, policyNS)
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation(appName,
+			"200m", "512Mi", "200m", "512Mi",
+			"200m", "64Mi", "200m", "64Mi"),
+	}
+
+	count, history := reconciler.executeResizes(
+		context.Background(),
+		policy,
+		[]client.Object{deploy},
+		recommendations,
+		podMap(appName, pod),
+		nil,
+		nil,
+	)
+	assert.Equal(t, 0, count)
+	assert.Empty(t, history)
+	assert.Equal(t, 0, resizeSubresourceCount(reconciler.Clientset.(*kubefake.Clientset)))
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "ResizeSkipped") && strings.Contains(event, "memory limit decrease") {
+				found = true
+			}
+		default:
+			require.True(t, found, "expected ResizeSkipped when live Get fails on a memory-limit decrease")
+			return
+		}
+	}
+}
+
+// TestExecuteResizes_LiveGetFail_AllowsRequestOnlyDecrease: request
+// decreases that are not memory-limit decreases still proceed when live
+// Get fails (same as node-unavailable decreases).
+func TestExecuteResizes_LiveGetFail_AllowsRequestOnlyDecrease(t *testing.T) {
+	const (
+		policyNS   = "default"
+		policyName = "live-get-fail-dec-policy"
+		appName    = "live-get-fail-dec"
+	)
+
+	pod := newResizePod(appName, "500m", "512Mi", "1000m", "1Gi")
+	deploy := newTestDeployment(appName, policyNS, map[string]string{"app": appName})
+	reconciler, _ := newResizeReconciler(pod, deploy)
+	failFirstPodGet(reconciler.Clientset.(*kubefake.Clientset))
+
+	policy := newTestPolicy(policyName, policyNS)
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation(appName,
+			"500m", "512Mi", "1000m", "1Gi",
+			"200m", "256Mi", "1000m", "1Gi"),
+	}
+
+	count, history := reconciler.executeResizes(
+		context.Background(),
+		policy,
+		[]client.Object{deploy},
+		recommendations,
+		podMap(appName, pod),
+		nil,
+		nil,
+	)
+	assert.Equal(t, 1, count, "request-only decrease may proceed when live Get fails")
+	require.NotEmpty(t, history)
+	assert.Greater(t, resizeSubresourceCount(reconciler.Clientset.(*kubefake.Clientset)), 0)
 }
 
 func TestComputeSavings_ReclaimedAliases(t *testing.T) {

--- a/internal/controller/namespace_freeze_test.go
+++ b/internal/controller/namespace_freeze_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -263,6 +264,158 @@ func TestReconcile_NamespaceFreeze(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcile_NamespaceFreeze_SkipsOnRecommendationPersist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		freeze     bool
+		wantPatch  bool
+		wantFrozen bool
+	}{
+		{
+			name:       "freeze=true skips OnRecommendation persist",
+			freeze:     true,
+			wantPatch:  false,
+			wantFrozen: true,
+		},
+		{
+			name:      "freeze absent persists OnRecommendation",
+			freeze:    false,
+			wantPatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			policy := newTestPolicy("test-policy", "default")
+			policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeRecommend
+			policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+				Enabled: boolPtr(true),
+				When:    attunev1alpha1.TemplatePersistenceOnRecommendation,
+			}
+
+			deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+			pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+			nsAnns := map[string]string{}
+			if tt.freeze {
+				nsAnns[conflict.AnnotationFreeze] = "true"
+			}
+			ns := newTestNamespace("default", nsAnns)
+
+			mc := &mockCollector{
+				queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+					return generateSamples(200, 0.1), nil
+				},
+			}
+
+			scheme := testScheme()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(policy, deploy, pod, ns).
+				WithStatusSubresource(&attunev1alpha1.AttunePolicy{}).
+				Build()
+			reconciler := newReconcilerForReconcileWithClient(mc, fakeClient, scheme)
+
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+			})
+			require.NoError(t, err)
+
+			var updated attunev1alpha1.AttunePolicy
+			require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+				Name: "test-policy", Namespace: "default",
+			}, &updated))
+			require.NotEmpty(t, updated.Status.Recommendations)
+
+			var gotDeploy appsv1.Deployment
+			require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+				Name: "api-server", Namespace: "default",
+			}, &gotDeploy))
+			cpuMilli := gotDeploy.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
+			if tt.wantPatch {
+				assert.NotEqual(t, int64(500), cpuMilli, "expected OnRecommendation persist to change template CPU")
+			} else {
+				assert.Equal(t, int64(500), cpuMilli, "frozen namespace must not persist template")
+			}
+
+			cond := meta.FindStatusCondition(updated.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+			if tt.wantFrozen {
+				require.NotNil(t, cond)
+				assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
+			} else if cond != nil {
+				assert.NotEqual(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
+			}
+		})
+	}
+}
+
+func TestReconcile_NamespaceFreeze_RecheckBeforeExecuteResizes(t *testing.T) {
+	t.Parallel()
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.CPU.MaxChangePercent = int32Ptr(100)
+
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+	ns := newTestNamespace("default", nil)
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return generateSamples(200, 0.1), nil
+		},
+	}
+
+	scheme := testScheme()
+	nsGets := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy, deploy, pod, ns).
+		WithStatusSubresource(&attunev1alpha1.AttunePolicy{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if nsObj, ok := obj.(*corev1.Namespace); ok {
+					if err := c.Get(ctx, key, obj, opts...); err != nil {
+						return err
+					}
+					nsGets++
+					if nsGets > 1 {
+						if nsObj.Annotations == nil {
+							nsObj.Annotations = map[string]string{}
+						}
+						nsObj.Annotations[conflict.AnnotationFreeze] = "true"
+					}
+					return nil
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	reconciler := newReconcilerForReconcileWithClient(mc, fakeClient, scheme)
+	reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var updated attunev1alpha1.AttunePolicy
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "test-policy", Namespace: "default",
+	}, &updated))
+
+	assert.Greater(t, updated.Status.Workloads.WithRecommendations, int32(0))
+	assert.Equal(t, int32(0), updated.Status.Workloads.Resized, "second freeze check must skip executeResizes")
+	assert.GreaterOrEqual(t, nsGets, 2, "expected a second namespace Get before apply")
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+	require.NotNil(t, cond)
+	assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
 }
 
 // capturingEventRecorder records the last Eventf reason and formatted note.

--- a/internal/controller/namespace_freeze_test.go
+++ b/internal/controller/namespace_freeze_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/conflict"
+	rsmetrics "github.com/attune-io/attune/internal/metrics"
+)
+
+func newTestNamespace(name string, annotations map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+	}
+}
+
+func TestNamespaceApplyFrozen(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		ns         *corev1.Namespace
+		getErr     error
+		wantFrozen bool
+		wantErr    bool
+	}{
+		{
+			name:       "freeze=true skips apply",
+			ns:         newTestNamespace("default", map[string]string{conflict.AnnotationFreeze: "true"}),
+			wantFrozen: true,
+		},
+		{
+			name:       "freeze=false does not skip apply",
+			ns:         newTestNamespace("default", map[string]string{conflict.AnnotationFreeze: "false"}),
+			wantFrozen: false,
+		},
+		{
+			name:       "freeze absent does not skip apply",
+			ns:         newTestNamespace("default", nil),
+			wantFrozen: false,
+		},
+		{
+			name:       "True is not freeze (same parser as skip)",
+			ns:         newTestNamespace("default", map[string]string{conflict.AnnotationFreeze: "True"}),
+			wantFrozen: false,
+		},
+		{
+			name:       "Get error fail-closed",
+			ns:         newTestNamespace("default", nil),
+			getErr:     fmt.Errorf("simulated namespace get failure"),
+			wantFrozen: true,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			scheme := testScheme()
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.ns != nil && tt.getErr == nil {
+				builder = builder.WithObjects(tt.ns)
+			}
+			if tt.getErr != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.Namespace); ok {
+							return tt.getErr
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				})
+			}
+			r := NewAttunePolicyReconciler()
+			r.Client = builder.Build()
+			r.Scheme = scheme
+
+			frozen, err := r.namespaceApplyFrozen(context.Background(), "default")
+			assert.Equal(t, tt.wantFrozen, frozen)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReconcile_NamespaceFreeze(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		freezeValue     string // empty means omit the annotation
+		skipWorkload    bool
+		getErr          bool
+		wantRecs        bool
+		wantResized     bool
+		wantFrozenCond  bool
+		wantFrozenEvent bool
+	}{
+		{
+			name:            "freeze=true skips resize and still computes recommendations",
+			freezeValue:     "true",
+			wantRecs:        true,
+			wantResized:     false,
+			wantFrozenCond:  true,
+			wantFrozenEvent: true,
+		},
+		{
+			name:        "freeze=false does not skip resize",
+			freezeValue: "false",
+			wantRecs:    true,
+			wantResized: true,
+		},
+		{
+			name:        "freeze absent does not skip resize",
+			wantRecs:    true,
+			wantResized: true,
+		},
+		{
+			name:            "Get error fail-closed skips resize",
+			getErr:          true,
+			wantRecs:        true,
+			wantResized:     false,
+			wantFrozenCond:  true,
+			wantFrozenEvent: true,
+		},
+		{
+			name:            "workload skip still works independently of freeze",
+			freezeValue:     "true",
+			skipWorkload:    true,
+			wantRecs:        false,
+			wantResized:     false,
+			wantFrozenCond:  true,
+			wantFrozenEvent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			policy := newTestPolicy("test-policy", "default")
+			policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+			policy.Spec.CPU.MaxChangePercent = int32Ptr(100)
+
+			deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+			if tt.skipWorkload {
+				deploy.Annotations = map[string]string{conflict.AnnotationSkip: "true"}
+			}
+			pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+
+			nsAnns := map[string]string{}
+			if tt.freezeValue != "" {
+				nsAnns[conflict.AnnotationFreeze] = tt.freezeValue
+			}
+			ns := newTestNamespace("default", nsAnns)
+
+			mc := &mockCollector{
+				queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+					return generateSamples(200, 0.1), nil
+				},
+			}
+
+			scheme := testScheme()
+			builder := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(policy, deploy, pod, ns).
+				WithStatusSubresource(&attunev1alpha1.AttunePolicy{})
+			if tt.getErr {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.Namespace); ok {
+							return fmt.Errorf("simulated namespace get failure")
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				})
+			}
+			fakeClient := builder.Build()
+			reconciler := newReconcilerForReconcileWithClient(mc, fakeClient, scheme)
+			reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
+
+			var eventReason, eventNote string
+			reconciler.Recorder = &capturingEventRecorder{reason: &eventReason, note: &eventNote}
+
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+			})
+			require.NoError(t, err)
+
+			var updated attunev1alpha1.AttunePolicy
+			require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+				Name: "test-policy", Namespace: "default",
+			}, &updated))
+
+			assert.Equal(t, int32(1), updated.Status.Workloads.Discovered)
+			if tt.wantRecs {
+				assert.Greater(t, updated.Status.Workloads.WithRecommendations, int32(0))
+				require.NotEmpty(t, updated.Status.Recommendations)
+			} else {
+				assert.Equal(t, int32(0), updated.Status.Workloads.WithRecommendations)
+				assert.Empty(t, updated.Status.Recommendations)
+			}
+
+			if tt.wantResized {
+				assert.Greater(t, updated.Status.Workloads.Resized, int32(0), "expected a live resize")
+			} else {
+				assert.Equal(t, int32(0), updated.Status.Workloads.Resized)
+			}
+
+			cond := meta.FindStatusCondition(updated.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+			if tt.wantFrozenCond {
+				require.NotNil(t, cond)
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
+				assert.Contains(t, cond.Message, "resizes skipped")
+			} else if cond != nil {
+				assert.NotEqual(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
+			}
+
+			if tt.wantFrozenEvent {
+				assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, eventReason)
+				assert.Contains(t, eventNote, "resizes skipped")
+			} else {
+				assert.NotEqual(t, attunev1alpha1.ReasonNamespaceFrozen, eventReason)
+			}
+		})
+	}
+}
+
+// capturingEventRecorder records the last Eventf reason and formatted note.
+type capturingEventRecorder struct {
+	reason *string
+	note   *string
+}
+
+func (c *capturingEventRecorder) Eventf(_, _ runtime.Object, _, reason, _, note string, args ...interface{}) {
+	if reason != attunev1alpha1.ReasonNamespaceFrozen {
+		return
+	}
+	if c.reason != nil {
+		*c.reason = reason
+	}
+	if c.note != nil {
+		*c.note = fmt.Sprintf(note, args...)
+	}
+}

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -600,6 +600,31 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	containerRec, resizer, monitor, now := p.ContainerRec, p.Resizer, p.Monitor, p.Now
 	target := p.Target
 
+	// Live-Get before floor and pressure gates. The listed/informer pod can
+	// lag a prior in-place resize: a stale-low limit clips the usage floor
+	// below live usage; a stale-high request classifies a live increase as
+	// a decrease and skips MemoryPressure / unavailable / neighbor gates.
+	// Fail-closed for request increases and memory-limit decreases when
+	// Get fails (same philosophy as node status unavailable). Request-only
+	// decreases may still proceed against the listed snapshot.
+	if live, err := r.fetchLivePodForResize(ctx, pod); err != nil {
+		increase := targetIncreasesRequests(pod, containerRec.Name, target)
+		limitDec := targetDecreasesMemoryLimit(pod, containerRec.Name, target)
+		if increase || limitDec {
+			reason := "pod status unavailable; skipping request increase"
+			if !increase {
+				reason = "pod status unavailable; skipping memory limit decrease"
+			}
+			logger.Info("Skipping resize: "+reason,
+				"pod", pod.Name, "container", containerRec.Name)
+			r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
+				"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
+			return nil, resizeOutcomeNone
+		}
+	} else if live != nil {
+		pod = live
+	}
+
 	// Apply clamp + Guaranteed raise + usage floor before skip checks so
 	// shouldSkipResize sees the values that will be sent to the API server.
 	target, applyMeta := r.applyLiveResizeTarget(policy, pod, containerRec, target)
@@ -696,13 +721,6 @@ func (r *AttunePolicyReconciler) resizeContainer(
 				Resource: "cpu+memory", Method: "Eviction", Result: attunev1alpha1.ResizeResultEvicted,
 			},
 		}
-	}
-
-	// Live Get before Infeasible: the informer pod can lag kubelet (or an
-	// E2E inject loop) by a watch interval. Same class as the node
-	// pressure re-check above. Get failure keeps the listed object.
-	if live := r.livePodForResize(ctx, pod); live != nil {
-		pod = live
 	}
 
 	// Pods already marked Infeasible cannot be resized in-place on the current node.
@@ -1746,6 +1764,24 @@ func targetIncreasesRequests(pod *corev1.Pod, containerName string, target corev
 	return cpuInc || memInc
 }
 
+// targetDecreasesMemoryLimit reports whether target lowers the named
+// container's memory limit relative to the pod spec.
+func targetDecreasesMemoryLimit(pod *corev1.Pod, containerName string, target corev1.ResourceRequirements) bool {
+	c := findContainerByName(pod, containerName)
+	if c == nil {
+		return false
+	}
+	targetLim, ok := target.Limits[corev1.ResourceMemory]
+	if !ok || targetLim.IsZero() {
+		return false
+	}
+	currentLim, ok := c.Resources.Limits[corev1.ResourceMemory]
+	if !ok || currentLim.IsZero() {
+		return false
+	}
+	return targetLim.Cmp(currentLim) < 0
+}
+
 // emitLiveResizeApply writes clamp/floor events and metrics from apply meta.
 func (r *AttunePolicyReconciler) emitLiveResizeApply(
 	ctx context.Context,
@@ -1864,19 +1900,31 @@ func recentMemoryUsage(containerRec attunev1alpha1.ContainerRecommendation) (res
 	return u, true
 }
 
-// livePodForResize returns the named pod from the typed Clientset when
-// configured. Used immediately before the Infeasible eviction decision so
-// a stale informer snapshot cannot hide a live Infeasible (or keep a
-// cleared one). Returns listed on Get error or when Clientset is unset.
-func (r *AttunePolicyReconciler) livePodForResize(ctx context.Context, listed *corev1.Pod) *corev1.Pod {
+// fetchLivePodForResize returns the named pod from the typed Clientset.
+// Get errors are returned so callers can fail-closed for request increases
+// and memory-limit decreases. When Clientset is unset, listed is returned
+// with a nil error.
+func (r *AttunePolicyReconciler) fetchLivePodForResize(ctx context.Context, listed *corev1.Pod) (*corev1.Pod, error) {
 	if r.Clientset == nil || listed == nil {
-		return listed
+		return listed, nil
 	}
 	fresh, err := r.Clientset.CoreV1().Pods(listed.Namespace).Get(ctx, listed.Name, metav1.GetOptions{})
 	if err != nil {
+		return listed, err
+	}
+	return fresh, nil
+}
+
+// livePodForResize returns the named pod from the typed Clientset when
+// configured. Used by OneShot selection so a stale informer snapshot
+// cannot hide a live Infeasible (or keep a cleared one). Returns listed
+// on Get error or when Clientset is unset.
+func (r *AttunePolicyReconciler) livePodForResize(ctx context.Context, listed *corev1.Pod) *corev1.Pod {
+	live, err := r.fetchLivePodForResize(ctx, listed)
+	if err != nil || live == nil {
 		return listed
 	}
-	return fresh
+	return live
 }
 
 // getNodeForResize returns the named node for capacity/pressure checks.

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -1921,12 +1921,12 @@ func nodePressureBlocksIncrease(node *corev1.Node, pod *corev1.Pod, containerNam
 		switch cond.Type {
 		case corev1.NodeMemoryPressure:
 			if memInc {
-				return "node has MemoryPressure; skipping memory request increase"
+				return "node has MemoryPressure; skipping memory request increase (CPU increases and all decreases still apply; retry when the node condition clears)"
 			}
 		case corev1.NodeDiskPressure:
-			return "node has DiskPressure; skipping resource request increase"
+			return "node has DiskPressure; skipping resource request increase (every increase is blocked; all decreases still apply; retry when the node condition clears)"
 		case corev1.NodePIDPressure:
-			return "node has PIDPressure; skipping resource request increase"
+			return "node has PIDPressure; skipping resource request increase (every increase is blocked; all decreases still apply; retry when the node condition clears)"
 		}
 	}
 	return ""

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -89,7 +89,12 @@ func (r *AttunePolicyReconciler) firstOneShotPodNeedingResize(
 			continue
 		}
 		// Live Get before Infeasible / shouldSkipResize, matching apply.
-		if live := r.livePodForResize(ctx, p); live != nil {
+		// Get errors fail closed: do not select the listed snapshot.
+		live, err := r.fetchLivePodForResize(ctx, p)
+		if err != nil {
+			continue
+		}
+		if live != nil {
 			p = live
 		}
 		if r.oneShotPodAlreadyAtTarget(policy, p, rec) {
@@ -604,23 +609,15 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	// lag a prior in-place resize: a stale-low limit clips the usage floor
 	// below live usage; a stale-high request classifies a live increase as
 	// a decrease and skips MemoryPressure / unavailable / neighbor gates.
-	// Fail-closed for request increases and memory-limit decreases when
-	// Get fails (same philosophy as node status unavailable). Request-only
-	// decreases may still proceed against the listed snapshot.
+	// Fail-closed on Get error: do not classify increase vs decrease
+	// against the listed snapshot (it may be stale-high).
 	if live, err := r.fetchLivePodForResize(ctx, pod); err != nil {
-		increase := targetIncreasesRequests(pod, containerRec.Name, target)
-		limitDec := targetDecreasesMemoryLimit(pod, containerRec.Name, target)
-		if increase || limitDec {
-			reason := "pod status unavailable; skipping request increase"
-			if !increase {
-				reason = "pod status unavailable; skipping memory limit decrease"
-			}
-			logger.Info("Skipping resize: "+reason,
-				"pod", pod.Name, "container", containerRec.Name)
-			r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
-				"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
-			return nil, resizeOutcomeNone
-		}
+		reason := "pod status unavailable; skipping resize"
+		logger.Info("Skipping resize: "+reason,
+			"pod", pod.Name, "container", containerRec.Name)
+		r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
+			"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
+		return nil, resizeOutcomeNone
 	} else if live != nil {
 		pod = live
 	}
@@ -1901,9 +1898,8 @@ func recentMemoryUsage(containerRec attunev1alpha1.ContainerRecommendation) (res
 }
 
 // fetchLivePodForResize returns the named pod from the typed Clientset.
-// Get errors are returned so callers can fail-closed for request increases
-// and memory-limit decreases. When Clientset is unset, listed is returned
-// with a nil error.
+// Get errors are returned so callers can fail-closed and skip apply.
+// When Clientset is unset, listed is returned with a nil error.
 func (r *AttunePolicyReconciler) fetchLivePodForResize(ctx context.Context, listed *corev1.Pod) (*corev1.Pod, error) {
 	if r.Clientset == nil || listed == nil {
 		return listed, nil
@@ -1913,18 +1909,6 @@ func (r *AttunePolicyReconciler) fetchLivePodForResize(ctx context.Context, list
 		return listed, err
 	}
 	return fresh, nil
-}
-
-// livePodForResize returns the named pod from the typed Clientset when
-// configured. Used by OneShot selection so a stale informer snapshot
-// cannot hide a live Infeasible (or keep a cleared one). Returns listed
-// on Get error or when Clientset is unset.
-func (r *AttunePolicyReconciler) livePodForResize(ctx context.Context, listed *corev1.Pod) *corev1.Pod {
-	live, err := r.fetchLivePodForResize(ctx, listed)
-	if err != nil || live == nil {
-		return listed
-	}
-	return live
 }
 
 // getNodeForResize returns the named node for capacity/pressure checks.

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -92,6 +92,8 @@ func (r *AttunePolicyReconciler) firstOneShotPodNeedingResize(
 		// Get errors fail closed: do not select the listed snapshot.
 		live, err := r.fetchLivePodForResize(ctx, p)
 		if err != nil {
+			log.FromContext(ctx).V(1).Info("OneShot: skipping pod after live Get error",
+				"pod", p.Name, "namespace", p.Namespace, "error", err)
 			continue
 		}
 		if live != nil {
@@ -614,9 +616,10 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	if live, err := r.fetchLivePodForResize(ctx, pod); err != nil {
 		reason := "pod status unavailable; skipping resize"
 		logger.Info("Skipping resize: "+reason,
-			"pod", pod.Name, "container", containerRec.Name)
+			"pod", pod.Name, "namespace", pod.Namespace, "container", containerRec.Name, "error", err)
 		r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
 			"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
+		recordCapacitySkip(policy, reason)
 		return nil, resizeOutcomeNone
 	} else if live != nil {
 		pod = live
@@ -1642,7 +1645,8 @@ func recordCapacitySkip(policy *attunev1alpha1.AttunePolicy, reason string) {
 		strings.Contains(reason, "PIDPressure"),
 		strings.Contains(reason, "node pressure"):
 		operatormetrics.CapacitySkipTotal.WithLabelValues(policy.Namespace, policy.Name, "pressure").Inc()
-	case strings.Contains(reason, "node status unavailable"):
+	case strings.Contains(reason, "node status unavailable"),
+		strings.Contains(reason, "pod status unavailable"):
 		operatormetrics.CapacitySkipTotal.WithLabelValues(policy.Namespace, policy.Name, "unavailable").Inc()
 	}
 }

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -81,16 +81,21 @@ func (r *AttunePolicyReconciler) firstOneShotPodNeedingResize(
 	policy *attunev1alpha1.AttunePolicy,
 	pods []corev1.Pod,
 	rec attunev1alpha1.WorkloadRecommendation,
+	checks *resizePreChecks,
 ) []corev1.Pod {
 	for i := range pods {
 		p := &pods[i]
 		if !resize.IsEligibleForResize(p) {
 			continue
 		}
-		if r.oneShotPodAlreadyAtTarget(ctx, policy, p, rec) {
+		// Live Get before Infeasible / shouldSkipResize, matching apply.
+		if live := r.livePodForResize(ctx, p); live != nil {
+			p = live
+		}
+		if r.oneShotPodAlreadyAtTarget(policy, p, rec) {
 			continue
 		}
-		if r.oneShotPodAllNeedingContainersBlocked(ctx, policy, p, rec) {
+		if r.oneShotPodAllNeedingContainersBlocked(ctx, policy, p, rec, checks) {
 			continue
 		}
 		return []corev1.Pod{*p}
@@ -98,44 +103,80 @@ func (r *AttunePolicyReconciler) firstOneShotPodNeedingResize(
 	return nil
 }
 
+// liveResizeApplyMeta is the clamp/floor result of applyLiveResizeTarget
+// so callers can emit events and metrics without re-deriving decisions.
+type liveResizeApplyMeta struct {
+	PreClamped              corev1.ResourceRequirements
+	PlatformClamped         bool
+	RequestedMemLimit       resource.Quantity
+	ClampedMemLimit         resource.Quantity
+	GuaranteedRequestRaised bool
+	FloorApplied            bool
+	FloorFromLimit          resource.Quantity
+	FloorToLimit            resource.Quantity
+	FloorUsage              resource.Quantity
+	FloorMargin             float64
+	FloorEqualsCurrent      bool
+}
+
+// applyLiveResizeTarget applies ClampMemoryLimitForPolicy, the Guaranteed
+// request raise when platform-clamped, and the usage floor otherwise.
+// OneShot compare and resizeContainer must share this so they cannot drift.
+func (r *AttunePolicyReconciler) applyLiveResizeTarget(
+	policy *attunev1alpha1.AttunePolicy,
+	pod *corev1.Pod,
+	containerRec attunev1alpha1.ContainerRecommendation,
+	target corev1.ResourceRequirements,
+) (corev1.ResourceRequirements, liveResizeApplyMeta) {
+	meta := liveResizeApplyMeta{PreClamped: *target.DeepCopy()}
+	target = resize.ClampMemoryLimitForPolicy(pod, containerRec.Name, target, r.AllowInPlaceMemoryLimitDecrease)
+	if memLim, ok := meta.PreClamped.Limits[corev1.ResourceMemory]; ok {
+		if clampedLim, cok := target.Limits[corev1.ResourceMemory]; cok && !memLim.Equal(clampedLim) {
+			meta.PlatformClamped = true
+			meta.RequestedMemLimit = memLim
+			meta.ClampedMemLimit = clampedLim
+			if pod.Status.QOSClass == corev1.PodQOSGuaranteed {
+				if memReq, rok := target.Requests[corev1.ResourceMemory]; rok && memReq.Cmp(clampedLim) < 0 {
+					target.Requests[corev1.ResourceMemory] = clampedLim.DeepCopy()
+					meta.GuaranteedRequestRaised = true
+				}
+			}
+		}
+	}
+	if !meta.PlatformClamped {
+		floored, applied, usage, margin := r.computeMemoryUsageFloor(policy, pod, containerRec, target)
+		if applied {
+			fromLim := target.Limits[corev1.ResourceMemory]
+			toLim := floored.Limits[corev1.ResourceMemory]
+			meta.FloorApplied = true
+			meta.FloorFromLimit = fromLim
+			meta.FloorToLimit = toLim
+			meta.FloorUsage = usage
+			meta.FloorMargin = margin
+			meta.FloorEqualsCurrent = toLim.Equal(liveContainerCurrent(pod, containerRec).MemoryLimit)
+			target = floored
+		}
+		target = resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
+	}
+	return target, meta
+}
+
 // appliedResizeTarget is the clamp + Guaranteed QoS raise + usage floor that
 // resizeContainer applies before shouldSkipResize. OneShot selection must
 // compare and skip against this same applied target.
 func (r *AttunePolicyReconciler) appliedResizeTarget(
-	ctx context.Context,
 	policy *attunev1alpha1.AttunePolicy,
 	pod *corev1.Pod,
 	containerRec attunev1alpha1.ContainerRecommendation,
 ) corev1.ResourceRequirements {
 	target, _ := buildResizeTarget(containerRec)
-	preClamped := target.DeepCopy()
-	target = resize.ClampMemoryLimitForPolicy(pod, containerRec.Name, target, r.AllowInPlaceMemoryLimitDecrease)
-	platformClamped := false
-	if memLim, ok := preClamped.Limits[corev1.ResourceMemory]; ok {
-		if clampedLim, cok := target.Limits[corev1.ResourceMemory]; cok && !memLim.Equal(clampedLim) {
-			platformClamped = true
-			if pod.Status.QOSClass == corev1.PodQOSGuaranteed {
-				if memReq, rok := target.Requests[corev1.ResourceMemory]; rok && memReq.Cmp(clampedLim) < 0 {
-					target.Requests[corev1.ResourceMemory] = clampedLim.DeepCopy()
-				}
-			}
-		}
-	}
-	if !platformClamped {
-		target = r.applyMemoryUsageFloor(ctx, policy, pod, containerRec, target)
-		target = resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
-	}
-	return target
+	applied, _ := r.applyLiveResizeTarget(policy, pod, containerRec, target)
+	return applied
 }
 
 // oneShotPodAlreadyAtTarget is true when every recommended container already
-// matches the applied (clamped/floored) target. resizeContainer applies
-// ClampMemoryLimitForPolicy and applyMemoryUsageFloor before shouldSkipResize,
-// so OneShot must compare against that same applied target. Otherwise a
-// replica whose live limit stayed at the clamped/floored value is re-selected
-// every cycle and later replicas never move.
+// matches the applied (clamped/floored) target from applyLiveResizeTarget.
 func (r *AttunePolicyReconciler) oneShotPodAlreadyAtTarget(
-	ctx context.Context,
 	policy *attunev1alpha1.AttunePolicy,
 	pod *corev1.Pod,
 	rec attunev1alpha1.WorkloadRecommendation,
@@ -144,7 +185,7 @@ func (r *AttunePolicyReconciler) oneShotPodAlreadyAtTarget(
 		return true
 	}
 	for _, containerRec := range rec.Containers {
-		target := r.appliedResizeTarget(ctx, policy, pod, containerRec)
+		target := r.appliedResizeTarget(policy, pod, containerRec)
 		c := findContainerByName(pod, containerRec.Name)
 		if c == nil || !containerMatchesAppliedTarget(c, target) {
 			return false
@@ -176,12 +217,13 @@ func (r *AttunePolicyReconciler) oneShotPodAllNeedingContainersBlocked(
 	policy *attunev1alpha1.AttunePolicy,
 	pod *corev1.Pod,
 	rec attunev1alpha1.WorkloadRecommendation,
+	checks *resizePreChecks,
 ) bool {
 	infeasibleBlocked := resize.IsResizeInfeasible(pod) && resizeMethodIsInPlaceOnly(policy)
 	needing := 0
 	blocked := 0
 	for _, containerRec := range rec.Containers {
-		target := r.appliedResizeTarget(ctx, policy, pod, containerRec)
+		target := r.appliedResizeTarget(policy, pod, containerRec)
 		c := findContainerByName(pod, containerRec.Name)
 		if c != nil && containerMatchesAppliedTarget(c, target) {
 			continue
@@ -191,7 +233,7 @@ func (r *AttunePolicyReconciler) oneShotPodAllNeedingContainersBlocked(
 			blocked++
 			continue
 		}
-		skip, reason := r.shouldSkipResize(ctx, policy, pod, containerRec, target, nil)
+		skip, reason := r.shouldSkipResize(ctx, policy, pod, containerRec, target, checks)
 		if skip && reason != "" {
 			blocked++
 		}
@@ -385,9 +427,13 @@ func (r *AttunePolicyReconciler) executeResizes(
 				wlMode = attunev1alpha1.UpdateTypeCanary
 			}
 		}
-		selectedPods := selectPodsForResize(pods, wlMode, canaryPct)
+		var selectedPods []corev1.Pod
 		if wlMode == attunev1alpha1.UpdateTypeOneShot {
-			selectedPods = r.firstOneShotPodNeedingResize(ctx, policy, pods, rec)
+			// OneShot walks remaining replicas; selectPodsForResize OneShot
+			// is eligible[:1] and would pin the first replica forever (#682).
+			selectedPods = r.firstOneShotPodNeedingResize(ctx, policy, pods, rec, checks)
+		} else {
+			selectedPods = selectPodsForResize(pods, wlMode, canaryPct)
 		}
 		logger.V(1).Info("Pod selection for resize",
 			"workload", rec.Workload, "total", len(pods),
@@ -554,49 +600,11 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	containerRec, resizer, monitor, now := p.ContainerRec, p.Resizer, p.Monitor, p.Now
 	target := p.Target
 
-	// Clamp the target memory limit before skip checks (including QoS
-	// preservation). K8s v1.33 forbids in-place memory limit decreases
-	// when the resize policy is NotRequired. Applying the clamp early
-	// ensures shouldSkipResize sees the actual values that will be sent
-	// to the API server. Without this, a Guaranteed QoS pod could pass
-	// the QoS check with the unclamped target but then have its memory
-	// limit preserved by the resize engine, breaking requests == limits.
-	preClamped := target.DeepCopy()
-	target = resize.ClampMemoryLimitForPolicy(pod, containerRec.Name, target, r.AllowInPlaceMemoryLimitDecrease)
-	platformClamped := false
-	if memLim, ok := preClamped.Limits[corev1.ResourceMemory]; ok {
-		if clampedLim, cok := target.Limits[corev1.ResourceMemory]; cok && !memLim.Equal(clampedLim) {
-			platformClamped = true
-			logger.Info("Memory limit decrease clamped by resize policy",
-				"pod", pod.Name, "container", containerRec.Name,
-				"requestedLimit", memLim.String(), "clampedLimit", clampedLim.String())
-			r.emitEventOnce(policy, corev1.EventTypeWarning, "MemoryLimitClamped", "resize",
-				"Container %s in pod %s: memory limit decrease blocked (NotRequired resize policy); limit preserved at %s",
-				containerRec.Name, pod.Name, clampedLim.String())
-			operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
-				policy.Namespace, policy.Name, "clamped_platform").Inc()
-			// For Guaranteed QoS pods, the memory request must also be raised
-			// to match the clamped limit. Otherwise requests != limits and
-			// PreservesQoS blocks the resize entirely, preventing CPU changes
-			// that would otherwise succeed.
-			if pod.Status.QOSClass == corev1.PodQOSGuaranteed {
-				if memReq, rok := target.Requests[corev1.ResourceMemory]; rok && memReq.Cmp(clampedLim) < 0 {
-					target.Requests[corev1.ResourceMemory] = clampedLim.DeepCopy()
-					logger.Info("Memory request raised to match clamped limit for Guaranteed QoS",
-						"pod", pod.Name, "container", containerRec.Name,
-						"request", clampedLim.String())
-				}
-			}
-		}
-	}
-
-	// Client-side pre-check: do not apply a memory limit at or below recent
-	// usage (plus configurable margin). Uses recommendation RawPercentile as
-	// recent usage from the metrics window (#444 / #428).
-	if !platformClamped {
-		target = r.applyMemoryUsageFloor(ctx, policy, pod, containerRec, target)
-		target = resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
-	}
+	// Apply clamp + Guaranteed raise + usage floor before skip checks so
+	// shouldSkipResize sees the values that will be sent to the API server.
+	target, applyMeta := r.applyLiveResizeTarget(policy, pod, containerRec, target)
+	r.emitLiveResizeApply(ctx, policy, pod, containerRec, applyMeta)
+	preClamped := applyMeta.PreClamped
 
 	skip, reason := r.shouldSkipResize(ctx, policy, pod, containerRec, target, p.Checks)
 	if skip {
@@ -1504,9 +1512,7 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 	// Already at target (compare against clamped target, not raw recommendation,
 	// so requests clamped to limits are correctly detected as no-ops).
 	if c := findContainerByName(pod, containerRec.Name); c != nil {
-		if c.Resources.Requests.Cpu().MilliValue() == target.Requests.Cpu().MilliValue() &&
-			c.Resources.Requests.Memory().Value() == target.Requests.Memory().Value() &&
-			targetLimitsMatchLive(c.Resources.Limits, target.Limits) {
+		if containerMatchesAppliedTarget(c, target) {
 			return true, ""
 		}
 	}
@@ -1596,15 +1602,9 @@ func (r *AttunePolicyReconciler) shouldSkipResize(
 		}
 	}
 
-	// QoS class change.
+	// QoS class change. Callers emit the user-visible event from the reason.
 	if !resize.PreservesQoS(pod, containerRec.Name, target) {
-		if r.Recorder != nil {
-			r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, "ResizeSkipped", "resize",
-				"Skipping resize for pod %s container %s: would change QoS class from Guaranteed. "+
-					"Use controlledValues: RequestsAndLimits, or on K8s v1.33 set resizePolicy to RestartContainer for memory",
-				pod.Name, containerRec.Name)
-		}
-		return true, "would change QoS class"
+		return true, "would change QoS class from Guaranteed. Use controlledValues: RequestsAndLimits, or on K8s v1.33 set resizePolicy to RestartContainer for memory"
 	}
 
 	return false, ""
@@ -1746,6 +1746,83 @@ func targetIncreasesRequests(pod *corev1.Pod, containerName string, target corev
 	return cpuInc || memInc
 }
 
+// emitLiveResizeApply writes clamp/floor events and metrics from apply meta.
+func (r *AttunePolicyReconciler) emitLiveResizeApply(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	pod *corev1.Pod,
+	containerRec attunev1alpha1.ContainerRecommendation,
+	meta liveResizeApplyMeta,
+) {
+	logger := log.FromContext(ctx)
+	if meta.PlatformClamped {
+		logger.Info("Memory limit decrease clamped by resize policy",
+			"pod", pod.Name, "container", containerRec.Name,
+			"requestedLimit", meta.RequestedMemLimit.String(),
+			"clampedLimit", meta.ClampedMemLimit.String())
+		r.emitEventOnce(policy, corev1.EventTypeWarning, "MemoryLimitClamped", "resize",
+			"Container %s in pod %s: memory limit decrease blocked (NotRequired resize policy); limit preserved at %s",
+			containerRec.Name, pod.Name, meta.ClampedMemLimit.String())
+		operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
+			policy.Namespace, policy.Name, "clamped_platform").Inc()
+		if meta.GuaranteedRequestRaised {
+			logger.Info("Memory request raised to match clamped limit for Guaranteed QoS",
+				"pod", pod.Name, "container", containerRec.Name,
+				"request", meta.ClampedMemLimit.String())
+		}
+	}
+	if meta.FloorApplied {
+		logger.Info("Memory limit decrease floored above recent usage",
+			"pod", pod.Name, "container", containerRec.Name,
+			"requestedLimit", meta.FloorFromLimit.String(),
+			"usage", meta.FloorUsage.String(),
+			"marginPercent", meta.FloorMargin,
+			"flooredLimit", meta.FloorToLimit.String())
+		r.emitEventOnce(policy, corev1.EventTypeWarning, "MemoryLimitUsageFloor", "resize",
+			"Container %s in pod %s: memory limit decrease raised from %s to %s (usage %s + %.0f%% margin)",
+			containerRec.Name, pod.Name, meta.FloorFromLimit.String(), meta.FloorToLimit.String(),
+			meta.FloorUsage.String(), meta.FloorMargin)
+		if meta.FloorEqualsCurrent {
+			operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
+				policy.Namespace, policy.Name, "skipped_unsafe").Inc()
+		} else {
+			operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
+				policy.Namespace, policy.Name, "clamped_usage").Inc()
+		}
+	}
+}
+
+// computeMemoryUsageFloor raises a decreasing memory limit so it stays above
+// recent usage * (1 + margin/100). Silent: callers emit events from the result.
+func (r *AttunePolicyReconciler) computeMemoryUsageFloor(
+	policy *attunev1alpha1.AttunePolicy,
+	pod *corev1.Pod,
+	containerRec attunev1alpha1.ContainerRecommendation,
+	target corev1.ResourceRequirements,
+) (corev1.ResourceRequirements, bool, resource.Quantity, float64) {
+	targetLim, ok := target.Limits[corev1.ResourceMemory]
+	if !ok {
+		return target, false, resource.Quantity{}, 0
+	}
+	currentLim := liveContainerCurrent(pod, containerRec).MemoryLimit
+	if currentLim.IsZero() || targetLim.Cmp(currentLim) >= 0 {
+		return target, false, resource.Quantity{}, 0
+	}
+	usage, hasUsage := recentMemoryUsage(containerRec)
+	if !hasUsage {
+		return target, false, resource.Quantity{}, 0
+	}
+	margin := float64(attunev1alpha1.DefaultDecreaseUsageMarginPercent)
+	if policy != nil && policy.Spec.Memory.DecreaseUsageMarginPercent != nil {
+		margin = float64(*policy.Spec.Memory.DecreaseUsageMarginPercent)
+	}
+	floored, applied := resize.FloorMemoryLimitForUsage(target, currentLim, usage, margin)
+	if !applied {
+		return target, false, usage, margin
+	}
+	return floored, true, usage, margin
+}
+
 // applyMemoryUsageFloor raises a decreasing memory limit so it stays above
 // recent usage * (1 + margin/100). Recent usage is the memory recommendation
 // RawPercentile (historical usage percentile before overhead).
@@ -1756,49 +1833,21 @@ func (r *AttunePolicyReconciler) applyMemoryUsageFloor(
 	containerRec attunev1alpha1.ContainerRecommendation,
 	target corev1.ResourceRequirements,
 ) corev1.ResourceRequirements {
-	logger := log.FromContext(ctx)
-	targetLim, ok := target.Limits[corev1.ResourceMemory]
-	if !ok {
-		return target
-	}
-	currentLim := liveContainerCurrent(pod, containerRec).MemoryLimit
-	if currentLim.IsZero() || targetLim.Cmp(currentLim) >= 0 {
-		return target
-	}
-
-	usage, hasUsage := recentMemoryUsage(containerRec)
-	if !hasUsage {
-		return target
-	}
-
-	margin := float64(attunev1alpha1.DefaultDecreaseUsageMarginPercent)
-	if policy.Spec.Memory.DecreaseUsageMarginPercent != nil {
-		margin = float64(*policy.Spec.Memory.DecreaseUsageMarginPercent)
-	}
-
-	floored, applied := resize.FloorMemoryLimitForUsage(target, currentLim, usage, margin)
+	floored, applied, usage, margin := r.computeMemoryUsageFloor(policy, pod, containerRec, target)
 	if !applied {
 		return target
 	}
-
-	newLim := floored.Limits[corev1.ResourceMemory]
-	logger.Info("Memory limit decrease floored above recent usage",
-		"pod", pod.Name, "container", containerRec.Name,
-		"requestedLimit", targetLim.String(),
-		"usage", usage.String(),
-		"marginPercent", margin,
-		"flooredLimit", newLim.String())
-	r.emitEventOnce(policy, corev1.EventTypeWarning, "MemoryLimitUsageFloor", "resize",
-		"Container %s in pod %s: memory limit decrease raised from %s to %s (usage %s + %.0f%% margin)",
-		containerRec.Name, pod.Name, targetLim.String(), newLim.String(), usage.String(), margin)
-
-	if newLim.Equal(currentLim) {
-		operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
-			policy.Namespace, policy.Name, "skipped_unsafe").Inc()
-	} else {
-		operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
-			policy.Namespace, policy.Name, "clamped_usage").Inc()
-	}
+	currentLim := liveContainerCurrent(pod, containerRec).MemoryLimit
+	fromLim := target.Limits[corev1.ResourceMemory]
+	toLim := floored.Limits[corev1.ResourceMemory]
+	r.emitLiveResizeApply(ctx, policy, pod, containerRec, liveResizeApplyMeta{
+		FloorApplied:       true,
+		FloorFromLimit:     fromLim,
+		FloorToLimit:       toLim,
+		FloorUsage:         usage,
+		FloorMargin:        margin,
+		FloorEqualsCurrent: toLim.Equal(currentLim),
+	})
 	return floored
 }
 

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -240,7 +240,7 @@ func (r *AttunePolicyReconciler) oneShotPodAllNeedingContainersBlocked(
 			blocked++
 			continue
 		}
-		skip, reason := r.shouldSkipResize(ctx, policy, pod, containerRec, target, checks)
+		skip, reason := r.shouldSkipResize(ctx, pod, containerRec, target, checks)
 		if skip && reason != "" {
 			blocked++
 		}
@@ -631,7 +631,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	r.emitLiveResizeApply(ctx, policy, pod, containerRec, applyMeta)
 	preClamped := applyMeta.PreClamped
 
-	skip, reason := r.shouldSkipResize(ctx, policy, pod, containerRec, target, p.Checks)
+	skip, reason := r.shouldSkipResize(ctx, pod, containerRec, target, p.Checks)
 	if skip {
 		if reason != "" {
 			logger.Info("Skipping resize: "+reason,
@@ -1521,7 +1521,6 @@ func targetLimitsMatchLive(live, target corev1.ResourceList) bool {
 // pod already matches the recommendation (no log needed).
 func (r *AttunePolicyReconciler) shouldSkipResize(
 	ctx context.Context,
-	policy *attunev1alpha1.AttunePolicy,
 	pod *corev1.Pod,
 	containerRec attunev1alpha1.ContainerRecommendation,
 	target corev1.ResourceRequirements,
@@ -1763,24 +1762,6 @@ func targetIncreasesRequests(pod *corev1.Pod, containerName string, target corev
 	cpuInc := target.Requests.Cpu().MilliValue() > c.Resources.Requests.Cpu().MilliValue()
 	memInc := target.Requests.Memory().Value() > c.Resources.Requests.Memory().Value()
 	return cpuInc || memInc
-}
-
-// targetDecreasesMemoryLimit reports whether target lowers the named
-// container's memory limit relative to the pod spec.
-func targetDecreasesMemoryLimit(pod *corev1.Pod, containerName string, target corev1.ResourceRequirements) bool {
-	c := findContainerByName(pod, containerName)
-	if c == nil {
-		return false
-	}
-	targetLim, ok := target.Limits[corev1.ResourceMemory]
-	if !ok || targetLim.IsZero() {
-		return false
-	}
-	currentLim, ok := c.Resources.Limits[corev1.ResourceMemory]
-	if !ok || currentLim.IsZero() {
-		return false
-	}
-	return targetLim.Cmp(currentLim) < 0
 }
 
 // emitLiveResizeApply writes clamp/floor events and metrics from apply meta.

--- a/internal/controller/resize_live_current_test.go
+++ b/internal/controller/resize_live_current_test.go
@@ -85,7 +85,6 @@ func TestShouldSkipResize_QuotaBaselineUsesLiveNotTemplate(t *testing.T) {
 		},
 	}
 	r := NewAttunePolicyReconciler()
-	policy := &attunev1alpha1.AttunePolicy{}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
 		Spec: corev1.PodSpec{

--- a/internal/controller/resize_live_current_test.go
+++ b/internal/controller/resize_live_current_test.go
@@ -115,7 +115,7 @@ func TestShouldSkipResize_QuotaBaselineUsesLiveNotTemplate(t *testing.T) {
 	}
 	checks := &resizePreChecks{quotas: []corev1.ResourceQuota{quota}}
 
-	skip, reason := r.shouldSkipResize(context.Background(), policy, pod, containerRec, target, checks)
+	skip, reason := r.shouldSkipResize(context.Background(), pod, containerRec, target, checks)
 	assert.False(t, skip, "decrease from live 1Gi to 512Mi must not use template 256Mi as quota baseline, reason=%q", reason)
 	assert.Empty(t, reason)
 }

--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -150,7 +150,7 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 							corev1.ResourceMemory: c.Resources.Requests.Memory().DeepCopy(),
 						},
 					}
-					if skip, reason := r.shouldSkipResize(ctx, policy, pod, boostRec, boostTarget, checks); skip {
+					if skip, reason := r.shouldSkipResize(ctx, pod, boostRec, boostTarget, checks); skip {
 						if reason == "" {
 							reason = "already at target"
 						}
@@ -254,7 +254,7 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 								corev1.ResourceMemory: c.Resources.Requests.Memory().DeepCopy(),
 							},
 						}
-						if skip, reason := r.shouldSkipResize(ctx, policy, pod, expireRec, expireTarget, checks); skip {
+						if skip, reason := r.shouldSkipResize(ctx, pod, expireRec, expireTarget, checks); skip {
 							if reason == "" {
 								reason = "already at target"
 							}

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -627,6 +627,146 @@ func TestSuccessfulResizeWorkloads(t *testing.T) {
 	assert.True(t, got["d"], "Evicted InPlaceOrRecreate must trigger AfterSuccessfulResize persist")
 }
 
+func TestApplyTemplatePersistence_AfterSuccessfulResize_EvictedGetsTemplate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("512Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("200m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+			},
+		}},
+	}}
+	only := successfulResizeWorkloads([]attunev1alpha1.ResizeHistoryEntry{{
+		Workload: "api",
+		Method:   "Eviction",
+		Result:   attunev1alpha1.ResizeResultEvicted,
+	}})
+
+	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
+		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, only)
+	require.Len(t, history, 1)
+	assert.Equal(t, attunev1alpha1.ResizeResultTemplatePatched, history[0].Result)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.Equal(t, int64(200), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
+	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"default AllowDecrease=false keeps template memory 512Mi")
+}
+
+func TestApplyTemplatePersistence_AfterSuccessfulResize_EvictedMissingDeploymentFailed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("512Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("200m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+			},
+		}},
+	}}
+	only := successfulResizeWorkloads([]attunev1alpha1.ResizeHistoryEntry{{
+		Workload: "api",
+		Method:   "Eviction",
+		Result:   attunev1alpha1.ResizeResultEvicted,
+	}})
+
+	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
+		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, only)
+	require.Len(t, history, 1)
+	assert.Equal(t, attunev1alpha1.ResizeResultFailed, history[0].Result)
+}
+
 func TestLaggingAfterResizeWorkloads(t *testing.T) {
 	now := metav1.Now()
 	t0 := metav1.NewTime(now.Add(-2 * time.Hour))

--- a/internal/resize/usage_floor.go
+++ b/internal/resize/usage_floor.go
@@ -45,34 +45,10 @@ func FloorMemoryLimitForUsage(
 	if recentUsage.IsZero() || recentUsage.Sign() <= 0 {
 		return target, false
 	}
-	if math.IsNaN(marginPercent) || math.IsInf(marginPercent, 0) {
-		marginPercent = 0
-	}
-	if marginPercent < 0 {
-		marginPercent = 0
-	}
-	if marginPercent > 100 {
-		marginPercent = 100
-	}
 
-	// floorBytes = usage * (1 + margin/100), rounded up to whole bytes.
-	usageBytes := float64(recentUsage.Value())
-	floorBytes := usageBytes * (1.0 + marginPercent/100.0)
-	if floorBytes <= 0 || math.IsNaN(floorBytes) || math.IsInf(floorBytes, 0) {
+	floor := MemoryUsageFloorQuantity(recentUsage, marginPercent)
+	if floor.IsZero() {
 		return target, false
-	}
-	// Round up so we never floor below the fractional product.
-	floorInt := int64(math.Ceil(floorBytes))
-	if floorInt <= 0 {
-		return target, false
-	}
-	floor := *resource.NewQuantity(floorInt, resource.BinarySI)
-
-	// Limit must be strictly above recent usage when margin is 0, so when
-	// floor equals usage, require at least usage+1 byte if target would be
-	// at or below usage.
-	if marginPercent == 0 && floor.Cmp(recentUsage) <= 0 {
-		floor = *resource.NewQuantity(recentUsage.Value()+1, resource.BinarySI)
 	}
 
 	if targetLim.Cmp(floor) >= 0 {

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -111,6 +111,8 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 		return admission.Allowed("cannot read namespace for freeze, skipping initial sizing")
 	}
 	if frozen {
+		h.Logger.Info("skipping initial sizing: namespace has attune.io/freeze=true",
+			"namespace", req.Namespace, "policy", policy.Name)
 		return admission.Allowed("namespace has attune.io/freeze=true")
 	}
 

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/conflict"
 	"github.com/attune-io/attune/internal/operatormetrics"
 	"github.com/attune-io/attune/internal/resize"
 )
@@ -99,6 +100,18 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 	policy, rec := h.findMatchingPolicy(ctx, req.Namespace, policies.Items, ownerKind, ownerName, pod.Name)
 	if policy == nil || rec == nil {
 		return admission.Allowed("no matching policy with initial sizing")
+	}
+
+	// Namespace freeze is an incident kill-switch: do not CREATE-size.
+	// Get errors fail closed (do not mutate). Exact "true" only.
+	frozen, err := conflict.NamespaceApplyFrozen(ctx, h.Client, req.Namespace)
+	if err != nil {
+		h.Logger.Error(err, "getting namespace for attune.io/freeze; skipping initial sizing",
+			"namespace", req.Namespace)
+		return admission.Allowed("cannot read namespace for freeze, skipping initial sizing")
+	}
+	if frozen {
+		return admission.Allowed("namespace has attune.io/freeze=true")
 	}
 
 	// Mutate the pod's containers.

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/conflict"
 )
 
 // patchedPod applies the admission response patches to the original pod bytes.
@@ -78,6 +79,12 @@ func testScheme() *runtime.Scheme {
 func testDeployment(name, ns string, labels map[string]string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: labels},
+	}
+}
+
+func testNamespace(name string, annotations map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
 	}
 }
 
@@ -211,7 +218,7 @@ func TestPodMutatingHandler_HappyPath(t *testing.T) {
 	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
 
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	req := makeAdmissionRequest(t, pod, "default")
@@ -238,6 +245,77 @@ func TestPodMutatingHandler_SkipAnnotation(t *testing.T) {
 	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
 	assert.True(t, resp.Allowed)
 	assert.Nil(t, resp.Patches, "expected no patches for skipped pod")
+}
+
+func TestPodMutatingHandler_NamespaceFreeze(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		ns          *corev1.Namespace
+		getErr      bool
+		wantPatches bool
+		wantMsg     string
+	}{
+		{
+			name:        "freeze=true skips CREATE sizing",
+			ns:          testNamespace("default", map[string]string{conflict.AnnotationFreeze: "true"}),
+			wantPatches: false,
+			wantMsg:     "attune.io/freeze=true",
+		},
+		{
+			name:        "freeze absent mutates",
+			ns:          testNamespace("default", nil),
+			wantPatches: true,
+		},
+		{
+			name:        "True is not freeze",
+			ns:          testNamespace("default", map[string]string{conflict.AnnotationFreeze: "True"}),
+			wantPatches: true,
+		},
+		{
+			name:        "Get error fail-closed",
+			getErr:      true,
+			wantPatches: false,
+			wantMsg:     "cannot read namespace for freeze",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+			pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+
+			builder := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy)
+			if tt.ns != nil {
+				builder = builder.WithObjects(tt.ns)
+			}
+			if tt.getErr {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.Namespace); ok {
+							return fmt.Errorf("simulated namespace get failure")
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				})
+			}
+			handler := &PodMutatingHandler{Client: builder.Build(), Logger: logr.Discard()}
+
+			resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
+			require.True(t, resp.Allowed)
+			if tt.wantPatches {
+				require.NotEmpty(t, resp.Patches, "expected CREATE initial sizing")
+			} else {
+				assert.Nil(t, resp.Patches, "expected no CREATE mutation")
+				if tt.wantMsg != "" {
+					require.NotNil(t, resp.Result)
+					assert.Contains(t, resp.Result.Message, tt.wantMsg)
+				}
+			}
+		})
+	}
 }
 
 func TestPodMutatingHandler_KubeSystem(t *testing.T) {
@@ -351,7 +429,7 @@ func TestPodMutatingHandler_ConflictCheckFailedDoesNotOverrideHealthyPolicy(t *t
 	policyA := testPolicy("policy-a", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
 	policyA.Spec.Weight = 1000
 
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policyA, policyB).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policyA, policyB, testNamespace("default", nil)).Build()
 	var logged string
 	handler := &PodMutatingHandler{
 		Client: cl,
@@ -422,7 +500,7 @@ func TestPodMutatingHandler_LowConfidence_SuccessfulHistoryApplies(t *testing.T)
 	}
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
 
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
@@ -478,7 +556,7 @@ func TestPodMutatingHandler_LowConfidence_EmptyMethodHistoryApplies(t *testing.T
 		},
 	}
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
@@ -490,7 +568,7 @@ func TestPodMutatingHandler_StatefulSet(t *testing.T) {
 	policy := testPolicy("sts-policy", "default", "StatefulSet", "my-sts", true, attunev1alpha1.UpdateTypeAuto)
 	pod := testPod("my-sts-0", "StatefulSet", "my-sts")
 
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	req := makeAdmissionRequest(t, pod, "default")
@@ -511,7 +589,7 @@ func TestPodMutatingHandler_RequestsAndLimits(t *testing.T) {
 	policy.Status.Recommendations[0].Containers[0].Recommended.MemoryLimit = resource.MustParse("512Mi")
 
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	req := makeAdmissionRequest(t, pod, "default")
@@ -547,7 +625,7 @@ func TestPodMutatingHandler_RequestsAndLimits_UsageFloorGuaranteed(t *testing.T)
 	}
 
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	req := makeAdmissionRequest(t, pod, "default")
@@ -612,7 +690,7 @@ func TestPodMutatingHandler_OneShotMode(t *testing.T) {
 	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeOneShot)
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
 
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
@@ -672,7 +750,7 @@ func TestPodMutatingHandler_CanaryMode_MutatesCanarySlice(t *testing.T) {
 	}
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
 
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))
@@ -707,7 +785,7 @@ func TestPodMutatingHandler_CanaryMode_PromotedAppOnly(t *testing.T) {
 		},
 	}
 
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	aNew := testPod("app-a-new", "ReplicaSet", "app-a-abc")
@@ -760,7 +838,7 @@ func TestPodMutatingHandler_SelectorPolicy_CanaryIsolation(t *testing.T) {
 	deployOther := testDeployment("other", "default", map[string]string{"tier": "batch"})
 
 	cl := fake.NewClientBuilder().WithScheme(testScheme()).
-		WithObjects(policy, deployA, deployB, deployOther).Build()
+		WithObjects(policy, deployA, deployB, deployOther, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	respA := handler.Handle(context.Background(), makeAdmissionRequest(t,
@@ -823,7 +901,7 @@ func TestPodMutatingHandler_CanaryMode_MutatesAfterPromote(t *testing.T) {
 	}
 	pod := testPod("my-app-new-xyz", "ReplicaSet", "my-app-abc")
 
-	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy).Build()
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
 	resp := handler.Handle(context.Background(), makeAdmissionRequest(t, pod, "default"))

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -335,7 +335,7 @@ func warnIneffectiveSettings(policy *attunev1alpha1.AttunePolicy) admission.Warn
 
 	// maxConcurrentResizes > 1 in OneShot mode.
 	if mode == attunev1alpha1.UpdateTypeOneShot && policy.Spec.UpdateStrategy.MaxConcurrentResizes > 1 {
-		w = append(w, "maxConcurrentResizes > 1 has no effect in OneShot mode; OneShot applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.")
+		w = append(w, "maxConcurrentResizes > 1 has no effect in OneShot mode; OneShot applies at most one needing pod per cycle and skips already-at-target or blocked replicas.")
 	}
 
 	// memoryFromCpuRatio makes memory percentile/overhead redundant.

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -335,7 +335,7 @@ func warnIneffectiveSettings(policy *attunev1alpha1.AttunePolicy) admission.Warn
 
 	// maxConcurrentResizes > 1 in OneShot mode.
 	if mode == attunev1alpha1.UpdateTypeOneShot && policy.Spec.UpdateStrategy.MaxConcurrentResizes > 1 {
-		w = append(w, "maxConcurrentResizes > 1 has no effect in OneShot mode; only one pod is resized per cycle")
+		w = append(w, "maxConcurrentResizes > 1 has no effect in OneShot mode; OneShot applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.")
 	}
 
 	// memoryFromCpuRatio makes memory percentile/overhead redundant.

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -1754,7 +1754,7 @@ func TestWarn_MaxConcurrentInOneShotMode(t *testing.T) {
 
 	w, err := validator.ValidateCreate(context.Background(), policy)
 	assert.NoError(t, err)
-	assert.Contains(t, w, "maxConcurrentResizes > 1 has no effect in OneShot mode; only one pod is resized per cycle")
+	assert.Contains(t, w, "maxConcurrentResizes > 1 has no effect in OneShot mode; OneShot applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.")
 }
 
 func TestWarn_MemoryFromCpuRatioOverridesPercentile(t *testing.T) {

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -1754,7 +1754,7 @@ func TestWarn_MaxConcurrentInOneShotMode(t *testing.T) {
 
 	w, err := validator.ValidateCreate(context.Background(), policy)
 	assert.NoError(t, err)
-	assert.Contains(t, w, "maxConcurrentResizes > 1 has no effect in OneShot mode; OneShot applies at most one needing pod per cycle. Replicas that are already at the applied target, or that are blocked by QoS, node pressure, quota, or Infeasible plus InPlaceOnly, are skipped so another replica can still resize.")
+	assert.Contains(t, w, "maxConcurrentResizes > 1 has no effect in OneShot mode; OneShot applies at most one needing pod per cycle and skips already-at-target or blocked replicas.")
 }
 
 func TestWarn_MemoryFromCpuRatioOverridesPercentile(t *testing.T) {

--- a/scripts/test_e2e_wait_cadvisor.sh
+++ b/scripts/test_e2e_wait_cadvisor.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Copyright 2026 attune Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Classifier for hack/e2e-wait-cadvisor.sh: PR-CI composite and local
+# _deploy-stack must share the helper; missing series is a soft fail.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT}/hack/e2e-wait-cadvisor.sh"
+MAKEFILE="${ROOT}/Makefile"
+COMPOSITE="${ROOT}/.github/actions/setup-e2e-cluster/action.yaml"
+
+echo "PLAN: classify e2e-wait-cadvisor.sh"
+
+fail() {
+  echo "FAIL: $*"
+  echo "DONE: ok=false"
+  exit 1
+}
+
+[[ -f "${SCRIPT}" ]] || fail "missing ${SCRIPT}"
+[[ -x "${SCRIPT}" ]] || fail "${SCRIPT} is not executable"
+
+echo "DO: setup-e2e-cluster and Makefile must call the helper"
+grep -F -q 'hack/e2e-wait-cadvisor.sh' "${COMPOSITE}" \
+  || fail "setup-e2e-cluster/action.yaml does not invoke hack/e2e-wait-cadvisor.sh"
+grep -F -q 'hack/e2e-wait-cadvisor.sh' "${MAKEFILE}" \
+  || fail "Makefile does not invoke hack/e2e-wait-cadvisor.sh"
+if grep -n 'Waiting for Prometheus to scrape cAdvisor metrics' "${COMPOSITE}"; then
+  fail "inline cAdvisor wait still present in setup-e2e-cluster; use the helper"
+fi
+echo "OK: both install paths call the helper"
+
+echo "DO: Makefile pins Prometheus image and uses 5m Helm timeout"
+grep -qE 'PROMETHEUS_IMAGE \?= quay.io/prometheus/prometheus:v3.4.1' "${MAKEFILE}" \
+  || fail "Makefile missing PROMETHEUS_IMAGE pin matching CI"
+if ! awk '
+  /helm install prometheus / {p=1}
+  p && /--wait --timeout 5m/ {found=1}
+  p && /^[^[:space:]#]/ && !/helm install prometheus / {exit}
+  END {exit found ? 0 : 1}
+' "${MAKEFILE}"; then
+  fail "Makefile Prometheus helm install is not --wait --timeout 5m"
+fi
+echo "OK: Makefile Prometheus pin and timeout"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+write_kubectl() {
+  local empty_queries="$1"
+  cat >"${TMP}/kubectl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+STATE="${TMP}/state"
+mkdir -p "\${STATE}"
+cmd="\${1:-}"
+shift || true
+case "\${cmd}" in
+  get)
+    if [[ "\${NO_POD:-0}" == "1" ]]; then
+      exit 0
+    fi
+    echo "pod/prometheus-server-0"
+    exit 0
+    ;;
+  exec)
+    n=\$(cat "\${STATE}/query" 2>/dev/null || echo 0)
+    n=\$((n + 1))
+    echo "\${n}" >"\${STATE}/query"
+    if (( n <= ${empty_queries} )); then
+      echo '{"status":"success","data":{"resultType":"vector","result":[]}}'
+      exit 0
+    fi
+    echo '{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"container_cpu_usage_seconds_total"},"value":[1,"1"]}]}}'
+    exit 0
+    ;;
+  *)
+    echo "unexpected kubectl \${cmd} \$*" >&2
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "${TMP}/kubectl"
+}
+
+run_helper() {
+  KUBECTL="${TMP}/kubectl" \
+    CADVISOR_ATTEMPTS=3 \
+    CADVISOR_SLEEP=0 \
+    bash "${SCRIPT}"
+}
+
+echo "DO: first empty query then series must report found"
+rm -rf "${TMP}/state"
+write_kubectl 1
+out="$(run_helper)"
+echo "${out}" | grep -q 'found=true' || fail "expected found=true, got: ${out}"
+query_n="$(cat "${TMP}/state/query")"
+[[ "${query_n}" == "2" ]] || fail "expected 2 queries, got ${query_n}"
+echo "OK: waited then found series"
+
+echo "DO: never-found series must soft-fail and exit 0"
+rm -rf "${TMP}/state"
+write_kubectl 99
+if ! out="$(run_helper)"; then
+  fail "missing series should exit 0"
+fi
+echo "${out}" | grep -q 'found=false' || fail "expected found=false, got: ${out}"
+query_n="$(cat "${TMP}/state/query")"
+[[ "${query_n}" == "3" ]] || fail "expected 3 queries, got ${query_n}"
+echo "OK: exhausted attempts and proceeded"
+
+echo "DO: missing Prometheus pod must soft-fail and skip exec"
+rm -rf "${TMP}/state"
+write_kubectl 0
+if ! out="$(NO_POD=1 run_helper)"; then
+  fail "missing pod should exit 0"
+fi
+echo "${out}" | grep -q 'found=false' || fail "missing pod expected found=false, got: ${out}"
+if [[ -f "${TMP}/state/query" ]]; then
+  fail "exec must not run when no Prometheus pod exists"
+fi
+echo "OK: no pod proceeds without exec"
+
+echo "DONE: ok=true"
+echo "NEXT: none"
+exit 0


### PR DESCRIPTION
## What This PR Does

Adds a namespace freeze kill-switch (`attune.io/freeze=true`) and hardens OneShot apply so clamp, usage floor, and MemoryPressure use the live pod spec, not a stale informer snapshot.

## Why

Incident response needed a namespace-wide apply pause that still collects metrics and recommendations. A stale cache can also make MemoryPressure look like a decrease (or skip a needed floor) when the live spec already moved. OneShot selection and apply must share the same post-clamp target or later replicas never move.

## How to Test

```bash
make verify-quick
```

Local result: 2429 tests, 93.4% coverage, exit 0.

Freeze: annotate the policy namespace `attune.io/freeze=true`. In-place resize, eviction, startup boost, template persist, and CREATE initial sizing skip. `ResizeBlocked=True` with `reason=NamespaceFrozen`. Recommendations still update. Only the exact string `true` freezes (`True`, `1`, and `yes` do not).

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] CRD changes regenerated (`make manifests`)
- [x] Documentation updated (if user-facing)
- [x] Helm chart updated (if applicable)
- [x] No breaking API changes (or documented in CHANGELOG)
