### PR TITLE
fix: preserve extended resources and cut steady-state live gets

### DIFF
--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -216,7 +216,7 @@ type AttunePolicyReconciler struct {
 
 	// evictionLocks serializes last-replica List+Evict per workload so two
 	// concurrent resize goroutines cannot both observe running==2 and evict.
-	// Key is namespace+"/"+workloadName. Zero value is an empty sync.Map.
+	// Key is namespace+"/"+workloadName. Entries are deleted on release.
 	evictionLocks sync.Map // map[string]*sync.Mutex
 
 	// nodeNeighborFlight single-flights the live node pod List used for

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10723,6 +10723,175 @@ func TestExecuteResizes_BudgetUsesGuaranteedRaisedTarget(t *testing.T) {
 	assert.Equal(t, 0, count, "budget must see the Guaranteed-raised request, not the raw rec request")
 }
 
+func TestExecuteResizes_AlreadyAtTargetSkipsLiveGet(t *testing.T) {
+	// Converged two-container pod: listed snapshot already matches the
+	// applied target, so executeResizes must not live-Get.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "api-server-abc-1", Namespace: "default",
+			Labels: map[string]string{"app": "api-server"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "nginx", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}},
+				{Name: "sidecar", Image: "envoy", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+				}},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", Ready: true},
+				{Name: "sidecar", Ready: true},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recommendations := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api-server",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{
+			{
+				Name: "main",
+				Current: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("200m"), MemoryRequest: resource.MustParse("256Mi"),
+				},
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("200m"), MemoryRequest: resource.MustParse("256Mi"),
+				},
+			},
+			{
+				Name: "sidecar",
+				Current: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("50m"), MemoryRequest: resource.MustParse("32Mi"),
+				},
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("50m"), MemoryRequest: resource.MustParse("32Mi"),
+				},
+			},
+		},
+	}}
+
+	count, _ := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recommendations, map[string][]corev1.Pod{"api-server": {*pod}}, nil, nil)
+	assert.Equal(t, 0, count)
+
+	gets := 0
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "get" && a.GetResource().Resource == "pods" {
+			gets++
+		}
+	}
+	assert.Equal(t, 0, gets, "listed already at target must skip the live pod Get")
+}
+
+func TestExecuteResizes_MultiContainerStillResizesBoth(t *testing.T) {
+	// Two containers that both need work still both reach UpdateResize
+	// after the per-pod live Get hoist. Get-count is covered by
+	// TestExecuteResizes_AlreadyAtTargetSkipsLiveGet.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "api-server-abc-1", Namespace: "default",
+			Labels: map[string]string{"app": "api-server"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "nginx", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}},
+				{Name: "sidecar", Image: "envoy", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+				}},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", Ready: true},
+				{Name: "sidecar", Ready: true},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recommendations := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api-server",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{
+			{
+				Name: "main",
+				Current: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("500m"), MemoryRequest: resource.MustParse("256Mi"),
+				},
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("250m"), MemoryRequest: resource.MustParse("128Mi"),
+				},
+			},
+			{
+				Name: "sidecar",
+				Current: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("100m"), MemoryRequest: resource.MustParse("64Mi"),
+				},
+				Recommended: attunev1alpha1.ResourceValues{
+					CPURequest: resource.MustParse("50m"), MemoryRequest: resource.MustParse("32Mi"),
+				},
+			},
+		},
+	}}
+
+	count, _ := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recommendations, map[string][]corev1.Pod{"api-server": {*pod}}, nil, nil)
+	assert.Equal(t, 1, count)
+
+	updates := 0
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			updates++
+		}
+	}
+	assert.GreaterOrEqual(t, updates, 2, "both containers should reach UpdateResize")
+}
+
 func TestExecuteResizes_BudgetCapsSkipDoesNotConsumeBudget(t *testing.T) {
 	pod1 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
 	pod1.Name = "api-server-abc-1"

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -11239,6 +11239,234 @@ func TestExecuteResizes_EvictionBlockedKeepsPriorInPlaceSuccess(t *testing.T) {
 	assert.True(t, sidecarBlocked, "history should record eviction_last_replica for sidecar")
 }
 
+func TestExecuteResizes_EvictionBlockedStillResizesSiblingInPlace(t *testing.T) {
+	// First container's in-place resize fails and last-replica blocks
+	// eviction. The sibling must still get an in-place attempt.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "api-server-abc-1", Namespace: "default",
+			Labels: map[string]string{"app": "api-server"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "nginx", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}},
+				{Name: "sidecar", Image: "envoy", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+				}},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", Ready: true, RestartCount: 0},
+				{Name: "sidecar", Ready: true, RestartCount: 0},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	deploy.Spec.Replicas = int32Ptr(1)
+	deploy.Status.Replicas = 1
+	deploy.Status.UpdatedReplicas = 1
+	deploy.Status.AvailableReplicas = 1
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+
+	var resizeAttempts atomic.Int32
+	clientset.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "resize" {
+			return false, nil, nil
+		}
+		if resizeAttempts.Add(1) == 1 {
+			return true, nil, fmt.Errorf("in-place resize rejected for first container")
+		}
+		return false, nil, nil
+	})
+
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
+
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "api-server",
+			Kind:     "Deployment",
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name: "main",
+					Current: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("500m"), MemoryRequest: resource.MustParse("256Mi"),
+					},
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("250m"), MemoryRequest: resource.MustParse("128Mi"),
+					},
+				},
+				{
+					Name: "sidecar",
+					Current: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("100m"), MemoryRequest: resource.MustParse("64Mi"),
+					},
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("50m"), MemoryRequest: resource.MustParse("32Mi"),
+					},
+				},
+			},
+		},
+	}
+
+	_, history := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy}, recommendations,
+		map[string][]corev1.Pod{"api-server": {*pod}}, nil, nil)
+
+	mainBlocked := false
+	sidecarSuccess := false
+	for _, h := range history {
+		if h.Container == "main" && h.Reason == reasonEvictionLastReplica {
+			mainBlocked = true
+		}
+		if h.Container == "sidecar" && h.Method == resize.MethodInPlace && h.Result == attunev1alpha1.ResizeResultSuccess {
+			sidecarSuccess = true
+		}
+	}
+	assert.True(t, mainBlocked, "main should record last-replica eviction block")
+	assert.True(t, sidecarSuccess, "sidecar must still resize in place after sibling eviction block")
+	assert.GreaterOrEqual(t, resizeAttempts.Load(), int32(2), "sidecar must reach UpdateResize")
+}
+
+func TestExecuteResizes_EvictionBlockedDoesNotRepeatList(t *testing.T) {
+	// Both containers fail in-place. Eviction is last-replica blocked.
+	// The second container must still be attempted in-place, but List+Evict
+	// must run only once for the pod.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "api-server-abc-1", Namespace: "default",
+			Labels: map[string]string{"app": "api-server"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "nginx", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}},
+				{Name: "sidecar", Image: "envoy", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+				}},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", Ready: true, RestartCount: 0},
+				{Name: "sidecar", Ready: true, RestartCount: 0},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	deploy.Spec.Replicas = int32Ptr(1)
+	deploy.Status.Replicas = 1
+	deploy.Status.UpdatedReplicas = 1
+	deploy.Status.AvailableReplicas = 1
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod).Build()
+	clientset := kubefake.NewSimpleClientset(pod.DeepCopy())
+	clientset.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "resize" {
+			return false, nil, nil
+		}
+		return true, nil, fmt.Errorf("in-place resize rejected")
+	})
+
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.ResizeMethod = attunev1alpha1.ResizeMethodInPlaceOrRecreate
+
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "api-server",
+			Kind:     "Deployment",
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name: "main",
+					Current: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("500m"), MemoryRequest: resource.MustParse("256Mi"),
+					},
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("250m"), MemoryRequest: resource.MustParse("128Mi"),
+					},
+				},
+				{
+					Name: "sidecar",
+					Current: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("100m"), MemoryRequest: resource.MustParse("64Mi"),
+					},
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("50m"), MemoryRequest: resource.MustParse("32Mi"),
+					},
+				},
+			},
+		},
+	}
+
+	evictionBefore := promtestutil.ToFloat64(operatormetrics.EvictionTotal.WithLabelValues("default", "api-server", "last_replica"))
+	_, history := reconciler.executeResizes(context.Background(), policy,
+		[]client.Object{deploy}, recommendations,
+		map[string][]corev1.Pod{"api-server": {*pod}}, nil, nil)
+
+	lists := 0
+	for _, a := range clientset.Actions() {
+		if a.GetVerb() == "list" && a.GetResource().Resource == "pods" {
+			lists++
+		}
+	}
+	assert.Equal(t, 1, lists, "eviction last-replica List must run once per pod, not once per container")
+	assert.Equal(t, evictionBefore+1, promtestutil.ToFloat64(operatormetrics.EvictionTotal.WithLabelValues("default", "api-server", "last_replica")),
+		"last_replica eviction metric must increment once")
+
+	sawMain := false
+	sawSidecar := false
+	for _, h := range history {
+		if h.Container == "main" && h.Reason == reasonEvictionLastReplica {
+			sawMain = true
+		}
+		if h.Container == "sidecar" {
+			sawSidecar = true
+		}
+	}
+	assert.True(t, sawMain, "main must record last-replica block")
+	assert.True(t, sawSidecar, "sidecar must still be processed after the eviction block")
+}
+
 func TestExecuteResizes_MultiContainer_BudgetExhaustion(t *testing.T) {
 	// A pod with two containers where the CPU budget is exhausted after the
 	// first container resize. The second container should be skipped (budget

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10700,6 +10700,29 @@ func TestExecuteResizes_BudgetCapsClampedTargetUsesAppliedIncrease(t *testing.T)
 	assert.Equal(t, 1, count, "budget should use the clamped applied increase, not the raw recommendation delta")
 }
 
