### PR TITLE
fix: share stale-current usage floor and revert raise

### DIFF
--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -119,14 +119,9 @@ func materializeContainerResources(
 			if policy.Spec.Memory.DecreaseUsageMarginPercent != nil {
 				margin = float64(*policy.Spec.Memory.DecreaseUsageMarginPercent)
 			}
-			// rec.Current may be the stale template; max with usageFloor so
-			// an increase vs Current still cannot land below usage.
-			currentLimit := c.Current.MemoryLimit.DeepCopy()
-			usageFloor := resize.MemoryUsageFloorQuantity(usage, margin)
-			if !usageFloor.IsZero() && usageFloor.Cmp(currentLimit) > 0 {
-				currentLimit = usageFloor
-			}
-			floored, applied := resize.FloorMemoryLimitForUsage(out, currentLimit, usage, margin)
+			// rec.Current may be the stale template after in-place resize.
+			floored, applied := resize.FloorMemoryLimitAgainstStaleCurrent(
+				out, c.Current.MemoryLimit, usage, margin)
 			if applied {
 				out = floored
 			}

--- a/internal/resize/usage_floor.go
+++ b/internal/resize/usage_floor.go
@@ -76,6 +76,22 @@ func FloorMemoryLimitForUsage(
 	return *adjusted, true
 }
 
+// FloorMemoryLimitAgainstStaleCurrent raises currentLimit to the usage
+// floor when usage exceeds the recorded current, then applies
+// FloorMemoryLimitForUsage. Persist and CREATE use this because
+// rec.Current can stay at the old template after an in-place resize.
+func FloorMemoryLimitAgainstStaleCurrent(
+	target corev1.ResourceRequirements,
+	currentLimit, recentUsage resource.Quantity,
+	marginPercent float64,
+) (corev1.ResourceRequirements, bool) {
+	usageFloor := MemoryUsageFloorQuantity(recentUsage, marginPercent)
+	if !usageFloor.IsZero() && usageFloor.Cmp(currentLimit) > 0 {
+		currentLimit = usageFloor
+	}
+	return FloorMemoryLimitForUsage(target, currentLimit, recentUsage, marginPercent)
+}
+
 // RaiseGuaranteedMemoryRequestToLimit sets memory request equal to memory
 // limit when the pod is Guaranteed and request is below the (possibly
 // floored) limit. No-op when target has no memory limit (RequestsOnly).

--- a/internal/resize/usage_floor_test.go
+++ b/internal/resize/usage_floor_test.go
@@ -220,3 +220,26 @@ func TestFloorMemoryLimitForUsage_NaNMargin(t *testing.T) {
 	// margin treated as 0 → limit strictly above usage
 	assert.Greater(t, got.Limits.Memory().Value(), usage.Value())
 }
+
+func TestFloorMemoryLimitAgainstStaleCurrent(t *testing.T) {
+	t.Parallel()
+	// Persist/CREATE see rec.Current as the old template (64Mi) after an
+	// in-place resize. Raw FloorMemoryLimitForUsage then no-ops because
+	// target 64Mi is not a decrease vs that stale current. Raising
+	// current to the usage floor first is what lets the floor apply.
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("64Mi")},
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("64Mi")},
+	}
+	staleCurrent := resource.MustParse("64Mi")
+	usage := resource.MustParse("300Mi")
+
+	raw, rawApplied := FloorMemoryLimitForUsage(target, staleCurrent, usage, 0)
+	assert.False(t, rawApplied, "raw floor must no-op when target equals stale current")
+	assert.True(t, raw.Limits.Memory().Equal(staleCurrent))
+
+	got, applied := FloorMemoryLimitAgainstStaleCurrent(target, staleCurrent, usage, 0)
+	require.True(t, applied, "stale-current helper must still floor above usage")
+	assert.Greater(t, got.Limits.Memory().Value(), usage.Value())
+	assert.Equal(t, usage.Value()+1, got.Limits.Memory().Value(), "margin 0 is usage+1 byte")
+}

