### PR TITLE
fix: resolve applied targets through one clamp-floor-raise path

### DIFF
--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -140,37 +140,38 @@ func (r *AttunePolicyReconciler) applyLiveResizeTarget(
 	containerRec attunev1alpha1.ContainerRecommendation,
 	target corev1.ResourceRequirements,
 ) (corev1.ResourceRequirements, liveResizeApplyMeta) {
-	meta := liveResizeApplyMeta{PreClamped: *target.DeepCopy()}
-	target = resize.ClampMemoryLimitForPolicy(pod, containerRec.Name, target, r.AllowInPlaceMemoryLimitDecrease)
-	if memLim, ok := meta.PreClamped.Limits[corev1.ResourceMemory]; ok {
-		if clampedLim, cok := target.Limits[corev1.ResourceMemory]; cok && !memLim.Equal(clampedLim) {
-			meta.PlatformClamped = true
-			meta.RequestedMemLimit = memLim
-			meta.ClampedMemLimit = clampedLim
-			if pod.Status.QOSClass == corev1.PodQOSGuaranteed {
-				if memReq, rok := target.Requests[corev1.ResourceMemory]; rok && memReq.Cmp(clampedLim) < 0 {
-					target.Requests[corev1.ResourceMemory] = clampedLim.DeepCopy()
-					meta.GuaranteedRequestRaised = true
-				}
-			}
-		}
+	usage, hasUsage := recentMemoryUsage(containerRec)
+	margin := float64(attunev1alpha1.DefaultDecreaseUsageMarginPercent)
+	if policy != nil && policy.Spec.Memory.DecreaseUsageMarginPercent != nil {
+		margin = float64(*policy.Spec.Memory.DecreaseUsageMarginPercent)
 	}
-	if !meta.PlatformClamped {
-		floored, applied, usage, margin := r.computeMemoryUsageFloor(policy, pod, containerRec, target)
-		if applied {
-			fromLim := target.Limits[corev1.ResourceMemory]
-			toLim := floored.Limits[corev1.ResourceMemory]
-			meta.FloorApplied = true
-			meta.FloorFromLimit = fromLim
-			meta.FloorToLimit = toLim
-			meta.FloorUsage = usage
-			meta.FloorMargin = margin
-			meta.FloorEqualsCurrent = toLim.Equal(liveContainerCurrent(pod, containerRec).MemoryLimit)
-			target = floored
-		}
-		target = resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
+	current := liveContainerCurrent(pod, containerRec).MemoryLimit
+	applied, resMeta := resize.ResolveAppliedTarget(resize.ResolveInput{
+		Target:                     target,
+		Pod:                        pod,
+		Container:                  containerRec.Name,
+		AllowInPlaceMemoryDecrease: r.AllowInPlaceMemoryLimitDecrease,
+		ApplyUsageFloor:            hasUsage,
+		CurrentMemoryLimit:         current,
+		RecentUsage:                usage,
+		UsageMarginPercent:         margin,
+	})
+	meta := liveResizeApplyMeta{
+		PreClamped:              resMeta.PreClamped,
+		PlatformClamped:         resMeta.PlatformClamped,
+		RequestedMemLimit:       resMeta.RequestedMemLimit,
+		ClampedMemLimit:         resMeta.ClampedMemLimit,
+		GuaranteedRequestRaised: resMeta.GuaranteedRequestRaised,
+		FloorApplied:            resMeta.FloorApplied,
+		FloorFromLimit:          resMeta.FloorFromLimit,
+		FloorToLimit:            resMeta.FloorToLimit,
+		FloorUsage:              usage,
+		FloorMargin:             margin,
 	}
-	return target, meta
+	if resMeta.FloorApplied {
+		meta.FloorEqualsCurrent = resMeta.FloorToLimit.Equal(current)
+	}
+	return applied, meta
 }
 
 // appliedResizeTarget is the clamp + Guaranteed QoS raise + usage floor that
@@ -1866,37 +1867,6 @@ func (r *AttunePolicyReconciler) emitLiveResizeApply(
 				policy.Namespace, policy.Name, "clamped_usage").Inc()
 		}
 	}
