### PR TITLE
test: assert every resource key on restore and replace

### DIFF
--- a/internal/controller/resources_assert_test.go
+++ b/internal/controller/resources_assert_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// resourceListMap is every key, not a cpu/memory subset. #699: stop
+// choosing which resource fields to assert on.
+func resourceListMap(rl corev1.ResourceList) map[string]string {
+	out := map[string]string{}
+	for k, v := range rl {
+		out[string(k)] = v.String()
+	}
+	return out
+}
+
+func assertFullResources(t *testing.T, got, want corev1.ResourceRequirements, msg string) {
+	t.Helper()
+	assert.Equal(t, resourceListMap(want.Requests), resourceListMap(got.Requests), msg+" requests")
+	assert.Equal(t, resourceListMap(want.Limits), resourceListMap(got.Limits), msg+" limits")
+}
+
+func TestReplaceCPUMemoryResources_KeepsEveryNonCPUMemoryKey(t *testing.T) {
+	t.Parallel()
+	gpu := corev1.ResourceName("nvidia.com/gpu")
+	huge := corev1.ResourceName("hugepages-2Mi")
+	eph := corev1.ResourceEphemeralStorage
+	current := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+			gpu:                   resource.MustParse("1"),
+			huge:                  resource.MustParse("4Mi"),
+			eph:                   resource.MustParse("1Gi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+			gpu:                   resource.MustParse("1"),
+			huge:                  resource.MustParse("4Mi"),
+			eph:                   resource.MustParse("1Gi"),
+		},
+	}
+	want := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+	got := replaceCPUMemoryResources(current, want)
+	assertFullResources(t, got, corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			gpu:                   resource.MustParse("1"),
+			huge:                  resource.MustParse("4Mi"),
+			eph:                   resource.MustParse("1Gi"),
+		},
+		Limits: corev1.ResourceList{
+			gpu:  resource.MustParse("1"),
+			huge: resource.MustParse("4Mi"),
+			eph:  resource.MustParse("1Gi"),
+		},
+	}, "replace must keep every non-cpu/memory key and drop omitted cpu/memory limits")
+}

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -1896,16 +1896,16 @@ func TestRestoreTemplateAfterSafetyRevert_PreservesExtendedResources(t *testing.
 	var updated appsv1.Deployment
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
 	got := updated.Spec.Template.Spec.Containers[0].Resources
-	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("256Mi")),
-		"template memory request must restore to the pre-resize snapshot")
-	reqGPU, hasGPUReq := got.Requests[gpu]
-	require.True(t, hasGPUReq, "restore must keep nvidia.com/gpu request")
-	assert.True(t, reqGPU.Equal(resource.MustParse("1")))
-	limGPU, hasGPULim := got.Limits[gpu]
-	require.True(t, hasGPULim, "restore must keep nvidia.com/gpu limit")
-	assert.True(t, limGPU.Equal(resource.MustParse("1")))
-	_, hasMemLimit := got.Limits[corev1.ResourceMemory]
-	assert.False(t, hasMemLimit, "restore must still clear persist-added memory limit")
+	assertFullResources(t, got, corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			gpu:                   resource.MustParse("1"),
+		},
+		Limits: corev1.ResourceList{
+			gpu: resource.MustParse("1"),
+		},
+	}, "restore must match the full resource set, not only cpu/memory")
 }
 
 func TestRestoreTemplateAfterSafetyRevert_DisabledNoOp(t *testing.T) {


### PR DESCRIPTION
Second slice of the #699 testing-strategy work.

Ref #699

## What changed

- `assertFullResources` compares every request and limit key, not a cpu/memory subset.
- `replaceCPUMemoryResources` is locked against dropping GPU, hugepages, or ephemeral-storage, and against leaving omitted cpu/memory limits.
- The safety-restore extended-resource test now uses that full-set helper.

No new dependencies.

## Not in this PR

Golden files for whole pod/workload objects, and rapid property tests, stay on #699.