--- a/internal/safety/monitor.go
+++ b/internal/safety/monitor.go
@@ -437,19 +437,15 @@ func (m *Monitor) RevertPod(ctx context.Context, record ResizeRecord) error {
 		// safer clamp path (same as pre-1.35). Controllers on 1.35+ that
 		// unclamp apply may still need clamp on revert if original is lower.
 		revertTarget := resize.ClampMemoryLimitForPolicy(pod, record.Container, record.OriginalResources, false)
-		// For Guaranteed QoS pods, the memory limit clamp may cause
-		// requests != limits, which K8s rejects ("Pod QOS Class may not
-		// change as a result of resizing"). Raise the memory request to
-		// match the clamped limit, mirroring the controller's resize path
-		// in internal/controller/resize.go.
-		if pod.Status.QOSClass == corev1.PodQOSGuaranteed {
-			if memLim, ok := revertTarget.Limits[corev1.ResourceMemory]; ok {
-				if memReq, rok := revertTarget.Requests[corev1.ResourceMemory]; rok && memReq.Cmp(memLim) < 0 {
-					revertTarget.Requests[corev1.ResourceMemory] = memLim.DeepCopy()
-					m.logger.Info("Memory request raised to match clamped limit for Guaranteed QoS revert",
-						"pod", record.PodName, "namespace", record.Namespace,
-						"container", record.Container, "request", memLim.String())
-				}
+		// Guaranteed raise after the 1.33 clamp, same helper as live apply
+		// and appliedRevertTarget so the three cannot drift.
+		beforeRaise := revertTarget.DeepCopy()
+		revertTarget = resize.RaiseGuaranteedMemoryRequestToLimit(pod, revertTarget)
+		if memReq, ok := revertTarget.Requests[corev1.ResourceMemory]; ok {
+			if was, wok := beforeRaise.Requests[corev1.ResourceMemory]; wok && !memReq.Equal(was) {
+				m.logger.Info("Memory request raised to match clamped limit for Guaranteed QoS revert",
+					"pod", record.PodName, "namespace", record.Namespace,
+					"container", record.Container, "request", memReq.String())
 			}
 		}
 		found := false

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -351,12 +351,8 @@ func applyCreateMemoryUsageFloor(
 			if policy != nil && policy.Spec.Memory.DecreaseUsageMarginPercent != nil {
 				margin = float64(*policy.Spec.Memory.DecreaseUsageMarginPercent)
 			}
-			currentLimit := cr.Current.MemoryLimit.DeepCopy()
-			usageFloor := resize.MemoryUsageFloorQuantity(usage, margin)
-			if !usageFloor.IsZero() && usageFloor.Cmp(currentLimit) > 0 {
-				currentLimit = usageFloor
-			}
-			if floored, applied := resize.FloorMemoryLimitForUsage(target, currentLimit, usage, margin); applied {
+			if floored, applied := resize.FloorMemoryLimitAgainstStaleCurrent(
+				target, cr.Current.MemoryLimit, usage, margin); applied {
 				target = floored
 			}
 		}


### PR DESCRIPTION
First slice of the #697 apply-pipeline unification.

Ref #697

## What changed

- Persist and CREATE initial sizing share `FloorMemoryLimitAgainstStaleCurrent`. After an in-place resize, `rec.Current` can stay at the old template; the helper raises that current to the usage floor before `FloorMemoryLimitForUsage`, so a recommended decrease still cannot land below usage.
- `RevertPod` uses `RaiseGuaranteedMemoryRequestToLimit` after the 1.33 clamp, matching `appliedRevertTarget`.

## Tests

- `TestFloorMemoryLimitAgainstStaleCurrent`: raw `FloorMemoryLimitForUsage` no-ops when target equals the stale current; the helper still floors above usage.

## Not in this PR

The rest of #697 (full `ResolveTarget`, plan/apply, in-band lifecycle) stays on the issue. #698 and #699 are separate.
