### PR TITLE
feat: add per-minute resize increase rate caps

### DIFF
--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -552,6 +552,21 @@ type UpdateStrategy struct {
 	// +optional
 	MaxTotalMemoryIncrease *resource.Quantity `json:"maxTotalMemoryIncrease,omitempty"`
 
+	// MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+	// allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+	// time, so the cap does not change if reconcileInterval changes.
+	// When set, it applies in addition to maxTotalCpuIncrease.
+	// Decreases do not consume budget. Default: unlimited.
+	// +optional
+	MaxCPUIncreasePerMinute *resource.Quantity `json:"maxCpuIncreasePerMinute,omitempty"`
+
+	// MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+	// allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+	// time. When set, it applies in addition to maxTotalMemoryIncrease.
+	// Decreases do not consume budget. Default: unlimited.
+	// +optional
+	MaxMemoryIncreasePerMinute *resource.Quantity `json:"maxMemoryIncreasePerMinute,omitempty"`
+
 	// SafetyObservationPeriod is how long to observe a pod after resize before
 	// concluding the resize is safe. Applies to all modes (Auto, OneShot, Canary).
 	// Takes precedence over canary.observationPeriod when set. Must be >= 1m.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1068,6 +1068,16 @@ func (in *UpdateStrategy) DeepCopyInto(out *UpdateStrategy) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.MaxCPUIncreasePerMinute != nil {
+		in, out := &in.MaxCPUIncreasePerMinute, &out.MaxCPUIncreasePerMinute
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MaxMemoryIncreasePerMinute != nil {
+		in, out := &in.MaxMemoryIncreasePerMinute, &out.MaxMemoryIncreasePerMinute
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	if in.SafetyObservationPeriod != nil {
 		in, out := &in.SafetyObservationPeriod, &out.SafetyObservationPeriod
 		*out = new(v1.Duration)

--- a/charts/attune/crds/attune.io_attunedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunedefaults.yaml
@@ -699,6 +699,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are

--- a/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
@@ -700,6 +700,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -792,6 +792,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are

--- a/charts/attune/templates/defaults.yaml
+++ b/charts/attune/templates/defaults.yaml
@@ -58,6 +58,12 @@ spec:
     {{- with .maxTotalMemoryIncrease }}
     maxTotalMemoryIncrease: {{ . }}
     {{- end }}
+    {{- with .maxCpuIncreasePerMinute }}
+    maxCpuIncreasePerMinute: {{ . }}
+    {{- end }}
+    {{- with .maxMemoryIncreasePerMinute }}
+    maxMemoryIncreasePerMinute: {{ . }}
+    {{- end }}
     {{- with .safetyObservationPeriod }}
     safetyObservationPeriod: {{ . }}
     {{- end }}

--- a/charts/attune/values.yaml
+++ b/charts/attune/values.yaml
@@ -276,6 +276,9 @@ defaults:
     # -- Per-cycle budget caps (optional)
     # maxTotalCpuIncrease: "2000m"
     # maxTotalMemoryIncrease: "4Gi"
+    # -- Per-minute increase rates (optional). Wall-clock token bucket.
+    # maxCpuIncreasePerMinute: "2000m"
+    # maxMemoryIncreasePerMinute: "4Gi"
 
 # -- Cluster size preset: sets resources, rate limits, and replica count.
 # Valid values: small, medium, large, xlarge, or "" (no preset).

--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -1383,6 +1383,8 @@ func printEffectivePolicySummary(item unstructured.Unstructured, effective *attu
 	printEffectiveField("Pod aggregation", getNestedString(item, "spec", "metricsSource", "podAggregation"), podAggEffective, selected, metricsDefaults != nil && metricsDefaults.PodAggregation != "")
 	printEffectiveField("Max total CPU increase", getNestedString(item, "spec", "updateStrategy", "maxTotalCPUIncrease"), formatQuantityPtr(effective.Spec.UpdateStrategy.MaxTotalCPUIncrease), selected, updateDefaults != nil && updateDefaults.MaxTotalCPUIncrease != nil)
 	printEffectiveField("Max total memory increase", getNestedString(item, "spec", "updateStrategy", "maxTotalMemoryIncrease"), formatQuantityPtr(effective.Spec.UpdateStrategy.MaxTotalMemoryIncrease), selected, updateDefaults != nil && updateDefaults.MaxTotalMemoryIncrease != nil)
+	printEffectiveField("Max CPU increase per minute", getNestedString(item, "spec", "updateStrategy", "maxCpuIncreasePerMinute"), formatQuantityPtr(effective.Spec.UpdateStrategy.MaxCPUIncreasePerMinute), selected, updateDefaults != nil && updateDefaults.MaxCPUIncreasePerMinute != nil)
+	printEffectiveField("Max memory increase per minute", getNestedString(item, "spec", "updateStrategy", "maxMemoryIncreasePerMinute"), formatQuantityPtr(effective.Spec.UpdateStrategy.MaxMemoryIncreasePerMinute), selected, updateDefaults != nil && updateDefaults.MaxMemoryIncreasePerMinute != nil)
 
 	// Export awareness in explain (full support for #145/#146)
 	exportConfigured := ""

--- a/config/crd/bases/attune.io_attunedefaults.yaml
+++ b/config/crd/bases/attune.io_attunedefaults.yaml
@@ -699,6 +699,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are

--- a/config/crd/bases/attune.io_attunenamespacedefaults.yaml
+++ b/config/crd/bases/attune.io_attunenamespacedefaults.yaml
@@ -700,6 +700,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -792,6 +792,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -699,6 +699,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are
@@ -1594,6 +1617,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are
@@ -2581,6 +2627,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -698,6 +698,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are
@@ -1593,6 +1616,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are
@@ -2580,6 +2626,29 @@ spec:
                     maximum: 50
                     minimum: 1
                     type: integer
+                  maxCpuIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxCPUIncreasePerMinute is the maximum aggregate CPU increase
+                      allowed per wall-clock minute (e.g. "2000m"). Refilled by elapsed
+                      time, so the cap does not change if reconcileInterval changes.
+                      When set, it applies in addition to maxTotalCpuIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxMemoryIncreasePerMinute:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxMemoryIncreasePerMinute is the maximum aggregate memory increase
+                      allowed per wall-clock minute (e.g. "4Gi"). Refilled by elapsed
+                      time. When set, it applies in addition to maxTotalMemoryIncrease.
+                      Decreases do not consume budget. Default: unlimited.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxStatusRecommendations:
                     description: |-
                       MaxStatusRecommendations caps how many workload recommendations are

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -291,6 +291,8 @@ that do not set them explicitly. Policy-level values always take precedence.
 | `includeExplanationsInStatus` | *bool | `true` | When false, strip recommendation explanation chains from status |
 | `maxTotalCpuIncrease` | quantity | (none) | Max aggregate CPU increase per cycle |
 | `maxTotalMemoryIncrease` | quantity | (none) | Max aggregate memory increase per cycle |
+| `maxCpuIncreasePerMinute` | quantity | (none) | Max aggregate CPU increase per wall-clock minute (token bucket) |
+| `maxMemoryIncreasePerMinute` | quantity | (none) | Max aggregate memory increase per wall-clock minute (token bucket) |
 | `schedule` | object | (none) | Time windows, days of week, timezone |
 | `export` | object | (none) | Metrics export configuration |
 | `safetyObservationPeriod` | duration | `5m` | Post-resize observation window (min: 1m) |
@@ -399,7 +401,7 @@ All fields from `AttuneDefaults` are available in
 | `metricsSource` | `prometheus.address`, `prometheus.headers`, `prometheus.queryParameters`, `prometheus.bearerTokenSecret`, `prometheus.tls`, `datadog.site`, `datadog.apiKeySecretRef`, `cloudwatch.region`, `cloudwatch.clusterName`, `cloudwatch.roleArn`, `historyWindow`, `minimumDataPoints`, `queryStep`, `rateWindow`, `podAggregation`, `cpuRecordingMetric`, `memoryRecordingMetric` |
 | `cpu` | `percentile`, `overhead`, `minAllowed`, `maxAllowed`, `controlledValues`, `burstSensitivity`, `allowDecrease`, `startupBoost`, `maxChangePercent`, `maxIncreasePercent`, `maxDecreasePercent` |
 | `memory` | Same as `cpu` (no `startupBoost`), plus `decreaseUsageMarginPercent` and `memoryFromCpuRatio` |
-| `updateStrategy` | `type`, `cooldown`, `autoRevert`, `resizeMethod`, `initialSizing`, `maxConcurrentResizes`, `maxStatusRecommendations`, `includeExplanationsInStatus`, `maxTotalCpuIncrease`, `maxTotalMemoryIncrease`, `schedule`, `export`, `canary`, `safetyObservationPeriod`, `sloGuardrails`, `templatePersistence` |
+| `updateStrategy` | `type`, `cooldown`, `autoRevert`, `resizeMethod`, `initialSizing`, `maxConcurrentResizes`, `maxStatusRecommendations`, `includeExplanationsInStatus`, `maxTotalCpuIncrease`, `maxTotalMemoryIncrease`, `maxCpuIncreasePerMinute`, `maxMemoryIncreasePerMinute`, `schedule`, `export`, `canary`, `safetyObservationPeriod`, `sloGuardrails`, `templatePersistence` |
 | `costPricing` | `cpuPerCoreHour`, `memoryPerGiBHour` |
 
 ## Alternative Metrics Sources

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -219,6 +219,10 @@ type AttunePolicyReconciler struct {
 	// Key is namespace+"/"+workloadName. Entries are deleted on release.
 	evictionLocks sync.Map // map[string]*sync.Mutex
 
+	// increaseRates holds per-policy wall-clock token buckets for
+	// maxCpuIncreasePerMinute / maxMemoryIncreasePerMinute.
+	increaseRates sync.Map // map[string]*increaseRateBucket
+
 	// nodeNeighborFlight single-flights the live node pod List used for
 	// neighbor request budget. Per-cycle results live in resizePreChecks.
 	nodeNeighborFlight singleflight.Group

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10540,6 +10540,45 @@ func TestBudgetIncrease_MixedDirections(t *testing.T) {
 	assert.Equal(t, int64(0), mem, "Memory decrease should be clamped to 0")
 }
 
+func TestExecuteResizes_RateCapDefersUntilRefill(t *testing.T) {
+	pod1 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod1.Name = "api-server-abc-1"
+	pod2 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod2.Name = "api-server-abc-2"
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy, pod1, pod2).Build()
+	clientset := kubefake.NewSimpleClientset(pod1.DeepCopy(), pod2.DeepCopy())
+	reconciler := NewAttunePolicyReconciler()
+	reconciler.Client = fakeClient
+	reconciler.Scheme = scheme
+	reconciler.Clientset = clientset
+
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	rate := resource.MustParse("300m")
+	policy.Spec.UpdateStrategy.MaxCPUIncreasePerMinute = &rate
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		newResizeRecommendation("api-server", "200m", "256Mi", "0", "0", "500m", "256Mi", "0", "0"),
+	}
+
+	count, _ := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recs, podMap("api-server", pod1, pod2), nil, nil)
+	assert.Equal(t, 1, count, "300m/min allows one 300m increase")
+
+	count, _ = reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recs, podMap("api-server", pod2), nil, nil)
+	assert.Equal(t, 0, count, "same minute must not allow a second 300m increase")
+
+	now = now.Add(time.Minute)
+	count, _ = reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recs, podMap("api-server", pod2), nil, nil)
+	assert.Equal(t, 1, count, "after a minute the rate bucket refills")
+}
+
 func TestExecuteResizes_BudgetCapsDefersExcessiveIncrease(t *testing.T) {
 	// Pod at 200m CPU, recommendation is 800m (increase of 600m).
 	// Budget cap is 500m, so the resize should be skipped.

--- a/internal/controller/increase_budget.go
+++ b/internal/controller/increase_budget.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sync"
+	"time"
+)
+
+// increaseRateBucket is a wall-clock token bucket for resize increases.
+// Rate is tokens per minute. Capacity is one minute of rate so a burst
+// cannot exceed that minute. -1 rate means that resource is unlimited.
+type increaseRateBucket struct {
+	mu      sync.Mutex
+	cpuLast time.Time
+	memLast time.Time
+	cpu     int64
+	mem     int64
+	cpuRate int64
+	memRate int64
+	cpuCap  int64
+	memCap  int64
+}
+
+func newIncreaseRateBucket(cpuRatePerMin, memRatePerMin int64, now time.Time) *increaseRateBucket {
+	b := &increaseRateBucket{
+		cpuLast: now,
+		memLast: now,
+		cpuRate: cpuRatePerMin,
+		memRate: memRatePerMin,
+		cpuCap:  cpuRatePerMin,
+		memCap:  memRatePerMin,
+		cpu:     cpuRatePerMin,
+		mem:     memRatePerMin,
+	}
+	if cpuRatePerMin < 0 {
+		b.cpuCap, b.cpu = -1, -1
+	}
+	if memRatePerMin < 0 {
+		b.memCap, b.mem = -1, -1
+	}
+	return b
+}
+
+func refillResource(tokens, rate, cap int64, last time.Time, now time.Time) (int64, time.Time) {
+	if rate < 0 {
+		return tokens, last
+	}
+	if !now.After(last) {
+		if now.Before(last) {
+			return tokens, now
+		}
+		return tokens, last
+	}
+	elapsed := now.Sub(last)
+	// Cap is one minute of rate. Longer idle just fills the bucket
+	// and avoids rate*elapsed overflowing int64.
+	if elapsed >= time.Minute {
+		return cap, now
+	}
+	add := rate * elapsed.Milliseconds() / 60000
+	if add <= 0 {
+		return tokens, last
+	}
+	tokens += add
+	if tokens > cap {
+		tokens = cap
+	}
+	return tokens, now
+}
+
+func (b *increaseRateBucket) refillLocked(now time.Time) {
+	b.cpu, b.cpuLast = refillResource(b.cpu, b.cpuRate, b.cpuCap, b.cpuLast, now)
+	b.mem, b.memLast = refillResource(b.mem, b.memRate, b.memCap, b.memLast, now)
+}
+
+func (b *increaseRateBucket) tryDraw(cpuMilli, memBytes int64, now time.Time) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.refillLocked(now)
+	if (b.cpuRate >= 0 && cpuMilli > b.cpu) || (b.memRate >= 0 && memBytes > b.mem) {
+		return false
+	}
+	if b.cpuRate >= 0 {
+		b.cpu -= cpuMilli
+	}
+	if b.memRate >= 0 {
+		b.mem -= memBytes
+	}
+	return true
+}
+
+func (b *increaseRateBucket) refund(cpuMilli, memBytes int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.cpuRate >= 0 {
+		b.cpu += cpuMilli
+		if b.cpu > b.cpuCap {
+			b.cpu = b.cpuCap
+		}
+	}
+	if b.memRate >= 0 {
+		b.mem += memBytes
+		if b.mem > b.memCap {
+			b.mem = b.memCap
+		}
+	}
+}