-}
-
-// computeMemoryUsageFloor raises a decreasing memory limit so it stays above
-// recent usage * (1 + margin/100). Silent: callers emit events from the result.
-func (r *AttunePolicyReconciler) computeMemoryUsageFloor(
-	policy *attunev1alpha1.AttunePolicy,
-	pod *corev1.Pod,
-	containerRec attunev1alpha1.ContainerRecommendation,
-	target corev1.ResourceRequirements,
-) (corev1.ResourceRequirements, bool, resource.Quantity, float64) {
-	targetLim, ok := target.Limits[corev1.ResourceMemory]
-	if !ok {
-		return target, false, resource.Quantity{}, 0
-	}
-	currentLim := liveContainerCurrent(pod, containerRec).MemoryLimit
-	if currentLim.IsZero() || targetLim.Cmp(currentLim) >= 0 {
-		return target, false, resource.Quantity{}, 0
-	}
-	usage, hasUsage := recentMemoryUsage(containerRec)
-	if !hasUsage {
-		return target, false, resource.Quantity{}, 0
-	}
-	margin := float64(attunev1alpha1.DefaultDecreaseUsageMarginPercent)
-	if policy != nil && policy.Spec.Memory.DecreaseUsageMarginPercent != nil {
-		margin = float64(*policy.Spec.Memory.DecreaseUsageMarginPercent)
-	}
-	floored, applied := resize.FloorMemoryLimitForUsage(target, currentLim, usage, margin)
-	if !applied {
-		return target, false, usage, margin
-	}
-	return floored, true, usage, margin
 }
 
 // recentMemoryUsage returns the raw usage percentile from the recommendation

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -538,8 +538,13 @@ func liveContainerMatchesOriginal(pod *corev1.Pod, record safety.ResizeRecord) b
 // ClampMemoryLimitForPolicy(allowInPlace=false) and the Guaranteed
 // memory request raise.
 func appliedRevertTarget(pod *corev1.Pod, record safety.ResizeRecord) corev1.ResourceRequirements {
-	target := resize.ClampMemoryLimitForPolicy(pod, record.Container, record.OriginalResources, false)
-	return resize.RaiseGuaranteedMemoryRequestToLimit(pod, target)
+	applied, _ := resize.ResolveAppliedTarget(resize.ResolveInput{
+		Target:                     record.OriginalResources,
+		Pod:                        pod,
+		Container:                  record.Container,
+		AllowInPlaceMemoryDecrease: false,
+	})
+	return applied
 }
 
 // confirmSafetyVerdict re-Gets the pod and re-evaluates before revert so a

--- a/internal/resize/resolve.go
+++ b/internal/resize/resolve.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resize
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// ResolveInput is the QoS source plus raw target for ResolveAppliedTarget.
+// Pod is required for clamp (resize policy + live limits) and live QoS.
+type ResolveInput struct {
+	Target                     corev1.ResourceRequirements
+	Pod                        *corev1.Pod
+	Container                  string
+	AllowInPlaceMemoryDecrease bool
+	// ApplyUsageFloor runs FloorMemoryLimitForUsage only when the
+	// platform clamp did not fire. Live apply sets this; revert does not.
+	ApplyUsageFloor    bool
+	CurrentMemoryLimit resource.Quantity
+	RecentUsage        resource.Quantity
+	UsageMarginPercent float64
+}
+
+// ResolveMeta is the clamp/floor/raise decision so callers can emit
+// events without re-deriving them.
+type ResolveMeta struct {
+	PreClamped              corev1.ResourceRequirements
+	PlatformClamped         bool
+	RequestedMemLimit       resource.Quantity
+	ClampedMemLimit         resource.Quantity
+	GuaranteedRequestRaised bool
+	FloorApplied            bool
+	FloorFromLimit          resource.Quantity
+	FloorToLimit            resource.Quantity
+}
+
+// ResolveAppliedTarget is clamp → (usage floor if not clamped) →
+// Guaranteed request raise. Live apply, OneShot compare, revert
+// compare, and RevertPod must share this so they cannot drift.
+func ResolveAppliedTarget(in ResolveInput) (corev1.ResourceRequirements, ResolveMeta) {
+	target := in.Target
+	meta := ResolveMeta{PreClamped: *target.DeepCopy()}
+	target = ClampMemoryLimitForPolicy(in.Pod, in.Container, target, in.AllowInPlaceMemoryDecrease)
+	if memLim, ok := meta.PreClamped.Limits[corev1.ResourceMemory]; ok {
+		if clampedLim, cok := target.Limits[corev1.ResourceMemory]; cok && !memLim.Equal(clampedLim) {
+			meta.PlatformClamped = true
+			meta.RequestedMemLimit = memLim
+			meta.ClampedMemLimit = clampedLim
+		}
+	}
+	if meta.PlatformClamped {
+		before := target.DeepCopy()
+		target = RaiseGuaranteedMemoryRequestToLimit(in.Pod, target)
+		meta.GuaranteedRequestRaised = memoryRequestRaised(before, &target)
+		return target, meta
+	}
+	if in.ApplyUsageFloor {
+		floored, applied := FloorMemoryLimitForUsage(target, in.CurrentMemoryLimit, in.RecentUsage, in.UsageMarginPercent)
+		if applied {
+			meta.FloorApplied = true
+			meta.FloorFromLimit = target.Limits[corev1.ResourceMemory]
+			meta.FloorToLimit = floored.Limits[corev1.ResourceMemory]
+			target = floored
+		}
+	}
+	target = RaiseGuaranteedMemoryRequestToLimit(in.Pod, target)
+	return target, meta
+}
+
+func memoryRequestRaised(before, after *corev1.ResourceRequirements) bool {
+	if before == nil || after == nil {
+		return false
+	}
+	got, ok := after.Requests[corev1.ResourceMemory]
+	if !ok {
+		return false
+	}
+	was, wok := before.Requests[corev1.ResourceMemory]
+	if !wok {
+		return true
+	}
+	return !got.Equal(was)
+}

