### PR TITLE
fix: close review-wave holes in safety, webhook, and ci

### DIFF
--- a/.github/workflows/bench-baseline.yaml
+++ b/.github/workflows/bench-baseline.yaml
@@ -73,4 +73,6 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: bench-baseline.txt
-          key: bench-baseline-${{ matrix.pkg }}-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          # SHA, not go.sum: a Go-source-only push must publish a new
+          # baseline. Cache is write-once per key.
+          key: bench-baseline-${{ matrix.pkg }}-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -521,7 +521,8 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: bench-baseline.txt
-          key: bench-baseline-${{ matrix.pkg }}-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          # Exact SHA misses on a PR; restore-keys takes the newest main save.
+          key: bench-baseline-${{ matrix.pkg }}-${{ runner.os }}-${{ github.sha }}
           restore-keys: bench-baseline-${{ matrix.pkg }}-${{ runner.os }}-
 
       - name: Run benchmarks

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -11,10 +11,54 @@ run the full E2E Nightly matrix on tip of `main` (see
 ## v0.1.26 to v0.1.27
 
 v0.1.27 tightens last-replica eviction, limit-only resizes, the memory
-usage floor, and kubectl `--sort-by` validation. Existing policy YAML
-keeps working. Read this section if you use `InPlaceOrRecreate`,
+usage floor, and kubectl `--sort-by` validation. It also adds a
+fail-closed namespace freeze kill-switch. Existing policy YAML keeps
+working. Read this section if you use `InPlaceOrRecreate`,
 `controlledValues: RequestsAndLimits`, memory limit decreases, eviction
-metrics, or `kubectl attune --sort-by`.
+metrics, `kubectl attune --sort-by`, hand-managed RBAC, OneShot, or
+`maxTotalCpuIncrease` / `maxTotalMemoryIncrease`.
+
+### Namespace reads are now required
+
+Apply now reads the policy namespace for `attune.io/freeze=true` and
+**fails closed** if that Get fails. A missing `namespaces` `get`,
+`list`, and `watch` grant looks like a cluster-wide freeze:
+
+- no in-place resize, eviction, startup boost, or template persist
+- CREATE initial sizing is skipped
+- `ResizeBlocked=True` with `reason=NamespaceFrozen`
+- webhook allow message:
+  `cannot read namespace for attune.io/freeze; skipping initial sizing (check namespaces get/list/watch RBAC)`
+
+Chart installs with `rbac.create=true` already have the verbs. If you
+maintain your own ClusterRole, add:
+
+```yaml
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
+```
+
+Then confirm the operator ServiceAccount can `get` the policy namespace.
+See [Troubleshooting: NamespaceFrozen](troubleshooting.md#namespacefrozen).
+The same annotation (`attune.io/freeze=true`) is the intentional
+incident kill-switch: recommendations and pending safety revert still
+run.
+
+### Total increase budgets now warn at admission
+
+Setting `maxTotalCpuIncrease` or `maxTotalMemoryIncrease` emits an
+admission warning that those fields are deprecated. Prefer
+`maxCpuIncreasePerMinute` / `maxMemoryIncreasePerMinute` so the cap
+does not depend on `reconcileInterval`. The old fields still apply
+until you migrate.
+
+### OneShot selection walks past a blocked first replica
+
+OneShot no longer sticks on the first listed replica when that pod is
+already at the applied target, or when MemoryPressure, Infeasible plus
+InPlaceOnly, quota, or QoS would skip it. Later replicas in the same
+workload can now move in the same cycle.
 
 ### RequestsAndLimits can apply a limit-only resize
 

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,6 +49,7 @@ import (
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/attune-io/attune/internal/conflict"
 	"github.com/attune-io/attune/internal/gitops"
+	"github.com/attune-io/attune/internal/lifecycle"
 	rsmetrics "github.com/attune-io/attune/internal/metrics"
 	"github.com/attune-io/attune/internal/operatormetrics"
 	"github.com/attune-io/attune/internal/resize"
@@ -305,13 +307,7 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := r.Get(ctx, req.NamespacedName, &policy); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("AttunePolicy resource not found, likely deleted")
-			// Clean up gauge values this policy previously set.
-			deletedPolicyKey := req.Namespace + "/" + req.Name
-			if prev, ok := r.gaugeKeys.LoadAndDelete(deletedPolicyKey); ok {
-				if keys, ok := prev.([]gaugeKey); ok {
-					deleteGaugeKeys(keys)
-				}
-			}
+			r.forgetPolicyRuntimeState(req.Namespace, req.Name)
 			return ctrl.Result{}, nil
 		}
 		operatormetrics.ReconcileErrorsTotal.WithLabelValues("fetch").Inc()
@@ -400,6 +396,8 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	var safetyObservationsPending bool
 	if autoRevertEnabled(policy.Spec.UpdateStrategy) {
 		safetyObservationsPending = r.checkPendingSafetyObservations(workloadCtx, &policy, collector, workloads)
+	} else {
+		r.setSafetyObservationCondition(&policy, lifecycle.Summary{})
 	}
 
 	logger.Info("Discovered workloads", "count", len(workloads))
@@ -1265,13 +1263,7 @@ func (r *AttunePolicyReconciler) handleDeletion(ctx context.Context, policy *att
 		return ctrl.Result{}, errors.Join(cleanupErrs...)
 	}
 
-	// Clean Prometheus gauge values this policy set.
-	policyKey := policy.Namespace + "/" + policy.Name
-	if prev, ok := r.gaugeKeys.LoadAndDelete(policyKey); ok {
-		if keys, ok := prev.([]gaugeKey); ok {
-			deleteGaugeKeys(keys)
-		}
-	}
+	r.forgetPolicyRuntimeState(policy.Namespace, policy.Name)
 
 	// Clean namespace-level savings gauges if this is the last policy in the namespace.
 	var policyList attunev1alpha1.AttunePolicyList
@@ -1301,6 +1293,20 @@ func (r *AttunePolicyReconciler) handleDeletion(ctx context.Context, policy *att
 
 	logger.Info("Completed deletion cleanup for policy", "policy", policy.Name)
 	return ctrl.Result{}, nil
+}
+
+// forgetPolicyRuntimeState drops in-memory per-policy maps so a recreate
+// does not inherit the previous object's gauges, rate tokens, or blocker
+// throttle clock.
+func (r *AttunePolicyReconciler) forgetPolicyRuntimeState(namespace, name string) {
+	policyKey := namespace + "/" + name
+	if prev, ok := r.gaugeKeys.LoadAndDelete(policyKey); ok {
+		if keys, ok := prev.([]gaugeKey); ok {
+			deleteGaugeKeys(keys)
+		}
+	}
+	r.increaseRates.Delete(policyKey)
+	r.lastBlockerRefresh.Delete(types.NamespacedName{Namespace: namespace, Name: name})
 }
 
 func progressPercent(collected, required int) int {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -682,6 +682,8 @@ func TestHandleDeletion_CleansAnnotationsAndGauges(t *testing.T) {
 	reconciler.gaugeKeys.Store("default/my-policy", []gaugeKey{
 		{Namespace: "default", Workload: "app", Container: "main"},
 	})
+	reconciler.increaseRates.Store("default/my-policy", newIncreaseRateBucket(100, 100, time.Now()))
+	reconciler.lastBlockerRefresh.Store(types.NamespacedName{Namespace: "default", Name: "my-policy"}, time.Now())
 
 	result, err := reconciler.handleDeletion(context.Background(), policy)
 	require.NoError(t, err)
@@ -703,6 +705,10 @@ func TestHandleDeletion_CleansAnnotationsAndGauges(t *testing.T) {
 	// Gauges should be cleaned.
 	_, loaded := reconciler.gaugeKeys.Load("default/my-policy")
 	assert.False(t, loaded, "gauge keys should be deleted")
+	_, loaded = reconciler.increaseRates.Load("default/my-policy")
+	assert.False(t, loaded, "increaseRates should be deleted")
+	_, loaded = reconciler.lastBlockerRefresh.Load(types.NamespacedName{Namespace: "default", Name: "my-policy"})
+	assert.False(t, loaded, "lastBlockerRefresh should be deleted")
 
 	// Finalizer should be removed.
 	assert.NotContains(t, policy.Finalizers, finalizerName,
@@ -6905,10 +6911,17 @@ func TestCheckPendingSafetyObservations_ThrottleDeferredLifecycle(t *testing.T) 
 func TestCheckPendingSafetyObservations_NilClientset(t *testing.T) {
 	reconciler := NewAttunePolicyReconciler()
 	policy := newTestPolicy("test-policy", "default")
+	meta.SetStatusCondition(&policy.Status.Conditions, metav1.Condition{
+		Type:   attunev1alpha1.ConditionSafetyObservation,
+		Status: metav1.ConditionTrue,
+		Reason: attunev1alpha1.ReasonSafetyEvaluating,
+	})
 
 	assert.NotPanics(t, func() {
 		reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
 	})
+	assert.Nil(t, meta.FindStatusCondition(policy.Status.Conditions, attunev1alpha1.ConditionSafetyObservation),
+		"nil Clientset must clear a stale SafetyObservation condition")
 }
 
 func TestCheckPendingSafetyObservations_UnsafeVerdictReverts(t *testing.T) {
@@ -7450,6 +7463,13 @@ func TestCheckPendingSafetyObservations_RestoreRetryWhenLiveMatchesClampedRevert
 	require.NoError(t, err)
 	_, err = clientset.CoreV1().Pods("default").UpdateStatus(context.Background(), live, metav1.UpdateOptions{})
 	require.NoError(t, err)
+
+	pending = reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+	assert.True(t, pending, "restore still failing; keep pending")
+	cond := meta.FindStatusCondition(policy.Status.Conditions, attunev1alpha1.ConditionSafetyObservation)
+	require.NotNil(t, cond)
+	assert.Equal(t, attunev1alpha1.ReasonSafetyRestorePending, cond.Reason)
+	assert.Contains(t, cond.Message, "restorePending=1")
 
 	failDeployPatch.Store(false)
 	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
@@ -8430,6 +8450,73 @@ func TestReconcile_FetchDefaultsErrorFailsClosed(t *testing.T) {
 }
 
 // ---------- Reconcile with AutoRevert checking safety observations ----------
+
+func TestReconcile_NotFoundClearsIncreaseRates(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	r.Client = fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	r.Scheme = testScheme()
+	now := time.Now()
+	r.increaseRates.Store("default/gone", newIncreaseRateBucket(100, 100, now))
+	r.lastBlockerRefresh.Store(types.NamespacedName{Namespace: "default", Name: "gone"}, now)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "gone", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	_, ok := r.increaseRates.Load("default/gone")
+	assert.False(t, ok, "not-found reconcile must drop the rate bucket")
+	_, ok = r.lastBlockerRefresh.Load(types.NamespacedName{Namespace: "default", Name: "gone"})
+	assert.False(t, ok, "not-found reconcile must drop the blocker clock")
+}
+
+func TestForgetPolicyRuntimeState_RecreateStartsFullBucket(t *testing.T) {
+	r := NewAttunePolicyReconciler()
+	now := time.Now()
+	old := newIncreaseRateBucket(1000, -1, now)
+	require.True(t, old.tryDraw(1000, 0, now))
+	assert.False(t, old.tryDraw(1, 0, now), "drained bucket must reject another draw")
+	r.increaseRates.Store("default/p", old)
+
+	r.forgetPolicyRuntimeState("default", "p")
+	_, ok := r.increaseRates.Load("default/p")
+	assert.False(t, ok)
+
+	fresh := newIncreaseRateBucket(1000, -1, now)
+	r.increaseRates.Store("default/p", fresh)
+	assert.True(t, fresh.tryDraw(1000, 0, now), "recreated policy must start with a full bucket")
+}
+
+func TestReconcile_AutoRevertDisabledClearsSafetyObservation(t *testing.T) {
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(false)
+	meta.SetStatusCondition(&policy.Status.Conditions, metav1.Condition{
+		Type:    attunev1alpha1.ConditionSafetyObservation,
+		Status:  metav1.ConditionTrue,
+		Reason:  attunev1alpha1.ReasonSafetyEvaluating,
+		Message: "stale observation",
+	})
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	pod := newTestPod("api-server-abc-1", "default", map[string]string{"app": "api-server"})
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, query string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return generateSamples(200, 0.1), nil
+		},
+	}
+	reconciler, fakeClient := newReconcilerForReconcile(mc, policy, deploy, pod)
+	reconciler.Clientset = kubefake.NewSimpleClientset()
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var updated attunev1alpha1.AttunePolicy
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "test-policy", Namespace: "default",
+	}, &updated))
+	assert.Nil(t, meta.FindStatusCondition(updated.Status.Conditions, attunev1alpha1.ConditionSafetyObservation),
+		"disabling autoRevert must clear SafetyObservation")
+}
 
 func TestReconcile_AutoRevertCallsSafetyObservations(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
@@ -10128,6 +10215,94 @@ func TestTryEvictionFallback_SkipsLastReplica(t *testing.T) {
 		assert.Contains(t, event, "NotReady")
 	default:
 		t.Error("expected EvictionBlocked event but none was emitted")
+	}
+}
+
+func TestExecuteResizes_FloorToCurrentEmitsResizeDeferred(t *testing.T) {
+	pod := newResizePod("api-server", "200m", "550Mi", "200m", "550Mi")
+	pod.Status.QOSClass = corev1.PodQOSGuaranteed
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	r, _ := newResizeReconciler(pod, deploy)
+	recorder := events.NewFakeRecorder(10)
+	r.Recorder = recorder
+	r.AllowInPlaceMemoryLimitDecrease = true
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.CPU.ControlledValues = &cv
+	policy.Spec.Memory.ControlledValues = &cv
+	allowDec := true
+	policy.Spec.Memory.AllowDecrease = &allowDec
+	margin := int32(10)
+	policy.Spec.Memory.DecreaseUsageMarginPercent = &margin
+
+	rec := newResizeRecommendation("api-server",
+		"200m", "550Mi", "200m", "550Mi",
+		"200m", "200Mi", "200m", "200Mi")
+	rec.Containers[0].Explanation = &attunev1alpha1.ContainerRecommendationExplanation{
+		Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+			RawPercentile: resource.MustParse("500Mi"),
+		},
+	}
+
+	count, _ := r.executeResizes(context.Background(), policy, []client.Object{deploy},
+		[]attunev1alpha1.WorkloadRecommendation{rec}, podMap("api-server", pod), nil, nil)
+	assert.Equal(t, 0, count, "floor-to-current must not apply a resize")
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "ResizeDeferred") {
+				found = true
+			}
+		default:
+			require.True(t, found, "executeResizes clamp/floor no-op must emit ResizeDeferred")
+			return
+		}
+	}
+}
+
+func TestResizeContainer_LiveAppliedClampNoopEmitsResizeDeferred(t *testing.T) {
+	pod := newResizePod("api-server", "500m", "512Mi", "500m", "512Mi")
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	r, _ := newResizeReconciler(pod, deploy)
+	recorder := events.NewFakeRecorder(10)
+	r.Recorder = recorder
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	target := pod.Spec.Containers[0].Resources.DeepCopy()
+	pre := target.DeepCopy()
+	pre.Requests[corev1.ResourceMemory] = resource.MustParse("64Mi")
+	pre.Limits[corev1.ResourceMemory] = resource.MustParse("64Mi")
+
+	entries, outcome := r.resizeContainer(context.Background(), resizeParams{
+		Policy:       policy,
+		Pod:          pod,
+		Workload:     deploy,
+		WorkloadName: "api-server",
+		ContainerRec: attunev1alpha1.ContainerRecommendation{Name: "main"},
+		Target:       *target,
+		LiveApplied:  true,
+		ApplyMeta:    liveResizeApplyMeta{PreClamped: *pre},
+		Now:          metav1.Now(),
+	})
+	assert.Equal(t, resizeOutcomeNone, outcome)
+	assert.Empty(t, entries)
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "ResizeDeferred") {
+				found = true
+			}
+		default:
+			require.True(t, found, "LiveApplied clamp-to-current must emit ResizeDeferred")
+			return
+		}
 	}
 }
 
