### PR TITLE
fix: retry safety restore and fail-closed observation cleanup

### DIFF
--- a/.github/actions/install-binary-tool/action.yaml
+++ b/.github/actions/install-binary-tool/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Restore ${{ inputs.name }} from cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: tool-cache
       with:
         path: ${{ runner.temp }}/bin-tool-cache/${{ inputs.name }}

--- a/.github/actions/install-go-tool/action.yaml
+++ b/.github/actions/install-go-tool/action.yaml
@@ -28,7 +28,7 @@ runs:
       run: echo "version=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
 
     - name: Restore ${{ inputs.name }} from cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: tool-cache
       with:
         path: ${{ runner.temp }}/go-tool-cache/${{ inputs.name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,10 @@ jobs:
               # job that runs verify-helm-rbac.sh.
               - 'config/rbac/**'
               - 'hack/verify-helm-rbac.sh'
+              # Helm Lint also runs these. A script-only change must
+              # wake Helm Lint, not only Lint or Docs Check.
+              - 'hack/verify-prometheusrule-metrics.sh'
+              - 'hack/verify-helm-schema-fields.sh'
               # Standalone Grafana JSON is the Helm dashboard source.
               # Dashboard-only PRs must run verify-dashboard-metrics.sh
               # without the full Go lint matrix.
@@ -113,6 +117,9 @@ jobs:
               - 'Makefile'
               - 'hack/verify-doc-defaults.sh'
               - 'hack/verify-doc-tool-versions.sh'
+              # Docs Check runs these on docs or helm changes.
+              - 'hack/verify-prometheusrule-metrics.sh'
+              - 'hack/verify-helm-schema-fields.sh'
               - 'charts/attune/README.md.gotmpl'
             e2e:
               - 'test/e2e/**'
@@ -122,6 +129,8 @@ jobs:
               - 'hack/e2e-install-cert-manager.sh'
               - 'hack/e2e-wait-cadvisor.sh'
               - 'hack/k3d-delete.sh'
+              # lint-chainsaw (if: e2e) runs verify-chainsaw-scripts.sh.
+              - 'hack/verify-chainsaw-scripts.sh'
             # CRDs, kustomize, and tracked release manifests (dist/).
             # Used by crd-freshness so dist/ cannot lag without a CI failure.
             manifests:
@@ -141,6 +150,10 @@ jobs:
               - 'hack/e2e-wait-cadvisor.sh'
               - 'hack/k3d-delete.sh'
               - 'hack/apply-release-notes.sh'
+              # Lint (scripts=true) runs these via python-test / make.
+              - 'hack/verify-prometheusrule-metrics.sh'
+              - 'hack/verify-helm-schema-fields.sh'
+              - 'hack/verify-chainsaw-scripts.sh'
               - '.github/actions/setup-e2e-cluster/**'
               - '.github/workflows/e2e-nightly.yaml'
             workflows:
@@ -413,7 +426,7 @@ jobs:
           gotestsum --format pkgname \
             --junitfile test-results/unit.xml \
             --rerun-fails --rerun-fails-max-failures=5 \
-            --packages="./api/... ./cmd/... ./internal/..." \
+            --packages="./api/... ./cmd/... ./internal/... ./pkg/..." \
             -- -race -timeout=10m \
             -coverpkg=./internal/... \
             -coverprofile=coverage.out \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,7 @@ jobs:
               - 'hack/verify-dashboard-metrics.sh'
             yaml:
               - 'config/**'
+              - '.yamllint.yaml'
               - '.github/workflows/**'
               - 'charts/attune/Chart.yaml'
               - 'charts/attune/values.yaml'

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ lint-fix: golangci-lint ## Run golangci-lint with auto-fix
 test: manifests generate gotestsum ## Run unit tests
 	$(GOTESTSUM) --format pkgname \
 		--rerun-fails --rerun-fails-max-failures=5 \
-		--packages="./api/... ./cmd/... ./internal/..." \
+		--packages="./api/... ./cmd/... ./internal/... ./pkg/..." \
 		-- -race -timeout=10m \
 		-coverpkg=./internal/... \
 		-coverprofile=coverage.out \

--- a/Makefile
+++ b/Makefile
@@ -426,6 +426,9 @@ _deploy-stack:
 		--set metrics.enabled=true \
 		--set leaderElection.enabled=false \
 		--set maxConcurrentReconciles=4 \
+		--set logging.level=1 \
+		--set resources.limits.memory=512Mi \
+		--set resources.requests.memory=256Mi \
 		--set fleetReport.enabled=true \
 		--set fleetReport.interval=30s \
 		--set fleetReport.clusterId=e2e \

--- a/cmd/kubectl-attune/doctor.go
+++ b/cmd/kubectl-attune/doctor.go
@@ -462,7 +462,7 @@ func runDoctor(ctx context.Context, stdout, stderr io.Writer, disc doctorDiscove
 	}
 	results := runDoctorChecks(ctx, disc, objects, err, ping)
 	printDoctorResults(stdout, results)
-	fmt.Fprintln(stdout, "Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.")
+	fmt.Fprintln(stdout, "Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply. Pending safety revert still runs.")
 	if doctorFailed(results) {
 		fmt.Fprintln(stderr, "doctor: one or more checks failed")
 		return 1

--- a/cmd/kubectl-attune/doctor_test.go
+++ b/cmd/kubectl-attune/doctor_test.go
@@ -535,7 +535,7 @@ func TestRunDoctor_ExitCodes(t *testing.T) {
 	assert.Contains(t, stdout.String(), "Kubernetes version     ok   [required]")
 	assert.Contains(t, stdout.String(), "Prometheus             WARN [optional] skipped (no address on policies or defaults)")
 	assert.Contains(t, stdout.String(), "AttunePolicies         WARN [optional] no AttunePolicies in scope")
-	assert.Contains(t, stdout.String(), "Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.")
+	assert.Contains(t, stdout.String(), "Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply. Pending safety revert still runs.")
 	assert.NotContains(t, stdout.String(), "Prometheus             ok")
 	assert.Empty(t, stderr.String())
 

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1503,7 +1503,16 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	printEffectiveField("  Decrease usage margin", formatPercentInt64Ptr(rawInt64Field(item, "spec", "memory", "decreaseUsageMarginPercent")), formatPercentPtr(effective.Spec.Memory.DecreaseUsageMarginPercent), selected, memDefaults != nil && memDefaults.DecreaseUsageMarginPercent != nil)
 	printEffectiveField("  Memory from CPU ratio", getNestedString(item, "spec", "memory", "memoryFromCpuRatio"), formatStringPtr(effective.Spec.Memory.MemoryFromCPURatio), selected, memDefaults != nil && memDefaults.MemoryFromCPURatio != nil)
 
-	fmt.Println("  Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.")
+	if getConditionReason(item, "ResizeBlocked") == "NamespaceFrozen" {
+		msg := getConditionMessage(item, "ResizeBlocked")
+		if msg == "" {
+			msg = "ResizeBlocked=NamespaceFrozen"
+		}
+		fmt.Printf("  Namespace freeze: %s\n", msg)
+	} else {
+		fmt.Println("  Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.")
+	}
+	fmt.Println("  Pending safety revert still runs.")
 
 	// Pure export / GitOps mode note (makes the recommended workflow first-class in CLI)
 	if effective.Spec.UpdateStrategy.Export != nil && effective.Spec.UpdateStrategy.Export.ConfigMap {

--- a/cmd/kubectl-attune/main_test.go
+++ b/cmd/kubectl-attune/main_test.go
@@ -2903,19 +2903,89 @@ func TestPrintEffectivePolicySummary_NamespaceFreezeHelp(t *testing.T) {
 			UpdateStrategy: &attunev1alpha1.UpdateStrategy{Type: attunev1alpha1.UpdateTypeAuto},
 		},
 	}
-	item := unstructured.Unstructured{Object: map[string]interface{}{
-		"spec": map[string]interface{}{},
-	}}
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	old := os.Stdout
-	os.Stdout = w
-	printEffectivePolicySummary(item, policy, selectedDefaults{})
-	_ = w.Close()
-	os.Stdout = old
-	out, err := io.ReadAll(r)
-	require.NoError(t, err)
-	assert.Contains(t, string(out), "Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.")
+	tests := []struct {
+		name    string
+		item    unstructured.Unstructured
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "not frozen prints annotate hint",
+			item: unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			}},
+			want: []string{
+				"Namespace freeze: annotate the namespace attune.io/freeze=true to skip apply.",
+				"Pending safety revert still runs.",
+			},
+		},
+		{
+			name: "frozen prints annotation condition message",
+			item: unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":    "ResizeBlocked",
+							"status":  "True",
+							"reason":  "NamespaceFrozen",
+							"message": "namespace has attune.io/freeze=true; new apply skipped (pending safety revert still runs)",
+						},
+					},
+				},
+			}},
+			want: []string{
+				"namespace has attune.io/freeze=true; new apply skipped (pending safety revert still runs)",
+				"Pending safety revert still runs.",
+			},
+			notWant: []string{
+				"annotate the namespace attune.io/freeze=true to skip apply.",
+			},
+		},
+		{
+			name: "frozen cannot-read prints RBAC condition message",
+			item: unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":    "ResizeBlocked",
+							"status":  "True",
+							"reason":  "NamespaceFrozen",
+							"message": "cannot read namespace for attune.io/freeze; new apply skipped (check namespaces get/list/watch RBAC)",
+						},
+					},
+				},
+			}},
+			want: []string{
+				"cannot read namespace for attune.io/freeze; new apply skipped (check namespaces get/list/watch RBAC)",
+				"Pending safety revert still runs.",
+			},
+			notWant: []string{
+				"annotate the namespace attune.io/freeze=true to skip apply.",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
+			old := os.Stdout
+			os.Stdout = w
+			printEffectivePolicySummary(tt.item, policy, selectedDefaults{})
+			_ = w.Close()
+			os.Stdout = old
+			out, err := io.ReadAll(r)
+			require.NoError(t, err)
+			got := string(out)
+			for _, want := range tt.want {
+				assert.Contains(t, got, want)
+			}
+			for _, notWant := range tt.notWant {
+				assert.NotContains(t, got, notWant)
+			}
+		})
+	}
 }
 
 func TestPrintEffectivePolicySummary_CostPricing(t *testing.T) {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1054,7 +1054,7 @@ Jobs:
     - yamllint for `config/` and Helm values/chart metadata
 
   test-unit:
-    - gotestsum over `./api/... ./cmd/... ./internal/...`
+    - gotestsum over `./api/... ./cmd/... ./internal/... ./pkg/...`
     - race-enabled coverage run
     - Upload JUnit results and Codecov coverage
     - Fail if coverage < 80%

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -11,7 +11,7 @@ This uses `gotestsum` with auto-retry for flaky tests:
 ```bash
 gotestsum --format pkgname \
   --rerun-fails --rerun-fails-max-failures=5 \
-  --packages="./api/... ./cmd/... ./internal/..." \
+  --packages="./api/... ./cmd/... ./internal/... ./pkg/..." \
   -- -race -timeout=10m \
   -coverpkg=./internal/... \
   -coverprofile=coverage.out \

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -779,7 +779,8 @@ A zero `attune_revert_failures_total` does not mean restore finished.
 That counter only counts failed `/resize` revert calls. Check
 `attune_reconcile_errors_total{error_type="safety_observation"}` if
 list, confirm, or cleanup also failed. Tracking stays; the next
-reconcile retries the restore.
+reconcile retries the restore even when the pod is Ready again, as
+long as live resources still match the original snapshot.
 
 ### Safety observation stuck
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -298,7 +298,10 @@ initial sizing (last-known values stay in status, but CREATE is not patched).
    Info line uses `generateName` (for example `my-app-abc-`), not the
    name kubelet later assigns.
 7. Check the namespace is not frozen. `attune.io/freeze=true` skips
-   CREATE initial sizing.
+   CREATE initial sizing. Confirm `ResizeBlocked=NamespaceFrozen` on
+   the policy. Grep webhook logs for the fail-closed admission message
+   `cannot read namespace for attune.io/freeze` (Allowed, not Denied)
+   if the operator cannot read the namespace.
 
 ### Paused
 
@@ -750,6 +753,57 @@ Common causes:
 sum by (namespace, workload) (rate(attune_revert_failures_total[5m])) > 0
 ```
 
+#### Template restore after safety revert
+
+**Symptom**: The live pod is back at the original resources after a
+safety revert, but the workload template still has the persisted
+post-resize requests. `.status.resizeHistory` still shows
+`result: Success` for that resize. There is no `TemplatePatchFailed`
+event. `attune_revert_failures_total` stays 0.
+
+**Cause**: The in-place `/resize` revert succeeded, then restoring the
+`AfterSuccessfulResize` template failed. The helper logs
+`Failed to restore template after safety revert` and returns before
+`attune_reverts_total` and the `Reverted` event. Tracking annotations
+stay on the pod so the next reconcile retries.
+
+**Fix**: Grep operator logs for the restore-fail line (not
+`Failed to revert`):
+
+```bash
+kubectl logs -l app.kubernetes.io/name=attune --tail=200 | grep \
+  "Failed to restore template after safety revert"
+```
+
+A zero `attune_revert_failures_total` does not mean restore finished.
+That counter only counts failed `/resize` revert calls. Check
+`attune_reconcile_errors_total{error_type="safety_observation"}` if
+list, confirm, or cleanup also failed. Tracking stays; the next
+reconcile retries the restore.
+
+### Safety observation stuck
+
+**Symptom**: Pods keep resize tracking annotations after the
+observation period, or
+`attune_reconcile_errors_total{error_type="safety_observation"}` is
+incrementing.
+
+**Cause**: Listing tracked pods, confirming an unsafe verdict,
+removing tracking annotations, or restoring the template after a
+safety revert failed. The operator keeps `observationsPending` so the
+next reconcile retries. Tracking stays until cleanup succeeds.
+
+**Fix**: Grep operator logs:
+
+```bash
+kubectl logs -l app.kubernetes.io/name=attune --tail=200 | grep -E \
+  "Failed to list pods for safety observation|Failed to remove resize tracking annotations|Safety confirm Get failed|Failed to restore template after safety revert"
+```
+
+```promql
+sum(rate(attune_reconcile_errors_total{error_type="safety_observation"}[5m])) > 0
+```
+
 ### Resizes not happening during expected window
 
 **Symptom**: Operator logs "Outside resize window, skipping resize" even
@@ -1133,6 +1187,13 @@ spec:
   never writes limits.
 - **Namespace freeze**: `attune.io/freeze=true` skips new persist.
   Pending safety restore still runs.
+- **Safety restore fail**: after a successful in-place revert, a failed
+  template restore leaves the pod at original resources, the template
+  at the persisted size, history at `Success`, and no
+  `TemplatePatchFailed` event. Operator logs
+  `Failed to restore template after safety revert`. Tracking stays;
+  the next reconcile retries. `attune_revert_failures_total` does not
+  increment.
 
 ### Mid-rollout or no-op
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,7 +41,7 @@ kubectl attune savings --sort-by savings -A
 |--------|-------------|
 | PENDING | Workloads with active recommendations that are still awaiting resize |
 | READY | Current `Ready` reason (`Monitoring`, `InsufficientData`, `NoWorkloadsFound`, `MetricsUnavailable` (alias `PrometheusUnavailable`), `InvalidConfig`, `WorkloadDiscoveryFailed`, `ConflictCheckFailed`, or `Paused`), or the current `Ready` condition message when `Ready=False` includes actionable details |
-| RESIZING | `InProgress`, `Idle`, `CooldownActive`, or `-` (non-resize modes) |
+| RESIZING | `InProgress`, `Idle`, `CooldownActive`, `NamespaceFrozen`, or `-` (non-resize modes). `NamespaceFrozen` is copied from `ResizeBlocked`; `READY` can stay `Monitoring`. |
 | DEGRADED | `HighRevertRate` or `-` |
 | CANARY | Canary phase. With per-app rows: `CanaryInProgress (1/2 apps)`. Legacy: `CanaryInProgress (2 pods)`. `-` when mode is not Canary |
 | EXPORT | `CM` when `export.configMap: true` (recommendations written to ConfigMaps for GitOps), `-` otherwise |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -456,6 +456,15 @@ parser as `attune.io/skip` (`True`, `1`, and `yes` do not freeze).
 kubectl annotate namespace <ns> attune.io/freeze=true
 ```
 
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production
+  annotations:
+    attune.io/freeze: "true"
+```
+
 | Annotation | Scope | Effect |
 |------------|-------|--------|
 | `attune.io/freeze=true` | Namespace | Skip new apply: in-place resize, eviction, startup boost, template persist, and CREATE initial sizing. Metrics, recommendations, status, and export still update. Pending safety observation still reverts unsafe pods and restores AfterSuccessfulResize templates. `ResizeBlocked=True` with `reason=NamespaceFrozen`. |

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -31,6 +31,12 @@ operator tried to restore a pod's original resources but the `/resize`
 subresource call failed, leaving the pod running with post-resize resources
 that may be causing issues.
 
+A zero value does not mean a safety restore finished. Template restore
+after a successful in-place revert is a separate path: it logs
+`Failed to restore template after safety revert` and does not increment
+this counter. The pod is already back at original resources; the
+template may still hold the persisted size until the next retry.
+
 | Label | Description |
 |-------|-------------|
 | `namespace` | Workload namespace |
@@ -73,6 +79,10 @@ Total number of reconciliation errors by type.
 | Label | Description |
 |-------|-------------|
 | `error_type` | `fetch`, `fetch_defaults`, `metrics_source`, `discover_workloads`, `list_policies`, `get_pods`, `compute_recommendations`, `status_update`, or `safety_observation` |
+
+`safety_observation` means a pending-observation list, confirm Get, safety
+check, or tracking-annotation cleanup failed. Tracking stays on the pod
+and the next reconcile retries.
 
 ### attune_webhook_validation_total
 

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -7170,6 +7170,142 @@ func TestCheckPendingSafetyObservations_RestoreTemplateFailsKeepsTrackingThenRet
 		"second restore must write the original 512Mi snapshot")
 }
 