+func TestExecuteResizes_BudgetUsesGuaranteedRaisedTarget(t *testing.T) {
+	// Guaranteed 256Mi/256Mi. Rec is 300Mi request / 400Mi limit.
+	// applyLiveResizeTarget raises the request to 400Mi. Budget 64Mi sits
+	// between the raw request delta (44Mi) and the applied delta (144Mi).
+	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod.Status.QOSClass = corev1.PodQOSGuaranteed
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	reconciler, _ := newResizeReconciler(pod, deploy)
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	memBudget := resource.MustParse("64Mi")
+	policy.Spec.UpdateStrategy.MaxTotalMemoryIncrease = &memBudget
+
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("api-server", "200m", "256Mi", "200m", "256Mi", "200m", "300Mi", "200m", "400Mi"),
+	}
+
+	count, _ := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recommendations, podMap("api-server", pod), nil, nil)
+	assert.Equal(t, 0, count, "budget must see the Guaranteed-raised request, not the raw rec request")
+}
+
 func TestExecuteResizes_BudgetCapsSkipDoesNotConsumeBudget(t *testing.T) {
 	pod1 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
 	pod1.Name = "api-server-abc-1"

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -121,6 +121,30 @@ func TestFirstOneShotPodNeedingResize_AllAtTarget(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestFirstOneShotPodNeedingResize_AllAtTargetSkipsLiveGet(t *testing.T) {
+	pods := []corev1.Pod{
+		oneshotResizePod("pod-0", "200m", "256Mi"),
+		oneshotResizePod("pod-1", "200m", "256Mi"),
+		oneshotResizePod("pod-2", "200m", "256Mi"),
+	}
+	rec := newResizeRecommendation("api", "500m", "512Mi", "0", "0", "200m", "256Mi", "0", "0")
+
+	r := newReconcilerWithClient()
+	cs := kubefake.NewSimpleClientset(pods[0].DeepCopy(), pods[1].DeepCopy(), pods[2].DeepCopy())
+	r.Clientset = cs
+
+	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec, nil)
+	assert.Empty(t, got)
+
+	gets := 0
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "get" && a.GetResource().Resource == "pods" {
+			gets++
+		}
+	}
+	assert.Equal(t, 0, gets, "converged OneShot must not live-Get replicas already at target")
+}
+
 func oneshotResizePodWithLimits(name, cpuReq, memReq, cpuLim, memLim string) corev1.Pod {
 	pod := oneshotResizePod(name, cpuReq, memReq)
 	pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -472,6 +472,7 @@ func (r *AttunePolicyReconciler) executeResizes(
 				var podHistory []attunev1alpha1.ResizeHistoryEntry
 				var podReservedCPU, podReservedMem int64
 				podResized := false
+				skipEviction := false
 
 				// Containers within the same pod must resize sequentially.
 				// Each UpdateResize bumps resourceVersion; using a stale copy
@@ -514,6 +515,7 @@ func (r *AttunePolicyReconciler) executeResizes(
 						Monitor:      monitor,
 						Now:          now,
 						Checks:       checks,
+						SkipEviction: skipEviction,
 					})
 					if outcome == resizeOutcomeNone {
 						podHistory = append(podHistory, entries...)
@@ -529,12 +531,14 @@ func (r *AttunePolicyReconciler) executeResizes(
 					}
 					if outcome == resizeOutcomeEvictionBlocked {
 						// Eviction was attempted and failed. Do not retry the
-						// same List+Evict for remaining containers on this pod.
+						// same List+Evict for remaining containers, but still
+						// let siblings take the in-place path.
 						// Leave podResized as-is so a prior in-place success
 						// still counts (unlike Evicted, which clears it).
 						refundBudget(cpuIncrease, memIncrease)
 						podHistory = append(podHistory, entries...)
-						break
+						skipEviction = true
+						continue
 					}
 					podHistory = append(podHistory, entries...)
 					podReservedCPU += cpuIncrease
@@ -579,6 +583,10 @@ type resizeParams struct {
 	Monitor      *safety.Monitor
 	Now          metav1.Time
 	Checks       *resizePreChecks
+	// SkipEviction is set after a sibling on this pod already failed
+	// eviction fallback, so later containers still try in-place but do
+	// not repeat List+Evict.
+	SkipEviction bool
 }
 
 // resizeOutcome tells executeResizes whether a container resize succeeded
@@ -725,7 +733,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 
 	// Pods already marked Infeasible cannot be resized in-place on the current node.
 	if resize.IsResizeInfeasible(pod) {
-		if policy.Spec.UpdateStrategy.ResizeMethod == attunev1alpha1.ResizeMethodInPlaceOrRecreate {
+		if policy.Spec.UpdateStrategy.ResizeMethod == attunev1alpha1.ResizeMethodInPlaceOrRecreate && !p.SkipEviction {
 			logger.Info("Pod resize is Infeasible, attempting eviction fallback",
 				"pod", pod.Name, "container", containerRec.Name)
 			evicted, reason := r.tryEvictionFallback(ctx, policy, pod, workload, workloadName, containerRec.Name, resizer)
@@ -740,6 +748,13 @@ func (r *AttunePolicyReconciler) resizeContainer(
 				Resource: "cpu+memory", Method: resize.MethodInPlace,
 				Result: attunev1alpha1.ResizeResultFailed, Reason: reason,
 			}}, resizeOutcomeEvictionBlocked
+		}
+		if p.SkipEviction {
+			return []attunev1alpha1.ResizeHistoryEntry{{
+				Timestamp: now, Workload: workloadName, Container: containerRec.Name,
+				Resource: "cpu+memory", Method: resize.MethodInPlace,
+				Result: attunev1alpha1.ResizeResultFailed, Reason: "infeasible",
+			}}, resizeOutcomeNone
 		}
 		logger.Info("Pod resize is Infeasible and resizeMethod is InPlaceOnly, skipping",
 			"pod", pod.Name, "container", containerRec.Name)
@@ -767,7 +782,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	results, err := resizer.ResizePod(ctx, pod, containerRec.Name, target)
 	if err != nil {
 		evictionFailReason := ""
-		if policy.Spec.UpdateStrategy.ResizeMethod == attunev1alpha1.ResizeMethodInPlaceOrRecreate {
+		if policy.Spec.UpdateStrategy.ResizeMethod == attunev1alpha1.ResizeMethodInPlaceOrRecreate && !p.SkipEviction {
 			evicted, reason := r.tryEvictionFallback(ctx, policy, pod, workload, workloadName, containerRec.Name, resizer)
 			if evicted {
 				return evictionHistory(), resizeOutcomeEvicted

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -88,6 +88,11 @@ func (r *AttunePolicyReconciler) firstOneShotPodNeedingResize(
 		if !resize.IsEligibleForResize(p) {
 			continue
 		}
+		// Screen the listed snapshot first so a converged OneShot
+		// fleet does not live-Get every replica every reconcile.
+		if r.oneShotPodAlreadyAtTarget(policy, p, rec) {
+			continue
+		}
 		// Live Get before Infeasible / shouldSkipResize, matching apply.
 		// Get errors fail closed: do not select the listed snapshot.
 		live, err := r.fetchLivePodForResize(ctx, p)
@@ -474,10 +479,31 @@ func (r *AttunePolicyReconciler) executeResizes(
 				podResized := false
 				skipEviction := false
 
+				// One live Get per pod, and only when the listed snapshot
+				// still differs from the applied target. A matching snapshot
+				// can skip the Get: the MemoryPressure hole is listed
+				// decrease vs live increase, which is listed != target.
+				if !r.oneShotPodAlreadyAtTarget(policy, &pod, rec) {
+					if live, err := r.fetchLivePodForResize(ctx, &pod); err != nil {
+						reason := "pod status unavailable; skipping resize"
+						for _, containerRec := range rec.Containers {
+							logger.Info("Skipping resize: "+reason,
+								"pod", pod.Name, "namespace", pod.Namespace,
+								"container", containerRec.Name, "error", err)
+							r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
+								"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
+							recordCapacitySkip(policy, reason)
+						}
+						return
+					} else if live != nil {
+						pod = *live
+					}
+				}
+
 				// Containers within the same pod must resize sequentially.
 				// Each UpdateResize bumps resourceVersion; using a stale copy
 				// for the next container causes a 409 Conflict.
-				for _, containerRec := range rec.Containers {
+				for i, containerRec := range rec.Containers {
 					target, clamped := buildResizeTarget(containerRec)
 					if len(clamped) > 0 {
 						logger.V(1).Info("Requests clamped to limits",
@@ -488,21 +514,8 @@ func (r *AttunePolicyReconciler) executeResizes(
 								policy.Namespace, policy.Name, containerRec.Name, res).Inc()
 						}
 					}
-					// Live Get + apply before reserve so the budget matches
-					// the target resizeContainer will send (clamp, floor,
-					// Guaranteed raise). Fail closed on Get error.
-					if live, err := r.fetchLivePodForResize(ctx, &pod); err != nil {
-						reason := "pod status unavailable; skipping resize"
-						logger.Info("Skipping resize: "+reason,
-							"pod", pod.Name, "namespace", pod.Namespace,
-							"container", containerRec.Name, "error", err)
-						r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
-							"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
-						recordCapacitySkip(policy, reason)
-						continue
-					} else if live != nil {
-						pod = *live
-					}
+					// Apply before reserve so the budget matches the target
+					// resizeContainer will send (clamp, floor, Guaranteed raise).
 					var applyMeta liveResizeApplyMeta
 					target, applyMeta = r.applyLiveResizeTarget(policy, &pod, containerRec, target)
 					r.emitLiveResizeApply(ctx, policy, &pod, containerRec, applyMeta)
@@ -563,9 +576,15 @@ func (r *AttunePolicyReconciler) executeResizes(
 					podReservedCPU += cpuIncrease
 					podReservedMem += memIncrease
 					podResized = true
-					// The pod variable is already updated by persistResizeAnnotations
-					// with a fresh resourceVersion and annotations, so no additional
-					// API Get is needed for the next container's UpdateResize call.
+					// persistResizeAnnotations refreshes RV and annotations.
+					// Re-Get so a kubelet Infeasible from this apply is
+					// visible to the next container. Skip on Get error:
+					// the persist copy is enough to continue.
+					if i < len(rec.Containers)-1 {
+						if live, err := r.fetchLivePodForResize(ctx, &pod); err == nil && live != nil {
+							pod = *live
+						}
+					}
 				}
 				if len(podHistory) > 0 {
 					historyMu.Lock()
@@ -606,8 +625,8 @@ type resizeParams struct {
 	// eviction fallback, so later containers still try in-place but do
 	// not repeat List+Evict.
 	SkipEviction bool
-	// LiveApplied means executeResizes already live-Got and ran
-	// applyLiveResizeTarget; Target is the applied value.
+	// LiveApplied means executeResizes already ran applyLiveResizeTarget
+	// (after at most one live Get for the pod). Target is the applied value.
 	LiveApplied bool
 }
 

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -488,6 +488,24 @@ func (r *AttunePolicyReconciler) executeResizes(
 								policy.Namespace, policy.Name, containerRec.Name, res).Inc()
 						}
 					}
+					// Live Get + apply before reserve so the budget matches
+					// the target resizeContainer will send (clamp, floor,
+					// Guaranteed raise). Fail closed on Get error.
+					if live, err := r.fetchLivePodForResize(ctx, &pod); err != nil {
+						reason := "pod status unavailable; skipping resize"
+						logger.Info("Skipping resize: "+reason,
+							"pod", pod.Name, "namespace", pod.Namespace,
+							"container", containerRec.Name, "error", err)
+						r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
+							"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
+						recordCapacitySkip(policy, reason)
+						continue
+					} else if live != nil {
+						pod = *live
+					}
+					var applyMeta liveResizeApplyMeta
+					target, applyMeta = r.applyLiveResizeTarget(policy, &pod, containerRec, target)
+					r.emitLiveResizeApply(ctx, policy, &pod, containerRec, applyMeta)
 					cpuIncrease, memIncrease := budgetIncrease(&pod, containerRec.Name, target)
 
 					// Reserve budget before resizing so concurrent goroutines cannot
@@ -516,6 +534,7 @@ func (r *AttunePolicyReconciler) executeResizes(
 						Now:          now,
 						Checks:       checks,
 						SkipEviction: skipEviction,
+						LiveApplied:  true,
 					})
 					if outcome == resizeOutcomeNone {
 						podHistory = append(podHistory, entries...)
@@ -587,6 +606,9 @@ type resizeParams struct {
 	// eviction fallback, so later containers still try in-place but do
 	// not repeat List+Evict.
 	SkipEviction bool
+	// LiveApplied means executeResizes already live-Got and ran
+	// applyLiveResizeTarget; Target is the applied value.
+	LiveApplied bool
 }
 
 // resizeOutcome tells executeResizes whether a container resize succeeded
@@ -615,28 +637,30 @@ func (r *AttunePolicyReconciler) resizeContainer(
 	containerRec, resizer, monitor, now := p.ContainerRec, p.Resizer, p.Monitor, p.Now
 	target := p.Target
 
-	// Live-Get before floor and pressure gates. The listed/informer pod can
-	// lag a prior in-place resize: a stale-low limit clips the usage floor
-	// below live usage; a stale-high request classifies a live increase as
-	// a decrease and skips MemoryPressure / unavailable / neighbor gates.
-	// Fail-closed on Get error: do not classify increase vs decrease
-	// against the listed snapshot (it may be stale-high).
-	if live, err := r.fetchLivePodForResize(ctx, pod); err != nil {
-		reason := "pod status unavailable; skipping resize"
-		logger.Info("Skipping resize: "+reason,
-			"pod", pod.Name, "namespace", pod.Namespace, "container", containerRec.Name, "error", err)
-		r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
-			"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
-		recordCapacitySkip(policy, reason)
-		return nil, resizeOutcomeNone
-	} else if live != nil {
-		pod = live
+	// Live-Get before floor and pressure gates unless executeResizes already
+	// applied the live target for budget accounting. The listed/informer pod
+	// can lag a prior in-place resize: a stale-low limit clips the usage
+	// floor below live usage; a stale-high request classifies a live
+	// increase as a decrease and skips MemoryPressure / unavailable /
+	// neighbor gates. Fail-closed on Get error.
+	var applyMeta liveResizeApplyMeta
+	if !p.LiveApplied {
+		if live, err := r.fetchLivePodForResize(ctx, pod); err != nil {
+			reason := "pod status unavailable; skipping resize"
+			logger.Info("Skipping resize: "+reason,
+				"pod", pod.Name, "namespace", pod.Namespace, "container", containerRec.Name, "error", err)
+			r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
+				"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
+			recordCapacitySkip(policy, reason)
+			return nil, resizeOutcomeNone
+		} else if live != nil {
+			pod = live
+		}
+		target, applyMeta = r.applyLiveResizeTarget(policy, pod, containerRec, target)
+		r.emitLiveResizeApply(ctx, policy, pod, containerRec, applyMeta)
+	} else {
+		applyMeta.PreClamped = *target.DeepCopy()
 	}
-
-	// Apply clamp + Guaranteed raise + usage floor before skip checks so
-	// shouldSkipResize sees the values that will be sent to the API server.
-	target, applyMeta := r.applyLiveResizeTarget(policy, pod, containerRec, target)
-	r.emitLiveResizeApply(ctx, policy, pod, containerRec, applyMeta)
 	preClamped := applyMeta.PreClamped
 
 	skip, reason := r.shouldSkipResize(ctx, pod, containerRec, target, p.Checks)

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -414,9 +414,11 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 	return observationsPending
 }
 
-// revertAndRestoreAfterSafety reverts the live pod, restores the workload
-// template, then records the revert metric, event, and history mark.
-// Callers keep path-specific continue / revertFailed handling.
+// revertAndRestoreAfterSafety reverts the live pod, records the revert
+// metric, event, and history mark, then restores the workload template.
+// The live revert is recorded even when template restore fails so the
+// consecutive-revert circuit breaker still trips. Callers keep
+// path-specific continue / revertFailed handling.
 func (r *AttunePolicyReconciler) revertAndRestoreAfterSafety(
 	ctx context.Context,
 	revertFn func(safety.ResizeRecord) error,
@@ -432,18 +434,18 @@ func (r *AttunePolicyReconciler) revertAndRestoreAfterSafety(
 		operatormetrics.RevertFailuresTotal.WithLabelValues(pod.Namespace, trackedWorkload, reason).Inc()
 		return err
 	}
-	if err := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); err != nil {
-		logger.Error(err, "Failed to restore template after safety revert",
-			"pod", pod.Name, "workload", record.WorkloadName, "container", record.Container)
-		operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
-		return err
-	}
 	operatormetrics.RevertsTotal.WithLabelValues(pod.Namespace, trackedWorkload, reason).Inc()
 	if r.Recorder != nil {
 		r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, string(attunev1alpha1.ResizeResultReverted), "revert",
 			eventFmt, pod.Name, record.Container, message)
 	}
 	markLatestCycleReverted(policy.Status.ResizeHistory, trackedWorkload, record.Container, reason)
+	if err := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); err != nil {
+		logger.Error(err, "Failed to restore template after safety revert",
+			"pod", pod.Name, "workload", record.WorkloadName, "container", record.Container)
+		operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
+		return err
+	}
 	return nil
 }
 

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -124,10 +124,8 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	// Serialize List + count + Evict per workload so two resize goroutines
 	// cannot both observe running==2 and take the Deployment to zero.
 	lockKey := pod.Namespace + "/" + workloadName
-	v, _ := r.evictionLocks.LoadOrStore(lockKey, &sync.Mutex{})
-	mu := v.(*sync.Mutex)
-	mu.Lock()
-	defer mu.Unlock()
+	mu := r.acquireEvictionLock(lockKey)
+	defer r.releaseEvictionLock(lockKey, mu)
 
 	running, err := r.countLiveRunningReplicas(ctx, pod.Namespace, selectorLabels)
 	if err != nil {
@@ -169,6 +167,26 @@ func (r *AttunePolicyReconciler) tryEvictionFallback(
 	logger.Info("Eviction fallback successful",
 		"pod", pod.Name, "workload", workloadName, "container", containerName)
 	return true, ""
+}
+
+// acquireEvictionLock returns the per-workload mutex and holds it. Release
+// with releaseEvictionLock so the map entry is removed when idle.
+func (r *AttunePolicyReconciler) acquireEvictionLock(key string) *sync.Mutex {
+	for {
+		v, _ := r.evictionLocks.LoadOrStore(key, &sync.Mutex{})
+		mu := v.(*sync.Mutex)
+		mu.Lock()
+		cur, ok := r.evictionLocks.Load(key)
+		if ok && cur == mu {
+			return mu
+		}
+		mu.Unlock()
+	}
+}
+
+func (r *AttunePolicyReconciler) releaseEvictionLock(key string, mu *sync.Mutex) {
+	r.evictionLocks.Delete(key)
+	mu.Unlock()
 }
 
 // countLiveRunningReplicas lists matching pods through the typed Clientset
@@ -338,6 +356,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 		}
 
 		var revertFailed, throttlePending bool
+		restoredThisPass := map[string]struct{}{}
 		for _, record := range records {
 			verdict, err := monitor.CheckPodObject(ctx, pod, record, r.now())
 			if err != nil {
@@ -377,6 +396,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 					revertFailed = true
 					continue
 				}
+				restoredThisPass[record.Container] = struct{}{}
 			}
 		}
 
@@ -393,10 +413,28 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 		// at OriginalResources while the AfterSuccessfulResize template is
 		// still the persisted rec. Restore only; do not revert again.
 		restoreFailed := false
-		for _, record := range records {
-			if err := r.retryTemplateRestoreIfAlreadyReverted(ctx, policy, workloads, pod, record); err != nil {
+		needRestoreRetry := templatePersistenceEnabled(policy.Spec.UpdateStrategy) &&
+			templatePersistenceWhen(policy.Spec.UpdateStrategy) == attunev1alpha1.TemplatePersistenceAfterSuccessfulResize
+		if needRestoreRetry {
+			live, liveErr := r.fetchLivePodForResize(ctx, pod)
+			if liveErr != nil {
+				logger.Error(liveErr, "Failed to fetch live pod for template restore retry",
+					"pod", pod.Name)
+				operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
 				restoreFailed = true
-				break
+			} else {
+				if live == nil {
+					live = pod
+				}
+				for _, record := range records {
+					if _, ok := restoredThisPass[record.Container]; ok {
+						continue
+					}
+					if err := r.retryTemplateRestoreIfAlreadyReverted(ctx, policy, workloads, live, record); err != nil {
+						restoreFailed = true
+						break
+					}
+				}
 			}
 		}
 		if restoreFailed {
@@ -452,6 +490,7 @@ func (r *AttunePolicyReconciler) revertAndRestoreAfterSafety(
 // retryTemplateRestoreIfAlreadyReverted restores an AfterSuccessfulResize
 // template when the live pod already matches the applied revert target
 // (RevertPod clamps memory limits and may raise Guaranteed requests).
+// listed must already be the live pod (caller Gets once per pod).
 // Restore still writes record.OriginalResources. Returns a non-nil error
 // when tracking must stay so the next reconcile retries.
 func (r *AttunePolicyReconciler) retryTemplateRestoreIfAlreadyReverted(
@@ -469,14 +508,7 @@ func (r *AttunePolicyReconciler) retryTemplateRestoreIfAlreadyReverted(
 	}
 
 	logger := log.FromContext(ctx)
-	live, err := r.fetchLivePodForResize(ctx, listed)
-	if err != nil {
-		logger.Error(err, "Failed to fetch live pod for template restore retry",
-			"pod", listed.Name, "container", record.Container)
-		operatormetrics.ReconcileErrorsTotal.WithLabelValues("safety_observation").Inc()
-		return err
-	}
-	if !liveContainerMatchesOriginal(live, record) {
+	if !liveContainerMatchesOriginal(listed, record) {
 		return nil
 	}
 	if err := r.restoreTemplateAfterSafetyRevert(ctx, policy, workloads, record); err != nil {

--- a/internal/controller/safety_test.go
+++ b/internal/controller/safety_test.go
@@ -18,21 +18,28 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+	"github.com/attune-io/attune/internal/operatormetrics"
 	"github.com/attune-io/attune/internal/safety"
 )
 
@@ -322,4 +329,58 @@ func TestRunImmediateSafetyCheck_NotReadyDoesNotRevert(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, reason, "transient not-ready must not trigger immediate revert")
 	assert.NotEqual(t, "notready", reason, "immediate check must not use full CheckPod")
+}
+
+func TestRevertAndRestoreAfterSafety_RecordsRevertWhenRestoreFails(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := persistAtRec64MiDeployment()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cw client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return fmt.Errorf("admission webhook denied template restore")
+			},
+		}).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{{
+		Timestamp: metav1.NewTime(time.Now()),
+		Workload:  "api",
+		Container: "app",
+		Resource:  "memory",
+		Result:    attunev1alpha1.ResizeResultSuccess,
+	}}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "api-abc", Namespace: "default"}}
+	reverted := false
+	before := promtestutil.ToFloat64(operatormetrics.RevertsTotal.WithLabelValues("default", "api", "oomkill"))
+
+	err := r.revertAndRestoreAfterSafety(
+		log.IntoContext(context.Background(), logr.Discard()),
+		func(safety.ResizeRecord) error {
+			reverted = true
+			return nil
+		},
+		policy, []client.Object{deploy}, original256MiRecord(), pod,
+		"api", "oomkill", "OOMKilled",
+		"Failed to revert pod during safety observation",
+		"Safety observation reverted resize on pod %s/%s: %s",
+	)
+	require.Error(t, err, "restore patch failure must still return an error")
+	assert.True(t, reverted, "live revert must run before restore")
+	assert.Equal(t, attunev1alpha1.ResizeResultReverted, policy.Status.ResizeHistory[0].Result,
+		"history must mark Reverted even when template restore fails")
+	assert.Equal(t, before+1, promtestutil.ToFloat64(operatormetrics.RevertsTotal.WithLabelValues("default", "api", "oomkill")),
+		"RevertsTotal must increment after a successful live revert")
 }

--- a/internal/controller/safety_test.go
+++ b/internal/controller/safety_test.go
@@ -384,3 +384,82 @@ func TestRevertAndRestoreAfterSafety_RecordsRevertWhenRestoreFails(t *testing.T)
 	assert.Equal(t, before+1, promtestutil.ToFloat64(operatormetrics.RevertsTotal.WithLabelValues("default", "api", "oomkill")),
 		"RevertsTotal must increment after a successful live revert")
 }
+
+func TestRetryTemplateRestoreIfAlreadyReverted_UsesCallerPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := persistAtRec64MiDeployment()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+	cs := kubefake.NewSimpleClientset()
+	cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("live Get must not run inside retry")
+	})
+	r.Clientset = cs
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+	record := original256MiRecord()
+	live := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "api-abc", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:      "app",
+				Resources: record.OriginalResources,
+			}},
+		},
+	}
+
+	err := r.retryTemplateRestoreIfAlreadyReverted(context.Background(), policy, []client.Object{deploy}, live, record)
+	require.NoError(t, err)
+
+	var got appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &got))
+	assert.True(t, got.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("256Mi")),
+		"restore must use the caller-supplied live pod, not a Clientset Get")
+}
+
+func TestAcquireReleaseEvictionLock_DeletesWhenIdle(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	key := "default/api"
+	mu := r.acquireEvictionLock(key)
+	_, ok := r.evictionLocks.Load(key)
+	assert.True(t, ok, "held lock must be in the map")
+	assert.False(t, mu.TryLock(), "acquired lock must be held")
+	r.releaseEvictionLock(key, mu)
+	_, ok = r.evictionLocks.Load(key)
+	assert.False(t, ok, "idle eviction lock must be removed")
+}
+
+func TestAcquireEvictionLock_SerializesSameKey(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	key := "default/api"
+	mu := r.acquireEvictionLock(key)
+	done := make(chan struct{})
+	go func() {
+		mu2 := r.acquireEvictionLock(key)
+		close(done)
+		r.releaseEvictionLock(key, mu2)
+	}()
+	select {
+	case <-done:
+		t.Fatal("second acquire must wait while the first holder is active")
+	case <-time.After(30 * time.Millisecond):
+	}
+	r.releaseEvictionLock(key, mu)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("second acquire must proceed after release")
+	}
+	_, ok := r.evictionLocks.Load(key)
+	assert.False(t, ok, "map must be empty after both holders release")
+}

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -386,9 +386,9 @@ func (r *AttunePolicyReconciler) applyTemplatePersistence(
 }
 
 // patchWorkloadTemplateResources updates container resources on the pod template.