@@ -16752,4 +16927,32 @@ func TestCheckPendingSafetyObservations_ListErrorReturnsObservationsPending(t *t
 
 	assert.True(t, pending,
 		"observationsPending should be true on List error (fail-safe requeue)")
+}
+
+func TestCheckPendingSafetyObservations_ListErrorClearsStaleCondition(t *testing.T) {
+	scheme := testScheme()
+	failingClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return fmt.Errorf("simulated API server error")
+			},
+		}).Build()
+
+	r := NewAttunePolicyReconciler()
+	r.Client = failingClient
+	r.Scheme = scheme
+	r.Clientset = kubefake.NewSimpleClientset()
+
+	policy := newTestPolicy("test-policy", "default")
+	meta.SetStatusCondition(&policy.Status.Conditions, metav1.Condition{
+		Type:    attunev1alpha1.ConditionSafetyObservation,
+		Status:  metav1.ConditionTrue,
+		Reason:  attunev1alpha1.ReasonSafetyEvaluating,
+		Message: "2 pod(s) in safety lifecycle (observing=0 evaluating=2 restorePending=0 incomplete=0)",
+	})
+
+	pending := r.checkPendingSafetyObservations(context.Background(), policy, nil, safetyWorkloads())
+	assert.True(t, pending)
+	assert.Nil(t, meta.FindStatusCondition(policy.Status.Conditions, attunev1alpha1.ConditionSafetyObservation),
+		"List failure must not keep a stale SafetyObservation count")
 }