--- a/internal/resize/resolve_test.go
+++ b/internal/resize/resolve_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func guaranteedMemPod(name, currentLim string) *corev1.Pod {
+	lim := resource.MustParse(currentLim)
+	return &corev1.Pod{
+		Status: corev1.PodStatus{QOSClass: corev1.PodQOSGuaranteed},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: name,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceMemory: lim.DeepCopy()},
+					Limits:   corev1.ResourceList{corev1.ResourceMemory: lim.DeepCopy()},
+				},
+			}},
+		},
+	}
+}
+
+func memPair(req, lim string) corev1.ResourceRequirements {
+	out := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(req)},
+	}
+	if lim != "" {
+		out.Limits = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(lim)}
+	}
+	return out
+}
+
+func TestResolveAppliedTarget_PlatformClampRaisesGuaranteed(t *testing.T) {
+	t.Parallel()
+	pod := guaranteedMemPod("app", "1Gi")
+	got, meta := ResolveAppliedTarget(ResolveInput{
+		Target:                     memPair("64Mi", "64Mi"),
+		Pod:                        pod,
+		Container:                  "app",
+		AllowInPlaceMemoryDecrease: false,
+		ApplyUsageFloor:            true,
+		CurrentMemoryLimit:         resource.MustParse("1Gi"),
+		RecentUsage:                resource.MustParse("300Mi"),
+	})
+	require.True(t, meta.PlatformClamped, "NotRequired must clamp 64Mi up to live 1Gi")
+	assert.False(t, meta.FloorApplied, "platform clamp skips the usage floor")
+	assert.True(t, meta.GuaranteedRequestRaised)
+	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("1Gi")), "got limit %s", got.Limits.Memory())
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("1Gi")), "got request %s", got.Requests.Memory())
+}
+
+func TestResolveAppliedTarget_UsageFloorThenGuaranteedRaise(t *testing.T) {
+	t.Parallel()
+	pod := guaranteedMemPod("app", "1Gi")
+	usage := resource.MustParse("300Mi")
+	got, meta := ResolveAppliedTarget(ResolveInput{
+		Target:                     memPair("64Mi", "64Mi"),
+		Pod:                        pod,
+		Container:                  "app",
+		AllowInPlaceMemoryDecrease: true,
+		ApplyUsageFloor:            true,
+		CurrentMemoryLimit:         resource.MustParse("1Gi"),
+		RecentUsage:                usage,
+		UsageMarginPercent:         0,
+	})
+	assert.False(t, meta.PlatformClamped)
+	require.True(t, meta.FloorApplied)
+	assert.Equal(t, usage.Value()+1, got.Limits.Memory().Value(), "margin 0 is usage+1")
+	assert.Equal(t, got.Limits.Memory().Value(), got.Requests.Memory().Value(),
+		"Guaranteed request must match the floored limit")
+}
+
+func TestResolveAppliedTarget_RevertSkipsFloor(t *testing.T) {
+	t.Parallel()
+	pod := guaranteedMemPod("app", "1Gi")
+	got, meta := ResolveAppliedTarget(ResolveInput{
+		Target:                     memPair("256Mi", "256Mi"),
+		Pod:                        pod,
+		Container:                  "app",
+		AllowInPlaceMemoryDecrease: false,
+	})
+	assert.True(t, meta.PlatformClamped, "revert still clamps a lower original limit")
+	assert.False(t, meta.FloorApplied)
+	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("1Gi")))
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("1Gi")))
+}
+
+func TestResolveAppliedTarget_RevertDoesNotFloorWhenClampIsOff(t *testing.T) {
+	t.Parallel()
+	// allowInPlace=true so clamp is a no-op. Usage would raise 256Mi if
+	// the floor ran. Revert must leave the original pair.
+	pod := guaranteedMemPod("app", "1Gi")
+	got, meta := ResolveAppliedTarget(ResolveInput{
+		Target:                     memPair("256Mi", "256Mi"),
+		Pod:                        pod,
+		Container:                  "app",
+		AllowInPlaceMemoryDecrease: true,
+		ApplyUsageFloor:            false,
+		CurrentMemoryLimit:         resource.MustParse("1Gi"),
+		RecentUsage:                resource.MustParse("400Mi"),
+		UsageMarginPercent:         0,
+	})
+	assert.False(t, meta.PlatformClamped)
+	assert.False(t, meta.FloorApplied)
+	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("256Mi")), "got limit %s", got.Limits.Memory())
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("256Mi")), "got request %s", got.Requests.Memory())
+}