--- a/internal/controller/increase_budget_test.go
+++ b/internal/controller/increase_budget_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIncreaseRateBucket_DrawAndRefill(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	b := newIncreaseRateBucket(1000, -1, now)
+
+	assert.True(t, b.tryDraw(600, 0, now), "full bucket must allow 600m")
+	assert.False(t, b.tryDraw(500, 0, now), "remaining 400m must reject 500m")
+	assert.True(t, b.tryDraw(400, 0, now), "exact remaining must pass")
+
+	later := now.Add(30 * time.Second)
+	assert.False(t, b.tryDraw(600, 0, later), "30s refill is 500m, not enough for 600m")
+	assert.True(t, b.tryDraw(500, 0, later), "30s of 1000m/min is 500m")
+
+	full := later.Add(time.Minute)
+	assert.True(t, b.tryDraw(1000, 0, full), "after a minute the bucket is full again")
+	assert.False(t, b.tryDraw(1, 0, full), "burst cannot exceed one minute of rate")
+}
+
+func TestIncreaseRateBucket_Refund(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	b := newIncreaseRateBucket(1000, 1<<30, now)
+	assert.True(t, b.tryDraw(800, 100, now))
+	b.refund(800, 100)
+	assert.True(t, b.tryDraw(1000, 1<<30, now), "refund must restore tokens up to cap")
+}
+
+func TestIncreaseRateBucket_UnlimitedResource(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	b := newIncreaseRateBucket(-1, 100, now)
+	assert.True(t, b.tryDraw(1<<40, 50, now))
+	assert.False(t, b.tryDraw(0, 60, now))
+}
+
+func TestIncreaseRateBucket_BothRatesDoNotStarveCPU(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	// Memory rate is large (bytes/min) so 1ms already refills mem.
+	// CPU is 1000m/min, so it needs a full second for ~16m.
+	b := newIncreaseRateBucket(1000, 1<<30, now)
+	assert.True(t, b.tryDraw(1000, 1<<30, now))
+	tick := now
+	for i := 0; i < 60; i++ {
+		tick = tick.Add(time.Second)
+		b.tryDraw(0, 0, tick)
+	}
+	assert.True(t, b.tryDraw(960, 0, tick), "CPU must refill across mem-driven 1s ticks")
+}
+
+func TestIncreaseRateBucket_LongIdleFillsToCap(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	b := newIncreaseRateBucket(1000, 1<<40, now)
+	assert.True(t, b.tryDraw(1000, 1<<40, now))
+	later := now.Add(365 * 24 * time.Hour)
+	assert.True(t, b.tryDraw(1000, 1<<40, later), "year-long idle must refill to cap, not overflow")
+}

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -349,6 +349,30 @@ func (r *AttunePolicyReconciler) executeResizes(
 	if policy.Spec.UpdateStrategy.MaxTotalMemoryIncrease != nil {
 		memBudget = policy.Spec.UpdateStrategy.MaxTotalMemoryIncrease.Value()
 	}
+	var rateBucket *increaseRateBucket
+	cpuRate, memRate := int64(-1), int64(-1)
+	if q := policy.Spec.UpdateStrategy.MaxCPUIncreasePerMinute; q != nil {
+		cpuRate = q.MilliValue()
+	}
+	if q := policy.Spec.UpdateStrategy.MaxMemoryIncreasePerMinute; q != nil {
+		memRate = q.Value()
+	}
+	if cpuRate >= 0 || memRate >= 0 {
+		key := policy.Namespace + "/" + policy.Name
+		created := newIncreaseRateBucket(cpuRate, memRate, r.now())
+		if v, ok := r.increaseRates.Load(key); ok {
+			existing := v.(*increaseRateBucket)
+			if existing.cpuRate == cpuRate && existing.memRate == memRate {
+				rateBucket = existing
+			} else {
+				r.increaseRates.Store(key, created)
+				rateBucket = created
+			}
+		} else {
+			actual, _ := r.increaseRates.LoadOrStore(key, created)
+			rateBucket = actual.(*increaseRateBucket)
+		}
+	}
 	reserveBudget := func(cpuIncrease, memIncrease int64) bool {
 		budgetMu.Lock()
 		defer budgetMu.Unlock()
@@ -356,6 +380,9 @@ func (r *AttunePolicyReconciler) executeResizes(
 		budgetExceeded := (cpuBudget >= 0 && cpuIncrease > cpuBudget) ||
 			(memBudget >= 0 && memIncrease > memBudget)
 		if budgetExceeded {
+			return false
+		}
+		if rateBucket != nil && !rateBucket.tryDraw(cpuIncrease, memIncrease, r.now()) {
 			return false
 		}
 		if cpuBudget >= 0 {
@@ -370,6 +397,9 @@ func (r *AttunePolicyReconciler) executeResizes(
 		budgetMu.Lock()
 		defer budgetMu.Unlock()
 
+		if rateBucket != nil {
+			rateBucket.refund(cpuRefund, memRefund)
+		}
 		if cpuBudget >= 0 {
 			cpuBudget += cpuRefund
 		}

--- a/internal/webhook/defaults_validation.go
+++ b/internal/webhook/defaults_validation.go
@@ -176,6 +176,12 @@ func validateDefaultsSpec(spec attunev1alpha1.AttuneDefaultsSpec) (admission.War
 		if q := spec.UpdateStrategy.MaxTotalMemoryIncrease; q != nil && q.Value() < 0 {
 			return warnings, fmt.Errorf("updateStrategy.maxTotalMemoryIncrease must be non-negative, got %s", q)
 		}
+		if q := spec.UpdateStrategy.MaxCPUIncreasePerMinute; q != nil && q.MilliValue() < 0 {
+			return warnings, fmt.Errorf("updateStrategy.maxCpuIncreasePerMinute must be non-negative, got %s", q)
+		}
+		if q := spec.UpdateStrategy.MaxMemoryIncreasePerMinute; q != nil && q.Value() < 0 {
+			return warnings, fmt.Errorf("updateStrategy.maxMemoryIncreasePerMinute must be non-negative, got %s", q)
+		}
 	}
 
 	// Validate safetyObservationPeriod has a minimum floor.

--- a/internal/webhook/defaults_validation_test.go
+++ b/internal/webhook/defaults_validation_test.go
@@ -792,6 +792,24 @@ func TestDefaultsValidate_BudgetCapInvalid(t *testing.T) {
 			},
 			wantErr: "maxTotalMemoryIncrease must be non-negative",
 		},
+		{
+			name: "negative maxCpuIncreasePerMinute",
+			spec: attunev1alpha1.AttuneDefaultsSpec{
+				UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+					MaxCPUIncreasePerMinute: resourcePtr("-500m"),
+				},
+			},
+			wantErr: "maxCpuIncreasePerMinute must be non-negative",
+		},
+		{
+			name: "negative maxMemoryIncreasePerMinute",
+			spec: attunev1alpha1.AttuneDefaultsSpec{
+				UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+					MaxMemoryIncreasePerMinute: resourcePtr("-1Gi"),
+				},
+			},
+			wantErr: "maxMemoryIncreasePerMinute must be non-negative",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -150,6 +150,12 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 	if q := us.MaxTotalMemoryIncrease; q != nil && q.Value() < 0 {
 		return warnings, fmt.Errorf("updateStrategy.maxTotalMemoryIncrease must be non-negative, got %s", q)
 	}
+	if q := us.MaxCPUIncreasePerMinute; q != nil && q.MilliValue() < 0 {
+		return warnings, fmt.Errorf("updateStrategy.maxCpuIncreasePerMinute must be non-negative, got %s", q)
+	}
+	if q := us.MaxMemoryIncreasePerMinute; q != nil && q.Value() < 0 {
+		return warnings, fmt.Errorf("updateStrategy.maxMemoryIncreasePerMinute must be non-negative, got %s", q)
+	}
 
 	// Validate historyWindow is within reasonable bounds (1h to 720h/30d).
 	if policy.Spec.MetricsSource.HistoryWindow != nil {
@@ -274,6 +280,12 @@ func warnIneffectiveSettings(policy *attunev1alpha1.AttunePolicy) admission.Warn
 		}
 		if policy.Spec.UpdateStrategy.MaxTotalMemoryIncrease != nil {
 			w = append(w, fmt.Sprintf("maxTotalMemoryIncrease has no effect in %s mode; no resizes occur", mode))
+		}
+		if policy.Spec.UpdateStrategy.MaxCPUIncreasePerMinute != nil {
+			w = append(w, fmt.Sprintf("maxCpuIncreasePerMinute has no effect in %s mode; no resizes occur", mode))
+		}
+		if policy.Spec.UpdateStrategy.MaxMemoryIncreasePerMinute != nil {
+			w = append(w, fmt.Sprintf("maxMemoryIncreasePerMinute has no effect in %s mode; no resizes occur", mode))
 		}
 	}
 

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -722,6 +722,24 @@ func TestValidate_NegativeBudgetCaps(t *testing.T) {
 		_, err := validator.ValidateCreate(context.Background(), policy)
 		assert.NoError(t, err)
 	})
+
+	t.Run("negative maxCpuIncreasePerMinute", func(t *testing.T) {
+		policy := validPolicy()
+		neg := resource.MustParse("-100m")
+		policy.Spec.UpdateStrategy.MaxCPUIncreasePerMinute = &neg
+		_, err := validator.ValidateCreate(context.Background(), policy)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "maxCpuIncreasePerMinute must be non-negative")
+	})
+
+	t.Run("negative maxMemoryIncreasePerMinute", func(t *testing.T) {
+		policy := validPolicy()
+		neg := resource.MustParse("-1Mi")
+		policy.Spec.UpdateStrategy.MaxMemoryIncreasePerMinute = &neg
+		_, err := validator.ValidateCreate(context.Background(), policy)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "maxMemoryIncreasePerMinute must be non-negative")
+	})
 }
 
 func TestValidate_OverheadExceedsMax(t *testing.T) {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -467,6 +467,14 @@ func MergeUpdateStrategy(policy *attunev1alpha1.UpdateStrategy, defaults *attune
 		policy.MaxTotalMemoryIncrease = defaults.MaxTotalMemoryIncrease
 		inherited = append(inherited, "maxTotalMemoryIncrease")
 	}
+	if policy.MaxCPUIncreasePerMinute == nil && defaults.MaxCPUIncreasePerMinute != nil {
+		policy.MaxCPUIncreasePerMinute = defaults.MaxCPUIncreasePerMinute
+		inherited = append(inherited, "maxCpuIncreasePerMinute")
+	}
+	if policy.MaxMemoryIncreasePerMinute == nil && defaults.MaxMemoryIncreasePerMinute != nil {
+		policy.MaxMemoryIncreasePerMinute = defaults.MaxMemoryIncreasePerMinute
+		inherited = append(inherited, "maxMemoryIncreasePerMinute")
+	}
 	if policy.Schedule == nil && defaults.Schedule != nil {
 		policy.Schedule = defaults.Schedule
 		inherited = append(inherited, "schedule")


### PR DESCRIPTION
Optional wall-clock increase rates so the growth cap does not depend on reconcileInterval.

Ref #698

## What changed

- New policy fields `maxCpuIncreasePerMinute` and `maxMemoryIncreasePerMinute`.
- Each is a token bucket: refill from elapsed wall-clock time, burst of one minute of rate.
- Existing `maxTotalCpuIncrease` / `maxTotalMemoryIncrease` keep their per-cycle meaning. When both are set, both apply.
- Validation, AttuneDefaults merge, `kubectl attune explain`, Helm defaults template, and configuration docs.

## Tests

- Bucket draw, refill, refund, unlimited resource.
- CPU still refills when a large memory rate also ticks.
- Year-long idle fills to cap (no overflow).
- `executeResizes` defers a second 300m increase until a minute has passed.
- Negative rate fields are rejected.

## Not in this PR

Per-cycle fields are not deprecated. In-band lifecycle and goldens stay on #697 / #699.