+func TestCheckPendingSafetyObservations_RestoreRetryAfterRevertWhenPodNowSafe(t *testing.T) {
+	t.Parallel()
+
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-retry-safe-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/original-cpu-limit.main":      "1000m",
+				"attune.io/original-memory-limit.main":   "1Gi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "nginx",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
+	}
+
+	deploy := recSizedAPIServerDeploy()
+	var failDeployPatch atomic.Bool
+	failDeployPatch.Store(true)
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(deploy, pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cw client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok && failDeployPatch.Load() {
+					return fmt.Errorf("simulated template patch failure")
+				}
+				return cw.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+	assert.True(t, pending, "failed template restore must keep observations pending")
+
+	var gotDeploy appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes := gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("256Mi")),
+		"template must stay at the recommended 256Mi after a failed restore")
+
+	var gotPod corev1.Pod
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "restore-retry-safe-pod", Namespace: "default",
+	}, &gotPod))
+	_, hasTracking := gotPod.Annotations[annotationResizedAt]
+	assert.True(t, hasTracking, "tracking annotations must remain so the next reconcile retries restore")
+
+	// Revert already landed; kubelet recovered. Informer and live Get now
+	// show Ready at the original snapshot, so CheckPodObject is Safe.
+	originalResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+	gotPod.Spec.Containers[0].Resources = originalResources
+	gotPod.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+	}
+	require.NoError(t, fakeClient.Update(context.Background(), &gotPod))
+
+	live, err := clientset.CoreV1().Pods("default").Get(context.Background(), "restore-retry-safe-pod", metav1.GetOptions{})
+	require.NoError(t, err)
+	live.Spec.Containers[0].Resources = originalResources
+	live.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+	}
+	_, err = clientset.CoreV1().Pods("default").Update(context.Background(), live, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	_, err = clientset.CoreV1().Pods("default").UpdateStatus(context.Background(), live, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	failDeployPatch.Store(false)
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes = gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"safe-path restore retry must write the original 512Mi snapshot")
+}
+
 func TestCheckPendingSafetyObservations_NotReadyFlapConfirmedBeforeRevert(t *testing.T) {
 	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
 	listed := &corev1.Pod{

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -4399,6 +4399,81 @@ func TestCheckPendingSafetyObservations_ObservationElapsed(t *testing.T) {
 	assert.False(t, hasContainer, "resized-container annotation should be removed")
 }
 
+func TestCheckPendingSafetyObservations_CleanupPatchFailureKeepsPending(t *testing.T) {
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cleanup-fail-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "nginx",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
+	}
+
+	policy := newTestPolicy("test-policy", "default")
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(safetyTestDeploy, pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cw client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if p, ok := obj.(*corev1.Pod); ok && p.Name == "cleanup-fail-pod" {
+					return fmt.Errorf("simulated tracking cleanup patch failure")
+				}
+				return cw.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	before := promtestutil.ToFloat64(operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation"))
+	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+	after := promtestutil.ToFloat64(operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation"))
+
+	assert.True(t, pending, "cleanup patch failure must keep observations pending")
+	assert.Equal(t, before+1, after, "safety_observation should increment on cleanup patch error")
+
+	var updated corev1.Pod
+	err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "cleanup-fail-pod", Namespace: "default",
+	}, &updated)
+	require.NoError(t, err)
+	_, hasResizedAt := updated.Annotations["attune.io/resized-at"]
+	assert.True(t, hasResizedAt, "tracking annotations must remain after cleanup patch failure")
+}
+
 func TestCheckPendingSafetyObservations_MalformedAnnotation(t *testing.T) {
 	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
 	pod := &corev1.Pod{

--- a/internal/controller/memory_usage_floor_test.go
+++ b/internal/controller/memory_usage_floor_test.go
@@ -32,7 +32,6 @@ import (
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/attune-io/attune/internal/operatormetrics"
-	"github.com/attune-io/attune/internal/resize"
 )
 
 func TestApplyMemoryUsageFloor_GuaranteedRaisesRequestToFlooredLimit(t *testing.T) {
@@ -52,6 +51,7 @@ func TestApplyMemoryUsageFloor_GuaranteedRaisesRequestToFlooredLimit(t *testing.
 	}
 	r := NewAttunePolicyReconciler()
 	r.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+	r.AllowInPlaceMemoryLimitDecrease = true
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
@@ -91,8 +91,7 @@ func TestApplyMemoryUsageFloor_GuaranteedRaisesRequestToFlooredLimit(t *testing.
 		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
 	}
 
-	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
-	got = resize.RaiseGuaranteedMemoryRequestToLimit(pod, got)
+	got, _ := r.applyLiveResizeTarget(policy, pod, rec, target)
 	want := resource.MustParse("550Mi")
 	require.NotNil(t, got.Limits)
 	assert.True(t, got.Limits.Memory().Equal(want),
@@ -139,7 +138,8 @@ func TestApplyMemoryUsageFloor_RaisesUnsafeLimit(t *testing.T) {
 
 	before := promtestutil.ToFloat64(operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
 		"default", "p", "clamped_usage"))
-	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
+	got, meta := r.applyLiveResizeTarget(policy, pod, rec, target)
+	r.emitLiveResizeApply(context.Background(), policy, pod, rec, meta)
 	// 500Mi * 1.1 = 550Mi
 	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("550Mi")),
 		"got %s", got.Limits.Memory().String())
@@ -184,7 +184,8 @@ func TestApplyMemoryUsageFloor_SkippedUnsafeIncrementsMetric(t *testing.T) {
 
 	before := promtestutil.ToFloat64(operatormetrics.MemoryLimitDecreaseTotal.WithLabelValues(
 		"ns-skip", "p-skip", "skipped_unsafe"))
-	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
+	got, meta := r.applyLiveResizeTarget(policy, pod, rec, target)
+	r.emitLiveResizeApply(context.Background(), policy, pod, rec, meta)
 	// Floor = max(target, usage*(1+m/100)) but never above current → stays 200Mi.
 	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("200Mi")),
 		"got %s", got.Limits.Memory().String())
@@ -225,7 +226,7 @@ func TestApplyMemoryUsageFloor_SafeDecreaseUnchanged(t *testing.T) {
 		Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("800Mi")},
 	}
 
-	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
+	got, _ := r.applyLiveResizeTarget(policy, pod, rec, target)
 	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("800Mi")))
 }
 