--- a/internal/controller/conditions_test.go
+++ b/internal/controller/conditions_test.go
@@ -316,6 +316,15 @@ func TestSetSafetyObservationCondition(t *testing.T) {
 		require.NotNil(t, cond)
 		assert.Equal(t, attunev1alpha1.ReasonSafetyIncomplete, cond.Reason)
 	})
+
+	t.Run("restore pending", func(t *testing.T) {
+		policy := &attunev1alpha1.AttunePolicy{ObjectMeta: metav1.ObjectMeta{Generation: 4}}
+		r.setSafetyObservationCondition(policy, lifecycle.Summary{Evaluating: 1, RestorePending: 1})
+		cond := meta.FindStatusCondition(policy.Status.Conditions, attunev1alpha1.ConditionSafetyObservation)
+		require.NotNil(t, cond)
+		assert.Equal(t, attunev1alpha1.ReasonSafetyRestorePending, cond.Reason)
+		assert.Contains(t, cond.Message, "restorePending=1")
+	})
 }
 
 // ---------- Consecutive reverts ----------

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -556,6 +556,7 @@ func (r *AttunePolicyReconciler) executeResizes(
 					}
 					r.emitLiveResizeApply(ctx, policy, &pod, action.ContainerRec, action.ApplyMeta)
 					if action.AtTarget {
+						r.emitResizeDeferredIfFilteredOrClamped(ctx, policy, &pod, action.ContainerRec, action.Target, action.ApplyMeta.PreClamped)
 						continue
 					}
 					cpuIncrease, memIncrease := action.CPUIncrease, action.MemIncrease
