### PR TITLE
fix: clamp leftover dest limits on create, persist, and resize

### DIFF
--- a/cmd/kubectl-attune/wizard.go
+++ b/cmd/kubectl-attune/wizard.go
@@ -243,6 +243,9 @@ func wizardCreate(ctx context.Context, dynClient dynamic.Interface, namespace st
 		}
 		fmt.Printf("AttunePolicy %q created in namespace %q.\n", policyName, ns)
 		fmt.Println("\nTip: Run \"kubectl attune status -w\" to watch data collection progress.")
+		if initialSizing {
+			fmt.Println(initialSizingNextSteps(ns))
+		}
 	case 1:
 		filename, err := p.Input("Filename", policyName+".yaml")
 		if err != nil {
@@ -378,9 +381,15 @@ func wizardPromote(ctx context.Context, dynClient dynamic.Interface, namespace s
 	}
 	fmt.Printf("Policy %q promoted to %s mode.\n", selected.GetName(), newMode)
 	if enableInitialSizing {
-		fmt.Printf("Initial sizing enabled. Label namespaces with: kubectl label namespace %s attune.io/initial-sizing=enabled\n", ns)
+		fmt.Println(initialSizingNextSteps(ns))
 	}
 	return nil
+}
+
+// initialSizingNextSteps lists both webhook gates required after enabling
+// policy-level initialSizing (Helm webhook default is false).
+func initialSizingNextSteps(ns string) string {
+	return fmt.Sprintf("Initial sizing also requires Helm initialSizing.enabled=true (webhook default is false) and: kubectl label namespace %s attune.io/initial-sizing=enabled", ns)
 }
 
 // selectNamespace lists cluster namespaces and prompts the user.

--- a/cmd/kubectl-attune/wizard_test.go
+++ b/cmd/kubectl-attune/wizard_test.go
@@ -397,6 +397,13 @@ func TestWizardCreate_NoWorkloads(t *testing.T) {
 	assert.Contains(t, err.Error(), "no Deployments found")
 }
 