@@ -246,6 +247,7 @@ func TestApplyMemoryUsageFloor_UsesLiveContainerLimit(t *testing.T) {
 	}
 	r := NewAttunePolicyReconciler()
 	r.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+	r.AllowInPlaceMemoryLimitDecrease = true
 
 	// Template Current is stale after in-place resize (512Mi). Live pod is 2Gi.
 	pod := &corev1.Pod{
@@ -276,7 +278,7 @@ func TestApplyMemoryUsageFloor_UsesLiveContainerLimit(t *testing.T) {
 		Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
 	}
 
-	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
+	got, _ := r.applyLiveResizeTarget(policy, pod, rec, target)
 	// Stale 512Mi would treat 1Gi as an increase and leave it unchanged.
 	assert.False(t, got.Limits.Memory().Equal(resource.MustParse("1Gi")),
 		"must not keep 1Gi when live limit is 2Gi and usage floor applies (got %s)",
@@ -323,7 +325,7 @@ func TestApplyMemoryUsageFloor_ZeroMargin(t *testing.T) {
 		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("64Mi")},
 	}
 
-	got := r.applyMemoryUsageFloor(context.Background(), policy, pod, rec, target)
+	got, _ := r.applyLiveResizeTarget(policy, pod, rec, target)
 	gotLim := got.Limits.Memory()
 	usage := resource.MustParse("200Mi")
 	want := *resource.NewQuantity(usage.Value()+1, resource.BinarySI)

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -1841,34 +1841,6 @@ func (r *AttunePolicyReconciler) computeMemoryUsageFloor(
 	return floored, true, usage, margin
 }
 
-// applyMemoryUsageFloor raises a decreasing memory limit so it stays above
-// recent usage * (1 + margin/100). Recent usage is the memory recommendation
-// RawPercentile (historical usage percentile before overhead).
-func (r *AttunePolicyReconciler) applyMemoryUsageFloor(
-	ctx context.Context,
-	policy *attunev1alpha1.AttunePolicy,
-	pod *corev1.Pod,
-	containerRec attunev1alpha1.ContainerRecommendation,
-	target corev1.ResourceRequirements,
-) corev1.ResourceRequirements {
-	floored, applied, usage, margin := r.computeMemoryUsageFloor(policy, pod, containerRec, target)
-	if !applied {
-		return target
-	}
-	currentLim := liveContainerCurrent(pod, containerRec).MemoryLimit
-	fromLim := target.Limits[corev1.ResourceMemory]
-	toLim := floored.Limits[corev1.ResourceMemory]
-	r.emitLiveResizeApply(ctx, policy, pod, containerRec, liveResizeApplyMeta{
-		FloorApplied:       true,
-		FloorFromLimit:     fromLim,
-		FloorToLimit:       toLim,
-		FloorUsage:         usage,
-		FloorMargin:        margin,
-		FloorEqualsCurrent: toLim.Equal(currentLim),
-	})
-	return floored
-}
-
 // recentMemoryUsage returns the raw usage percentile from the recommendation
 // explanation when available.
 func recentMemoryUsage(containerRec attunev1alpha1.ContainerRecommendation) (resource.Quantity, bool) {

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -387,6 +387,21 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 			observationsPending = true
 			continue
 		}
+
+		// Safe (or confirm-Safe) after a prior revert: live may already be
+		// at OriginalResources while the AfterSuccessfulResize template is
+		// still the persisted rec. Restore only; do not revert again.
+		restoreFailed := false
+		for _, record := range records {
+			if err := r.retryTemplateRestoreIfAlreadyReverted(ctx, policy, workloads, pod, record); err != nil {
+				restoreFailed = true
+				break
+			}
+		}
+		if restoreFailed {
+			observationsPending = true
+			continue
+		}
 		// Merge-patch nulls tracking keys. No Get and no resourceVersion,
 		// so kubelet status churn cannot 409 the cleanup.
 		if err := r.patchRemoveTrackingAnnotations(ctx, pod); err != nil {
@@ -427,6 +442,76 @@ func (r *AttunePolicyReconciler) revertAndRestoreAfterSafety(
 	}
 	markLatestCycleReverted(policy.Status.ResizeHistory, trackedWorkload, record.Container, reason)
 	return nil
+}
+
+// retryTemplateRestoreIfAlreadyReverted restores an AfterSuccessfulResize
+// template when the live pod is already back at OriginalResources (revert
+// landed, observation later reports Safe). Returns a non-nil error when
+// tracking must stay so the next reconcile retries.
+func (r *AttunePolicyReconciler) retryTemplateRestoreIfAlreadyReverted(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	workloads []client.Object,
+	listed *corev1.Pod,
+	record safety.ResizeRecord,
+) error {
+	if !templatePersistenceEnabled(policy.Spec.UpdateStrategy) {
+		return nil
+	}
+	if templatePersistenceWhen(policy.Spec.UpdateStrategy) != attunev1alpha1.TemplatePersistenceAfterSuccessfulResize {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	live, err := r.fetchLivePodForResize(ctx, listed)
+	if err != nil {
+		logger.Error(err, "Failed to fetch live pod for template restore retry",
+			"pod", listed.Name, "container", record.Container)
+		operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
+		return err
+	}
+	if !liveContainerMatchesOriginal(live, record) {
+		return nil
+	}
+	if err := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); err != nil {
+		logger.Error(err, "Failed to restore template after safety revert",
+			"pod", listed.Name, "workload", record.WorkloadName, "container", record.Container)
+		operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
+		return err
+	}
+	return nil
+}
+
+// liveContainerMatchesOriginal reports whether the named container's live
+// CPU and memory requests and limits equal the pre-resize snapshot.
+func liveContainerMatchesOriginal(pod *corev1.Pod, record safety.ResizeRecord) bool {
+	if pod == nil {
+		return false
+	}
+	c := findContainerByName(pod, record.Container)
+	if c == nil {
+		return false
+	}
+	return cpuMemQuantityEqual(c.Resources, record.OriginalResources)
+}
+
+func cpuMemQuantityEqual(a, b corev1.ResourceRequirements) bool {
+	return quantityPtrEqual(a.Requests, b.Requests, corev1.ResourceCPU) &&
+		quantityPtrEqual(a.Requests, b.Requests, corev1.ResourceMemory) &&
+		quantityPtrEqual(a.Limits, b.Limits, corev1.ResourceCPU) &&
+		quantityPtrEqual(a.Limits, b.Limits, corev1.ResourceMemory)
+}
+
+func quantityPtrEqual(a, b corev1.ResourceList, name corev1.ResourceName) bool {
+	qa, oka := a[name]
+	qb, okb := b[name]
+	if !oka && !okb {
+		return true
+	}
+	if !oka || !okb {
+		return false
+	}
+	return qa.Equal(qb)
 }
 
 // confirmSafetyVerdict re-Gets the pod and re-evaluates before revert so a

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -316,27 +316,13 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 							v = confirmed
 							logger.Info("Critical safety event detected during observation period, reverting early",
 								"pod", pod.Name, "container", record.Container, "reason", v.Reason)
-							if revertErr := revertPod(record); revertErr != nil {
-								logger.Error(revertErr, "Failed to revert pod during early critical check", "pod", pod.Name)
-								continue
-							}
-							if restoreErr := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); restoreErr != nil {
-								logger.Error(restoreErr, "Failed to restore template after safety revert",
-									"pod", pod.Name, "workload", record.WorkloadName, "container", record.Container)
+							if err := r.revertAndRestoreAfterSafety(ctx, revertPod, policy, workloads, record, pod, trackedWorkload,
+								v.Reason, v.Message,
+								"Failed to revert pod during early critical check",
+								"Early safety detection reverted resize on pod %s/%s: %s"); err != nil {
 								// Period has not elapsed; the branch sets observationsPending below.
 								continue
 							}
-							operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, v.Reason).Inc()
-							if r.Recorder != nil {
-								r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",
-									"Early safety detection reverted resize on pod %s/%s: %s", pod.Name, record.Container, v.Message)
-							}
-							// Mark history entries from the most recent resize cycle
-							// as reverted. Only entries whose timestamp matches the
-							// first (newest) match are marked, so entries from prior
-							// successful cycles are not poisoned and consecutiveReverts
-							// is not inflated.
-							markLatestCycleReverted(policy.Status.ResizeHistory, trackedWorkload, record.Container, v.Reason)
 						}
 					}
 				}