@@ -587,6 +588,7 @@ func (r *AttunePolicyReconciler) executeResizes(
 						Checks:       checks,
 						SkipEviction: skipEviction,
 						LiveApplied:  true,
+						ApplyMeta:    action.ApplyMeta,
 					})
 					if outcome == resizeOutcomeNone {
 						podHistory = append(podHistory, entries...)
@@ -667,6 +669,8 @@ type resizeParams struct {
 	// LiveApplied means executeResizes already ran applyLiveResizeTarget
 	// (after at most one live Get for the pod). Target is the applied value.
 	LiveApplied bool
+	// ApplyMeta is the clamp/floor result from plan when LiveApplied is set.
+	ApplyMeta liveResizeApplyMeta
 }
 
 // resizeOutcome tells executeResizes whether a container resize succeeded
@@ -717,7 +721,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 		target, applyMeta = r.applyLiveResizeTarget(policy, pod, containerRec, target)
 		r.emitLiveResizeApply(ctx, policy, pod, containerRec, applyMeta)
 	} else {
-		applyMeta.PreClamped = *target.DeepCopy()
+		applyMeta = p.ApplyMeta
 	}
 	preClamped := applyMeta.PreClamped
 
@@ -730,32 +734,7 @@ func (r *AttunePolicyReconciler) resizeContainer(
 				"Resize blocked for pod %s container %s: %s", pod.Name, containerRec.Name, reason)
 			recordCapacitySkip(policy, reason)
 		} else {
-			// Determine whether the "already at target" came from a change
-			// filter suppression (the raw recommendation differed but the
-			// delta was below 10%). When a change filter was active, the
-			// user needs to know; promote to Info level with an Event.
-			cpuFiltered := containerRec.Explanation != nil && containerRec.Explanation.CPU != nil &&
-				containerRec.Explanation.CPU.ChangeFilterApplied != ""
-			memFiltered := containerRec.Explanation != nil && containerRec.Explanation.Memory != nil &&
-				containerRec.Explanation.Memory.ChangeFilterApplied != ""
-			memoryClamped := !preClamped.Requests.Memory().Equal(*target.Requests.Memory())
-			if cpuFiltered || memFiltered || memoryClamped {
-				logger.Info("Resize deferred: resources at target after filtering/clamping",
-					"pod", pod.Name, "container", containerRec.Name,
-					"cpuTarget", target.Requests.Cpu().String(),
-					"memTarget", target.Requests.Memory().String(),
-					"cpuChangeFilter", cpuFiltered,
-					"memChangeFilter", memFiltered,
-					"memoryClamped", memoryClamped)
-				r.emitEventOnce(policy, corev1.EventTypeNormal, "ResizeDeferred", "resize",
-					"Container %s in pod %s: resources unchanged after change filtering and/or memory clamping (cpu=%s, mem=%s)",
-					containerRec.Name, pod.Name, target.Requests.Cpu().String(), target.Requests.Memory().String())
-			} else {
-				logger.V(1).Info("Skipping resize: already at target",
-					"pod", pod.Name, "container", containerRec.Name,
-					"cpuTarget", target.Requests.Cpu().String(),
-					"memTarget", target.Requests.Memory().String())
-			}
+			r.emitResizeDeferredIfFilteredOrClamped(ctx, policy, pod, containerRec, target, preClamped)
 		}
 		return nil, resizeOutcomeNone
 	}