+func TestInitialSizingNextSteps(t *testing.T) {
+	got := initialSizingNextSteps("prod")
+	assert.Contains(t, got, "initialSizing.enabled")
+	assert.Contains(t, got, "attune.io/initial-sizing=enabled")
+	assert.Contains(t, got, "prod")
+}
+
 func TestBuildPolicyObject_WithInitialSizing(t *testing.T) {
 	obj := buildPolicyObject("prod", "api-attune", "Deployment", "api-server",
 		"http://prom:9090", 95, 99, "Auto", true)

--- a/docs/architecture/resize-api.md
+++ b/docs/architecture/resize-api.md
@@ -254,8 +254,11 @@ stateDiagram-v2
   working set drops below the new limit. If the application holds onto
   allocated memory, the decrease has no practical effect until the process
   releases it.
-- **Init containers**: Not resizable in-place. The operator only resizes
-  regular containers.
+- **Init containers**: Traditional init containers (no `restartPolicy`, or
+  any value other than `Always`) are not resized in-place. Native sidecars
+  (`restartPolicy: Always`) are CREATE-sized, in-place resized, and
+  startup-boosted. They are still subject to `excludeKnownSidecars`. See
+  [Istio integration](../guides/istio-integration.md).
 - **Restart policy**: Containers with `resizePolicy: RestartContainer` will
   be restarted by the kubelet when their resources change.
 - **Prometheus address limit**: The operator caches at most 64 unique

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1128,9 +1128,10 @@ current limit. This happens when `controlledValues` is set to
 `RequestsOnly` (limits stay at their current values) and the
 recommendation grows beyond those limits. The same clamp runs on CREATE
 initial sizing (leftover pod limits, including LimitRange defaults) and
-on persist merge against leftover template limits. The operator caps the
-request at the limit to prevent the API server from rejecting the resize
-or the Deployment/StatefulSet patch.
+on persist merge against leftover template limits. Live resize also
+clamps to leftover pod limits (LimitRange), not only rec-blob limits.
+The operator caps the request at the limit to prevent the API server
+from rejecting the resize or the Deployment/StatefulSet patch.
 
 **Fix**: Either increase the container's limits, or switch to
 `controlledValues: RequestsAndLimits` so the operator can scale limits

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1126,16 +1126,20 @@ list of affected resources (e.g., `cpu`, `memory`).
 **Cause**: The recommended CPU or memory request exceeds the container's
 current limit. This happens when `controlledValues` is set to
 `RequestsOnly` (limits stay at their current values) and the
-recommendation grows beyond those limits. The operator caps the request
-at the limit to prevent the API server from rejecting the resize.
+recommendation grows beyond those limits. The same clamp runs on CREATE
+initial sizing (leftover pod limits, including LimitRange defaults) and
+on persist merge against leftover template limits. The operator caps the
+request at the limit to prevent the API server from rejecting the resize
+or the Deployment/StatefulSet patch.
 
 **Fix**: Either increase the container's limits, or switch to
 `controlledValues: RequestsAndLimits` so the operator can scale limits
 proportionally with requests.
 
 The `attune_request_clamped_total` counter increments each time a request
-is capped, broken down by container and resource. Use it to detect
-policies where limits are consistently too tight:
+is capped on live resize and on CREATE, broken down by container and
+resource. Use it to detect policies where limits are consistently too
+tight:
 
 ```promql
 rate(attune_request_clamped_total[1h]) > 0

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -625,7 +625,7 @@ on a policy or on `AttuneDefaults` / `AttuneNamespaceDefaults`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `updateStrategy.initialSizing` | bool | `false` | When true and the initial sizing webhook is enabled, new pods matching this policy (by `targetRef.name` or `targetRef.selector`) receive recommended resources at creation time via a mutating admission webhook. Requires the namespace label `attune.io/initial-sizing=enabled`. A rec is used when every container has confidence at least 0.5, or this workload already has a successful in-place resize. Canary still skips CREATE for an app until that app is promoted (or the assigned pod name is already in the canary slice). ReplicaSet CREATE with an empty name is not treated as a slice identity. |
+| `updateStrategy.initialSizing` | bool | `false` | When true and the initial sizing webhook is enabled, new pods matching this policy (by `targetRef.name` or `targetRef.selector`) receive recommended resources at creation time via a mutating admission webhook, clamped so requests do not exceed leftover limits (same as live resize). Native sidecars are included. Requires the namespace label `attune.io/initial-sizing=enabled`. A rec is used when every container has confidence at least 0.5, or this workload already has a successful in-place resize. Canary still skips CREATE for an app until that app is promoted (or the assigned pod name is already in the canary slice). ReplicaSet CREATE with an empty name is not treated as a slice identity. |
 
 ## Status Conditions
 

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -5060,6 +5060,93 @@ func TestCheckPendingSafetyObservations_EarlyCriticalConfirmGet500DoesNotRevert(
 	}
 }
 
+func TestCheckPendingSafetyObservations_EarlyCriticalConfirmGet404DoesNotRevert(t *testing.T) {
+	resizedAt := time.Now().UTC().Add(-10 * time.Second).Format(time.RFC3339)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oom-confirm-404",
+			Namespace: "default",
+			Labels:    map[string]string{"attune.io/tracked": "true"},
+			Annotations: map[string]string{
+				"attune.io/resized-at":                   resizedAt,
+				"attune.io/resized-workload":             "api-server",
+				"attune.io/resized-containers":           "main",
+				"attune.io/original-cpu-request.main":    "500m",
+				"attune.io/original-memory-request.main": "512Mi",
+				"attune.io/original-cpu-limit.main":      "1000m",
+				"attune.io/original-memory-limit.main":   "1Gi",
+				"attune.io/policy":                       "test-policy",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:     "OOMKilled",
+							FinishedAt: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	deploy := recSizedAPIServerDeploy()
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+
+	reconciler, fakeClient := newResizeReconciler(pod, deploy)
+	cs := reconciler.Clientset.(*kubefake.Clientset)
+	cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(corev1.Resource("pods"), "oom-confirm-404")
+	})
+
+	reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "resize" {
+			t.Fatal("early OOM confirm Get 404 must not revert")
+		}
+	}
+
+	var gotPod corev1.Pod
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "oom-confirm-404", Namespace: "default",
+	}, &gotPod))
+	_, hasTracking := gotPod.Annotations[annotationResizedAt]
+	assert.True(t, hasTracking, "tracking annotations must remain after confirm Get 404")
+
+	var gotDeploy appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server", Namespace: "default",
+	}, &gotDeploy))
+	gotRes := gotDeploy.Spec.Template.Spec.Containers[0].Resources
+	assert.True(t, gotRes.Requests.Cpu().Equal(resource.MustParse("250m")),
+		"template CPU request must stay at rec 250m, not original 500m")
+	assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("256Mi")),
+		"template memory request must stay at rec 256Mi, not original 512Mi")
+}
+
 // ---------- isCooldownActive parse error ----------
 
 func TestIsCooldownActive_MalformedDate(t *testing.T) {
@@ -7482,6 +7569,117 @@ func TestCheckPendingSafetyObservations_RestoreRetryWhenLiveMatchesClampedRevert
 		"restore must write the original 128Mi request, not the raised revert request")
 	assert.True(t, gotRes.Limits.Memory().Equal(resource.MustParse("256Mi")),
 		"restore must write the original 256Mi limit, not the clamped live 512Mi")
+}
+
+func TestCheckPendingSafetyObservations_RestoreRetryLiveGetErrorKeepsTracking(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		getErr  error
+		podName string
+	}{
+		{
+			name:    "get500",
+			getErr:  apierrors.NewInternalError(fmt.Errorf("injected restore Get 500")),
+			podName: "restore-retry-get-500",
+		},
+		{
+			name:    "get404",
+			getErr:  apierrors.NewNotFound(corev1.Resource("pods"), "restore-retry-get-404"),
+			podName: "restore-retry-get-404",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resizedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+			// Listed already matches the original snapshot so ignoring a
+			// live Get error would restore the AfterSuccessfulResize template.
+			original := corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1000m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.podName,
+					Namespace: "default",
+					Labels:    map[string]string{"app": "test", "attune.io/tracked": "true"},
+					Annotations: map[string]string{
+						"attune.io/resized-at":                   resizedAt,
+						"attune.io/resized-workload":             "api-server",
+						"attune.io/resized-containers":           "main",
+						"attune.io/original-cpu-request.main":    "500m",
+						"attune.io/original-memory-request.main": "512Mi",
+						"attune.io/original-cpu-limit.main":      "1000m",
+						"attune.io/original-memory-limit.main":   "1Gi",
+						"attune.io/policy":                       "test-policy",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:      "main",
+							Image:     "nginx",
+							Resources: original,
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "main", RestartCount: 0},
+					},
+				},
+			}
+
+			deploy := recSizedAPIServerDeploy()
+			reconciler, fakeClient := newResizeReconciler(pod, deploy)
+			cs := reconciler.Clientset.(*kubefake.Clientset)
+			cs.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, tt.getErr
+			})
+
+			policy := newTestPolicy("test-policy", "default")
+			policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+			policy.Spec.UpdateStrategy.AutoRevert = boolPtr(true)
+			policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+				Enabled: boolPtr(true),
+				When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+			}
+
+			pending := reconciler.checkPendingSafetyObservations(context.Background(), policy, nil, []client.Object{deploy})
+			assert.True(t, pending, "live Get error must keep observations pending")
+
+			var gotPod corev1.Pod
+			require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+				Name: tt.podName, Namespace: "default",
+			}, &gotPod))
+			_, hasTracking := gotPod.Annotations[annotationResizedAt]
+			assert.True(t, hasTracking, "tracking must remain when live Get fails")
+
+			var gotDeploy appsv1.Deployment
+			require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+				Name: "api-server", Namespace: "default",
+			}, &gotDeploy))
+			gotRes := gotDeploy.Spec.Template.Spec.Containers[0].Resources
+			assert.True(t, gotRes.Requests.Cpu().Equal(resource.MustParse("250m")),
+				"template CPU must stay at rec 250m, not listed original 500m")
+			assert.True(t, gotRes.Requests.Memory().Equal(resource.MustParse("256Mi")),
+				"template memory must stay at rec 256Mi, not listed original 512Mi")
+		})
+	}
 }
 
 func TestCheckPendingSafetyObservations_NotReadyFlapConfirmedBeforeRevert(t *testing.T) {

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -11424,7 +11424,7 @@ func TestExecuteResizes_EvictionSpendsFilterSlot(t *testing.T) {
 }
 
 func TestExecuteResizes_MixedOutcomePodDoesNotLeakSuccessOrBudget(t *testing.T) {
-	apiPod1 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	apiPod1 := newResizePod("api-server", "200m", "256Mi", "500m", "256Mi")
 	apiPod1.Name = "api-server-abc-1"
 	apiPod1.Spec.Containers = append(apiPod1.Spec.Containers, corev1.Container{
 		Name:  "sidecar",
@@ -11435,7 +11435,7 @@ func TestExecuteResizes_MixedOutcomePodDoesNotLeakSuccessOrBudget(t *testing.T) 
 				corev1.ResourceMemory: resource.MustParse("64Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceCPU:    resource.MustParse("200m"),
 				corev1.ResourceMemory: resource.MustParse("64Mi"),
 			},
 		},

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10252,6 +10252,44 @@ func TestExecuteResizes_RequestClampedMetric(t *testing.T) {
 	assert.Equal(t, beforeMem+1, afterMem, "RequestClampedTotal should increment for memory")
 }
 
+func TestExecuteResizes_DestClampAtTargetDoesNotIncrement(t *testing.T) {
+	// Rec 500m, leftover live limit 200m, live already at 200m. Plan dest-clamps
+	// every cycle; the counter must not tick after converge.
+	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	reconciler, _ := newResizeReconciler(pod, deploy)
+
+	recommendations := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "api-server",
+			Kind:     "Deployment",
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name: "main",
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest:    resource.MustParse("500m"),
+						MemoryRequest: resource.MustParse("256Mi"),
+					},
+					Current: attunev1alpha1.ResourceValues{
+						CPURequest:    resource.MustParse("200m"),
+						MemoryRequest: resource.MustParse("256Mi"),
+						CPULimit:      resource.MustParse("200m"),
+						MemoryLimit:   resource.MustParse("256Mi"),
+					},
+				},
+			},
+		},
+	}
+
+	beforeCPU := promtestutil.ToFloat64(operatormetrics.RequestClampedTotal.WithLabelValues("default", "test-policy", "main", "cpu"))
+	reconciler.executeResizes(context.Background(), policy, []client.Object{deploy},
+		recommendations, podMap("api-server", pod), nil, nil)
+	afterCPU := promtestutil.ToFloat64(operatormetrics.RequestClampedTotal.WithLabelValues("default", "test-policy", "main", "cpu"))
+	assert.Equal(t, beforeCPU, afterCPU, "AtTarget dest clamp must not increment RequestClampedTotal")
+}
+
 func TestTryEvictionFallback_EvictsWhenMultipleReplicas(t *testing.T) {
 	pod1 := newTestPod("api-server-abc-1", "default", map[string]string{"app": "api-server"})
 	pod2 := newTestPod("api-server-abc-2", "default", map[string]string{"app": "api-server"})

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10918,9 +10918,9 @@ func TestBudgetIncrease_MixedDirections(t *testing.T) {
 }
 
 func TestExecuteResizes_RateCapDefersUntilRefill(t *testing.T) {
-	pod1 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod1 := newResizePod("api-server", "200m", "256Mi", "500m", "256Mi")
 	pod1.Name = "api-server-abc-1"
-	pod2 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod2 := newResizePod("api-server", "200m", "256Mi", "500m", "256Mi")
 	pod2.Name = "api-server-abc-2"
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 	scheme := testScheme()
@@ -10959,7 +10959,7 @@ func TestExecuteResizes_RateCapDefersUntilRefill(t *testing.T) {
 func TestExecuteResizes_BudgetCapsDefersExcessiveIncrease(t *testing.T) {
 	// Pod at 200m CPU, recommendation is 800m (increase of 600m).
 	// Budget cap is 500m, so the resize should be skipped.
-	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod := newResizePod("api-server", "200m", "256Mi", "800m", "256Mi")
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 	reconciler, _ := newResizeReconciler(pod, deploy)
 	recorder := events.NewFakeRecorder(10)
@@ -11017,7 +11017,7 @@ doneEvents:
 func TestExecuteResizes_BudgetCapsAllowsWithinBudget(t *testing.T) {
 	// Pod at 200m CPU, recommendation is 500m (increase of 300m).
 	// Budget cap is 500m, so the resize should proceed.
-	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod := newResizePod("api-server", "200m", "256Mi", "500m", "256Mi")
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 	reconciler, _ := newResizeReconciler(pod, deploy)
 
@@ -11079,7 +11079,7 @@ func TestExecuteResizes_BudgetCapsMemory(t *testing.T) {
 
 func TestExecuteResizes_BudgetCapsExactlyEqualsPasses(t *testing.T) {
 	// Increase of exactly 500m with budget of 500m should pass (not strict >).
-	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod := newResizePod("api-server", "200m", "256Mi", "700m", "256Mi")
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 	reconciler, _ := newResizeReconciler(pod, deploy)
 
@@ -11339,9 +11339,9 @@ func TestExecuteResizes_BudgetCapsSkipDoesNotConsumeBudget(t *testing.T) {
 }
 
 func TestExecuteResizes_BudgetCapsResizeFailureSpendsFilterSlot(t *testing.T) {
-	pod1 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod1 := newResizePod("api-server", "200m", "256Mi", "500m", "256Mi")
 	pod1.Name = "api-server-abc-1"
-	pod2 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod2 := newResizePod("api-server", "200m", "256Mi", "500m", "256Mi")
 	pod2.Name = "api-server-abc-2"
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 
@@ -11382,14 +11382,14 @@ func TestExecuteResizes_BudgetCapsResizeFailureSpendsFilterSlot(t *testing.T) {
 }
 
 func TestExecuteResizes_EvictionSpendsFilterSlot(t *testing.T) {
-	pod1 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod1 := newResizePod("api-server", "200m", "256Mi", "500m", "256Mi")
 	pod1.Name = "api-server-abc-1"
 	pod1.Status.Conditions = append(pod1.Status.Conditions, corev1.PodCondition{
 		Type:   "PodResizePending",
 		Status: corev1.ConditionTrue,
 		Reason: "Infeasible",
 	})
-	pod2 := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
+	pod2 := newResizePod("api-server", "200m", "256Mi", "500m", "256Mi")
 	pod2.Name = "api-server-abc-2"
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 
@@ -11533,9 +11533,9 @@ func TestExecuteResizes_MixedOutcomePodDoesNotLeakSuccessOrBudget(t *testing.T) 
 }
 
 func TestExecuteResizes_BudgetCapsRevertSpendsFilterSlot(t *testing.T) {
-	pod1 := newResizePodWithStatus("api-server", "200m", "256Mi", "200m", "256Mi", 0)
+	pod1 := newResizePodWithStatus("api-server", "200m", "256Mi", "500m", "256Mi", 0)
 	pod1.Name = "api-server-abc-1"
-	pod2 := newResizePodWithStatus("api-server", "200m", "256Mi", "200m", "256Mi", 0)
+	pod2 := newResizePodWithStatus("api-server", "200m", "256Mi", "500m", "256Mi", 0)
 	pod2.Name = "api-server-abc-2"
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 
@@ -11572,9 +11572,9 @@ func TestExecuteResizes_BudgetCapsRevertSpendsFilterSlot(t *testing.T) {
 
 func TestExecuteResizes_ConcurrentResizes(t *testing.T) {
 	// Test that maxConcurrentResizes > 1 processes multiple pods without races.
-	pod1 := newResizePod("api-server", "500m", "256Mi", "500m", "256Mi")
+	pod1 := newResizePod("api-server", "500m", "256Mi", "750m", "384Mi")
 	pod1.Name = "api-server-abc-1"
-	pod2 := newResizePod("api-server", "500m", "256Mi", "500m", "256Mi")
+	pod2 := newResizePod("api-server", "500m", "256Mi", "750m", "384Mi")
 	pod2.Name = "api-server-abc-2"
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
 

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -1260,27 +1260,8 @@ func buildResizeTarget(rec attunev1alpha1.ContainerRecommendation) (corev1.Resou
 	// Clamp requests to not exceed limits. When ControlledValues is
 	// RequestsOnly, limits stay at current values and a growing request
 	// can exceed them, causing the API server to reject the resize.
-	clamped := clampRequestsToLimits(&target)
+	clamped := resize.ClampRequestsToLimits(&target)
 	return target, clamped
-}
-
-// clampRequestsToLimits ensures requests do not exceed limits for each resource.
-// When a limit is present and the request exceeds it, the request is capped
-// at the limit value to prevent API server rejection.
-func clampRequestsToLimits(target *corev1.ResourceRequirements) []string {
-	if target.Limits == nil {
-		return nil
-	}
-	var clamped []string
-	for _, res := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
-		lim, hasLim := target.Limits[res]
-		req, hasReq := target.Requests[res]
-		if hasLim && hasReq && req.Cmp(lim) > 0 {
-			target.Requests[res] = lim.DeepCopy()
-			clamped = append(clamped, string(res))
-		}
-	}
-	return clamped
 }
 
 // resolveCanaryPhase checks whether canary pods have passed the observation

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -129,11 +129,16 @@ type liveResizeApplyMeta struct {
 	FloorUsage              resource.Quantity
 	FloorMargin             float64
 	FloorEqualsCurrent      bool
+	// DestClamped is resource names whose requests were capped to leftover
+	// live container limits after ResolveAppliedTarget (LimitRange).
+	DestClamped []string
 }
 
 // applyLiveResizeTarget applies ClampMemoryLimitForPolicy, the Guaranteed
-// request raise when platform-clamped, and the usage floor otherwise.
-// OneShot compare and resizeContainer must share this so they cannot drift.
+// request raise when platform-clamped, the usage floor otherwise, then
+// leftover dest limits (same overlay as mergeResources) and
+// ClampRequestsToLimits. OneShot compare and resizeContainer must share
+// this so they cannot drift.
 func (r *AttunePolicyReconciler) applyLiveResizeTarget(
 	policy *attunev1alpha1.AttunePolicy,
 	pod *corev1.Pod,
@@ -170,6 +175,23 @@ func (r *AttunePolicyReconciler) applyLiveResizeTarget(
 	}
 	if resMeta.FloorApplied {
 		meta.FloorEqualsCurrent = resMeta.FloorToLimit.Equal(current)
+	}
+	if dest := findContainerByName(pod, containerRec.Name); dest != nil {
+		// Keep dest leftover limits when the rec blob omitted that resource.
+		if len(dest.Resources.Limits) > 0 {
+			if applied.Limits == nil {
+				applied.Limits = corev1.ResourceList{}
+			}
+			for _, res := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+				if _, set := applied.Limits[res]; set {
+					continue
+				}
+				if destLim, ok := dest.Resources.Limits[res]; ok && !destLim.IsZero() {
+					applied.Limits[res] = destLim.DeepCopy()
+				}
+			}
+		}
+		meta.DestClamped = resize.ClampRequestsToLimits(&applied)
 	}
 	return applied, meta
 }

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -567,7 +567,10 @@ func (r *AttunePolicyReconciler) executeResizes(
 				skipEviction := false
 
 				for i, action := range actions {
-					if len(action.Clamped) > 0 {
+					// Dest leftover clamp stays on the plan after converge
+					// (rec 500m, leftover 200m, live already 200m). Count
+					// only when this cycle still needs to apply.
+					if len(action.Clamped) > 0 && !action.AtTarget {
 						logger.V(1).Info("Requests clamped to limits",
 							"pod", pod.Name, "container", action.Container,
 							"clampedResources", action.Clamped)

--- a/internal/controller/resize_plan.go
+++ b/internal/controller/resize_plan.go
@@ -65,6 +65,9 @@ func (r *AttunePolicyReconciler) planPodActions(
 	for _, containerRec := range rec.Containers {
 		target, clamped := buildResizeTarget(containerRec)
 		target, applyMeta := r.applyLiveResizeTarget(policy, pod, containerRec, target)
+		if len(applyMeta.DestClamped) > 0 {
+			clamped = append(clamped, applyMeta.DestClamped...)
+		}
 		c := findContainerByName(pod, containerRec.Name)
 		atTarget := c != nil && containerMatchesAppliedTarget(c, target)
 		cpuInc, memInc := int64(0), int64(0)

--- a/internal/controller/resize_plan_test.go
+++ b/internal/controller/resize_plan_test.go
@@ -166,6 +166,46 @@ func TestPlanPodActions_UsesAppliedTargetAndSkipsAtTarget(t *testing.T) {
 	assert.Equal(t, int64(0), at[0].MemIncrease)
 }
 
+func TestPlanPodActions_ClampsToLiveLeftoverLimit(t *testing.T) {
+	t.Parallel()
+	// Live leftover CPU limit 200m (LimitRange). Rec request 500m has no
+	// CPU limit, so the plan must dest-clamp before AtTarget/budget.
+	pod := newResizePod("api-server", "100m", "256Mi", "200m", "256Mi")
+	r := NewAttunePolicyReconciler()
+	policy := newTestPolicy("p", "default")
+	rec := attunev1alpha1.WorkloadRecommendation{
+		Workload: "api-server",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "main",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("100m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+				CPULimit:      resource.MustParse("200m"),
+				MemoryLimit:   resource.MustParse("256Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+			},
+		}},
+	}
+
+	actions := r.planPodActions(policy, pod, rec)
+	require.Len(t, actions, 1)
+	assert.False(t, actions[0].AtTarget)
+	assert.Equal(t, int64(200), actions[0].Target.Requests.Cpu().MilliValue(),
+		"plan target must dest-clamp 500m to leftover live limit 200m")
+	assert.Contains(t, actions[0].Clamped, "cpu")
+	assert.Equal(t, int64(100), actions[0].CPUIncrease,
+		"plan cost must be 200-100, not the unclamped 500-100")
+
+	pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("200m")
+	at := r.planPodActions(policy, pod, rec)
+	require.Len(t, at, 1)
+	assert.True(t, at[0].AtTarget)
+	assert.Equal(t, int64(0), at[0].CPUIncrease)
+}
+
 func TestObserveAndPlanPod_SkipsLiveGetWhenListedAtTarget(t *testing.T) {
 	pod := newResizePod("api-server", "200m", "256Mi", "200m", "256Mi")
 	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -525,6 +525,7 @@ func replaceCPUMemoryResources(current, want corev1.ResourceRequirements) corev1
 
 // mergeTemplateResources applies want requests/limits onto current, keeping
 // existing limit entries when want does not set limits for that resource.
+// Requests are then clamped so they do not exceed leftover destination limits.
 func mergeTemplateResources(current, want corev1.ResourceRequirements) corev1.ResourceRequirements {
 	out := current.DeepCopy()
 	if out.Requests == nil {
@@ -541,6 +542,7 @@ func mergeTemplateResources(current, want corev1.ResourceRequirements) corev1.Re
 			out.Limits[k] = v.DeepCopy()
 		}
 	}
+	resize.ClampRequestsToLimits(out)
 	return *out
 }
 

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -335,9 +335,18 @@ func (r *AttunePolicyReconciler) applyTemplatePersistence(
 			}
 			if cachedSpec != nil {
 				if cur, ok := templateContainerResources(cachedSpec, c.Name); ok {
-					next := mergeTemplateResources(cur, want)
+					next, destClamped := mergeTemplateResources(cur, want)
 					if resourcesEqual(cur, next) {
 						continue
+					}
+					if len(destClamped) > 0 {
+						logger.V(1).Info("Requests clamped to leftover template limits",
+							"workload", rec.Workload, "container", c.Name,
+							"clampedResources", destClamped)
+						for _, res := range destClamped {
+							operatormetrics.RequestClampedTotal.WithLabelValues(
+								policy.Namespace, policy.Name, c.Name, res).Inc()
+						}
 					}
 				}
 			}
@@ -478,7 +487,7 @@ func applyContainerResources(c *corev1.Container, want corev1.ResourceRequiremen
 	if !replace {
 		// Merge first so RequestsOnly (Limits=nil) does not treat leftover
 		// template limits as a change when requests already match.
-		next = mergeTemplateResources(c.Resources, want)
+		next, _ = mergeTemplateResources(c.Resources, want)
 	} else {
 		next = replaceCPUMemoryResources(c.Resources, want)
 	}
@@ -526,7 +535,8 @@ func replaceCPUMemoryResources(current, want corev1.ResourceRequirements) corev1
 // mergeTemplateResources applies want requests/limits onto current, keeping
 // existing limit entries when want does not set limits for that resource.
 // Requests are then clamped so they do not exceed leftover destination limits.
-func mergeTemplateResources(current, want corev1.ResourceRequirements) corev1.ResourceRequirements {
+// The returned names are resources whose requests were dest-clamped.
+func mergeTemplateResources(current, want corev1.ResourceRequirements) (corev1.ResourceRequirements, []string) {
 	out := current.DeepCopy()
 	if out.Requests == nil {
 		out.Requests = corev1.ResourceList{}
@@ -542,8 +552,8 @@ func mergeTemplateResources(current, want corev1.ResourceRequirements) corev1.Re
 			out.Limits[k] = v.DeepCopy()
 		}
 	}
-	resize.ClampRequestsToLimits(out)
-	return *out
+	clamped := resize.ClampRequestsToLimits(out)
+	return *out, clamped
 }
 
 func workloadPodSpec(w client.Object) *corev1.PodSpec {

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -111,7 +111,7 @@ func materializeContainerResources(
 		out.Limits = limits
 	}
 	// Match resize path: requests must not exceed limits when both are set.
-	_ = clampRequestsToLimits(&out)
+	_ = resize.ClampRequestsToLimits(&out)
 
 	if _, ok := out.Limits[corev1.ResourceMemory]; ok {
 		if usage, hasUsage := recentMemoryUsage(c); hasUsage {

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -310,6 +310,24 @@ func TestMergeTemplateResources_PreservesUncontrolledLimits(t *testing.T) {
 	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("512Mi")), "existing memory limit preserved")
 }
 
+func TestMergeTemplateResources_ClampsHoldRequestToLeftoverLimit(t *testing.T) {
+	current := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+	}
+	want := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+	}
+
+	got := mergeTemplateResources(current, want)
+	require.NotNil(t, got.Requests)
+	require.NotNil(t, got.Limits)
+	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("512Mi")),
+		"hold request %s must clamp to leftover template limit 512Mi", got.Requests.Memory().String())
+	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("512Mi")),
+		"leftover memory limit must stay 512Mi, got %s", got.Limits.Memory().String())
+}
+
 func TestQuantityEqual_MissingAsZero(t *testing.T) {
 	a := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")}
 	b := corev1.ResourceList{}

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -302,12 +302,13 @@ func TestMergeTemplateResources_PreservesUncontrolledLimits(t *testing.T) {
 			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}
-	got := mergeTemplateResources(current, want)
+	got, destClamped := mergeTemplateResources(current, want)
 	assert.Equal(t, int64(200), got.Requests.Cpu().MilliValue())
 	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("256Mi")))
 	require.NotNil(t, got.Limits)
 	assert.Equal(t, int64(500), got.Limits.Cpu().MilliValue(), "existing CPU limit preserved")
 	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("512Mi")), "existing memory limit preserved")
+	assert.Empty(t, destClamped)
 }
 
 func TestMergeTemplateResources_ClampsHoldRequestToLeftoverLimit(t *testing.T) {
@@ -319,13 +320,14 @@ func TestMergeTemplateResources_ClampsHoldRequestToLeftoverLimit(t *testing.T) {
 		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
 	}
 
-	got := mergeTemplateResources(current, want)
+	got, destClamped := mergeTemplateResources(current, want)
 	require.NotNil(t, got.Requests)
 	require.NotNil(t, got.Limits)
 	assert.True(t, got.Requests.Memory().Equal(resource.MustParse("512Mi")),
 		"hold request %s must clamp to leftover template limit 512Mi", got.Requests.Memory().String())
 	assert.True(t, got.Limits.Memory().Equal(resource.MustParse("512Mi")),
 		"leftover memory limit must stay 512Mi, got %s", got.Limits.Memory().String())
+	assert.Equal(t, []string{"memory"}, destClamped)
 }
 
 func TestQuantityEqual_MissingAsZero(t *testing.T) {
@@ -1695,11 +1697,12 @@ func TestMergeTemplateResources_NilRequestsAndLimits(t *testing.T) {
 			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
 	}
-	got := mergeTemplateResources(corev1.ResourceRequirements{}, want)
+	got, destClamped := mergeTemplateResources(corev1.ResourceRequirements{}, want)
 	require.NotNil(t, got.Requests)
 	assert.Equal(t, "100m", got.Requests.Cpu().String())
 	assert.Equal(t, "128Mi", got.Requests.Memory().String())
 	assert.Nil(t, got.Limits)
+	assert.Empty(t, destClamped)
 
 	// Limits filled only when want has limits; existing limits preserved for other keys.
 	current := corev1.ResourceRequirements{
@@ -1710,7 +1713,8 @@ func TestMergeTemplateResources_NilRequestsAndLimits(t *testing.T) {
 		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
 		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("400m")},
 	}
-	got2 := mergeTemplateResources(current, want2)
+	got2, destClamped2 := mergeTemplateResources(current, want2)
+	assert.Empty(t, destClamped2)
 	assert.Equal(t, "200m", got2.Requests.Cpu().String())
 	assert.Equal(t, "400m", got2.Limits.Cpu().String())
 	assert.Equal(t, "256Mi", got2.Limits.Memory().String(), "unrelated existing limit kept")

--- a/internal/resize/clamp.go
+++ b/internal/resize/clamp.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resize
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ClampRequestsToLimits ensures requests do not exceed limits for each resource.
+// When a limit is present and the request exceeds it, the request is capped
+// at the limit value to prevent API server rejection.
+func ClampRequestsToLimits(target *corev1.ResourceRequirements) []string {
+	if target.Limits == nil {
+		return nil
+	}
+	var clamped []string
+	for _, res := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		lim, hasLim := target.Limits[res]
+		req, hasReq := target.Requests[res]
+		if hasLim && hasReq && req.Cmp(lim) > 0 {
+			target.Requests[res] = lim.DeepCopy()
+			clamped = append(clamped, string(res))
+		}
+	}
+	return clamped
+}

--- a/internal/resize/clamp_test.go
+++ b/internal/resize/clamp_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestClampRequestsToLimits_CPURequestExceedsLimit(t *testing.T) {
+	t.Parallel()
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+	}
+	clamped := ClampRequestsToLimits(&target)
+	assert.Equal(t, []string{"cpu"}, clamped)
+	assert.True(t, target.Requests[corev1.ResourceCPU].Equal(resource.MustParse("200m")))
+}
+
+func TestClampRequestsToLimits_MemoryRequestExceedsLimit(t *testing.T) {
+	t.Parallel()
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+		Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+	}
+	clamped := ClampRequestsToLimits(&target)
+	assert.Equal(t, []string{"memory"}, clamped)
+	assert.True(t, target.Requests[corev1.ResourceMemory].Equal(resource.MustParse("256Mi")))
+}
+
+func TestClampRequestsToLimits_NoLimitsIsNoOp(t *testing.T) {
+	t.Parallel()
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	clamped := ClampRequestsToLimits(&target)
+	assert.Nil(t, clamped)
+	assert.True(t, target.Requests[corev1.ResourceCPU].Equal(resource.MustParse("500m")))
+	assert.True(t, target.Requests[corev1.ResourceMemory].Equal(resource.MustParse("512Mi")))
+}
+
+func TestClampRequestsToLimits_RequestAtOrBelowLimitIsNoOp(t *testing.T) {
+	t.Parallel()
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+	clamped := ClampRequestsToLimits(&target)
+	assert.Nil(t, clamped)
+	assert.True(t, target.Requests[corev1.ResourceCPU].Equal(resource.MustParse("200m")))
+	assert.True(t, target.Requests[corev1.ResourceMemory].Equal(resource.MustParse("256Mi")))
+}

--- a/internal/resize/engine.go
+++ b/internal/resize/engine.go
@@ -89,7 +89,7 @@ func (r *PodResizer) ResizePod(ctx context.Context, pod *corev1.Pod, container s
 	// statuses) between our Get and UpdateResize, bumping resourceVersion.
 	// This is common during sequential multi-container resizes where the
 	// kubelet applies the first container's resize before we submit the second.
-	var current corev1.ResourceRequirements
+	var current, applied corev1.ResourceRequirements
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		fresh, fetchErr := r.client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if fetchErr != nil {
@@ -109,10 +109,12 @@ func (r *PodResizer) ResizePod(ctx context.Context, pod *corev1.Pod, container s
 		adjustedTarget := ClampMemoryLimitForPolicy(fresh, container, target, r.AllowInPlaceMemoryLimitDecrease)
 		if isInit {
 			current = fresh.Spec.InitContainers[idx].Resources
-			updated.Spec.InitContainers[idx].Resources = mergeResources(current, adjustedTarget)
+			applied = mergeResources(current, adjustedTarget)
+			updated.Spec.InitContainers[idx].Resources = applied
 		} else {
 			current = fresh.Spec.Containers[idx].Resources
-			updated.Spec.Containers[idx].Resources = mergeResources(current, adjustedTarget)
+			applied = mergeResources(current, adjustedTarget)
+			updated.Spec.Containers[idx].Resources = applied
 		}
 
 		r.logger.V(1).Info("resizing pod", "pod", pod.Name, "namespace", pod.Namespace,
@@ -129,9 +131,9 @@ func (r *PodResizer) ResizePod(ctx context.Context, pod *corev1.Pod, container s
 	}
 
 	fromCPU := current.Requests[corev1.ResourceCPU]
-	toCPU := target.Requests[corev1.ResourceCPU]
+	toCPU := applied.Requests[corev1.ResourceCPU]
 	fromMem := current.Requests[corev1.ResourceMemory]
-	toMem := target.Requests[corev1.ResourceMemory]
+	toMem := applied.Requests[corev1.ResourceMemory]
 
 	results := []ResizeResult{
 		{

--- a/internal/resize/engine.go
+++ b/internal/resize/engine.go
@@ -162,9 +162,10 @@ func (r *PodResizer) ResizePod(ctx context.Context, pod *corev1.Pod, container s
 }
 
 // mergeResources builds the final ResourceRequirements by applying target values on top
-// of the current resources. Requests are always taken from the target. Limits are taken
-// from the target only if the target specifies them; otherwise the pod's existing limits
-// are preserved. This prevents adding limits to pods that never had them.
+// of the current resources. Requests are taken from the target, then clamped so they
+// do not exceed leftover destination limits. Limits are taken from the target only if
+// the target specifies them; otherwise the pod's existing limits are preserved. This
+// prevents adding limits to pods that never had them.
 //
 // Memory limits are never decreased below the current value because Kubernetes
 // forbids in-place memory limit decreases (requires RestartContainer resize policy).
@@ -202,6 +203,7 @@ func mergeResources(current, target corev1.ResourceRequirements) corev1.Resource
 		}
 	}
 	// CPU limits are not clamped: K8s allows in-place CPU limit decreases.
+	ClampRequestsToLimits(&merged)
 	return merged
 }
 

--- a/internal/resize/engine_test.go
+++ b/internal/resize/engine_test.go
@@ -172,6 +172,28 @@ func TestResizePod_ReturnsCorrectFromTo(t *testing.T) {
 	assert.NoError(t, memResult.Error)
 }
 
+func TestResizePod_ToUsesMergedRequestWhenInboundExceedsLeftoverLimit(t *testing.T) {
+	pod := newTestPod("web-0", "default", "app", "100m", "128Mi", "200m", "256Mi")
+	fakeClient := fake.NewSimpleClientset(pod)
+	fakeClient.PrependReactor("update", "pods", resizeReactor)
+
+	resizer := NewPodResizer(fakeClient, testr.New(t))
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+
+	results, err := resizer.ResizePod(context.Background(), pod, "app", target)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.True(t, results[0].To.Equal(resource.MustParse("200m")),
+		"cpu To must be leftover live limit 200m, not inbound 500m; got %s", results[0].To.String())
+	assert.True(t, results[1].To.Equal(resource.MustParse("128Mi")),
+		"memory To must stay the inbound request %s", results[1].To.String())
+}
+
 func TestIsEligibleForResize(t *testing.T) {
 	now := metav1.NewTime(time.Now())
 

--- a/internal/resize/engine_test.go
+++ b/internal/resize/engine_test.go
@@ -809,6 +809,24 @@ func TestMergeResources(t *testing.T) {
 	}
 }
 
+func TestMergeResources_ClampsRequestToLeftoverLiveLimit(t *testing.T) {
+	current := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+	}
+	target := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+	}
+
+	merged := mergeResources(current, target)
+	require.NotNil(t, merged.Requests)
+	require.NotNil(t, merged.Limits)
+	assert.True(t, merged.Requests.Cpu().Equal(resource.MustParse("200m")),
+		"merged CPU request %s must clamp to leftover live limit 200m", merged.Requests.Cpu().String())
+	assert.True(t, merged.Limits.Cpu().Equal(resource.MustParse("200m")),
+		"leftover CPU limit must stay 200m, got %s", merged.Limits.Cpu().String())
+}
+
 func TestIsResizeInfeasible(t *testing.T) {
 	tests := []struct {
 		name string
@@ -970,7 +988,7 @@ func TestResizePod_InitContainer(t *testing.T) {
 							corev1.ResourceMemory: resource.MustParse("64Mi"),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
 							corev1.ResourceMemory: resource.MustParse("128Mi"),
 						},
 					},

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -328,7 +328,10 @@ func (h *PodMutatingHandler) mutateContainer(
 			}
 		}
 
-		_ = resize.ClampRequestsToLimits(&container.Resources)
+		for _, res := range resize.ClampRequestsToLimits(&container.Resources) {
+			operatormetrics.RequestClampedTotal.WithLabelValues(
+				policy.Namespace, policy.Name, container.Name, res).Inc()
+		}
 		return mutated
 	}
 	return false

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -116,12 +116,20 @@ func (h *PodMutatingHandler) Handle(ctx context.Context, req admission.Request) 
 		return admission.Allowed("namespace has attune.io/freeze=true")
 	}
 
-	// Mutate the pod's containers.
+	// Mutate the pod's containers and native sidecars (init restartPolicy Always).
 	mutated := false
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
 		if h.mutateContainer(container, rec, policy) {
 			mutated = true
+		}
+	}
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
+		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			if h.mutateContainer(container, rec, policy) {
+				mutated = true
+			}
 		}
 	}
 
@@ -320,6 +328,7 @@ func (h *PodMutatingHandler) mutateContainer(
 			}
 		}
 
+		_ = resize.ClampRequestsToLimits(&container.Resources)
 		return mutated
 	}
 	return false

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -26,6 +26,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -41,6 +42,7 @@ import (
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/attune-io/attune/internal/conflict"
+	"github.com/attune-io/attune/internal/operatormetrics"
 )
 
 // patchedPod applies the admission response patches to the original pod bytes.
@@ -717,6 +719,9 @@ func TestPodMutatingHandler_ClampsRequestToLeftoverLimit(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
 	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
 
+	beforeCPU := promtestutil.ToFloat64(operatormetrics.RequestClampedTotal.WithLabelValues(
+		"default", "my-policy", "app", "cpu"))
+
 	req := makeAdmissionRequest(t, pod, "default")
 	resp := handler.Handle(context.Background(), req)
 	require.True(t, resp.Allowed)
@@ -729,6 +734,11 @@ func TestPodMutatingHandler_ClampsRequestToLeftoverLimit(t *testing.T) {
 		"CREATE request %s must clamp to leftover limit 200m", gotReq.String())
 	assert.True(t, gotLim.Equal(resource.MustParse("200m")),
 		"leftover CPU limit must stay 200m, got %s", gotLim.String())
+
+	afterCPU := promtestutil.ToFloat64(operatormetrics.RequestClampedTotal.WithLabelValues(
+		"default", "my-policy", "app", "cpu"))
+	assert.Equal(t, beforeCPU+1, afterCPU,
+		"RequestClampedTotal should increment for CREATE leftover CPU clamp")
 }
 
 func TestPodMutatingHandler_NativeSidecarInitialSizing(t *testing.T) {

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -707,6 +707,105 @@ func TestPodMutatingHandler_RequestsAndLimits_UsageFloorGuaranteed(t *testing.T)
 		"Guaranteed CREATE request %s want %s", gotReq.String(), want.String())
 }
 
+func TestPodMutatingHandler_ClampsRequestToLeftoverLimit(t *testing.T) {
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+	pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("200m"),
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	req := makeAdmissionRequest(t, pod, "default")
+	resp := handler.Handle(context.Background(), req)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches, "expected patches")
+
+	mutatedPod := patchedPod(t, req.Object.Raw, resp)
+	gotReq := mutatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	gotLim := mutatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
+	assert.True(t, gotReq.Equal(resource.MustParse("200m")),
+		"CREATE request %s must clamp to leftover limit 200m", gotReq.String())
+	assert.True(t, gotLim.Equal(resource.MustParse("200m")),
+		"leftover CPU limit must stay 200m, got %s", gotLim.String())
+}
+
+func TestPodMutatingHandler_NativeSidecarInitialSizing(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	policy := testPolicy("my-policy", "default", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
+	policy.Status.Recommendations[0].Containers = []attunev1alpha1.ContainerRecommendation{
+		{
+			Name:       "sidecar",
+			Confidence: 0.8,
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("400m"),
+				MemoryRequest: resource.MustParse("128Mi"),
+			},
+		},
+		{
+			Name:       "bootstrap",
+			Confidence: 0.8,
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("300m"),
+				MemoryRequest: resource.MustParse("64Mi"),
+			},
+		},
+	}
+
+	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")
+	pod.Spec.InitContainers = []corev1.Container{
+		{
+			Name:          "sidecar",
+			RestartPolicy: &always,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+		},
+		{
+			Name: "bootstrap",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("50m"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(policy, testNamespace("default", nil)).Build()
+	handler := &PodMutatingHandler{Client: cl, Logger: logr.Discard()}
+
+	req := makeAdmissionRequest(t, pod, "default")
+	resp := handler.Handle(context.Background(), req)
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches, "native sidecar must produce a CREATE patch")
+
+	mutatedPod := patchedPod(t, req.Object.Raw, resp)
+	require.Len(t, mutatedPod.Spec.InitContainers, 2)
+	sidecar := mutatedPod.Spec.InitContainers[0]
+	gotSidecarCPU := sidecar.Resources.Requests[corev1.ResourceCPU]
+	gotSidecarMem := sidecar.Resources.Requests[corev1.ResourceMemory]
+	assert.True(t, gotSidecarCPU.Equal(resource.MustParse("400m")),
+		"native sidecar CPU request %s want 400m", gotSidecarCPU.String())
+	assert.True(t, gotSidecarMem.Equal(resource.MustParse("128Mi")),
+		"native sidecar memory request %s want 128Mi", gotSidecarMem.String())
+
+	bootstrap := mutatedPod.Spec.InitContainers[1]
+	gotInitCPU := bootstrap.Resources.Requests[corev1.ResourceCPU]
+	gotInitMem := bootstrap.Resources.Requests[corev1.ResourceMemory]
+	assert.True(t, gotInitCPU.Equal(resource.MustParse("50m")),
+		"regular init must not be CREATE-sized, got %s", gotInitCPU.String())
+	assert.True(t, gotInitMem.Equal(resource.MustParse("32Mi")),
+		"regular init memory must stay 32Mi, got %s", gotInitMem.String())
+}
+
 func TestPodMutatingHandler_WrongNamespace(t *testing.T) {
 	policy := testPolicy("my-policy", "production", "Deployment", "my-app", true, attunev1alpha1.UpdateTypeAuto)
 	pod := testPod("my-app-abc-xyz", "ReplicaSet", "my-app-abc")


### PR DESCRIPTION
Leftover destination limits (LimitRange defaults, leftover template limits) live on the pod or template, not on the recommendation blob. CREATE, persist, and live resize used to write or submit a request larger than that leftover limit. The API server rejected the object, and Auto/OneShot retried forever.

## Problem

Recommendations are built from the workload template. Live pods often have leftover CPU or memory limits the template does not. `buildResizeTarget` only clamped against recommended limits, so:

- CREATE wrote `request > leftover limit` and admission failed.
- Persist merged a hold request onto a leftover template limit and the Deployment patch failed.
- Live `/resize` merged the rec onto leftover live limits and `UpdateResize` was rejected.
- After apply-time clamp landed, plan/AtTarget still compared live to the unclamped rec, so history `To` lied and the next cycle never converged.

Native sidecars (`restartPolicy: Always`) were also skipped on CREATE even though live resize and persist already size them.

## Change

- Shared `resize.ClampRequestsToLimits`.
- CREATE clamps leftover limits and sizes native sidecars. Increments `attune_request_clamped_total`.
- `mergeResources` and `mergeTemplateResources` clamp after merge.
- `applyLiveResizeTarget` overlays dest leftover limits then clamps so plan, AtTarget, budget, history, and safety `NewResources` share the applied target.
- `RequestClampedTotal` does not tick every reconcile after leftover converge (AtTarget).
- Safety tests lock confirm Get 404 and restore-retry Get 500/404.
- Wizard create/promote print both initial-sizing gates (Helm webhook plus namespace label).
- Docs: native sidecars, CREATE clamp, leftover LimitRange clamp.

## Validation

- `make verify-quick` (lint 0 issues, 2586 unit tests, helm, docs, release artifacts)
- Red-green: leftover CREATE request stayed 500m without clamp; plan target stayed 500m without dest overlay (increase 400m, never AtTarget); AtTarget dest clamp incremented the counter every cycle before the last commit.

No issue closures. Community/human-blocked issues stay open.