@@ -383,23 +369,13 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 				verdict = confirmed
 				logger.Info("Deferred safety violation detected, reverting",
 					"pod", pod.Name, "container", record.Container, "reason", verdict.Reason)
-				if revertErr := revertPod(record); revertErr != nil {
-					logger.Error(revertErr, "Failed to revert pod during safety observation", "pod", pod.Name)
+				if err := r.revertAndRestoreAfterSafety(ctx, revertPod, policy, workloads, record, pod, trackedWorkload,
+					verdict.Reason, verdict.Message,
+					"Failed to revert pod during safety observation",
+					"Safety observation reverted resize on pod %s/%s: %s"); err != nil {
 					revertFailed = true
 					continue
 				}
-				if restoreErr := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); restoreErr != nil {
-					logger.Error(restoreErr, "Failed to restore template after safety revert",
-						"pod", pod.Name, "workload", record.WorkloadName, "container", record.Container)
-					revertFailed = true
-					continue
-				}
-				operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, verdict.Reason).Inc()
-				if r.Recorder != nil {
-					r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",
-						"Safety observation reverted resize on pod %s/%s: %s", pod.Name, record.Container, verdict.Message)
-				}
-				markLatestCycleReverted(policy.Status.ResizeHistory, trackedWorkload, record.Container, verdict.Reason)
 			}
 		}
 