-// When replace is true (safety restore), container resources are replaced with
-// the snapshot, including clearing limits persist added. Persist keeps merge.
-// Returns (changed, error).
+// When replace is true (safety restore), CPU/memory come from the snapshot and
+// omitted CPU/memory limit keys are deleted; other resource keys stay.
+// Persist keeps merge. Returns (changed, error).
 func (r *AttunePolicyReconciler) patchWorkloadTemplateResources(
 	ctx context.Context,
 	workload client.Object,
@@ -432,8 +432,8 @@ func (r *AttunePolicyReconciler) patchWorkloadTemplateResources(
 }
 
 // applyResourcesToPodSpec sets resources on matching containers and native sidecars.
-// replace=true writes want as-is (restore); replace=false merges (persist).
-// Returns true if any container was modified.
+// replace=true restores CPU/memory from want (extended keys stay);
+// replace=false merges (persist). Returns true if any container was modified.
 func applyResourcesToPodSpec(spec *corev1.PodSpec, desired map[string]corev1.ResourceRequirements, replace bool) bool {
 	modified := false
 	for i := range spec.Containers {
@@ -463,8 +463,9 @@ func applyResourcesToPodSpec(spec *corev1.PodSpec, desired map[string]corev1.Res
 }
 
 // applyContainerResources writes want onto a container. Persist merges so
-// RequestsOnly (Limits=nil) keeps leftover template limits. Restore replaces
-// so OriginalResources with empty Limits clears persist-added limits.
+// RequestsOnly (Limits=nil) keeps leftover template limits. Restore overwrites
+// CPU/memory from want and deletes only those CPU/memory limit keys that want
+// omits, so persist-added limits clear while extended resources stay.
 func applyContainerResources(c *corev1.Container, want corev1.ResourceRequirements, replace bool) bool {
 	var next corev1.ResourceRequirements
 	if !replace {
@@ -472,13 +473,47 @@ func applyContainerResources(c *corev1.Container, want corev1.ResourceRequiremen
 		// template limits as a change when requests already match.
 		next = mergeTemplateResources(c.Resources, want)
 	} else {
-		next = *want.DeepCopy()
+		next = replaceCPUMemoryResources(c.Resources, want)
 	}
 	if resourcesEqual(c.Resources, next) {
 		return false
 	}
 	c.Resources = next
 	return true
+}
+
+// replaceCPUMemoryResources copies current, then applies want's CPU and
+// memory requests/limits. Keys in want overwrite. CPU/memory keys absent
+// from want are deleted (clears persist-added limits). Every other resource
+// key (GPU, hugepages, ephemeral-storage) is left untouched.
+func replaceCPUMemoryResources(current, want corev1.ResourceRequirements) corev1.ResourceRequirements {
+	out := current.DeepCopy()
+	if out.Requests == nil {
+		out.Requests = corev1.ResourceList{}
+	}
+	for _, res := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if v, ok := want.Requests[res]; ok {
+			out.Requests[res] = v.DeepCopy()
+		} else {
+			delete(out.Requests, res)
+		}
+	}
+	if out.Limits == nil && len(want.Limits) > 0 {
+		out.Limits = corev1.ResourceList{}
+	}
+	if out.Limits != nil {
+		for _, res := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			if v, ok := want.Limits[res]; ok {
+				out.Limits[res] = v.DeepCopy()
+			} else {
+				delete(out.Limits, res)
+			}
+		}
+		if len(out.Limits) == 0 {
+			out.Limits = nil
+		}
+	}
+	return *out
 }
 
 // mergeTemplateResources applies want requests/limits onto current, keeping

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -321,6 +321,10 @@ func (r *AttunePolicyReconciler) applyTemplatePersistence(
 		}
 
 		// Build desired resources per container (skip excluded).
+		// Compare want to the cached template, not rec.Current: after
+		// in-place resize rec.Current can lag while the template is
+		// already at the rec (or still needs a usage-floor write).
+		cachedSpec := workloadPodSpec(w)
 		desired := make(map[string]corev1.ResourceRequirements)
 		for _, c := range rec.Containers {
 			if excludeSet[c.Name] {
@@ -333,6 +337,14 @@ func (r *AttunePolicyReconciler) applyTemplatePersistence(
 					"workload", rec.Workload, "container", c.Name,
 					"recommendedLimit", c.Recommended.MemoryLimit.String(),
 					"flooredLimit", recLim.String())
+			}
+			if cachedSpec != nil {
+				if cur, ok := templateContainerResources(cachedSpec, c.Name); ok {
+					next := mergeTemplateResources(cur, want)
+					if resourcesEqual(cur, next) {
+						continue
+					}
+				}
 			}
 			desired[c.Name] = want
 		}
@@ -535,6 +547,38 @@ func mergeTemplateResources(current, want corev1.ResourceRequirements) corev1.Re
 		}
 	}
 	return *out