@@ -1859,6 +1838,41 @@ func targetIncreasesRequests(pod *corev1.Pod, containerName string, target corev
 	cpuInc := target.Requests.Cpu().MilliValue() > c.Resources.Requests.Cpu().MilliValue()
 	memInc := target.Requests.Memory().Value() > c.Resources.Requests.Memory().Value()
 	return cpuInc || memInc
+}
+
+// emitResizeDeferredIfFilteredOrClamped emits ResizeDeferred when a no-op
+// is due to a change filter or a memory clamp/floor, not a true at-target.
+func (r *AttunePolicyReconciler) emitResizeDeferredIfFilteredOrClamped(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	pod *corev1.Pod,
+	containerRec attunev1alpha1.ContainerRecommendation,
+	target corev1.ResourceRequirements,
+	preClamped corev1.ResourceRequirements,
+) {
+	logger := log.FromContext(ctx)
+	cpuFiltered := containerRec.Explanation != nil && containerRec.Explanation.CPU != nil &&
+		containerRec.Explanation.CPU.ChangeFilterApplied != ""
+	memFiltered := containerRec.Explanation != nil && containerRec.Explanation.Memory != nil &&
+		containerRec.Explanation.Memory.ChangeFilterApplied != ""
+	memoryClamped := !preClamped.Requests.Memory().Equal(*target.Requests.Memory())
+	if cpuFiltered || memFiltered || memoryClamped {
+		logger.Info("Resize deferred: resources at target after filtering/clamping",
+			"pod", pod.Name, "container", containerRec.Name,
+			"cpuTarget", target.Requests.Cpu().String(),
+			"memTarget", target.Requests.Memory().String(),
+			"cpuChangeFilter", cpuFiltered,
+			"memChangeFilter", memFiltered,
+			"memoryClamped", memoryClamped)
+		r.emitEventOnce(policy, corev1.EventTypeNormal, "ResizeDeferred", "resize",
+			"Container %s in pod %s: resources unchanged after change filtering and/or memory clamping (cpu=%s, mem=%s)",
+			containerRec.Name, pod.Name, target.Requests.Cpu().String(), target.Requests.Memory().String())
+		return
+	}
+	logger.V(1).Info("Skipping resize: already at target",
+		"pod", pod.Name, "container", containerRec.Name,
+		"cpuTarget", target.Requests.Cpu().String(),
+		"memTarget", target.Requests.Memory().String())
 }
 
 // emitLiveResizeApply writes clamp/floor events and metrics from apply meta.