@@ -415,9 +391,42 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 		// so kubelet status churn cannot 409 the cleanup.
 		if err := r.patchRemoveTrackingAnnotations(ctx, pod); err != nil {
 			logger.Error(err, "Failed to remove resize tracking annotations", "pod", pod.Name)
+			operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
+			observationsPending = true
 		}
 	}
 	return observationsPending
+}
+
+// revertAndRestoreAfterSafety reverts the live pod, restores the workload
+// template, then records the revert metric, event, and history mark.
+// Callers keep path-specific continue / revertFailed handling.
+func (r *AttunePolicyReconciler) revertAndRestoreAfterSafety(
+	ctx context.Context,
+	revertFn func(safety.ResizeRecord) error,
+	policy *attunev1alpha1.AttunePolicy,
+	workloads []client.Object,
+	record safety.ResizeRecord,
+	pod *corev1.Pod,
+	trackedWorkload, reason, message, revertFailMsg, eventFmt string,
+) error {
+	logger := log.FromContext(ctx)
+	if err := revertFn(record); err != nil {
+		logger.Error(err, revertFailMsg, "pod", pod.Name)
+		return err
+	}
+	if err := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); err != nil {
+		logger.Error(err, "Failed to restore template after safety revert",
+			"pod", pod.Name, "workload", record.WorkloadName, "container", record.Container)
+		return err
+	}
+	operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, reason).Inc()
+	if r.Recorder != nil {
+		r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",
+			eventFmt, pod.Name, record.Container, message)
+	}
+	markLatestCycleReverted(policy.Status.ResizeHistory, trackedWorkload, record.Container, reason)
+	return nil
 }
 
 // confirmSafetyVerdict re-Gets the pod and re-evaluates before revert so a

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -108,7 +108,7 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 	if err != nil {
 		h.Logger.Error(err, "getting namespace for attune.io/freeze; skipping initial sizing",
 			"namespace", req.Namespace)
-		return admission.Allowed("cannot read namespace for freeze, skipping initial sizing")
+		return admission.Allowed("cannot read namespace for attune.io/freeze; skipping initial sizing (check namespaces get/list/watch RBAC)")
 	}
 	if frozen {
 		h.Logger.Info("skipping initial sizing: namespace has attune.io/freeze=true",

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -277,7 +277,7 @@ func TestPodMutatingHandler_NamespaceFreeze(t *testing.T) {
 			name:        "Get error fail-closed",
 			getErr:      true,
 			wantPatches: false,
-			wantMsg:     "cannot read namespace for freeze",
+			wantMsg:     "cannot read namespace for attune.io/freeze; skipping initial sizing (check namespaces get/list/watch RBAC)",
 		},
 	}
 


### PR DESCRIPTION
After a safety revert, a failed AfterSuccessfulResize template restore
could leave tracking on the pod, then drop it on the next observation
once the pod was Ready again. The live pod stayed at the original
size. The Deployment template stayed at the persisted rec. Rollouts
recreated the unsafe size.

## Changes

- Keep tracking and requeue at the observation interval when
  tracking-annotation cleanup fails.
- Retry template restore when live resources already match the
  original snapshot (do not revert again).
- Floor tests call `applyLiveResizeTarget` instead of a test-only
  twin.
- Operator docs for restore-fail, `safety_observation` retries, and
  freeze fail-closed. Webhook and `kubectl attune explain` match the
  controller NamespaceFrozen text.
- Unit tests include `./pkg/...`. Path filters wake Lint, Docs, Helm
  Lint, Chainsaw lint, and YAML lint when those jobs' verify scripts
  or `.yamllint.yaml` are the only files changed.
- `make k3d-deploy` sets the same Helm logging and memory flags as CI.
  Composite install actions use `actions/cache` v6.1.0.

## Validation

- `go test ./internal/controller/ -race -count=1` (1087 passed after
  the safety commits)
- `go test ./internal/webhook/ ./cmd/kubectl-attune/ -race -count=1`
  (694 passed)
- `go test ./pkg/... -race -count=1` (43 passed)
- `make verify-quick` (2501 unit tests, 93.1% coverage, Helm 119)

Release PR #670 stays user-gated.