+}
+
+func workloadPodSpec(w client.Object) *corev1.PodSpec {
+	switch o := w.(type) {
+	case *appsv1.Deployment:
+		return &o.Spec.Template.Spec
+	case *appsv1.StatefulSet:
+		return &o.Spec.Template.Spec
+	default:
+		return nil
+	}
+}
+
+func templateContainerResources(spec *corev1.PodSpec, name string) (corev1.ResourceRequirements, bool) {
+	if spec == nil {
+		return corev1.ResourceRequirements{}, false
+	}
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == name {
+			return spec.Containers[i].Resources, true
+		}
+	}
+	for i := range spec.InitContainers {
+		c := &spec.InitContainers[i]
+		if c.Name != name {
+			continue
+		}
+		if c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			return c.Resources, true
+		}
+	}
+	return corev1.ResourceRequirements{}, false
 }
 
 func workloadKindName(w client.Object) string {

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -1485,9 +1485,11 @@ func TestApplyTemplatePersistence_NoOpWhenTemplateMatches(t *testing.T) {
 		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
 	}
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	counter := &getCountingReader{Reader: cl}
 	r := NewAttunePolicyReconciler()
 	r.Client = cl
 	r.Scheme = scheme
+	r.APIReader = counter
 
 	policy := newTestPolicy("p", "default")
 	// Allow memory decrease so materialize keeps recommended 256Mi (matches template).
@@ -1517,6 +1519,17 @@ func TestApplyTemplatePersistence_NoOpWhenTemplateMatches(t *testing.T) {
 	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
 		attunev1alpha1.TemplatePersistenceOnRecommendation, nil)
 	assert.Empty(t, history, "template already matches desired; no history entry")
+	assert.Equal(t, 0, counter.n, "cached template match must skip the live workload Get")
+}
+
+type getCountingReader struct {
+	client.Reader
+	n int
+}
+
+func (g *getCountingReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	g.n++
+	return g.Reader.Get(ctx, key, obj, opts...)
 }
 
 func TestApplyTemplatePersistence_RequestsOnlyPreservesTemplateLimits(t *testing.T) {

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -1830,6 +1830,71 @@ func TestRestoreTemplateAfterSafetyRevert_ClearsPersistAddedLimits(t *testing.T)
 	assert.False(t, hasMemLimit, "restore must clear persist-added memory limit")
 }
 
