### PR TITLE
fix: emit ResizeDeferred on dest cpu clamp at target

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1138,9 +1138,10 @@ from rejecting the resize or the Deployment/StatefulSet patch.
 proportionally with requests.
 
 The `attune_request_clamped_total` counter increments each time a request
-is capped on live resize and on CREATE, broken down by container and
-resource. Use it to detect policies where limits are consistently too
-tight:
+is capped on a live apply, on CREATE, or on a persist write that still
+changes the template. A dest clamp that is already at the applied target
+does not increment. Use it to detect policies where limits are consistently
+too tight:
 
 ```promql
 rate(attune_request_clamped_total[1h]) > 0

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -10260,6 +10260,8 @@ func TestExecuteResizes_DestClampAtTargetDoesNotIncrement(t *testing.T) {
 	policy := newTestPolicy("test-policy", "default")
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
 	reconciler, _ := newResizeReconciler(pod, deploy)
+	recorder := events.NewFakeRecorder(10)
+	reconciler.Recorder = recorder
 
 	recommendations := []attunev1alpha1.WorkloadRecommendation{
 		{
@@ -10288,6 +10290,19 @@ func TestExecuteResizes_DestClampAtTargetDoesNotIncrement(t *testing.T) {
 		recommendations, podMap("api-server", pod), nil, nil)
 	afterCPU := promtestutil.ToFloat64(operatormetrics.RequestClampedTotal.WithLabelValues("default", "test-policy", "main", "cpu"))
 	assert.Equal(t, beforeCPU, afterCPU, "AtTarget dest clamp must not increment RequestClampedTotal")
+
+	found := false
+	for {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "ResizeDeferred") {
+				found = true
+			}
+		default:
+			require.True(t, found, "AtTarget dest CPU clamp must emit ResizeDeferred")
+			return
+		}
+	}
 }
 
 func TestTryEvictionFallback_EvictsWhenMultipleReplicas(t *testing.T) {

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -1861,17 +1861,19 @@ func (r *AttunePolicyReconciler) emitResizeDeferredIfFilteredOrClamped(
 		containerRec.Explanation.CPU.ChangeFilterApplied != ""
 	memFiltered := containerRec.Explanation != nil && containerRec.Explanation.Memory != nil &&
 		containerRec.Explanation.Memory.ChangeFilterApplied != ""
+	cpuClamped := !preClamped.Requests.Cpu().Equal(*target.Requests.Cpu())
 	memoryClamped := !preClamped.Requests.Memory().Equal(*target.Requests.Memory())
-	if cpuFiltered || memFiltered || memoryClamped {
+	if cpuFiltered || memFiltered || cpuClamped || memoryClamped {
 		logger.Info("Resize deferred: resources at target after filtering/clamping",
 			"pod", pod.Name, "container", containerRec.Name,
 			"cpuTarget", target.Requests.Cpu().String(),
 			"memTarget", target.Requests.Memory().String(),
 			"cpuChangeFilter", cpuFiltered,
 			"memChangeFilter", memFiltered,
+			"cpuClamped", cpuClamped,
 			"memoryClamped", memoryClamped)
 		r.emitEventOnce(policy, corev1.EventTypeNormal, "ResizeDeferred", "resize",
-			"Container %s in pod %s: resources unchanged after change filtering and/or memory clamping (cpu=%s, mem=%s)",
+			"Container %s in pod %s: resources unchanged after change filtering and/or request clamping (cpu=%s, mem=%s)",
 			containerRec.Name, pod.Name, target.Requests.Cpu().String(), target.Requests.Memory().String())
 		return
 	}


### PR DESCRIPTION
After leftover dest-limit clamp (#721), a rec of 500m against a leftover dest CPU limit of 200m is AtTarget when live is already 200m.

`emitResizeDeferredIfFilteredOrClamped` only treated a memory request change as a clamp. Dest CPU clamp (the common LimitRange leftover) took the V(1) already-at-target path and skipped `ResizeDeferred`. Memory dest clamp and usage-floor no-ops still emitted the event.

This matches the #720 contract: a clamp/floor no-op that is AtTarget in the plan must emit `ResizeDeferred`.

- Treat CPU request clamp the same as memory (raw rec vs dest-clamped applied target)
- Keep `RequestClampedTotal` quiet after converge (existing dest-clamp AtTarget test)
- Document persist increment vs AtTarget dest clamp on `attune_request_clamped_total`

Red: `TestExecuteResizes_DestClampAtTargetDoesNotIncrement` failed without the CPU check.
Green: dest-CPU AtTarget plus floor-to-current and LiveApplied clamp no-op tests pass.
