### PR TITLE
fix: keep safety revert running during namespace freeze

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,10 @@ jobs:
               - 'scripts/test_verify_helm_image_tag.sh'
               - 'hack/release-image-tags.sh'
               - 'scripts/test_release_image_tags.sh'
+              # role.yaml-only diffs skip go. Helm Lint is the only CI
+              # job that runs verify-helm-rbac.sh.
+              - 'config/rbac/**'
+              - 'hack/verify-helm-rbac.sh'
               # Standalone Grafana JSON is the Helm dashboard source.
               # Dashboard-only PRs must run verify-dashboard-metrics.sh
               # without the full Go lint matrix.

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ The dashboard includes:
   for JVM and heap-bound workloads.
 - Pause reconciliation: `spec.paused: true` halts all activity without
   reverting existing resizes.
+- Namespace freeze: annotate the namespace `attune.io/freeze=true` to skip new apply (resize, persist, CREATE). Pending safety revert still runs. Recommendations stay in status.
 - Webhook warnings: 13 admission-time warnings for nonsensical config
   combinations with 31 runtime K8s events and per-policy suppression.
 

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -566,6 +566,9 @@ func printStatusItems(allItems []unstructured.Unstructured, sortByFlag, filterFl
 		resized := getNestedInt64(item, "status", "workloads", "resized")
 		ready := policyReadyReason(item)
 		resizing := getConditionReason(item, "Resizing")
+		if blocked := getConditionReason(item, "ResizeBlocked"); blocked == "NamespaceFrozen" {
+			resizing = blocked
+		}
 		degraded := getConditionReason(item, "Degraded")
 		schedule := getConditionReason(item, "ScheduleBlocked")
 		canary := formatCanaryStatus(item)

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -655,6 +655,66 @@ func TestPrintStatus(t *testing.T) {
 	assert.Contains(t, output, "3           1         2")
 }
 
+func TestPrintStatus_NamespaceFrozen(t *testing.T) {
+	policy := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "attune.io/v1alpha1",
+			"kind":       "AttunePolicy",
+			"metadata": map[string]interface{}{
+				"name":              "web-app",
+				"namespace":         "production",
+				"creationTimestamp": "2026-01-01T00:00:00Z",
+			},
+			"spec": map[string]interface{}{
+				"updateStrategy": map[string]interface{}{
+					"type": "Auto",
+				},
+			},
+			"status": map[string]interface{}{
+				"workloads": map[string]interface{}{
+					"discovered": int64(3),
+					"pending":    int64(0),
+					"resized":    int64(2),
+				},
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+						"reason": "Monitoring",
+					},
+					map[string]interface{}{
+						"type":   "ResizeBlocked",
+						"status": "True",
+						"reason": "NamespaceFrozen",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{gvr: "AttunePolicyList"}, policy)
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	printStatus(context.Background(), dynClient, "production", "", "")
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+	output := buf.String()
+
+	assert.Contains(t, output, "NamespaceFrozen")
+	assert.Contains(t, output, "Monitoring")
+}
+
 func TestPrintStatus_ReadyContract(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -804,9 +804,10 @@ Before any resize:
 - Check for `attune.io/skip: "true"` annotation on workload (opt-out)
 - Check for `attune.io/freeze: "true"` on the policy namespace (skip apply
   only: resize, eviction, startup boost, template persist, CREATE initial
-  sizing; recommendations still compute; fail closed if the namespace
-  cannot be read). Freeze is re-checked immediately before apply so a
-  flag set during PromQL still skips persist and resize.
+  sizing; recommendations still compute; pending safety observation still
+  reverts unsafe pods and restores AfterSuccessfulResize templates; fail
+  closed if the namespace cannot be read). Freeze is re-checked immediately
+  before apply so a flag set during PromQL still skips persist and resize.
 - Check for active rollout on the parent Deployment (don't resize during rollouts)
 
 ---
@@ -1564,7 +1565,7 @@ attune/
 | Unified vertical CRD (not VPA+HPA) | Datadog | Single AttunePolicy instead of separate VPA + HPA objects |
 | Cron-style scheduling | Oblik | `schedule.windows` + `daysOfWeek` (Oblik uses `cron` + `cronAddRandomMax`) |
 | Annotation-based opt-out | CAST AI, Oblik | `attune.io/skip: "true"` for workload exclusion |
-| Namespace freeze kill-switch | Kilter | `attune.io/freeze: "true"` on the namespace skips apply (resize, persist, CREATE initial sizing) |
+| Namespace freeze kill-switch | Kilter | `attune.io/freeze: "true"` on the namespace skips apply (resize, persist, CREATE initial sizing); pending safety revert still runs |
 
 ### Anti-Patterns Avoided
 

--- a/docs/architecture/design.md
+++ b/docs/architecture/design.md
@@ -91,8 +91,9 @@ Located in `internal/conflict/`. Detects potential conflicts:
 - **VPA**: warns about active VPA objects targeting the same workload.
 - **Opt-out**: checks for the `attune.io/skip: "true"` annotation.
 - **Namespace freeze**: `attune.io/freeze=true` on the policy namespace
-  blocks apply (resize, eviction, boost, persist, CREATE initial sizing)
-  while recommendations continue.
+  blocks new apply (resize, eviction, boost, persist, CREATE initial sizing)
+  while recommendations continue. Pending safety observation still reverts
+  unsafe pods and restores AfterSuccessfulResize templates.
 - **Active rollout**: detects in-progress deployments.
 
 ### Status Reporter

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -317,9 +317,11 @@ Before resizing, the controller checks for potential conflicts:
 - **Opt-out annotation**: workloads with `attune.io/skip: "true"` are
   skipped entirely.
 - **Namespace freeze**: `attune.io/freeze=true` on the namespace skips
-  in-place resize, eviction, startup boost, template persist, and CREATE
-  initial sizing. Recommendations still compute. If the namespace cannot
-  be read, apply is skipped (fail closed).
+  new in-place resize, eviction, startup boost, template persist, and
+  CREATE initial sizing. Recommendations still compute. Pending safety
+  observation still reverts unsafe pods and restores AfterSuccessfulResize
+  templates. If the namespace cannot be read, apply is skipped (fail
+  closed).
 - **QoS preservation**: for Guaranteed-class pods, the resize is blocked if
   it would cause requests to differ from limits.
 - **HPA coexistence**: an informational notice is logged but resizing proceeds.

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -208,9 +208,11 @@ When a safety violation is detected:
    restart occurs.
 3. When `templatePersistence.when=AfterSuccessfulResize` is enabled, the
    controller also restores the Deployment/StatefulSet template for that
-   container from the pre-resize snapshot (`OriginalResources`). Persist
-   already patched the template on Success or Evicted, before the
-   observation window; without this restore, rollouts keep the unsafe size.
+   container from the pre-resize snapshot (`OriginalResources`). Restore
+   replaces the container resources, including clearing limits the persist
+   step added. Persist already patched the template on Success or Evicted,
+   before the observation window; without this restore, rollouts keep the
+   unsafe size.
    A failed template restore keeps tracking annotations so the next
    reconcile retries.
 4. The resize history entry is updated to `result: Reverted`.

--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -211,6 +211,8 @@ When a safety violation is detected:
    container from the pre-resize snapshot (`OriginalResources`). Persist
    already patched the template on Success or Evicted, before the
    observation window; without this restore, rollouts keep the unsafe size.
+   A failed template restore keeps tracking annotations so the next
+   reconcile retries.
 4. The resize history entry is updated to `result: Reverted`.
 5. The `attune_reverts_total` counter is incremented with the
    violation reason as a label.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -176,5 +176,6 @@ The operator detects:
 - **Active rollouts**: skips resizing during an in-progress deployment rollout.
 - **Opt-out annotation**: workloads with `attune.io/skip: "true"` are ignored.
 - **Namespace freeze**: `attune.io/freeze=true` on the namespace skips
-  resizes, evictions, startup boosts, template persist, and CREATE
-  initial sizing. Recommendations still update.
+  new resizes, evictions, startup boosts, template persist, and CREATE
+  initial sizing. Recommendations still update. Pending safety observation
+  still reverts unsafe pods and restores AfterSuccessfulResize templates.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -316,10 +316,12 @@ say `namespace has attune.io/freeze=true; resizes skipped`. Recommendations
 still appear in status.
 
 **Cause**: The policy namespace has `attune.io/freeze=true`, or the operator
-could not read the namespace (fail closed). In-place resizes, evictions,
+could not read the namespace (fail closed). New in-place resizes, evictions,
 startup boosts, template persistence, and CREATE initial sizing are skipped.
-Metrics collection and recommendations continue so `kubectl attune
-recommendations` still works.
+Freeze is not a rollback of already-applied successful recommendations.
+Pending safety observation still reverts unsafe pods and restores
+AfterSuccessfulResize templates. Metrics collection and recommendations
+continue so `kubectl attune recommendations` still works.
 
 **Fix**: Remove the annotation or set it to any value other than `true`:
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -297,6 +297,8 @@ initial sizing (last-known values stay in status, but CREATE is not patched).
    or `initial sizing applied`. When CREATE has no assigned name, that
    Info line uses `generateName` (for example `my-app-abc-`), not the
    name kubelet later assigns.
+7. Check the namespace is not frozen. `attune.io/freeze=true` skips
+   CREATE initial sizing.
 
 ### Paused
 
@@ -312,7 +314,7 @@ will resume reconciliation on the next cycle.
 ### NamespaceFrozen
 
 **Symptom**: ResizeBlocked is `True` with reason `NamespaceFrozen`. Events
-say `namespace has attune.io/freeze=true; resizes skipped`. Recommendations
+say `namespace has attune.io/freeze=true; new apply skipped (pending safety revert still runs)`. Recommendations
 still appear in status.
 
 **Cause**: The policy namespace has `attune.io/freeze=true`, or the operator
@@ -1129,6 +1131,8 @@ spec:
   recent usage (raw percentile plus `decreaseUsageMarginPercent`), even
   if `rec.Current` still shows the old template. `RequestsOnly` persist
   never writes limits.
+- **Namespace freeze**: `attune.io/freeze=true` skips new persist.
+  Pending safety restore still runs.
 
 ### Mid-rollout or no-op
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -216,7 +216,7 @@ the estimator chain: `rawPercentile`, `overhead`, `afterOverhead`,
 | `Resizing` | `InProgress`, `Idle`, `CooldownActive` | Active resize operation state. `CooldownActive` only when every matched app is still cooling |
 | `Degraded` | `HighRevertRate` | High revert rate detected (3+ of last 5 reverted) |
 | `ScheduleBlocked` | `OutsideWindow`, `InsideWindow` | Whether the current time is within the configured resize schedule window |
-| `ResizeBlocked` | `NamespaceFrozen`, `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Namespace freeze kill-switch (`attune.io/freeze=true` skips resize, persist, and CREATE initial sizing), or one or more target pods stuck Deferred (kubelet pending) or Infeasible; message includes sample pod names and next actions |
+| `ResizeBlocked` | `NamespaceFrozen`, `PodsDeferred`, `PodsInfeasible`, `PodsDeferredAndInfeasible` | Namespace freeze kill-switch (`attune.io/freeze=true` skips new resize, persist, and CREATE initial sizing; pending safety revert still runs), or one or more target pods stuck Deferred (kubelet pending) or Infeasible; message includes sample pod names and next actions |
 
 ### Print columns
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -458,12 +458,14 @@ kubectl annotate namespace <ns> attune.io/freeze=true
 
 | Annotation | Scope | Effect |
 |------------|-------|--------|
-| `attune.io/freeze=true` | Namespace | Skip in-place resize, eviction, startup boost, template persist, and CREATE initial sizing. Metrics, recommendations, status, and export still update. `ResizeBlocked=True` with `reason=NamespaceFrozen`. |
+| `attune.io/freeze=true` | Namespace | Skip new apply: in-place resize, eviction, startup boost, template persist, and CREATE initial sizing. Metrics, recommendations, status, and export still update. Pending safety observation still reverts unsafe pods and restores AfterSuccessfulResize templates. `ResizeBlocked=True` with `reason=NamespaceFrozen`. |
 | `attune.io/skip=true` | Workload | Skip that workload entirely (no recommendations). Independent of freeze. |
 
 If the operator cannot read the namespace, apply is skipped (fail closed)
-and the same `NamespaceFrozen` reason is set. Existing resizes are not
-reverted. Remove the annotation to resume apply on the next reconcile.
+and the same `NamespaceFrozen` reason is set. Freeze is not a rollback of
+already-applied successful recommendations. Pending safety observation
+still reverts unsafe pods and restores AfterSuccessfulResize templates.
+Remove the annotation to resume apply on the next reconcile.
 
 ### Container exclusion
 

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -930,15 +930,11 @@ func (r *AttunePolicyReconciler) applyNotFrozen(ctx context.Context, namespace s
 // markNamespaceFrozen records ResizeBlocked=NamespaceFrozen and emits a
 // single Warning. Recommendations remain in status; only apply is skipped.
 func (r *AttunePolicyReconciler) markNamespaceFrozen(policy *attunev1alpha1.AttunePolicy, freezeErr error) {
-	msg := "namespace has attune.io/freeze=true; resizes skipped"
+	msg := "namespace has attune.io/freeze=true; new apply skipped (pending safety revert still runs)"
 	if freezeErr != nil {
-		msg = "cannot read namespace for attune.io/freeze; resizes skipped"
-		r.emitEventOnce(policy, corev1.EventTypeWarning, attunev1alpha1.ReasonNamespaceFrozen, "resize",
-			"cannot read namespace for attune.io/freeze; resizes skipped")
-	} else {
-		r.emitEventOnce(policy, corev1.EventTypeWarning, attunev1alpha1.ReasonNamespaceFrozen, "resize",
-			"namespace has attune.io/freeze=true; resizes skipped")
+		msg = "cannot read namespace for attune.io/freeze; new apply skipped (check namespaces get/list/watch RBAC)"
 	}
+	r.emitEventOnce(policy, corev1.EventTypeWarning, attunev1alpha1.ReasonNamespaceFrozen, "resize", "%s", msg)
 	meta.SetStatusCondition(&policy.Status.Conditions, metav1.Condition{
 		Type:               attunev1alpha1.ConditionResizeBlocked,
 		Status:             metav1.ConditionTrue,

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -599,7 +599,14 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		r.applyNotFrozen(ctx, policy.Namespace, &applyFrozen, &freezeErr) {
 		resizedWLs := laggingAfterResizeWorkloads(cycleResizeHistory, policy.Status.ResizeHistory)
 		if len(resizedWLs) > 0 {
-			filtered := omitRevertedOrFailedContainers(recommendations, cycleResizeHistory)
+			// Status history already includes this-cycle executeResizes after
+			// append. Using only cycleResizeHistory misses a prior-cycle
+			// safety revert when freeze blocked persist, then lifted.
+			filtered := omitRevertedOrFailedContainers(recommendations, policy.Status.ResizeHistory)
+			if omitted := omittedPersistContainerNames(recommendations, filtered); len(omitted) > 0 {
+				logger.V(1).Info("Omitting reverted or failed containers from template persist",
+					"containers", omitted)
+			}
 			tplHistory := r.applyTemplatePersistence(ctx, &policy, workloads, filtered,
 				attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, resizedWLs)
 			if len(tplHistory) > 0 {

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -599,7 +599,8 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		r.applyNotFrozen(ctx, policy.Namespace, &applyFrozen, &freezeErr) {
 		resizedWLs := laggingAfterResizeWorkloads(cycleResizeHistory, policy.Status.ResizeHistory)
 		if len(resizedWLs) > 0 {
-			tplHistory := r.applyTemplatePersistence(ctx, &policy, workloads, recommendations,
+			filtered := omitRevertedOrFailedContainers(recommendations, cycleResizeHistory)
+			tplHistory := r.applyTemplatePersistence(ctx, &policy, workloads, filtered,
 				attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, resizedWLs)
 			if len(tplHistory) > 0 {
 				policy.Status.ResizeHistory = appendHistory(policy.Status.ResizeHistory, tplHistory, maxHistoryEntries)

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -392,8 +392,9 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Check pending safety observations from previous resizes before computing
 	// new recommendations. Uses already-discovered workloads for provenance.
+	// Freeze skips new apply, not pending safety revert.
 	var safetyObservationsPending bool
-	if !applyFrozen && autoRevertEnabled(policy.Spec.UpdateStrategy) {
+	if autoRevertEnabled(policy.Spec.UpdateStrategy) {
 		safetyObservationsPending = r.checkPendingSafetyObservations(workloadCtx, &policy, collector, workloads)
 	}
 

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -4325,6 +4325,19 @@ func safetyWorkloads() []client.Object {
 	return []client.Object{safetyTestDeploy}
 }
 
+// recSizedAPIServerDeploy returns a fresh api-server Deployment whose template
+// is already at the recommended size (250m/256Mi). Used by persist-on restore
+// tests so AfterSuccessfulResize restore is visible.
+func recSizedAPIServerDeploy() *appsv1.Deployment {
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	res := &deploy.Spec.Template.Spec.Containers[0].Resources
+	res.Requests[corev1.ResourceCPU] = resource.MustParse("250m")
+	res.Requests[corev1.ResourceMemory] = resource.MustParse("256Mi")
+	res.Limits[corev1.ResourceCPU] = resource.MustParse("500m")
+	res.Limits[corev1.ResourceMemory] = resource.MustParse("512Mi")
+	return deploy
+}
+
 // ---------- checkPendingSafetyObservations ----------
 
 func TestCheckPendingSafetyObservations_ObservationElapsed(t *testing.T) {
@@ -4622,6 +4635,95 @@ func TestCheckPendingSafetyObservations_EarlyCriticalOOMKill(t *testing.T) {
 		}
 	}
 	assert.True(t, foundResize, "OOMKill during observation period should trigger early revert")
+}
+
+func TestCheckPendingSafetyObservations_EarlyCriticalOOMKill_RestoresAfterSuccessfulResizeTemplate(t *testing.T) {
+	t.Parallel()
+
+	resizedAt := time.Now().UTC().Add(-10 * time.Second).Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oom-restore-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/original-cpu-limit.main":      "1000m",
+				"attune.io/original-memory-limit.main":   "1Gi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "nginx",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:     "OOMKilled",
+							FinishedAt: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	deploy := recSizedAPIServerDeploy()
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	reconciler, fakeClient := newResizeReconciler(pod, deploy)
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+
+	var foundResize bool
+	for _, a := range reconciler.Clientset.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			foundResize = true
+		}
+	}
+	assert.True(t, foundResize, "OOMKill during observation period should trigger early revert")
+
+	var gotDeploy appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes := gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, gotRes.Requests.Cpu().Equal(resource.MustParse("500m")),
+		"template CPU request must restore to original 500m")
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"template memory request must restore to original 512Mi")
+	assert.True(t, gotRes.Limits.Cpu().Equal(resource.MustParse("1000m")),
+		"template CPU limit must restore to original 1000m")
+	assert.True(t, gotRes.Limits.Memory().Equal(resource.MustParse("1Gi")),
+		"template memory limit must restore to original 1Gi")
 }
 
 func TestCheckPendingSafetyObservations_EarlyCriticalOOMKillNotConfirmed(t *testing.T) {
@@ -6796,6 +6898,94 @@ func TestCheckPendingSafetyObservations_UnsafeVerdictReverts(t *testing.T) {
 		}
 	}
 	assert.True(t, foundResize, "should have called UpdateResize to revert the pod")
+}
+
+func TestCheckPendingSafetyObservations_UnsafeVerdictReverts_RestoresAfterSuccessfulResizeTemplate(t *testing.T) {
+	t.Parallel()
+
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unsafe-restore-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/original-cpu-limit.main":      "1000m",
+				"attune.io/original-memory-limit.main":   "1Gi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "nginx",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
+	}
+
+	deploy := recSizedAPIServerDeploy()
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	reconciler, fakeClient := newResizeReconciler(pod, deploy)
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+
+	var foundResize bool
+	for _, a := range reconciler.Clientset.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			foundResize = true
+			reverted := a.(k8stesting.UpdateAction).GetObject().(*corev1.Pod)
+			cpu := reverted.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+			assert.True(t, cpu.Equal(resource.MustParse("500m")),
+				"CPU should be reverted to original 500m, got %s", cpu.String())
+		}
+	}
+	assert.True(t, foundResize, "should have called UpdateResize to revert the pod")
+
+	var gotDeploy appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes := gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, gotRes.Requests.Cpu().Equal(resource.MustParse("500m")),
+		"template CPU request must restore to original 500m")
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"template memory request must restore to original 512Mi")
+	assert.True(t, gotRes.Limits.Cpu().Equal(resource.MustParse("1000m")),
+		"template CPU limit must restore to original 1000m")
+	assert.True(t, gotRes.Limits.Memory().Equal(resource.MustParse("1Gi")),
+		"template memory limit must restore to original 1Gi")
 }
 
 func TestCheckPendingSafetyObservations_NotReadyFlapConfirmedBeforeRevert(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -6988,6 +6988,113 @@ func TestCheckPendingSafetyObservations_UnsafeVerdictReverts_RestoresAfterSucces
 		"template memory limit must restore to original 1Gi")
 }
 
+func TestCheckPendingSafetyObservations_RestoreTemplateFailsKeepsTrackingThenRetries(t *testing.T) {
+	t.Parallel()
+
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-fail-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/original-cpu-limit.main":      "1000m",
+				"attune.io/original-memory-limit.main":   "1Gi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "nginx",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
+	}
+
+	deploy := recSizedAPIServerDeploy()
+	var failDeployPatch atomic.Bool
+	failDeployPatch.Store(true)
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(deploy, pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cw client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok && failDeployPatch.Load() {
+					return fmt.Errorf("simulated template patch failure")
+				}
+				return cw.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+	assert.True(t, pending, "failed template restore must keep observations pending")
+
+	var gotDeploy appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes := gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("256Mi")),
+		"template must stay at the recommended 256Mi after a failed restore")
+
+	var gotPod corev1.Pod
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "restore-fail-pod", Namespace: "default",
+	}, &gotPod))
+	_, hasTracking := gotPod.Annotations[annotationResizedAt]
+	assert.True(t, hasTracking, "tracking annotations must remain so the next reconcile retries restore")
+
+	failDeployPatch.Store(false)
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes = gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"second restore must write the original 512Mi snapshot")
+}
+
 func TestCheckPendingSafetyObservations_NotReadyFlapConfirmedBeforeRevert(t *testing.T) {
 	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
 	listed := &corev1.Pod{

--- a/internal/controller/namespace_freeze_test.go
+++ b/internal/controller/namespace_freeze_test.go
@@ -252,14 +252,14 @@ func TestReconcile_NamespaceFreeze(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, metav1.ConditionTrue, cond.Status)
 				assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
-				assert.Contains(t, cond.Message, "resizes skipped")
+				assert.Contains(t, cond.Message, "new apply skipped")
 			} else if cond != nil {
 				assert.NotEqual(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
 			}
 
 			if tt.wantFrozenEvent {
 				assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, eventReason)
-				assert.Contains(t, eventNote, "resizes skipped")
+				assert.Contains(t, eventNote, "new apply skipped")
 			} else {
 				assert.NotEqual(t, attunev1alpha1.ReasonNamespaceFrozen, eventReason)
 			}

--- a/internal/controller/namespace_freeze_test.go
+++ b/internal/controller/namespace_freeze_test.go
@@ -27,6 +27,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -352,6 +353,164 @@ func TestReconcile_NamespaceFreeze_SkipsOnRecommendationPersist(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcile_NamespaceFreeze_StillRevertsPendingSafety(t *testing.T) {
+	t.Parallel()
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+	policy.Spec.CPU.MaxChangePercent = int32Ptr(100)
+
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	res := &deploy.Spec.Template.Spec.Containers[0].Resources
+	res.Requests[corev1.ResourceCPU] = resource.MustParse("250m")
+	res.Requests[corev1.ResourceMemory] = resource.MustParse("256Mi")
+	res.Limits[corev1.ResourceCPU] = resource.MustParse("500m")
+	res.Limits[corev1.ResourceMemory] = resource.MustParse("512Mi")
+
+	resizedAt := time.Now().UTC().Add(-10 * time.Second).Format(time.RFC3339)
+	pod := newResizePod("api-server", "250m", "256Mi", "500m", "512Mi")
+	pod.Labels[labelTracked] = "true"
+	pod.Annotations = map[string]string{
+		annotationResizedAt:                          resizedAt,
+		annotationResizedWorkload:                    "api-server",
+		annotationResizedContainers:                  "main",
+		annotationOriginalCPUPrefix + "main":         "500m",
+		annotationOriginalMemoryPrefix + "main":      "512Mi",
+		annotationOriginalCPULimitPrefix + "main":    "1000m",
+		annotationOriginalMemoryLimitPrefix + "main": "1Gi",
+		annotationPolicy:                             "test-policy",
+	}
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+		{
+			Name: "main",
+			LastTerminationState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					Reason:     "OOMKilled",
+					FinishedAt: metav1.NewTime(time.Now()),
+				},
+			},
+		},
+	}
+
+	ns := newTestNamespace("default", map[string]string{conflict.AnnotationFreeze: "true"})
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return generateSamples(200, 0.1), nil
+		},
+	}
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy, deploy, pod, ns).
+		WithStatusSubresource(&attunev1alpha1.AttunePolicy{}).
+		Build()
+	reconciler := newReconcilerForReconcileWithClient(mc, fakeClient, scheme)
+	reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var updated attunev1alpha1.AttunePolicy
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "test-policy", Namespace: "default",
+	}, &updated))
+
+	assert.Greater(t, updated.Status.Workloads.WithRecommendations, int32(0),
+		"freeze is apply-only; recommendations must still compute")
+	require.NotEmpty(t, updated.Status.Recommendations)
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+	require.NotNil(t, cond)
+	assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
+
+	var foundResize bool
+	for _, a := range reconciler.Clientset.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			foundResize = true
+		}
+	}
+	assert.True(t, foundResize, "frozen namespace must still revert pending safety observations")
+
+	var gotDeploy appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes := gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.Equal(t, int64(500), gotRes.Requests.Cpu().MilliValue(),
+		"safety revert must restore template CPU to original 500m")
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"safety revert must restore template memory to original 512Mi")
+
+	assert.Equal(t, int32(0), updated.Status.Workloads.Resized, "freeze must skip new apply")
+}
+
+func TestReconcile_NamespaceFreeze_SkipsAfterSuccessfulResizePersist(t *testing.T) {
+	t.Parallel()
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{{
+		Timestamp: metav1.NewTime(time.Now().Add(-2 * time.Minute)),
+		Workload:  "api-server",
+		Container: "main",
+		Method:    "InPlace",
+		Result:    attunev1alpha1.ResizeResultSuccess,
+	}}
+
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+	ns := newTestNamespace("default", map[string]string{conflict.AnnotationFreeze: "true"})
+
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return generateSamples(200, 0.1), nil
+		},
+	}
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy, deploy, pod, ns).
+		WithStatusSubresource(&attunev1alpha1.AttunePolicy{}).
+		Build()
+	reconciler := newReconcilerForReconcileWithClient(mc, fakeClient, scheme)
+	reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var updated attunev1alpha1.AttunePolicy
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "test-policy", Namespace: "default",
+	}, &updated))
+	require.NotEmpty(t, updated.Status.Recommendations)
+
+	var gotDeploy appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	assert.Equal(t, int64(500), gotDeploy.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(),
+		"frozen namespace must not persist AfterSuccessfulResize template")
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+	require.NotNil(t, cond)
+	assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
 }
 
 func TestReconcile_NamespaceFreeze_RecheckBeforeExecuteResizes(t *testing.T) {

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -323,7 +323,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 							if restoreErr := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); restoreErr != nil {
 								logger.Error(restoreErr, "Failed to restore template after safety revert",
 									"pod", pod.Name, "workload", record.WorkloadName, "container", record.Container)
-								observationsPending = true
+								// Period has not elapsed; the branch sets observationsPending below.
 								continue
 							}
 							operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, v.Reason).Inc()

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -320,7 +320,12 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 								logger.Error(revertErr, "Failed to revert pod during early critical check", "pod", pod.Name)
 								continue
 							}
-							r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record)
+							if restoreErr := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); restoreErr != nil {
+								logger.Error(restoreErr, "Failed to restore template after safety revert",
+									"pod", pod.Name, "workload", record.WorkloadName, "container", record.Container)
+								observationsPending = true
+								continue
+							}
 							operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, v.Reason).Inc()
 							if r.Recorder != nil {
 								r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",
@@ -383,7 +388,12 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 					revertFailed = true
 					continue
 				}
-				r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record)
+				if restoreErr := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); restoreErr != nil {
+					logger.Error(restoreErr, "Failed to restore template after safety revert",
+						"pod", pod.Name, "workload", record.WorkloadName, "container", record.Container)
+					revertFailed = true
+					continue
+				}
 				operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, verdict.Reason).Inc()
 				if r.Recorder != nil {
 					r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -203,19 +203,22 @@ func quantityEqual(a, b corev1.ResourceList, name corev1.ResourceName) bool {
 // the Deployment/StatefulSet template after a successful live-pod revert.
 // AfterSuccessfulResize already patched the unsafe rec before observation;
 // without this restore, new pods and rollouts start at the size that just
-// failed safety.
+// failed safety. Returns nil when persist is disabled, When is not
+// AfterSuccessfulResize, the workload is missing, or the template is
+// already at the snapshot. Callers must keep tracking annotations when
+// the returned error is non-nil so the next reconcile retries.
 func (r *AttunePolicyReconciler) restoreTemplateAfterSafetyRevert(
 	ctx context.Context,
 	policy *attunev1alpha1.AttunePolicy,
 	workloads []client.Object,
 	record safety.ResizeRecord,
-) {
+) error {
 	logger := log.FromContext(ctx)
 	if !templatePersistenceEnabled(policy.Spec.UpdateStrategy) {
-		return
+		return nil
 	}
 	if templatePersistenceWhen(policy.Spec.UpdateStrategy) != attunev1alpha1.TemplatePersistenceAfterSuccessfulResize {
-		return
+		return nil
 	}
 
 	var workload client.Object
@@ -230,7 +233,7 @@ func (r *AttunePolicyReconciler) restoreTemplateAfterSafetyRevert(
 		break
 	}
 	if workload == nil {
-		return
+		return nil
 	}
 
 	desired := map[string]corev1.ResourceRequirements{
@@ -238,14 +241,14 @@ func (r *AttunePolicyReconciler) restoreTemplateAfterSafetyRevert(
 	}
 	changed, err := r.patchWorkloadTemplateResources(ctx, workload, desired)
 	if err != nil {
-		logger.Error(err, "Failed to restore template after safety revert",
-			"workload", record.WorkloadName, "container", record.Container)
-		return
+		return fmt.Errorf("restoring template after safety revert for %s/%s: %w",
+			record.WorkloadName, record.Container, err)
 	}
 	if changed {
 		logger.Info("Restored template after safety revert",
 			"workload", record.WorkloadName, "container", record.Container)
 	}
+	return nil
 }
 
 // applyTemplatePersistence patches Deployment/StatefulSet pod templates for
@@ -510,6 +513,45 @@ func isSuccessfulResizeForPersist(h attunev1alpha1.ResizeHistoryEntry) bool {
 		return true
 	}
 	return resizeHistoryMethod(h) == "Eviction" && h.Result == attunev1alpha1.ResizeResultEvicted
+}
+
+// omitRevertedOrFailedContainers drops containers that already have a
+// this-cycle Reverted or Failed history row. AfterSuccessfulResize persist
+// is keyed by workload; without this filter a Success on container A still
+// writes container B's rec onto the template.
+func omitRevertedOrFailedContainers(
+	recs []attunev1alpha1.WorkloadRecommendation,
+	cycleHistory []attunev1alpha1.ResizeHistoryEntry,
+) []attunev1alpha1.WorkloadRecommendation {
+	skip := make(map[string]bool)
+	for _, h := range cycleHistory {
+		if h.Result != attunev1alpha1.ResizeResultReverted && h.Result != attunev1alpha1.ResizeResultFailed {
+			continue
+		}
+		if h.Workload == "" || h.Container == "" || h.Container == "*" {
+			continue
+		}
+		skip[h.Workload+"/"+h.Container] = true
+	}
+	if len(skip) == 0 {
+		return recs
+	}
+	out := make([]attunev1alpha1.WorkloadRecommendation, 0, len(recs))
+	for _, rec := range recs {
+		filtered := make([]attunev1alpha1.ContainerRecommendation, 0, len(rec.Containers))
+		for _, c := range rec.Containers {
+			if skip[rec.Workload+"/"+c.Name] {
+				continue
+			}
+			filtered = append(filtered, c)
+		}
+		if len(filtered) == 0 {
+			continue
+		}
+		rec.Containers = filtered
+		out = append(out, rec)
+	}
+	return out
 }
 
 // successfulResizeWorkloads returns workload names that had a successful

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -239,7 +239,7 @@ func (r *AttunePolicyReconciler) restoreTemplateAfterSafetyRevert(
 	desired := map[string]corev1.ResourceRequirements{
 		record.Container: record.OriginalResources,
 	}
-	changed, err := r.patchWorkloadTemplateResources(ctx, workload, desired)
+	changed, err := r.patchWorkloadTemplateResources(ctx, workload, desired, true)
 	if err != nil {
 		return fmt.Errorf("restoring template after safety revert for %s/%s: %w",
 			record.WorkloadName, record.Container, err)
@@ -342,7 +342,7 @@ func (r *AttunePolicyReconciler) applyTemplatePersistence(
 			continue
 		}
 
-		changed, err := r.patchWorkloadTemplateResources(ctx, w, desired)
+		changed, err := r.patchWorkloadTemplateResources(ctx, w, desired, false)
 		if err != nil {
 			logger.Error(err, "Failed to patch workload template",
 				"workload", rec.Workload, "kind", kind)
@@ -386,11 +386,14 @@ func (r *AttunePolicyReconciler) applyTemplatePersistence(
 }
 
 // patchWorkloadTemplateResources updates container resources on the pod template.
+// When replace is true (safety restore), container resources are replaced with
+// the snapshot, including clearing limits persist added. Persist keeps merge.
 // Returns (changed, error).
 func (r *AttunePolicyReconciler) patchWorkloadTemplateResources(
 	ctx context.Context,
 	workload client.Object,
 	desired map[string]corev1.ResourceRequirements,
+	replace bool,
 ) (bool, error) {
 	var changed bool
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -405,7 +408,7 @@ func (r *AttunePolicyReconciler) patchWorkloadTemplateResources(
 				return err
 			}
 			original := deploy.DeepCopy()
-			if !applyResourcesToPodSpec(&deploy.Spec.Template.Spec, desired) {
+			if !applyResourcesToPodSpec(&deploy.Spec.Template.Spec, desired, replace) {
 				return nil
 			}
 			changed = true
@@ -416,7 +419,7 @@ func (r *AttunePolicyReconciler) patchWorkloadTemplateResources(
 				return err
 			}
 			original := sts.DeepCopy()
-			if !applyResourcesToPodSpec(&sts.Spec.Template.Spec, desired) {
+			if !applyResourcesToPodSpec(&sts.Spec.Template.Spec, desired, replace) {
 				return nil
 			}
 			changed = true
@@ -429,8 +432,9 @@ func (r *AttunePolicyReconciler) patchWorkloadTemplateResources(
 }
 
 // applyResourcesToPodSpec sets resources on matching containers and native sidecars.
+// replace=true writes want as-is (restore); replace=false merges (persist).
 // Returns true if any container was modified.
-func applyResourcesToPodSpec(spec *corev1.PodSpec, desired map[string]corev1.ResourceRequirements) bool {
+func applyResourcesToPodSpec(spec *corev1.PodSpec, desired map[string]corev1.ResourceRequirements, replace bool) bool {
 	modified := false
 	for i := range spec.Containers {
 		c := &spec.Containers[i]
@@ -438,14 +442,9 @@ func applyResourcesToPodSpec(spec *corev1.PodSpec, desired map[string]corev1.Res
 		if !ok {
 			continue
 		}
-		// Merge first so RequestsOnly (Limits=nil) does not treat leftover
-		// template limits as a change when requests already match.
-		merged := mergeTemplateResources(c.Resources, want)
-		if resourcesEqual(c.Resources, merged) {
-			continue
+		if applyContainerResources(c, want, replace) {
+			modified = true
 		}
-		c.Resources = merged
-		modified = true
 	}
 	for i := range spec.InitContainers {
 		c := &spec.InitContainers[i]
@@ -456,14 +455,30 @@ func applyResourcesToPodSpec(spec *corev1.PodSpec, desired map[string]corev1.Res
 		if !ok {
 			continue
 		}
-		merged := mergeTemplateResources(c.Resources, want)
-		if resourcesEqual(c.Resources, merged) {
-			continue
+		if applyContainerResources(c, want, replace) {
+			modified = true
 		}
-		c.Resources = merged
-		modified = true
 	}
 	return modified
+}
+
+// applyContainerResources writes want onto a container. Persist merges so
+// RequestsOnly (Limits=nil) keeps leftover template limits. Restore replaces
+// so OriginalResources with empty Limits clears persist-added limits.
+func applyContainerResources(c *corev1.Container, want corev1.ResourceRequirements, replace bool) bool {
+	next := want
+	if !replace {
+		// Merge first so RequestsOnly (Limits=nil) does not treat leftover
+		// template limits as a change when requests already match.
+		next = mergeTemplateResources(c.Resources, want)
+	} else {
+		next = *want.DeepCopy()
+	}
+	if resourcesEqual(c.Resources, next) {
+		return false
+	}
+	c.Resources = next
+	return true
 }
 
 // mergeTemplateResources applies want requests/limits onto current, keeping
@@ -515,23 +530,35 @@ func isSuccessfulResizeForPersist(h attunev1alpha1.ResizeHistoryEntry) bool {
 	return resizeHistoryMethod(h) == "Eviction" && h.Result == attunev1alpha1.ResizeResultEvicted
 }
 
-// omitRevertedOrFailedContainers drops containers that already have a
-// this-cycle Reverted or Failed history row. AfterSuccessfulResize persist
-// is keyed by workload; without this filter a Success on container A still
-// writes container B's rec onto the template.
+// omitRevertedOrFailedContainers drops containers whose latest
+// persist-relevant history row is Reverted or Failed. AfterSuccessfulResize
+// persist is keyed by workload; without this filter a Success on container A
+// still writes container B's rec onto the template. History is oldest-first
+// (appendHistory); walk newest last so a later Success can persist again.
+// Skip Resource=="template" and Method==TemplatePersistence so a
+// TemplatePatched row cannot hide a Reverted or Failed resize outcome.
 func omitRevertedOrFailedContainers(
 	recs []attunev1alpha1.WorkloadRecommendation,
-	cycleHistory []attunev1alpha1.ResizeHistoryEntry,
+	history []attunev1alpha1.ResizeHistoryEntry,
 ) []attunev1alpha1.WorkloadRecommendation {
 	skip := make(map[string]bool)
-	for _, h := range cycleHistory {
-		if h.Result != attunev1alpha1.ResizeResultReverted && h.Result != attunev1alpha1.ResizeResultFailed {
+	seen := make(map[string]bool)
+	for i := len(history) - 1; i >= 0; i-- {
+		h := history[i]
+		if h.Resource == "template" || h.Method == "TemplatePersistence" {
 			continue
 		}
 		if h.Workload == "" || h.Container == "" || h.Container == "*" {
 			continue
 		}
-		skip[h.Workload+"/"+h.Container] = true
+		key := h.Workload + "/" + h.Container
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		if h.Result == attunev1alpha1.ResizeResultReverted || h.Result == attunev1alpha1.ResizeResultFailed {
+			skip[key] = true
+		}
 	}
 	if len(skip) == 0 {
 		return recs
@@ -552,6 +579,29 @@ func omitRevertedOrFailedContainers(
 		out = append(out, rec)
 	}
 	return out
+}
+
+// omittedPersistContainerNames lists workload/container keys present in recs
+// but dropped by omitRevertedOrFailedContainers.
+func omittedPersistContainerNames(
+	recs, filtered []attunev1alpha1.WorkloadRecommendation,
+) []string {
+	keep := make(map[string]bool)
+	for _, rec := range filtered {
+		for _, c := range rec.Containers {
+			keep[rec.Workload+"/"+c.Name] = true
+		}
+	}
+	var omitted []string
+	for _, rec := range recs {
+		for _, c := range rec.Containers {
+			key := rec.Workload + "/" + c.Name
+			if !keep[key] {
+				omitted = append(omitted, key)
+			}
+		}
+	}
+	return omitted
 }
 
 // successfulResizeWorkloads returns workload names that had a successful

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -466,7 +466,7 @@ func applyResourcesToPodSpec(spec *corev1.PodSpec, desired map[string]corev1.Res
 // RequestsOnly (Limits=nil) keeps leftover template limits. Restore replaces
 // so OriginalResources with empty Limits clears persist-added limits.
 func applyContainerResources(c *corev1.Container, want corev1.ResourceRequirements, replace bool) bool {
-	next := want
+	var next corev1.ResourceRequirements
 	if !replace {
 		// Merge first so RequestsOnly (Limits=nil) does not treat leftover
 		// template limits as a change when requests already match.

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -1755,7 +1755,8 @@ func TestRestoreTemplateAfterSafetyRevert_AfterSuccessfulResize(t *testing.T) {
 		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
 	}
 
-	r.restoreTemplateAfterSafetyRevert(context.Background(), policy, []client.Object{deploy}, original256MiRecord())
+	err := r.restoreTemplateAfterSafetyRevert(context.Background(), policy, []client.Object{deploy}, original256MiRecord())
+	require.NoError(t, err)
 
 	var updated appsv1.Deployment
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
@@ -1782,10 +1783,201 @@ func TestRestoreTemplateAfterSafetyRevert_DisabledNoOp(t *testing.T) {
 		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
 	}
 
-	r.restoreTemplateAfterSafetyRevert(context.Background(), policy, []client.Object{deploy}, original256MiRecord())
+	err := r.restoreTemplateAfterSafetyRevert(context.Background(), policy, []client.Object{deploy}, original256MiRecord())
+	require.NoError(t, err)
 
 	var updated appsv1.Deployment
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
 	assert.True(t, updated.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("64Mi")),
 		"disabled persist must leave the template at the recommended size")
+}
+
+func TestOmitRevertedOrFailedContainers(t *testing.T) {
+	t.Parallel()
+
+	two := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{
+			{Name: "app"},
+			{Name: "worker"},
+		},
+	}}
+	otherWL := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload:   "api",
+			Containers: []attunev1alpha1.ContainerRecommendation{{Name: "app"}},
+		},
+		{
+			Workload:   "web",
+			Containers: []attunev1alpha1.ContainerRecommendation{{Name: "app"}},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		recs    []attunev1alpha1.WorkloadRecommendation
+		history []attunev1alpha1.ResizeHistoryEntry
+		want    [][]string
+	}{
+		{
+			name: "success plus reverted drops reverted container",
+			recs: two,
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "api", Container: "app", Result: attunev1alpha1.ResizeResultSuccess},
+				{Workload: "api", Container: "worker", Result: attunev1alpha1.ResizeResultReverted},
+			},
+			want: [][]string{{"app"}},
+		},
+		{
+			name: "failed container is omitted",
+			recs: two,
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "api", Container: "app", Result: attunev1alpha1.ResizeResultSuccess},
+				{Workload: "api", Container: "worker", Result: attunev1alpha1.ResizeResultFailed},
+			},
+			want: [][]string{{"app"}},
+		},
+		{
+			name: "all containers reverted omits the rec",
+			recs: two,
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "api", Container: "app", Result: attunev1alpha1.ResizeResultReverted},
+				{Workload: "api", Container: "worker", Result: attunev1alpha1.ResizeResultFailed},
+			},
+			want: nil,
+		},
+		{
+			name:    "empty history returns recs unchanged",
+			recs:    two,
+			history: nil,
+			want:    [][]string{{"app", "worker"}},
+		},
+		{
+			name: "revert on other workload leaves this rec",
+			recs: otherWL,
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "web", Container: "app", Result: attunev1alpha1.ResizeResultReverted},
+			},
+			want: [][]string{{"app"}},
+		},
+		{
+			name: "wildcard container is ignored",
+			recs: two,
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "api", Container: "*", Result: attunev1alpha1.ResizeResultFailed},
+			},
+			want: [][]string{{"app", "worker"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := omitRevertedOrFailedContainers(tt.recs, tt.history)
+			if tt.want == nil {
+				assert.Empty(t, got)
+				return
+			}
+			require.Len(t, got, len(tt.want))
+			for i, names := range tt.want {
+				var gotNames []string
+				for _, c := range got[i].Containers {
+					gotNames = append(gotNames, c.Name)
+				}
+				assert.Equal(t, names, gotNames)
+			}
+		})
+	}
+}
+
+func TestApplyTemplatePersistence_AfterSuccessfulResize_OmitsRevertedContainer(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "app",
+							Image: "nginx",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+							},
+						},
+						{
+							Name:  "worker",
+							Image: "nginx",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("400m")},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{
+			{
+				Name: "app",
+				Current: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("500m"),
+				},
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("200m"),
+				},
+			},
+			{
+				Name: "worker",
+				Current: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("400m"),
+				},
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("100m"),
+				},
+			},
+		},
+	}}
+	cycle := []attunev1alpha1.ResizeHistoryEntry{
+		{Workload: "api", Container: "app", Method: "InPlace", Result: attunev1alpha1.ResizeResultSuccess},
+		{Workload: "api", Container: "worker", Method: "InPlace", Result: attunev1alpha1.ResizeResultReverted},
+	}
+	filtered := omitRevertedOrFailedContainers(recs, cycle)
+	only := successfulResizeWorkloads(cycle)
+
+	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, filtered,
+		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, only)
+	require.Len(t, history, 1)
+	assert.Equal(t, attunev1alpha1.ResizeResultTemplatePatched, history[0].Result)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	assert.Equal(t, int64(200), updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(),
+		"successful container A must persist")
+	assert.Equal(t, int64(400), updated.Spec.Template.Spec.Containers[1].Resources.Requests.Cpu().MilliValue(),
+		"reverted container B must stay at the original template request")
 }

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -126,7 +126,7 @@ func TestApplyResourcesToPodSpec_NoOpWhenEqual(t *testing.T) {
 			},
 		},
 	}
-	assert.False(t, applyResourcesToPodSpec(spec, desired))
+	assert.False(t, applyResourcesToPodSpec(spec, desired, false))
 }
 
 func TestApplyResourcesToPodSpec_UpdatesContainer(t *testing.T) {
@@ -149,7 +149,7 @@ func TestApplyResourcesToPodSpec_UpdatesContainer(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, applyResourcesToPodSpec(spec, desired))
+	assert.True(t, applyResourcesToPodSpec(spec, desired, false))
 	assert.Equal(t, int64(200), spec.Containers[0].Resources.Requests.Cpu().MilliValue())
 }
 
@@ -187,7 +187,7 @@ func TestApplyResourcesToPodSpec_NativeSidecarInitContainer(t *testing.T) {
 			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("99m")},
 		},
 	}
-	assert.True(t, applyResourcesToPodSpec(spec, desired))
+	assert.True(t, applyResourcesToPodSpec(spec, desired, false))
 	assert.Equal(t, int64(80), spec.InitContainers[0].Resources.Requests.Cpu().MilliValue())
 	assert.Equal(t, int64(10), spec.InitContainers[1].Resources.Requests.Cpu().MilliValue(),
 		"non-native init container must not be modified")
@@ -239,7 +239,7 @@ func TestApplyResourcesToPodSpec_RequestsOnlyKeepsLimitsAndNoOps(t *testing.T) {
 		},
 	}
 
-	assert.False(t, applyResourcesToPodSpec(spec, desired),
+	assert.False(t, applyResourcesToPodSpec(spec, desired, false),
 		"RequestsOnly with matching requests must not treat leftover limits as a change")
 	assert.Equal(t, int64(200), spec.Containers[0].Resources.Requests.Cpu().MilliValue())
 	assert.True(t, spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("256Mi")))
@@ -276,7 +276,7 @@ func TestApplyResourcesToPodSpec_RequestsOnlyUpdatesRequestsKeepsLimits(t *testi
 		},
 	}
 
-	assert.True(t, applyResourcesToPodSpec(spec, desired))
+	assert.True(t, applyResourcesToPodSpec(spec, desired, false))
 	assert.Equal(t, int64(200), spec.Containers[0].Resources.Requests.Cpu().MilliValue())
 	assert.True(t, spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("256Mi")))
 	require.NotNil(t, spec.Containers[0].Resources.Limits)
@@ -1764,6 +1764,72 @@ func TestRestoreTemplateAfterSafetyRevert_AfterSuccessfulResize(t *testing.T) {
 		"template memory request must restore to the pre-resize snapshot")
 }
 
+func TestRestoreTemplateAfterSafetyRevert_ClearsPersistAddedLimits(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	record := safety.ResizeRecord{
+		PodName:      "api-abc",
+		Namespace:    "default",
+		Container:    "app",
+		WorkloadName: "api",
+		OriginalResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	}
+	err := r.restoreTemplateAfterSafetyRevert(context.Background(), policy, []client.Object{deploy}, record)
+	require.NoError(t, err)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	got := updated.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"template memory request must restore to the pre-resize snapshot")
+	_, hasMemLimit := got.Limits[corev1.ResourceMemory]
+	assert.False(t, hasMemLimit, "restore must clear persist-added memory limit")
+}
+
 func TestRestoreTemplateAfterSafetyRevert_DisabledNoOp(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, appsv1.AddToScheme(scheme))
@@ -1868,6 +1934,50 @@ func TestOmitRevertedOrFailedContainers(t *testing.T) {
 				{Workload: "api", Container: "*", Result: attunev1alpha1.ResizeResultFailed},
 			},
 			want: [][]string{{"app", "worker"}},
+		},
+		{
+			name: "old reverted then later success keeps container",
+			recs: two,
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "api", Container: "worker", Result: attunev1alpha1.ResizeResultReverted},
+				{Workload: "api", Container: "app", Result: attunev1alpha1.ResizeResultSuccess},
+				{Workload: "api", Container: "worker", Result: attunev1alpha1.ResizeResultSuccess},
+			},
+			want: [][]string{{"app", "worker"}},
+		},
+		{
+			name: "success then later reverted omits container",
+			recs: two,
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "api", Container: "app", Result: attunev1alpha1.ResizeResultSuccess},
+				{Workload: "api", Container: "worker", Result: attunev1alpha1.ResizeResultSuccess},
+				{Workload: "api", Container: "worker", Result: attunev1alpha1.ResizeResultReverted},
+			},
+			want: [][]string{{"app"}},
+		},
+		{
+			name: "template patched does not hide later reverted",
+			recs: two,
+			history: []attunev1alpha1.ResizeHistoryEntry{
+				{Workload: "api", Container: "app", Result: attunev1alpha1.ResizeResultSuccess},
+				{Workload: "api", Container: "worker", Result: attunev1alpha1.ResizeResultSuccess},
+				{
+					Workload:  "api",
+					Container: "worker",
+					Resource:  "template",
+					Method:    "TemplatePersistence",
+					Result:    attunev1alpha1.ResizeResultTemplatePatched,
+				},
+				{Workload: "api", Container: "worker", Result: attunev1alpha1.ResizeResultReverted},
+				{
+					Workload:  "api",
+					Container: "worker",
+					Resource:  "template",
+					Method:    "TemplatePersistence",
+					Result:    attunev1alpha1.ResizeResultTemplatePatched,
+				},
+			},
+			want: [][]string{{"app"}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Namespace freeze is an apply-only incident kill-switch. Pending safety
observation still reverts unsafe pods and restores AfterSuccessfulResize
templates so rollouts do not keep the size that just failed safety.

## Problem

Freeze used to skip `checkPendingSafetyObservations`. After
`AfterSuccessfulResize` persist, a later `attune.io/freeze=true` left
the live pod and the template at the rec that failed observation.

A failed template restore then dropped tracking annotations, so the
next reconcile did not retry. Lagging persist also keyed only on
this-cycle `executeResizes` history, so a freeze-then-revert container
was written again when freeze lifted. Restore merged resources and
could not clear limits persist had added.

`kubectl attune status` never showed `NamespaceFrozen` (Ready stayed
`Monitoring`). Helm Lint is the only CI job that runs
`verify-helm-rbac.sh`, and a `config/rbac`-only change skipped that job.

## Change

- Run pending safety observation even when the namespace is frozen
- Keep tracking annotations when template restore fails; retry next cycle
- Omit containers whose latest persist-relevant history is Reverted or Failed
- Restore replaces template resources (clears persist-added limits)
- Status prints `NamespaceFrozen` in the RESIZING column
- Events say new apply is skipped and pending safety revert still runs
- CI `helm` path filter includes `config/rbac/**` and `hack/verify-helm-rbac.sh`

## Validation

- `make verify-quick`
- `go test ./internal/controller/ -race -count=1` (freeze, restore, omit, persist)
- `go test ./cmd/kubectl-attune/ -race -count=1 -run TestPrintStatus`

Release PR #670 stays user-gated. Community issues stay open.