+func TestRestoreTemplateAfterSafetyRevert_PreservesExtendedResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	gpu := corev1.ResourceName("nvidia.com/gpu")
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("200m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								gpu:                   resource.MustParse("1"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								gpu:                   resource.MustParse("1"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	err := r.restoreTemplateAfterSafetyRevert(context.Background(), policy, []client.Object{deploy}, original256MiRecord())
+	require.NoError(t, err)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	got := updated.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("256Mi")),
+		"template memory request must restore to the pre-resize snapshot")
+	reqGPU, hasGPUReq := got.Requests[gpu]
+	require.True(t, hasGPUReq, "restore must keep nvidia.com/gpu request")
+	assert.True(t, reqGPU.Equal(resource.MustParse("1")))
+	limGPU, hasGPULim := got.Limits[gpu]
+	require.True(t, hasGPULim, "restore must keep nvidia.com/gpu limit")
+	assert.True(t, limGPU.Equal(resource.MustParse("1")))
+	_, hasMemLimit := got.Limits[corev1.ResourceMemory]
+	assert.False(t, hasMemLimit, "restore must still clear persist-added memory limit")
+}
+
 func TestRestoreTemplateAfterSafetyRevert_DisabledNoOp(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, appsv1.AddToScheme(scheme))


### PR DESCRIPTION
Safety revert, sibling resize, budget accounting, and steady-state live Get fixes from the #690-#696 review.

