### PR TITLE
fix: plan container resizes before claiming cycle budget

### DIFF
--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -501,37 +501,35 @@ func (r *AttunePolicyReconciler) executeResizes(
 					}
 				}
 
-				// Containers within the same pod must resize sequentially.
-				// Each UpdateResize bumps resourceVersion; using a stale copy
-				// for the next container causes a 409 Conflict.
-				for i, containerRec := range rec.Containers {
-					target, clamped := buildResizeTarget(containerRec)
-					if len(clamped) > 0 {
+				// Plan on the observed pod, then apply. Budget is claimed
+				// against the planned applied target, not recomputed later.
+				actions := r.planPodActions(policy, &pod, rec)
+				for i, action := range actions {
+					if len(action.Clamped) > 0 {
 						logger.V(1).Info("Requests clamped to limits",
-							"pod", pod.Name, "container", containerRec.Name,
-							"clampedResources", clamped)
-						for _, res := range clamped {
+							"pod", pod.Name, "container", action.Container,
+							"clampedResources", action.Clamped)
+						for _, res := range action.Clamped {
 							operatormetrics.RequestClampedTotal.WithLabelValues(
-								policy.Namespace, policy.Name, containerRec.Name, res).Inc()
+								policy.Namespace, policy.Name, action.Container, res).Inc()
 						}
 					}
-					// Apply before reserve so the budget matches the target
-					// resizeContainer will send (clamp, floor, Guaranteed raise).
-					var applyMeta liveResizeApplyMeta
-					target, applyMeta = r.applyLiveResizeTarget(policy, &pod, containerRec, target)
-					r.emitLiveResizeApply(ctx, policy, &pod, containerRec, applyMeta)
-					cpuIncrease, memIncrease := budgetIncrease(&pod, containerRec.Name, target)
+					r.emitLiveResizeApply(ctx, policy, &pod, action.ContainerRec, action.ApplyMeta)
+					if action.AtTarget {
+						continue
+					}
+					cpuIncrease, memIncrease := action.CPUIncrease, action.MemIncrease
 
 					// Reserve budget before resizing so concurrent goroutines cannot
 					// overspend the cap. Refund it below if the resize did not stick.
 					if !reserveBudget(cpuIncrease, memIncrease) {
 						logger.Info("Budget exhausted, deferring resize to next cycle",
-							"pod", pod.Name, "container", containerRec.Name)
+							"pod", pod.Name, "container", action.Container)
 						operatormetrics.BudgetExhaustedTotal.WithLabelValues(policy.Namespace, policy.Name).Inc()
 						if r.Recorder != nil {
 							r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, "BudgetExhausted", "resize",
 								"Resize deferred for pod %s container %s: per-cycle budget exhausted",
-								pod.Name, containerRec.Name)
+								pod.Name, action.Container)
 						}
 						continue
 					}