--- a/internal/controller/safety.go
+++ b/internal/controller/safety.go
@@ -235,6 +235,7 @@ func (r *AttunePolicyReconciler) countLiveRunningReplicas(
 func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Context, policy *attunev1alpha1.AttunePolicy, collector rsmetrics.MetricsCollector, workloads []client.Object) (observationsPending bool) {
 	logger := log.FromContext(ctx)
 	if r.Clientset == nil {
+		r.setSafetyObservationCondition(policy, lifecycle.Summary{})
 		return false
 	}
 
@@ -246,6 +247,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 		// Fail safe: assume observations are pending so the reconciler
 		// requeues at the short observation interval instead of the full
 		// cooldown, avoiding a delayed safety detection window.
+		r.setSafetyObservationCondition(policy, lifecycle.Summary{})
 		observationsPending = true
 		return
 	}
@@ -315,13 +317,7 @@ func (r *AttunePolicyReconciler) checkPendingSafetyObservations(ctx context.Cont
 			continue
 		}
 
-		tracked := pod.Labels[labelTracked] == "true"
-		resizedAt := ""
-		if pod.Annotations != nil {
-			resizedAt = pod.Annotations[annotationResizedAt]
-		}
-		safetySummary.Add(lifecycle.Classify(lifecycle.InputFromAnnotations(
-			tracked, resizedAt, r.now(), observationPeriod)))
+		safetySummary.Add(lifecycle.Classify(safetyLifecycleInput(policy, pod, r.now(), observationPeriod)))
 
 		records, err := parseResizeRecords(pod, observationPeriod, r.now())
 		if err != nil {
@@ -529,6 +525,34 @@ func (r *AttunePolicyReconciler) retryTemplateRestoreIfAlreadyReverted(
 		return err
 	}
 	return nil
+}
+
+// safetyLifecycleInput fills Classify flags the annotation constructor
+// leaves false: persist-after-success and live match to the applied
+// revert target (the retry-restore state).
+func safetyLifecycleInput(policy *attunev1alpha1.AttunePolicy, pod *corev1.Pod, now time.Time, observationPeriod time.Duration) lifecycle.Input {
+	tracked := pod.Labels[labelTracked] == "true"
+	resizedAt := ""
+	if pod.Annotations != nil {
+		resizedAt = pod.Annotations[annotationResizedAt]
+	}
+	in := lifecycle.InputFromAnnotations(tracked, resizedAt, now, observationPeriod)
+	if policy == nil || !templatePersistenceEnabled(policy.Spec.UpdateStrategy) ||
+		templatePersistenceWhen(policy.Spec.UpdateStrategy) != attunev1alpha1.TemplatePersistenceAfterSuccessfulResize {
+		return in
+	}
+	in.PersistAfterSuccess = true
+	recs, err := buildResizeRecords(pod, observationPeriod)
+	if err != nil {
+		return in
+	}
+	for _, rec := range recs {
+		if liveContainerMatchesOriginal(pod, rec) {
+			in.LiveMatchesOriginal = true
+			break
+		}
+	}
+	return in
 }
 
 // liveContainerMatchesOriginal reports whether the named container's live

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -301,6 +301,7 @@ func (h *PodMutatingHandler) mutateContainer(
 					container.Resources.Limits = corev1.ResourceList{}
 				}
 				container.Resources.Limits[corev1.ResourceCPU] = cr.Recommended.CPULimit