Closes #690
Closes #691
Closes #692
Closes #693
Closes #694
Closes #695
Closes #696

Ref #697
Ref #698
Ref #699

## What changed

- Restore after safety revert overwrites only CPU/memory and deletes omitted CPU/memory limit keys, so persist-added limits clear while GPU, hugepages, and ephemeral-storage stay.
- Live revert is recorded (metric, event, history) even when template restore fails, so the consecutive-revert circuit breaker still trips.
- EvictionBlocked no longer `break`s the container loop. Siblings still try in-place; List+Evict is not repeated (`SkipEviction`).
- Per-cycle increase budget is reserved against the applied target (clamp, usage floor, Guaranteed request raise), not `buildResizeTarget` on the listed snapshot.
- Live pod Get is once per pod, and only when the listed snapshot still differs from the applied target. OneShot screens the listed replica first. Persist compares want to the cached template, not `rec.Current`.
- Restore-retry Gets the live pod once per observation when AfterSuccessfulResize is on, and skips the retry patch for containers already restored in this pass.
- `evictionLocks` deletes the map entry on release so preview-workload churn cannot grow it without bound.

## Tests

- Restore keeps `nvidia.com/gpu` (and other extended keys) while clearing persist-added CPU/memory limits.
- Revert metric and history mark increment when restore fails.
- Eviction-blocked sibling still resizes in-place; List+Evict runs once.
- Guaranteed raise above the raw rec request is charged to the budget cap.
- Converged two-container Auto, converged OneShot, and matching-template persist issue 0 live Gets.
- Restore retry uses the caller-supplied live pod (Clientset Get is not required).
- Eviction lock is removed when idle and serializes the same key.

## Not in this PR

#697 (plan/apply pipeline), #698 (rate-denominated budget), and #699 (golden/property tests) stay architecture/API/testing backlog.