@@ -541,8 +539,8 @@ func (r *AttunePolicyReconciler) executeResizes(
 						Pod:          &pod,
 						Workload:     matchedWorkload,
 						WorkloadName: workloadName,
-						ContainerRec: containerRec,
-						Target:       target,
+						ContainerRec: action.ContainerRec,
+						Target:       action.Target,
 						Resizer:      resizer,
 						Monitor:      monitor,
 						Now:          now,
@@ -581,7 +579,7 @@ func (r *AttunePolicyReconciler) executeResizes(
 					// Re-Get so a kubelet Infeasible from this apply is
 					// visible to the next container. Skip on Get error:
 					// the persist copy is enough to continue.
-					if i < len(rec.Containers)-1 {
+					if i < len(actions)-1 {
 						if live, err := r.fetchLivePodForResize(ctx, &pod); err == nil && live != nil {
 							pod = *live
 						}

--- a/internal/controller/resize_plan.go
+++ b/internal/controller/resize_plan.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+)
+
+// resizeAction is one container apply computed from an observed pod.
+// Plan is pure: no client Get. Budget filter and execute consume this.
+type resizeAction struct {
+	Container    string
+	ContainerRec attunev1alpha1.ContainerRecommendation
+	Target       corev1.ResourceRequirements
+	ApplyMeta    liveResizeApplyMeta
+	Clamped      []string
+	CPUIncrease  int64
+	MemIncrease  int64
+	// AtTarget means the observed container already matches the applied
+	// target. Execute still emits clamp/floor, then skips reserve/apply.
+	AtTarget bool
+}
+
+// planPodActions builds the applied target for every recommended container
+// that still differs on the observed pod. I/O (live Get) belongs to the
+// caller so this stays table-testable.
+func (r *AttunePolicyReconciler) planPodActions(
+	policy *attunev1alpha1.AttunePolicy,
+	pod *corev1.Pod,
+	rec attunev1alpha1.WorkloadRecommendation,
+) []resizeAction {
+	if pod == nil {
+		return nil
+	}
+	var actions []resizeAction
+	for _, containerRec := range rec.Containers {
+		target, clamped := buildResizeTarget(containerRec)
+		target, applyMeta := r.applyLiveResizeTarget(policy, pod, containerRec, target)
+		c := findContainerByName(pod, containerRec.Name)
+		atTarget := c != nil && containerMatchesAppliedTarget(c, target)
+		cpuInc, memInc := int64(0), int64(0)
+		if !atTarget {
+			cpuInc, memInc = budgetIncrease(pod, containerRec.Name, target)
+		}
+		actions = append(actions, resizeAction{
+			Container:    containerRec.Name,
+			ContainerRec: containerRec,
+			Target:       target,
+			ApplyMeta:    applyMeta,
+			Clamped:      clamped,
+			CPUIncrease:  cpuInc,
+			MemIncrease:  memInc,
+			AtTarget:     atTarget,
+		})
+	}
+	return actions
+}
+
+// filterActionsByBudget keeps actions whose increases fit the remaining
+// cycle caps and defers the rest. A later cheaper action can still be
+// kept after an over-budget one (same as reserveBudget continue).
+// cpuBudget/memBudget of -1 means unlimited. Decreases (zero cost) always fit.
+func filterActionsByBudget(actions []resizeAction, cpuBudget, memBudget int64) (keep, deferred []resizeAction) {
+	for _, a := range actions {
+		exceeded := (cpuBudget >= 0 && a.CPUIncrease > cpuBudget) ||
+			(memBudget >= 0 && a.MemIncrease > memBudget)
+		if exceeded {
+			deferred = append(deferred, a)
+			continue
+		}
+		keep = append(keep, a)
+		if cpuBudget >= 0 {
+			cpuBudget -= a.CPUIncrease
+		}
+		if memBudget >= 0 {
+			memBudget -= a.MemIncrease
+		}
+	}
+	return keep, deferred
+}

--- a/internal/controller/resize_plan_test.go
+++ b/internal/controller/resize_plan_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+)
+
+func TestFilterActionsByBudget(t *testing.T) {
+	t.Parallel()
+	act := func(name string, cpu, mem int64) resizeAction {
+		return resizeAction{Container: name, CPUIncrease: cpu, MemIncrease: mem}
+	}
+	tests := []struct {
+		name      string
+		actions   []resizeAction
+		cpu, mem  int64
+		wantKeep  []string
+		wantDefer []string
+	}{
+		{
+			name:      "unlimited keeps all",
+			actions:   []resizeAction{act("a", 100, 0), act("b", 200, 0)},
+			cpu:       -1,
+			mem:       -1,
+			wantKeep:  []string{"a", "b"},
+			wantDefer: nil,
+		},
+		{
+			name:      "second increase exceeds remaining",
+			actions:   []resizeAction{act("a", 200, 0), act("b", 200, 0)},
+			cpu:       300,
+			mem:       -1,
+			wantKeep:  []string{"a"},
+			wantDefer: []string{"b"},
+		},
+		{
+			name:      "decrease is free and does not consume",
+			actions:   []resizeAction{act("down", 0, 0), act("up", 250, 0)},
+			cpu:       250,
+			mem:       -1,
+			wantKeep:  []string{"down", "up"},
+			wantDefer: nil,
+		},
+		{
+			name:      "exact budget keeps the last action",
+			actions:   []resizeAction{act("a", 100, 0), act("b", 200, 0)},
+			cpu:       300,
+			mem:       -1,
+			wantKeep:  []string{"a", "b"},
+			wantDefer: nil,
+		},
+		{
+			name:      "memory cap defers independently",
+			actions:   []resizeAction{act("a", 0, 100), act("b", 0, 100)},
+			cpu:       -1,
+			mem:       100,
+			wantKeep:  []string{"a"},
+			wantDefer: []string{"b"},
+		},
+		{
+			name:      "later cheaper action still kept",
+			actions:   []resizeAction{act("big", 200, 0), act("small", 50, 0)},
+			cpu:       100,
+			mem:       -1,
+			wantKeep:  []string{"small"},
+			wantDefer: []string{"big"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			keep, deferred := filterActionsByBudget(tc.actions, tc.cpu, tc.mem)
+			var gotKeep, gotDefer []string
+			for _, a := range keep {
+				gotKeep = append(gotKeep, a.Container)
+			}
+			for _, a := range deferred {
+				gotDefer = append(gotDefer, a.Container)
+			}
+			assert.Equal(t, tc.wantKeep, gotKeep)
+			assert.Equal(t, tc.wantDefer, gotDefer)
+		})
+	}
+}
+
+func TestPlanPodActions_UsesAppliedTargetAndSkipsAtTarget(t *testing.T) {
+	t.Parallel()
+	// Guaranteed 256Mi/256Mi. Rec 300Mi request / 400Mi limit is raised
+	// to 400/400. Listed already at 400/400 must produce no action.
+	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod.Status.QOSClass = corev1.PodQOSGuaranteed
+	pod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = resource.MustParse("256Mi")
+	r := NewAttunePolicyReconciler()
+	policy := newTestPolicy("p", "default")
+	rec := attunev1alpha1.WorkloadRecommendation{
+		Workload: "api-server",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "main",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("200m"), MemoryRequest: resource.MustParse("256Mi"),
+				CPULimit: resource.MustParse("200m"), MemoryLimit: resource.MustParse("256Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest: resource.MustParse("200m"), MemoryRequest: resource.MustParse("300Mi"),
+				CPULimit: resource.MustParse("200m"), MemoryLimit: resource.MustParse("400Mi"),
+			},
+		}},
+	}
+
+	actions := r.planPodActions(policy, pod, rec)
+	require.Len(t, actions, 1)
+	assert.False(t, actions[0].AtTarget)
+	assert.Equal(t, int64(400-256)<<20, actions[0].MemIncrease,
+		"plan cost must be the Guaranteed-raised delta, not the raw 44Mi rec")
+
+	pod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse("400Mi")
+	pod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = resource.MustParse("400Mi")
+	at := r.planPodActions(policy, pod, rec)
+	require.Len(t, at, 1)
+	assert.True(t, at[0].AtTarget)
+	assert.Equal(t, int64(0), at[0].MemIncrease)
+}


### PR DESCRIPTION
Third slice of the #697 apply-pipeline unification.

Ref #697

## What changed

- `planPodActions` builds a per-container plan from an observed pod: applied target (clamp, floor, Guaranteed raise), budget cost, and whether the container is already at that target.
- `filterActionsByBudget` is a pure filter over that plan (unlimited is -1; later cheaper actions can still fit after an over-budget one).
- `executeResizes` live-Gets, plans once, emits clamp/floor for every planned container, then reserves and applies only actions that still need work.

Reserve/refund stays for concurrent pods and apply failures. Cycle-wide serial plan is the next slice.

## Tests

- Filter table: unlimited, remaining cap, free decreases, exact budget, memory cap, later cheaper action kept.
- Plan cost is the Guaranteed-raised delta, not the raw rec. Already-at-target is marked, cost 0.

## Not in this PR

Plan/apply still does not drop reserve/refund. In-band lifecycle stays on #697. #698 and #699 are separate.