--- a/internal/safety/monitor.go
+++ b/internal/safety/monitor.go
@@ -436,17 +436,18 @@ func (m *Monitor) RevertPod(ctx context.Context, record ResizeRecord) error {
 		// Monitor does not know cluster version; pass false to keep the
 		// safer clamp path (same as pre-1.35). Controllers on 1.35+ that
 		// unclamp apply may still need clamp on revert if original is lower.
-		revertTarget := resize.ClampMemoryLimitForPolicy(pod, record.Container, record.OriginalResources, false)
-		// Guaranteed raise after the 1.33 clamp, same helper as live apply
-		// and appliedRevertTarget so the three cannot drift.
-		beforeRaise := revertTarget.DeepCopy()
-		revertTarget = resize.RaiseGuaranteedMemoryRequestToLimit(pod, revertTarget)
-		if memReq, ok := revertTarget.Requests[corev1.ResourceMemory]; ok {
-			if was, wok := beforeRaise.Requests[corev1.ResourceMemory]; wok && !memReq.Equal(was) {
-				m.logger.Info("Memory request raised to match clamped limit for Guaranteed QoS revert",
-					"pod", record.PodName, "namespace", record.Namespace,
-					"container", record.Container, "request", memReq.String())
-			}
+		// Same clamp + Guaranteed raise as appliedRevertTarget / live apply.
+		// Reverts often lower memory; allowInPlace=false keeps the 1.33 clamp.
+		revertTarget, revertMeta := resize.ResolveAppliedTarget(resize.ResolveInput{
+			Target:                     record.OriginalResources,
+			Pod:                        pod,
+			Container:                  record.Container,
+			AllowInPlaceMemoryDecrease: false,
+		})
+		if revertMeta.GuaranteedRequestRaised {
+			m.logger.Info("Memory request raised to match clamped limit for Guaranteed QoS revert",
+				"pod", record.PodName, "namespace", record.Namespace,
+				"container", record.Container, "request", revertTarget.Requests.Memory().String())
 		}
 		found := false
 		for i, c := range updated.Spec.InitContainers {


### PR DESCRIPTION
Second slice of the #697 apply-pipeline unification.

Ref #697

## What changed

- New `resize.ResolveAppliedTarget`: clamp, then usage floor only if the platform clamp did not fire, then Guaranteed request raise.
- Live apply (`applyLiveResizeTarget`), revert compare (`appliedRevertTarget`), and `RevertPod` all call it.
- Platform clamp still skips the floor. Revert still does not floor.

## Tests

- Clamp on NotRequired raises Guaranteed request and does not floor.
- With in-place decrease allowed, usage floor then raises Guaranteed request.
- Revert-shaped input (no floor flag) leaves the original pair when clamp is off, even if usage is present.

## Not in this PR

Plan/apply and in-band lifecycle stay on #697. Persist/CREATE already share `FloorMemoryLimitAgainstStaleCurrent` from #701.
