### PR TITLE
fix: match clamped revert target for safety restore retry

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -776,11 +776,13 @@ kubectl logs -l app.kubernetes.io/name=attune --tail=200 | grep \
 ```
 
 A zero `attune_revert_failures_total` does not mean restore finished.
-That counter only counts failed `/resize` revert calls. Check
+That counter counts failed `/resize` revert calls only, including
+observation-window revert. Check
 `attune_reconcile_errors_total{error_type="safety_observation"}` if
-list, confirm, or cleanup also failed. Tracking stays; the next
-reconcile retries the restore even when the pod is Ready again, as
-long as live resources still match the original snapshot.
+list, confirm, cleanup, or template restore also failed. Tracking
+stays; the next reconcile retries the restore even when the pod is
+Ready again, as long as live resources still match the applied
+revert target (clamped original, not always the raw snapshot).
 
 ### Safety observation stuck
 
@@ -1193,8 +1195,8 @@ spec:
   at the persisted size, history at `Success`, and no
   `TemplatePatchFailed` event. Operator logs
   `Failed to restore template after safety revert`. Tracking stays;
-  the next reconcile retries. `attune_revert_failures_total` does not
-  increment.
+  the next reconcile retries when live resources match the applied
+  revert target. `attune_revert_failures_total` does not increment.
 
 ### Mid-rollout or no-op
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -28,7 +28,8 @@ Total number of resize reverts triggered by the safety monitor.
 
 Total number of failed resize revert attempts. A non-zero value means the
 operator tried to restore a pod's original resources but the `/resize`
-subresource call failed, leaving the pod running with post-resize resources
+subresource call failed (immediate apply-path revert or safety
+observation revert), leaving the pod running with post-resize resources
 that may be causing issues.
 
 A zero value does not mean a safety restore finished. Template restore

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -7308,6 +7308,158 @@ func TestCheckPendingSafetyObservations_RestoreRetryAfterRevertWhenPodNowSafe(t 
 		"safe-path restore retry must write the original 512Mi snapshot")
 }
 
+func TestCheckPendingSafetyObservations_RestoreRetryWhenLiveMatchesClampedRevert(t *testing.T) {
+	t.Parallel()
+
+	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	notRequiredMem := []corev1.ContainerResizePolicy{
+		{ResourceName: corev1.ResourceMemory, RestartPolicy: corev1.NotRequired},
+		{ResourceName: corev1.ResourceCPU, RestartPolicy: corev1.NotRequired},
+	}
+	// Rec / live after resize: higher memory limit than the original snapshot.
+	// RevertPod(allowInPlace=false) keeps this limit when policy is NotRequired.
+	postResize := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-retry-clamped-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "128Mi",
+				"attune.io/original-cpu-limit.main":      "1000m",
+				"attune.io/original-memory-limit.main":   "256Mi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:         "main",
+					Image:        "nginx",
+					Resources:    postResize,
+					ResizePolicy: notRequiredMem,
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase:    corev1.PodRunning,
+			QOSClass: corev1.PodQOSGuaranteed,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", RestartCount: 0},
+			},
+		},
+	}
+
+	deploy := recSizedAPIServerDeploy()
+	var failDeployPatch atomic.Bool
+	failDeployPatch.Store(true)
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(deploy, pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cw client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok && failDeployPatch.Load() {
+					return fmt.Errorf("simulated template patch failure")
+				}
+				return cw.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+	assert.True(t, pending, "failed template restore must keep observations pending")
+
+	var gotDeploy appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes := gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("256Mi")),
+		"template must stay at the recommended 256Mi after a failed restore")
+
+	var gotPod corev1.Pod
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "restore-retry-clamped-pod", Namespace: "default",
+	}, &gotPod))
+	_, hasTracking := gotPod.Annotations[annotationResizedAt]
+	assert.True(t, hasTracking, "tracking annotations must remain so the next reconcile retries restore")
+
+	// Revert already landed. Live memory limit stays at the post-resize
+	// value (ClampMemoryLimitForPolicy, allowInPlace=false). Guaranteed
+	// QoS raises the memory request to that clamped limit. CPU is original.
+	clampedRevert := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	gotPod.Spec.Containers[0].Resources = clampedRevert
+	gotPod.Spec.Containers[0].ResizePolicy = notRequiredMem
+	gotPod.Status.QOSClass = corev1.PodQOSGuaranteed
+	gotPod.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+	}
+	require.NoError(t, fakeClient.Update(context.Background(), &gotPod))
+
+	live, err := clientset.CoreV1().Pods("default").Get(context.Background(), "restore-retry-clamped-pod", metav1.GetOptions{})
+	require.NoError(t, err)
+	live.Spec.Containers[0].Resources = clampedRevert
+	live.Spec.Containers[0].ResizePolicy = notRequiredMem
+	live.Status.QOSClass = corev1.PodQOSGuaranteed
+	live.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+	}
+	_, err = clientset.CoreV1().Pods("default").Update(context.Background(), live, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	_, err = clientset.CoreV1().Pods("default").UpdateStatus(context.Background(), live, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	failDeployPatch.Store(false)
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes = gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("128Mi")),
+		"restore must write the original 128Mi request, not the raised revert request")
+	assert.True(t, gotRes.Limits.Memory().Equal(resource.MustParse("256Mi")),
+		"restore must write the original 256Mi limit, not the clamped live 512Mi")
+}
+
 func TestCheckPendingSafetyObservations_NotReadyFlapConfirmedBeforeRevert(t *testing.T) {
 	resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
 	listed := &corev1.Pod{

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -4393,10 +4393,12 @@ func TestCheckPendingSafetyObservations_ObservationElapsed(t *testing.T) {
 		Name: "test-pod", Namespace: "default",
 	}, &updated)
 	require.NoError(t, err)
-	_, hasResizedAt := updated.Annotations["attune.io/resized-at"]
+	_, hasResizedAt := updated.Annotations[annotationResizedAt]
 	assert.False(t, hasResizedAt, "resized-at annotation should be removed")
-	_, hasContainer := updated.Annotations["attune.io/resized-container"]
-	assert.False(t, hasContainer, "resized-container annotation should be removed")
+	_, hasContainers := updated.Annotations[annotationResizedContainers]
+	assert.False(t, hasContainers, "resized-containers annotation should be removed")
+	_, hasTracked := updated.Labels[labelTracked]
+	assert.False(t, hasTracked, "tracked label should be removed")
 }
 
 func TestCheckPendingSafetyObservations_CleanupPatchFailureKeepsPending(t *testing.T) {
@@ -7776,13 +7778,13 @@ func TestCheckPendingSafetyObservations_RestartCountParsed(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"attune.io/tracked": "true"},
 			Annotations: map[string]string{
-				"attune.io/resized-at":                   resizedAt,
-				"attune.io/resized-workload":             "api-server",
-				"attune.io/resized-containers":           "main",
-				"attune.io/original-cpu-request.main":    "500m",
-				"attune.io/original-memory-request.main": "512Mi",
-				"attune.io/original-restart-count":       "3",
-				"attune.io/policy":                       "test-policy",
+				"attune.io/resized-at":                        resizedAt,
+				"attune.io/resized-workload":                  "api-server",
+				"attune.io/resized-containers":                "main",
+				"attune.io/original-cpu-request.main":         "500m",
+				"attune.io/original-memory-request.main":      "512Mi",
+				annotationOriginalRestartCountPrefix + "main": "3",
+				"attune.io/policy":                            "test-policy",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -7817,6 +7819,14 @@ func TestCheckPendingSafetyObservations_RestartCountParsed(t *testing.T) {
 
 	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
 
+	var foundResize bool
+	for _, a := range reconciler.Clientset.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			foundResize = true
+		}
+	}
+	assert.False(t, foundResize, "safe restart count must not UpdateResize")
+
 	var updated corev1.Pod
 	err := fakeClient.Get(context.Background(), types.NamespacedName{
 		Name: "restart-pod", Namespace: "default",
@@ -7834,13 +7844,13 @@ func TestCheckPendingSafetyObservations_RestartCountExceeded(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"attune.io/tracked": "true"},
 			Annotations: map[string]string{
-				"attune.io/resized-at":                   resizedAt,
-				"attune.io/resized-workload":             "api-server",
-				"attune.io/resized-containers":           "main",
-				"attune.io/original-cpu-request.main":    "500m",
-				"attune.io/original-memory-request.main": "512Mi",
-				"attune.io/original-restart-count":       "3",
-				"attune.io/policy":                       "test-policy",
+				"attune.io/resized-at":                        resizedAt,
+				"attune.io/resized-workload":                  "api-server",
+				"attune.io/resized-containers":                "main",
+				"attune.io/original-cpu-request.main":         "500m",
+				"attune.io/original-memory-request.main":      "512Mi",
+				annotationOriginalRestartCountPrefix + "main": "3",
+				"attune.io/policy":                            "test-policy",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -7892,13 +7902,13 @@ func TestCheckPendingSafetyObservations_InvalidRestartCount(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"attune.io/tracked": "true"},
 			Annotations: map[string]string{
-				"attune.io/resized-at":                   resizedAt,
-				"attune.io/resized-workload":             "api-server",
-				"attune.io/resized-containers":           "main",
-				"attune.io/original-cpu-request.main":    "500m",
-				"attune.io/original-memory-request.main": "512Mi",
-				"attune.io/original-restart-count":       "not-a-number",
-				"attune.io/policy":                       "test-policy",
+				"attune.io/resized-at":                        resizedAt,
+				"attune.io/resized-workload":                  "api-server",
+				"attune.io/resized-containers":                "main",
+				"attune.io/original-cpu-request.main":         "500m",
+				"attune.io/original-memory-request.main":      "512Mi",
+				annotationOriginalRestartCountPrefix + "main": "not-a-number",
+				"attune.io/policy":                            "test-policy",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -7921,8 +7931,8 @@ func TestCheckPendingSafetyObservations_InvalidRestartCount(t *testing.T) {
 				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 			},
 			ContainerStatuses: []corev1.ContainerStatus{
-				// RestartCount 1 with baseline defaulting to 0 (parse failed):
-				// 1 < 0+2 = safe, annotations should be removed normally.
+				// Parse of original-restart-count.<container> fails; the
+				// observation skips this pod and keeps tracking annotations.
 				{Name: "main", RestartCount: 1},
 			},
 		},
@@ -7931,16 +7941,19 @@ func TestCheckPendingSafetyObservations_InvalidRestartCount(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	reconciler, fakeClient := newSafetyTestReconciler(pod)
 
+	before := promtestutil.ToFloat64(operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation"))
 	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+	after := promtestutil.ToFloat64(operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation"))
+	assert.Equal(t, before+1, after, "safety_observation should increment on restart-count parse error")
 
 	var updated corev1.Pod
 	err := fakeClient.Get(context.Background(), types.NamespacedName{
 		Name: "bad-annotation-pod", Namespace: "default",
 	}, &updated)
 	require.NoError(t, err)
-	// Invalid restart count should default to 0; pod with 1 restart is safe.
+	// Invalid restart count is a parse error; skip the pod and keep annotations.
 	_, hasResizedAt := updated.Annotations["attune.io/resized-at"]
-	assert.False(t, hasResizedAt, "pod should complete observation despite invalid restart count")
+	assert.True(t, hasResizedAt, "parse error must keep tracking annotations")
 }
 
 func TestCheckPendingSafetyObservations_ListErrorIncrementsCounter(t *testing.T) {
@@ -15683,7 +15696,33 @@ func TestCheckPendingSafetyObservations_AnnotationCleanupPatch(t *testing.T) {
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 
 	scheme := testScheme()
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod).Build()
+	var observing atomic.Bool
+	observing.Store(true)
+	var patchCalls atomic.Int32
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cw client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if p, ok := obj.(*corev1.Pod); ok && p.Name == pod.Name && p.Namespace == pod.Namespace {
+					require.Equal(t, types.MergePatchType, patch.Type(), "cleanup must use a merge patch")
+					patchCalls.Add(1)
+				}
+				return cw.Patch(ctx, obj, patch, opts...)
+			},
+			Get: func(ctx context.Context, cw client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Pod); ok && observing.Load() {
+					t.Errorf("cleanup must not Get the pod via the controller-runtime client")
+					return fmt.Errorf("unexpected Get on pod %s/%s", key.Namespace, key.Name)
+				}
+				return cw.Get(ctx, key, obj, opts...)
+			},
+			Update: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.UpdateOption) error {
+				if p, ok := obj.(*corev1.Pod); ok && observing.Load() {
+					t.Errorf("cleanup must not Update the pod via the controller-runtime client")
+					return fmt.Errorf("unexpected Update on pod %s/%s", p.Namespace, p.Name)
+				}
+				return fmt.Errorf("unexpected Update on %T", obj)
+			},
+		}).Build()
 	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
 
 	reconciler := NewAttunePolicyReconciler()
@@ -15696,7 +15735,9 @@ func TestCheckPendingSafetyObservations_AnnotationCleanupPatch(t *testing.T) {
 	policy.Spec.UpdateStrategy.SafetyObservationPeriod = &metav1.Duration{Duration: 5 * time.Minute}
 
 	pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, &mockCollector{}, []client.Object{deploy})
+	observing.Store(false)
 	assert.False(t, pending, "should not be pending after successful cleanup")
+	assert.Greater(t, patchCalls.Load(), int32(0), "cleanup must Patch the tracked pod")
 
 	var updated corev1.Pod
 	err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), &updated)
@@ -15713,10 +15754,6 @@ func TestCheckPendingSafetyObservations_AnnotationCleanupPatch(t *testing.T) {
 	assert.False(t, hasOrigMem)
 	_, hasTracked := updated.Labels[labelTracked]
 	assert.False(t, hasTracked, "tracked label should be removed after cleanup")
-
-	for _, a := range clientset.Actions() {
-		assert.NotEqual(t, "get", a.GetVerb(), "cleanup must not Get the pod")
-	}
 }
 
 // --- Issue #440: startup boost expiry memory regression test ---

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -306,6 +306,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 							confirmed, confirmErr := r.confirmCriticalStatuses(ctx, pod, record)
 							if confirmErr != nil {
 								logger.Error(confirmErr, "Early critical confirm Get failed", "pod", pod.Name)
+								operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
 								continue
 							}
 							if confirmed == nil {
@@ -428,11 +429,13 @@ func (r *AttunePolicyReconciler) revertAndRestoreAfterSafety(
 	logger := log.FromContext(ctx)
 	if err := revertFn(record); err != nil {
 		logger.Error(err, revertFailMsg, "pod", pod.Name)
+		operatormetrics.RevertFailuresTotal.WithLabelValues(pod.Namespace, trackedWorkload, reason).Inc()
 		return err
 	}
 	if err := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); err != nil {
 		logger.Error(err, "Failed to restore template after safety revert",
 			"pod", pod.Name, "workload", record.WorkloadName, "container", record.Container)
+		operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
 		return err
 	}
 	operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, reason).Inc()
@@ -445,9 +448,10 @@ func (r *AttunePolicyReconciler) revertAndRestoreAfterSafety(
 }
 
 // retryTemplateRestoreIfAlreadyReverted restores an AfterSuccessfulResize
-// template when the live pod is already back at OriginalResources (revert
-// landed, observation later reports Safe). Returns a non-nil error when
-// tracking must stay so the next reconcile retries.
+// template when the live pod already matches the applied revert target
+// (RevertPod clamps memory limits and may raise Guaranteed requests).
+// Restore still writes record.OriginalResources. Returns a non-nil error
+// when tracking must stay so the next reconcile retries.
 func (r *AttunePolicyReconciler) retryTemplateRestoreIfAlreadyReverted(
 	ctx context.Context,
 	policy *attunev1alpha1.AttunePolicy,
@@ -483,7 +487,8 @@ func (r *AttunePolicyReconciler) retryTemplateRestoreIfAlreadyReverted(
 }
 
 // liveContainerMatchesOriginal reports whether the named container's live
-// CPU and memory requests and limits equal the pre-resize snapshot.
+// CPU and memory match the applied revert target (clamp + Guaranteed raise),
+// not the raw original snapshot.
 func liveContainerMatchesOriginal(pod *corev1.Pod, record safety.ResizeRecord) bool {
 	if pod == nil {
 		return false
@@ -492,26 +497,15 @@ func liveContainerMatchesOriginal(pod *corev1.Pod, record safety.ResizeRecord) b
 	if c == nil {
 		return false
 	}
-	return cpuMemQuantityEqual(c.Resources, record.OriginalResources)
+	return resourcesEqual(c.Resources, appliedRevertTarget(pod, record))
 }
 
-func cpuMemQuantityEqual(a, b corev1.ResourceRequirements) bool {
-	return quantityPtrEqual(a.Requests, b.Requests, corev1.ResourceCPU) &&
-		quantityPtrEqual(a.Requests, b.Requests, corev1.ResourceMemory) &&
-		quantityPtrEqual(a.Limits, b.Limits, corev1.ResourceCPU) &&
-		quantityPtrEqual(a.Limits, b.Limits, corev1.ResourceMemory)
-}
-
-func quantityPtrEqual(a, b corev1.ResourceList, name corev1.ResourceName) bool {
-	qa, oka := a[name]
-	qb, okb := b[name]
-	if !oka && !okb {
-		return true
-	}
-	if !oka || !okb {
-		return false
-	}
-	return qa.Equal(qb)
+// appliedRevertTarget is the resource set RevertPod writes after
+// ClampMemoryLimitForPolicy(allowInPlace=false) and the Guaranteed
+// memory request raise.
+func appliedRevertTarget(pod *corev1.Pod, record safety.ResizeRecord) corev1.ResourceRequirements {
+	target := resize.ClampMemoryLimitForPolicy(pod, record.Container, record.OriginalResources, false)
+	return resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
 }
 
 // confirmSafetyVerdict re-Gets the pod and re-evaluates before revert so a


### PR DESCRIPTION
Safety observation restore retry compared live resources to the raw
original snapshot. RevertPod clamps memory limits and may raise the
Guaranteed request, so a successful revert never matched. Tracking
was stripped and the template stayed at the persisted rec.

## Changes

- Compare live resources to the applied RevertPod target (clamp plus
  Guaranteed raise). Template restore still writes the raw original.
- Increment `attune_revert_failures_total` when observation revert
  fails, and `attune_reconcile_errors_total{safety_observation}` on
  restore fail and early confirm Get fail.
- Restart-count tests use `original-restart-count.<container>`.
  Invalid parse keeps tracking. Cleanup asserts a merge patch on the
  controller-runtime client. Elapsed cleanup asserts
  `resized-containers`.
- Docs: revert-failure counter includes observation `/resize` revert.
  Restore retry matches the applied revert target.

## Validation

- `go test ./internal/controller/ -race -count=1` (1089 passed)
- Red-green: `RestoreRetryWhenLiveMatchesClampedRevert` failed when
  match used raw original (template stayed 256Mi), then passed
- `make verify-quick`

Release PR #670 stays user-gated.
