### PR TITLE
fix: observe and plan selected pods before concurrent apply

### DIFF
--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -465,45 +465,39 @@ func (r *AttunePolicyReconciler) executeResizes(
 		}
 
 		var workloadResized int32 // atomic for concurrent access
+		var planned []plannedPod
 		for _, pod := range selectedPods {
-			// Capture loop variables for the goroutine.
-			pod, workloadName := pod, rec.Workload
+			item, err := r.observeAndPlanPod(ctx, policy, pod, rec, matchedWorkload)
+			if err != nil {
+				reason := "pod status unavailable; skipping resize"
+				for _, containerRec := range rec.Containers {
+					logger.Info("Skipping resize: "+reason,
+						"pod", pod.Name, "namespace", pod.Namespace,
+						"container", containerRec.Name, "error", err)
+					r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
+						"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
+					recordCapacitySkip(policy, reason)
+				}
+				continue
+			}
+			planned = append(planned, item)
+		}
 
+		for _, item := range planned {
+			item, workloadName := item, rec.Workload
 			wg.Add(1)
-			sem <- struct{}{} // acquire semaphore
+			sem <- struct{}{}
 			go func() {
 				defer wg.Done()
-				defer func() { <-sem }() // release semaphore
+				defer func() { <-sem }()
 
+				pod := item.Pod
+				actions := item.Actions
 				var podHistory []attunev1alpha1.ResizeHistoryEntry
 				var podReservedCPU, podReservedMem int64
 				podResized := false
 				skipEviction := false
 
-				// One live Get per pod, and only when the listed snapshot
-				// still differs from the applied target. A matching snapshot
-				// can skip the Get: the MemoryPressure hole is listed
-				// decrease vs live increase, which is listed != target.
-				if !r.oneShotPodAlreadyAtTarget(policy, &pod, rec) {
-					if live, err := r.fetchLivePodForResize(ctx, &pod); err != nil {
-						reason := "pod status unavailable; skipping resize"
-						for _, containerRec := range rec.Containers {
-							logger.Info("Skipping resize: "+reason,
-								"pod", pod.Name, "namespace", pod.Namespace,
-								"container", containerRec.Name, "error", err)
-							r.emitEventOnce(policy, corev1.EventTypeWarning, "ResizeSkipped", "resize",
-								"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
-							recordCapacitySkip(policy, reason)
-						}
-						return
-					} else if live != nil {
-						pod = *live
-					}
-				}
-
-				// Plan on the observed pod, then apply. Budget is claimed
-				// against the planned applied target, not recomputed later.
-				actions := r.planPodActions(policy, &pod, rec)
 				for i, action := range actions {
 					if len(action.Clamped) > 0 {
 						logger.V(1).Info("Requests clamped to limits",

--- a/internal/controller/resize_plan.go
+++ b/internal/controller/resize_plan.go
@@ -17,10 +17,22 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
+
+// plannedPod is one observed pod plus its container plan for this cycle.
+type plannedPod struct {
+	Pod      corev1.Pod
+	Rec      attunev1alpha1.WorkloadRecommendation
+	Workload client.Object
+	Name     string
+	Actions  []resizeAction
+}
 
 // resizeAction is one container apply computed from an observed pod.
 // Plan is pure: no client Get. Budget filter and execute consume this.
@@ -70,6 +82,30 @@ func (r *AttunePolicyReconciler) planPodActions(
 		})
 	}
 	return actions
+}
+
+// observeAndPlanPod live-Gets when the listed snapshot is not already at
+// the applied target, then plans container actions on that observation.
+func (r *AttunePolicyReconciler) observeAndPlanPod(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	pod corev1.Pod,
+	rec attunev1alpha1.WorkloadRecommendation,
+	workload client.Object,
+) (plannedPod, error) {
+	out := plannedPod{Rec: rec, Workload: workload, Name: rec.Workload}
+	if !r.oneShotPodAlreadyAtTarget(policy, &pod, rec) {
+		live, err := r.fetchLivePodForResize(ctx, &pod)
+		if err != nil {
+			return plannedPod{}, err
+		}
+		if live != nil {
+			pod = *live
+		}
+	}
+	out.Pod = pod
+	out.Actions = r.planPodActions(policy, &pod, rec)
+	return out, nil
 }
 
 // filterActionsByBudget keeps actions whose increases fit the remaining

--- a/internal/controller/resize_plan_test.go
+++ b/internal/controller/resize_plan_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
@@ -140,4 +145,40 @@ func TestPlanPodActions_UsesAppliedTargetAndSkipsAtTarget(t *testing.T) {
 	require.Len(t, at, 1)
 	assert.True(t, at[0].AtTarget)
 	assert.Equal(t, int64(0), at[0].MemIncrease)
+}
+
+func TestObserveAndPlanPod_SkipsLiveGetWhenListedAtTarget(t *testing.T) {
+	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	r, _ := newResizeReconciler(pod, deploy)
+	policy := newTestPolicy("p", "default")
+	rec := newResizeRecommendation("api-server", "200m", "256Mi", "0", "0", "200m", "256Mi", "0", "0")
+
+	got, err := r.observeAndPlanPod(context.Background(), policy, *pod, rec, deploy)
+	require.NoError(t, err)
+	require.Len(t, got.Actions, 1)
+	assert.True(t, got.Actions[0].AtTarget)
+
+	gets := 0
+	for _, a := range r.Clientset.(*kubefake.Clientset).Actions() {
+		if a.GetVerb() == "get" && a.GetResource().Resource == "pods" {
+			gets++
+		}
+	}
+	assert.Equal(t, 0, gets, "listed already at target must skip the live Get")
+}
+
+func TestObserveAndPlanPod_LiveGetError(t *testing.T) {
+	pod := newResizePod("api-server", "500m", "256Mi", "500m", "256Mi")
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	r, _ := newResizeReconciler(pod, deploy)
+	cs := r.Clientset.(*kubefake.Clientset)
+	cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("injected live Get 403")
+	})
+	policy := newTestPolicy("p", "default")
+	rec := newResizeRecommendation("api-server", "500m", "256Mi", "0", "0", "200m", "256Mi", "0", "0")
+
+	_, err := r.observeAndPlanPod(context.Background(), policy, *pod, rec, deploy)
+	require.Error(t, err)
 }


### PR DESCRIPTION
Fourth slice of the #697 apply-pipeline unification.

Ref #697

## What changed

- `observeAndPlanPod` live-Gets only when the listed snapshot is not already at the applied target, then plans container actions.
- `executeResizes` observes every selected pod first, then applies the planned set concurrently.
- A live Get error still skip-emits per container and does not enter apply.

Reserve/refund is unchanged. Cycle-wide budget-as-filter and in-band lifecycle stay on #697.

## Tests

- Listed already at target: 0 live Gets, action marked AtTarget.
- Live Get error: observe returns error (caller skips apply).
