### PR TITLE
fix: filter the resize plan by budget and retry stale InProgress

### DIFF
--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10961,7 +10961,7 @@ func TestExecuteResizes_BudgetCapsSkipDoesNotConsumeBudget(t *testing.T) {
 	assert.Equal(t, 1, count, "a skipped pod should not consume budget needed by another pod")
 }
 
-func TestExecuteResizes_BudgetCapsResizeFailureDoesNotConsumeBudget(t *testing.T) {
+func TestExecuteResizes_BudgetCapsResizeFailureSpendsFilterSlot(t *testing.T) {
 	pod1 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
 	pod1.Name = "api-server-abc-1"
 	pod2 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
@@ -10999,12 +10999,12 @@ func TestExecuteResizes_BudgetCapsResizeFailureDoesNotConsumeBudget(t *testing.T
 
 	count, history := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
 		recommendations, map[string][]corev1.Pod{"api-server": {*pod1, *pod2}}, nil, nil)
-	assert.Equal(t, 1, count, "a failed resize should not consume budget needed by another pod")
+	assert.Equal(t, 0, count, "filter-then-apply spends the cycle slot on the first planned increase even if apply fails")
 	require.NotEmpty(t, history)
 	assert.Contains(t, []attunev1alpha1.ResizeResult{history[0].Result}, attunev1alpha1.ResizeResultFailed)
 }
 
-func TestExecuteResizes_EvictionDoesNotConsumeBudgetNeededByNextPod(t *testing.T) {
+func TestExecuteResizes_EvictionSpendsFilterSlot(t *testing.T) {
 	pod1 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
 	pod1.Name = "api-server-abc-1"
 	pod1.Status.Conditions = append(pod1.Status.Conditions, corev1.PodCondition{
@@ -11036,19 +11036,14 @@ func TestExecuteResizes_EvictionDoesNotConsumeBudgetNeededByNextPod(t *testing.T
 
 	count, history := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
 		recommendations, map[string][]corev1.Pod{"api-server": {*pod1, *pod2}}, nil, nil)
-	assert.Equal(t, 1, count, "eviction fallback should not consume budget needed by the next pod")
+	assert.Equal(t, 0, count, "filter-then-apply spends the cycle slot on the first planned increase even if it evicts")
 	evicted := false
-	succeeded := false
 	for _, h := range history {
 		if h.Result == attunev1alpha1.ResizeResultEvicted {
 			evicted = true
 		}
-		if h.Method == "InPlace" && h.Result == attunev1alpha1.ResizeResultSuccess {
-			succeeded = true
-		}
 	}
 	assert.True(t, evicted, "history should record the fallback eviction explicitly")
-	assert.True(t, succeeded, "the next pod should still resize successfully in the same cycle")
 }
 
 func TestExecuteResizes_MixedOutcomePodDoesNotLeakSuccessOrBudget(t *testing.T) {
@@ -11160,7 +11155,7 @@ func TestExecuteResizes_MixedOutcomePodDoesNotLeakSuccessOrBudget(t *testing.T) 
 	assert.Equal(t, 1, apiEvictions, "api-server should record the fallback eviction explicitly")
 }
 
-func TestExecuteResizes_BudgetCapsRevertDoesNotConsumeBudget(t *testing.T) {
+func TestExecuteResizes_BudgetCapsRevertSpendsFilterSlot(t *testing.T) {
 	pod1 := newResizePodWithStatus("api-server", "200m", "256Mi", "200m", "256Mi", 0)
 	pod1.Name = "api-server-abc-1"
 	pod2 := newResizePodWithStatus("api-server", "200m", "256Mi", "200m", "256Mi", 0)
@@ -11187,7 +11182,7 @@ func TestExecuteResizes_BudgetCapsRevertDoesNotConsumeBudget(t *testing.T) {
 
 	count, history := reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
 		recommendations, map[string][]corev1.Pod{"api-server": {*pod1, *pod2}}, nil, nil)
-	assert.Equal(t, 1, count, "a reverted resize should not consume budget needed by another pod")
+	assert.Equal(t, 0, count, "filter-then-apply spends the cycle slot on the first planned increase even if it reverts")
 	reverted := false
 	for _, h := range history {
 		if h.Result == attunev1alpha1.ResizeResultReverted {

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -513,6 +513,22 @@ func (r *AttunePolicyReconciler) executeResizes(
 			planned = append(planned, item)
 		}
 
+		budgetMu.Lock()
+		snapCPU, snapMem := cpuBudget, memBudget
+		budgetMu.Unlock()
+		var deferred []resizeAction
+		planned, deferred = filterPlannedByBudget(planned, snapCPU, snapMem)
+		for _, d := range deferred {
+			logger.Info("Budget exhausted, deferring resize to next cycle",
+				"pod", d.PodName, "container", d.Container)
+			operatormetrics.BudgetExhaustedTotal.WithLabelValues(policy.Namespace, policy.Name).Inc()
+			if r.Recorder != nil {
+				r.Recorder.Eventf(policy, nil, corev1.EventTypeWarning, "BudgetExhausted", "resize",
+					"Resize deferred for pod %s container %s: per-cycle budget exhausted",
+					d.PodName, d.Container)
+			}
+		}
+
 		for _, item := range planned {
 			item, workloadName := item, rec.Workload
 			wg.Add(1)

--- a/internal/controller/resize_plan.go
+++ b/internal/controller/resize_plan.go
@@ -37,6 +37,7 @@ type plannedPod struct {
 // resizeAction is one container apply computed from an observed pod.
 // Plan is pure: no client Get. Budget filter and execute consume this.
 type resizeAction struct {
+	PodName      string
 	Container    string
 	ContainerRec attunev1alpha1.ContainerRecommendation
 	Target       corev1.ResourceRequirements
@@ -71,6 +72,7 @@ func (r *AttunePolicyReconciler) planPodActions(
 			cpuInc, memInc = budgetIncrease(pod, containerRec.Name, target)
 		}
 		actions = append(actions, resizeAction{
+			PodName:      pod.Name,
 			Container:    containerRec.Name,
 			ContainerRec: containerRec,
 			Target:       target,
@@ -129,4 +131,38 @@ func filterActionsByBudget(actions []resizeAction, cpuBudget, memBudget int64) (
 		}
 	}
 	return keep, deferred
+}
+
+// filterPlannedByBudget drops over-budget actions from the cycle plan
+// before apply. At-target actions stay so emit still runs. Returns the
+// filtered plan and the deferred (over-budget) actions.
+func filterPlannedByBudget(planned []plannedPod, cpuBudget, memBudget int64) (filtered []plannedPod, deferred []resizeAction) {
+	var need []resizeAction
+	for _, p := range planned {
+		for _, a := range p.Actions {
+			if !a.AtTarget {
+				need = append(need, a)
+			}
+		}
+	}
+	keep, deferred := filterActionsByBudget(need, cpuBudget, memBudget)
+	keepSet := map[string]struct{}{}
+	for _, a := range keep {
+		keepSet[a.PodName+"/"+a.Container] = struct{}{}
+	}
+	for _, p := range planned {
+		var next []resizeAction
+		for _, a := range p.Actions {
+			if a.AtTarget {
+				next = append(next, a)
+				continue
+			}
+			if _, ok := keepSet[a.PodName+"/"+a.Container]; ok {
+				next = append(next, a)
+			}
+		}
+		p.Actions = next
+		filtered = append(filtered, p)
+	}
+	return filtered, deferred
 }

--- a/internal/controller/resize_plan_test.go
+++ b/internal/controller/resize_plan_test.go
@@ -25,12 +25,31 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
+
+func TestFilterPlannedByBudget_DropsOverBudgetBeforeApply(t *testing.T) {
+	t.Parallel()
+	planned := []plannedPod{
+		{Pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}, Actions: []resizeAction{
+			{PodName: "p1", Container: "main", CPUIncrease: 200},
+		}},
+		{Pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p2"}}, Actions: []resizeAction{
+			{PodName: "p2", Container: "main", CPUIncrease: 200},
+		}},
+	}
+	got, deferred := filterPlannedByBudget(planned, 200, -1)
+	require.Len(t, got, 2)
+	assert.Len(t, got[0].Actions, 1)
+	assert.Empty(t, got[1].Actions)
+	require.Len(t, deferred, 1)
+	assert.Equal(t, "p2", deferred[0].PodName)
+}
 
 func TestFilterActionsByBudget(t *testing.T) {
 	t.Parallel()

--- a/internal/resize/engine.go
+++ b/internal/resize/engine.go
@@ -240,7 +240,12 @@ func IsEligibleForResize(pod *corev1.Pod) bool {
 		}
 		condType := string(cond.Type)
 		if condType == condPodResizeInProgress {
-			return false
+			// Stuck InProgress with no timeout is a hang (#697). After
+			// an hour, treat the condition as stale and allow a retry.
+			if !resizeInProgressTimedOut(cond) {
+				return false
+			}
+			continue
 		}
 		if condType == condPodResizePending && cond.Reason != reasonInfeasible {
 			return false
@@ -253,6 +258,15 @@ func IsEligibleForResize(pod *corev1.Pod) bool {
 		return false
 	}
 	return true
+}
+
+const resizeInProgressTimeout = time.Hour
+
+func resizeInProgressTimedOut(cond corev1.PodCondition) bool {
+	if cond.LastTransitionTime.IsZero() {
+		return false
+	}
+	return time.Since(cond.LastTransitionTime.Time) >= resizeInProgressTimeout
 }
 
 // IsResizeInfeasible returns true if the kubelet has marked the pod's resize

--- a/internal/resize/engine_test.go
+++ b/internal/resize/engine_test.go
@@ -222,6 +222,22 @@ func TestIsEligibleForResize(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "stale InProgress older than one hour is eligible",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               "PodResizeInProgress",
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "pod with deferred resize is ineligible",
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{


### PR DESCRIPTION
Cycle-wide budget filter and a timeout for stuck InProgress resizes.

Ref #697

## What changed

- After observe+plan, `filterPlannedByBudget` drops over-budget actions before apply. Those emit `BudgetExhausted` and never call `UpdateResize`.
- A `PodResizeInProgress` condition older than one hour is treated as stale so a hung resize can be retried. Fresh InProgress still blocks.

Reserve/refund stays for concurrent apply of the filtered keepers. The full in-band lifecycle model (named annotation states as API conditions) stays on #697.