+				mutated = true
 			}
 		}
 
@@ -312,6 +313,7 @@ func (h *PodMutatingHandler) mutateContainer(
 				}
 				memTarget := applyCreateMemoryUsageFloor(container.Resources, cr, policy)
 				container.Resources.Limits[corev1.ResourceMemory] = memTarget.Limits[corev1.ResourceMemory]
+				mutated = true
 				if req, ok := memTarget.Requests[corev1.ResourceMemory]; ok {
 					container.Resources.Requests[corev1.ResourceMemory] = req
 				}

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -602,6 +602,69 @@ func TestPodMutatingHandler_RequestsAndLimits(t *testing.T) {
 	assert.Equal(t, resource.MustParse("512Mi"), mutatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
 }
 
+func TestPodMutatingHandler_LimitsOnlyCPUProducesPatch(t *testing.T) {
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.CPU.ControlledValues = &cv
+	cr := &policy.Status.Recommendations[0].Containers[0]
+	cr.Recommended.CPURequest = resource.Quantity{}
+	cr.Recommended.MemoryRequest = resource.Quantity{}
+	cr.Recommended.CPULimit = resource.MustParse("1")
+	cr.Recommended.MemoryLimit = resource.Quantity{}
+
+	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	req := makeAdmissionRequest(t, pod, "default")
+	resp := handler.Handle(context.Background(), req)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches, "limits-only CPU rec must produce a patch")
+
+	mutatedPod := patchedPod(t, req.Object.Raw, resp)
+	assert.True(t, mutatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU].Equal(resource.MustParse("1")))
+}
+
+func TestPodMutatingHandler_LimitsOnlyMemoryFloorProducesPatch(t *testing.T) {
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.Memory.ControlledValues = &cv
+	cr := &policy.Status.Recommendations[0].Containers[0]
+	cr.Recommended.CPURequest = resource.Quantity{}
+	cr.Recommended.MemoryRequest = resource.Quantity{}
+	cr.Recommended.CPULimit = resource.Quantity{}
+	cr.Recommended.MemoryLimit = resource.MustParse("200Mi")
+	cr.Current = attunev1alpha1.ResourceValues{
+		MemoryRequest: resource.MustParse("1Gi"),
+		MemoryLimit:   resource.MustParse("1Gi"),
+	}
+	cr.Explanation = &attunev1alpha1.ContainerRecommendationExplanation{
+		Memory: &attunev1alpha1.ResourceRecommendationExplanation{
+			RawPercentile: resource.MustParse("500Mi"),
+		},
+	}
+
+	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+	pod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse("1Gi")
+	pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("1Gi"),
+	}
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	req := makeAdmissionRequest(t, pod, "default")
+	resp := handler.Handle(context.Background(), req)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches, "limits-only memory rec must produce a patch")
+
+	mutatedPod := patchedPod(t, req.Object.Raw, resp)
+	want := resource.MustParse("550Mi")
+	gotLim := mutatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
+	gotReq := mutatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
+	assert.True(t, gotLim.Equal(want), "CREATE floor limit %s want %s", gotLim.String(), want.String())
+	assert.True(t, gotReq.Equal(want), "CREATE floor request %s want %s", gotReq.String(), want.String())
+}
+
 func TestPodMutatingHandler_RequestsAndLimits_UsageFloorGuaranteed(t *testing.T) {
 	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
 	cv := attunev1alpha1.ControlledRequestsAndLimits


### PR DESCRIPTION
## Summary

Fixes the seven accepted findings from the other-LLM review wave (#712, #714-#719). #713 is closed as not planned: the pinned `?event=push` CI badge still shows passing, and dropping the pin paints the leftover red dispatch.

## The problem

- The 0.1.27 upgrade guide omitted fail-closed namespace freeze and the `namespaces` RBAC grant.
- Bench baseline cache was keyed only on `go.sum`, so Go-source-only main pushes never refreshed it.
- `RestorePending` was never classified in production because persist/live flags stayed false.
- `SafetyObservation` could stay True with a stale count after a pod list error or after `autoRevert` was turned off.
- `increaseRates` leaked on delete and a same-name recreate reused the drained bucket.
- A clamp or usage-floor no-op skipped `resizeContainer` and never emitted `ResizeDeferred`.
- Webhook limit writes did not set `mutated`, so a limits-only CREATE dropped the memory floor patch.

## The change

- [upgrading.md](https://github.com/attune-io/attune/blob/main/docs/guides/upgrading.md): namespace freeze RBAC, admission budget warnings, OneShot walk-past-blocked replica.
- [bench-baseline.yaml](https://github.com/attune-io/attune/blob/main/.github/workflows/bench-baseline.yaml) / [ci.yaml](https://github.com/attune-io/attune/blob/main/.github/workflows/ci.yaml): save and restore keys use `github.sha`; PRs still take the newest main baseline via `restore-keys`.
- Safety classify now sets persist-after-success and live match; tests assert `ReasonSafetyRestorePending`.
- List error, nil Clientset, and `autoRevert=false` clear `SafetyObservation`.
- `forgetPolicyRuntimeState` deletes gauges, rate buckets, and the blocker clock on delete and not-found.
- `executeResizes` emits `ResizeDeferred` on an `AtTarget` clamp/floor no-op; webhook sets `mutated` on every limit write.

## Validation

- `go test ./internal/controller/ ./internal/webhook/ ./internal/lifecycle/ -race -count=1`
- `make lint` (0 issues)
- Local reviewer: one bug (`AtTarget` skipped `ResizeDeferred`) and one nit (truncated webhook message). Both fixed before push.

## Issue reference

Closes #712
Closes #714
Closes #715
Closes #716
Closes #717
Closes #718
Closes #719
