### PR TITLE
feat: deprecate per-cycle increase caps and e2e the rate bucket

### DIFF
--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -543,8 +543,8 @@ type UpdateStrategy struct {
 	// Once exhausted, remaining pods are deferred to the next cycle.
 	// Decreases do not consume budget. Default: unlimited.
 	//
-	// Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-	// real-world rate depends on reconcileInterval.
+	// Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+	// compatibility; its real-world rate depends on reconcileInterval.
 	// +optional
 	MaxTotalCPUIncrease *resource.Quantity `json:"maxTotalCpuIncrease,omitempty"`
 
@@ -553,8 +553,8 @@ type UpdateStrategy struct {
 	// Once exhausted, remaining pods are deferred to the next cycle.
 	// Decreases do not consume budget. Default: unlimited.
 	//
-	// Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-	// real-world rate depends on reconcileInterval.
+	// Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+	// compatibility; its real-world rate depends on reconcileInterval.
 	// +optional
 	MaxTotalMemoryIncrease *resource.Quantity `json:"maxTotalMemoryIncrease,omitempty"`
 

--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -542,6 +542,9 @@ type UpdateStrategy struct {
 	// across all pods in a single reconcile cycle (e.g. "2000m", "4").
 	// Once exhausted, remaining pods are deferred to the next cycle.
 	// Decreases do not consume budget. Default: unlimited.
+	//
+	// Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+	// real-world rate depends on reconcileInterval.
 	// +optional
 	MaxTotalCPUIncrease *resource.Quantity `json:"maxTotalCpuIncrease,omitempty"`
 
@@ -549,6 +552,9 @@ type UpdateStrategy struct {
 	// allowed across all pods in a single reconcile cycle (e.g. "4Gi").
 	// Once exhausted, remaining pods are deferred to the next cycle.
 	// Decreases do not consume budget. Default: unlimited.
+	//
+	// Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+	// real-world rate depends on reconcileInterval.
 	// +optional
 	MaxTotalMemoryIncrease *resource.Quantity `json:"maxTotalMemoryIncrease,omitempty"`
 

--- a/charts/attune/crds/attune.io_attunedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunedefaults.yaml
@@ -741,6 +741,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -752,6 +755,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/charts/attune/crds/attune.io_attunedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunedefaults.yaml
@@ -742,8 +742,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -756,8 +756,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
@@ -742,6 +742,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -753,6 +756,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
+++ b/charts/attune/crds/attune.io_attunenamespacedefaults.yaml
@@ -743,8 +743,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -757,8 +757,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -835,8 +835,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -849,8 +849,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -834,6 +834,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -845,6 +848,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/config/crd/bases/attune.io_attunedefaults.yaml
+++ b/config/crd/bases/attune.io_attunedefaults.yaml
@@ -741,6 +741,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -752,6 +755,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/config/crd/bases/attune.io_attunedefaults.yaml
+++ b/config/crd/bases/attune.io_attunedefaults.yaml
@@ -742,8 +742,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -756,8 +756,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/config/crd/bases/attune.io_attunenamespacedefaults.yaml
+++ b/config/crd/bases/attune.io_attunenamespacedefaults.yaml
@@ -742,6 +742,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -753,6 +756,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/config/crd/bases/attune.io_attunenamespacedefaults.yaml
+++ b/config/crd/bases/attune.io_attunenamespacedefaults.yaml
@@ -743,8 +743,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -757,8 +757,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -835,8 +835,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -849,8 +849,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -834,6 +834,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -845,6 +848,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -742,8 +742,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -756,8 +756,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:
@@ -1666,8 +1666,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -1680,8 +1680,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:
@@ -2682,8 +2682,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -2696,8 +2696,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -741,6 +741,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -752,6 +755,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:
@@ -1659,6 +1665,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -1670,6 +1679,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:
@@ -2669,6 +2681,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -2680,6 +2695,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -740,6 +740,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -751,6 +754,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:
@@ -1658,6 +1664,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -1669,6 +1678,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:
@@ -2668,6 +2680,9 @@ spec:
                       across all pods in a single reconcile cycle (e.g. "2000m", "4").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -2679,6 +2694,9 @@ spec:
                       allowed across all pods in a single reconcile cycle (e.g. "4Gi").
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
+
+                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
+                      real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -741,8 +741,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -755,8 +755,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:
@@ -1665,8 +1665,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -1679,8 +1679,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:
@@ -2681,8 +2681,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxCPUIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxCPUIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   maxTotalMemoryIncrease:
@@ -2695,8 +2695,8 @@ spec:
                       Once exhausted, remaining pods are deferred to the next cycle.
                       Decreases do not consume budget. Default: unlimited.
 
-                      Deprecated: prefer MaxMemoryIncreasePerMinute. The per-cycle cap's
-                      real-world rate depends on reconcileInterval.
+                      Prefer MaxMemoryIncreasePerMinute. This per-cycle field is kept for
+                      compatibility; its real-world rate depends on reconcileInterval.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   resizeMethod:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -289,8 +289,8 @@ that do not set them explicitly. Policy-level values always take precedence.
 | `maxConcurrentResizes` | int32 | `1` (built-in when unset) | Max pods to resize simultaneously. Omitted on the policy so AttuneDefaults can apply before the built-in 1. |
 | `maxStatusRecommendations` | *int32 | `100` (operator default) | Cap for `status.recommendations` length; full set still drives resizes |
 | `includeExplanationsInStatus` | *bool | `true` | When false, strip recommendation explanation chains from status |
-| `maxTotalCpuIncrease` | quantity | (none) | Max aggregate CPU increase per cycle |
-| `maxTotalMemoryIncrease` | quantity | (none) | Max aggregate memory increase per cycle |
+| `maxTotalCpuIncrease` | quantity | (none) | Deprecated. Max aggregate CPU increase per cycle. Prefer `maxCpuIncreasePerMinute`. |
+| `maxTotalMemoryIncrease` | quantity | (none) | Deprecated. Max aggregate memory increase per cycle. Prefer `maxMemoryIncreasePerMinute`. |
 | `maxCpuIncreasePerMinute` | quantity | (none) | Max aggregate CPU increase per wall-clock minute (token bucket) |
 | `maxMemoryIncreasePerMinute` | quantity | (none) | Max aggregate memory increase per wall-clock minute (token bucket) |
 | `schedule` | object | (none) | Time windows, days of week, timezone |

--- a/internal/webhook/defaults_validation.go
+++ b/internal/webhook/defaults_validation.go
@@ -182,6 +182,12 @@ func validateDefaultsSpec(spec attunev1alpha1.AttuneDefaultsSpec) (admission.War
 		if q := spec.UpdateStrategy.MaxMemoryIncreasePerMinute; q != nil && q.Value() < 0 {
 			return warnings, fmt.Errorf("updateStrategy.maxMemoryIncreasePerMinute must be non-negative, got %s", q)
 		}
+		if spec.UpdateStrategy.MaxTotalCPUIncrease != nil {
+			warnings = append(warnings, "maxTotalCpuIncrease is deprecated; prefer maxCpuIncreasePerMinute so the cap does not depend on reconcileInterval")
+		}
+		if spec.UpdateStrategy.MaxTotalMemoryIncrease != nil {
+			warnings = append(warnings, "maxTotalMemoryIncrease is deprecated; prefer maxMemoryIncreasePerMinute so the cap does not depend on reconcileInterval")
+		}
 	}
 
 	// Validate safetyObservationPeriod has a minimum floor.

--- a/internal/webhook/validation.go
+++ b/internal/webhook/validation.go
@@ -156,6 +156,12 @@ func (v *AttunePolicyValidator) validate(policy *attunev1alpha1.AttunePolicy) (a
 	if q := us.MaxMemoryIncreasePerMinute; q != nil && q.Value() < 0 {
 		return warnings, fmt.Errorf("updateStrategy.maxMemoryIncreasePerMinute must be non-negative, got %s", q)
 	}
+	if us.MaxTotalCPUIncrease != nil {
+		warnings = append(warnings, "maxTotalCpuIncrease is deprecated; prefer maxCpuIncreasePerMinute so the cap does not depend on reconcileInterval")
+	}
+	if us.MaxTotalMemoryIncrease != nil {
+		warnings = append(warnings, "maxTotalMemoryIncrease is deprecated; prefer maxMemoryIncreasePerMinute so the cap does not depend on reconcileInterval")
+	}
 
 	// Validate historyWindow is within reasonable bounds (1h to 720h/30d).
 	if policy.Spec.MetricsSource.HistoryWindow != nil {

--- a/internal/webhook/validation_test.go
+++ b/internal/webhook/validation_test.go
@@ -740,6 +740,15 @@ func TestValidate_NegativeBudgetCaps(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "maxMemoryIncreasePerMinute must be non-negative")
 	})
+
+	t.Run("deprecated cycle budget warns", func(t *testing.T) {
+		policy := validPolicy()
+		q := resource.MustParse("2000m")
+		policy.Spec.UpdateStrategy.MaxTotalCPUIncrease = &q
+		w, err := validator.ValidateCreate(context.Background(), policy)
+		assert.NoError(t, err)
+		assert.Contains(t, w, "maxTotalCpuIncrease is deprecated; prefer maxCpuIncreasePerMinute so the cap does not depend on reconcileInterval")
+	})
 }
 
 func TestValidate_OverheadExceedsMax(t *testing.T) {

--- a/test/e2e-go/e2e_test.go
+++ b/test/e2e-go/e2e_test.go
@@ -1368,6 +1368,106 @@ func TestE2E_BudgetCaps_LimitsPerCycleIncrease(t *testing.T) {
 		"increase larger than maxTotalCpuIncrease must not set workloads.resized")
 }
 
+// TestE2E_BudgetCaps_LimitsPerMinuteIncrease proves maxCpuIncreasePerMinute
+// blocks a live CPU increase that exceeds the wall-clock rate.
+func TestE2E_BudgetCaps_LimitsPerMinuteIncrease(t *testing.T) {
+	t.Parallel()
+	ns := uniqueNS("budrate")
+	createNamespace(t, ns)
+
+	const app = "budrate-app"
+	origCPU := resource.MustParse("50m")
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: app, Namespace: ns,
+			Labels: map[string]string{"app": app},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": app}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": app}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "app",
+						Image:   cpuBurnImage,
+						Command: []string{"sh", "-c", "while true; do :; done"},
+						ResizePolicy: []corev1.ContainerResizePolicy{
+							{ResourceName: corev1.ResourceCPU, RestartPolicy: corev1.NotRequired},
+							{ResourceName: corev1.ResourceMemory, RestartPolicy: corev1.NotRequired},
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    origCPU,
+								corev1.ResourceMemory: resource.MustParse("32Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, deploy))
+	waitForDeploymentReady(t, app, ns, 180*time.Second)
+
+	cpuRate := resource.MustParse("20m")
+	maxCPU := resource.MustParse("300m")
+	memPin := resource.MustParse("32Mi")
+	deployName := app
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "budrate-policy", Namespace: ns},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			TargetRef: attunev1alpha1.TargetRef{Kind: "Deployment", Name: &deployName},
+			MetricsSource: attunev1alpha1.MetricsSource{
+				Prometheus:        &attunev1alpha1.PrometheusConfig{Address: promAddr},
+				MinimumDataPoints: int32Ptr(1),
+				HistoryWindow:     &metav1.Duration{Duration: time.Hour},
+				QueryStep:         &metav1.Duration{Duration: 30 * time.Second},
+				RateWindow:        &metav1.Duration{Duration: 5 * time.Minute},
+			},
+			CPU: attunev1alpha1.ResourceConfig{
+				Percentile:       95,
+				Overhead:         "20",
+				MinAllowed:       quantityPtr("50m"),
+				MaxAllowed:       &maxCPU,
+				MaxChangePercent: int32Ptr(100),
+			},
+			Memory: attunev1alpha1.ResourceConfig{
+				Percentile:       99,
+				Overhead:         "30",
+				AllowDecrease:    boolPtr(false),
+				MinAllowed:       &memPin,
+				MaxAllowed:       &memPin,
+				MaxChangePercent: int32Ptr(100),
+			},
+			UpdateStrategy: &attunev1alpha1.UpdateStrategy{
+				Type:                    attunev1alpha1.UpdateTypeAuto,
+				Cooldown:                &metav1.Duration{Duration: time.Minute},
+				AutoRevert:              boolPtr(false),
+				MaxCPUIncreasePerMinute: &cpuRate,
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, policy))
+
+	waitForPolicyDiscovered(t, "budrate-policy", ns, 2*time.Minute)
+
+	require.NoError(t, wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		if policyHasEvent(t, ns, "budrate-policy", "BudgetExhausted") {
+			return true, nil
+		}
+		return false, nil
+	}), "timed out waiting for BudgetExhausted (CPU increase over maxCpuIncreasePerMinute)")
+
+	stillAtOrig := countPodsWithCPURequest(t, ns, app, origCPU)
+	require.Equal(t, 1, stillAtOrig,
+		"pod CPU must remain at original 50m when increase exceeds maxCpuIncreasePerMinute")
+	var p attunev1alpha1.AttunePolicy
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "budrate-policy", Namespace: ns}, &p))
+	assert.Equal(t, int32(0), p.Status.Workloads.Resized,
+		"increase larger than maxCpuIncreasePerMinute must not set workloads.resized")
+}
+
 // TestE2E_GuaranteedQoS_CPUResizeWithMemoryHeld verifies that when memory
 // cannot decrease (Guaranteed + allowDecrease=false / minAllowed=current),
 // an overprovisioned CPU request still resizes live via /resize. This is


### PR DESCRIPTION
Deprecate per-cycle increase caps and add an E2E for the per-minute rate.

Closes #698

## What changed

- `maxTotalCpuIncrease` and `maxTotalMemoryIncrease` are marked Deprecated. Prefer `maxCpuIncreasePerMinute` / `maxMemoryIncreasePerMinute`.
- Admission warns on AttunePolicy and AttuneDefaults when the old fields are set. Admission still succeeds.
- E2E `TestE2E_BudgetCaps_LimitsPerMinuteIncrease` proves a 20m/min cap blocks a burn-driven increase.

The per-cycle fields still work. Both apply when both are set.
