### PR TITLE
fix: keep dest leftover limits and retune hpa from applied cpu

### DIFF
--- a/cmd/kubectl-attune/main.go
+++ b/cmd/kubectl-attune/main.go
@@ -249,6 +249,9 @@ func run(args []string, buildClient dynamicClientFactory) int {
 		case "diff":
 			printDiffItems(items, "")
 		}
+		if multiClusterFailed(len(ctxList), len(warnings), len(items)) {
+			return 1
+		}
 		return 0
 	}
 

--- a/cmd/kubectl-attune/multicluster.go
+++ b/cmd/kubectl-attune/multicluster.go
@@ -129,6 +129,12 @@ func fetchMultiCluster(
 	return items, warnings
 }
 
+// multiClusterFailed is true when every requested context errored and
+// no policies were collected.
+func multiClusterFailed(nctx, nwarn, nitems int) bool {
+	return nctx > 0 && nwarn == nctx && nitems == 0
+}
+
 // tagItems annotates each item with the cluster context name.
 func tagItems(items []unstructured.Unstructured, cluster string) {
 	for i := range items {

--- a/cmd/kubectl-attune/multicluster_test.go
+++ b/cmd/kubectl-attune/multicluster_test.go
@@ -157,6 +157,24 @@ func TestFetchMultiCluster_AllContextsFail(t *testing.T) {
 	assert.Len(t, warnings, 2)
 }
 
+func TestMultiClusterFailed(t *testing.T) {
+	assert.True(t, multiClusterFailed(2, 2, 0), "every context failed and no items")
+	assert.False(t, multiClusterFailed(2, 1, 0), "one success with empty list stays 0")
+	assert.False(t, multiClusterFailed(2, 0, 0), "all succeeded with empty list stays 0")
+	assert.False(t, multiClusterFailed(2, 1, 1), "partial failure with items stays 0")
+	assert.False(t, multiClusterFailed(0, 0, 0), "no contexts is not a failure")
+}
+
+func TestRun_MultiClusterAllContextsFail(t *testing.T) {
+	factory := fakeMultiContextFactory(t, map[string][]runtime.Object{})
+	exitCode, stdout, stderr := captureRun(t,
+		[]string{"status", "--contexts", "a,b"},
+		factory)
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stdout, "No AttunePolicies found")
+	assert.Contains(t, stderr, "WARNING")
+}
+
 // ---------- printStatusItems multi-cluster ----------
 
 func TestPrintStatusItems_ShowsClusterColumn(t *testing.T) {

--- a/cmd/kubectl-attune/wizard.go
+++ b/cmd/kubectl-attune/wizard.go
@@ -509,14 +509,54 @@ func detectPrometheus(ctx context.Context, dynClient dynamic.Interface) []string
 		if !found || len(ports) == 0 {
 			continue
 		}
-		port, _ := ports[0].(map[string]interface{})
-		portNum, _, _ := unstructured.NestedInt64(port, "port")
-		if portNum == 0 {
-			portNum = 80
-		}
-		results = append(results, fmt.Sprintf("http://%s.%s:%d", name, ns, portNum))
+		portNum := pickPrometheusPort(ports)
+		results = append(results, fmt.Sprintf("http://%s.%s.svc:%d", name, ns, portNum))
 	}
 	return results
+}
+
+// pickPrometheusPort prefers an HTTP-named port, then common HTTP numbers,
+// then the first port that is not a Thanos gRPC port, then the first port.
+func pickPrometheusPort(ports []interface{}) int64 {
+	type pinfo struct {
+		name string
+		num  int64
+	}
+	parsed := make([]pinfo, 0, len(ports))
+	for _, raw := range ports {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		num, _, _ := unstructured.NestedInt64(m, "port")
+		if num == 0 {
+			num = 80
+		}
+		name, _, _ := unstructured.NestedString(m, "name")
+		parsed = append(parsed, pinfo{name: name, num: num})
+	}
+	if len(parsed) == 0 {
+		return 80
+	}
+	for _, p := range parsed {
+		n := strings.ToLower(p.name)
+		if strings.Contains(n, "http") || strings.Contains(n, "web") || strings.Contains(n, "metrics") {
+			return p.num
+		}
+	}
+	for _, want := range []int64{9090, 9091, 8080, 80} {
+		for _, p := range parsed {
+			if p.num == want {
+				return p.num
+			}
+		}
+	}
+	for _, p := range parsed {
+		if p.num != 10901 && p.num != 10902 {
+			return p.num
+		}
+	}
+	return parsed[0].num
 }
 
 // buildPolicyObject constructs an unstructured AttunePolicy.

--- a/cmd/kubectl-attune/wizard_test.go
+++ b/cmd/kubectl-attune/wizard_test.go
@@ -115,6 +115,12 @@ func unstructuredDeployment(name, namespace string, replicas int64) *unstructure
 }
 
 func unstructuredService(name, namespace string, port int64) *unstructured.Unstructured {
+	return unstructuredServicePorts(name, namespace, []interface{}{
+		map[string]interface{}{"port": port},
+	})
+}
+
+func unstructuredServicePorts(name, namespace string, ports []interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -124,9 +130,7 @@ func unstructuredService(name, namespace string, port int64) *unstructured.Unstr
 				"namespace": namespace,
 			},
 			"spec": map[string]interface{}{
-				"ports": []interface{}{
-					map[string]interface{}{"port": port},
-				},
+				"ports": ports,
 			},
 		},
 	}
@@ -309,8 +313,21 @@ func TestDetectPrometheus(t *testing.T) {
 
 	results := detectPrometheus(context.Background(), dynClient)
 	assert.Len(t, results, 2)
-	assert.Contains(t, results, "http://prometheus-server.monitoring:9090")
-	assert.Contains(t, results, "http://thanos-query.monitoring:10902")
+	assert.Contains(t, results, "http://prometheus-server.monitoring.svc:9090")
+	assert.Contains(t, results, "http://thanos-query.monitoring.svc:10902")
+}
+
+func TestDetectPrometheus_PrefersHTTPPort(t *testing.T) {
+	dynClient := newFakeDynClient(
+		unstructuredServicePorts("thanos-query", "monitoring", []interface{}{
+			map[string]interface{}{"name": "grpc", "port": int64(10901)},
+			map[string]interface{}{"name": "http", "port": int64(9090)},
+		}),
+	)
+
+	results := detectPrometheus(context.Background(), dynClient)
+	require.Len(t, results, 1)
+	assert.Equal(t, "http://thanos-query.monitoring.svc:9090", results[0])
 }
 
 func TestDetectPrometheus_NoMatches(t *testing.T) {

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -31,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -562,34 +561,7 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		if resizedCount > 0 {
 			policy.Status.Workloads.Resized = safeInt32(resizedCount)
-			// Auto-tune HPA targets only for workloads that were actually
-			// resized, using aggregate CPU across all containers.
-			resizedWorkloads := make(map[string]bool, len(history))
-			for _, h := range history {
-				if isSuccessfulInPlaceHistory(h) {
-					resizedWorkloads[h.Workload] = true
-				}
-			}
-			for _, rec := range recommendations {
-				if !resizedWorkloads[rec.Workload] {
-					continue
-				}
-				if mode == attunev1alpha1.UpdateTypeCanary && !policy.Status.Canary.AllowsHPARetune(rec.Workload) {
-					continue
-				}
-				var totalOldCPU, totalNewCPU, totalCPULimit int64
-				for _, c := range rec.Containers {
-					totalOldCPU += c.Current.CPURequest.MilliValue()
-					totalNewCPU += c.Recommended.CPURequest.MilliValue()
-					totalCPULimit += c.Recommended.CPULimit.MilliValue()
-				}
-				if totalOldCPU != totalNewCPU {
-					r.adjustHPATargets(ctx, hpaList.Items, rec.Workload, rec.Kind,
-						*resource.NewMilliQuantity(totalOldCPU, resource.DecimalSI),
-						*resource.NewMilliQuantity(totalNewCPU, resource.DecimalSI),
-						*resource.NewMilliQuantity(totalCPULimit, resource.DecimalSI))
-				}
-			}
+			r.retuneHPAAfterResize(ctx, &policy, mode, history, recommendations, hpaList.Items, podsByWorkload)
 		}
 	}
 	// Template persistence after successful in-place resizes (this cycle and

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -6526,6 +6526,9 @@ func TestExecuteResizes_GuaranteedQoS_MemoryClampAllowsCPUResize(t *testing.T) {
 
 	policy := newTestPolicy("test-policy", "default")
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.CPU.ControlledValues = &cv
+	policy.Spec.Memory.ControlledValues = &cv
 
 	// Recommend CPU decrease (500m → 50m) and memory decrease (256Mi → 64Mi).
 	// Both limits also decrease (ControlledValues: RequestsAndLimits behavior).
@@ -11495,7 +11498,7 @@ func TestExecuteResizes_MixedOutcomePodDoesNotLeakSuccessOrBudget(t *testing.T) 
 	})
 	apiPod2 := apiPod1.DeepCopy()
 	apiPod2.Name = "api-server-abc-2"
-	workerPod := newResizePod("worker", "200m", "256Mi", "200m", "256Mi")
+	workerPod := newResizePod("worker", "200m", "256Mi", "1000m", "256Mi")
 	workerPod.Name = "worker-abc-1"
 
 	apiDeploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})

--- a/internal/controller/canary_test.go
+++ b/internal/controller/canary_test.go
@@ -168,7 +168,11 @@ func TestFirstOneShotPodNeedingResize_SkipsClampedMemoryLimit(t *testing.T) {
 
 	r := newReconcilerWithClient()
 	r.AllowInPlaceMemoryLimitDecrease = false
-	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec, nil)
+	policy := newTestPolicy("test-policy", "default")
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.CPU.ControlledValues = &cv
+	policy.Spec.Memory.ControlledValues = &cv
+	got := r.firstOneShotPodNeedingResize(context.Background(), policy, pods, rec, nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name)
 }
@@ -270,7 +274,11 @@ func TestFirstOneShotPodNeedingResize_SkipsFlooredGuaranteed(t *testing.T) {
 
 	r := newReconcilerWithClient()
 	r.AllowInPlaceMemoryLimitDecrease = true
-	got := r.firstOneShotPodNeedingResize(context.Background(), newTestPolicy("test-policy", "default"), pods, rec, nil)
+	policy := newTestPolicy("test-policy", "default")
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.CPU.ControlledValues = &cv
+	policy.Spec.Memory.ControlledValues = &cv
+	got := r.firstOneShotPodNeedingResize(context.Background(), policy, pods, rec, nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, "pod-1", got[0].Name)
 }

--- a/internal/controller/capacity_skip_test.go
+++ b/internal/controller/capacity_skip_test.go
@@ -199,7 +199,7 @@ func TestExecuteResizes_NodeAllocatable_EmitsResizeSkippedAndCapacitySkipMetric(
 		appName    = "alloc-app"
 	)
 
-	pod := newResizePod(appName, "500m", "512Mi", "1000m", "1Gi")
+	pod := newResizePod(appName, "500m", "512Mi", "2000m", "1Gi")
 	pod.Spec.NodeName = nodeName
 	deploy := newTestDeployment(appName, policyNS, map[string]string{"app": appName})
 	// Node too small for recommended CPU (would be 2 + sidecar-less 2).
@@ -552,6 +552,9 @@ func TestExecuteResizes_UsageFloorUsesLiveLimitNotStaleInformer(t *testing.T) {
 
 	policy := newTestPolicy(policyName, policyNS)
 	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.CPU.ControlledValues = &cv
+	policy.Spec.Memory.ControlledValues = &cv
 	recommendations := []attunev1alpha1.WorkloadRecommendation{
 		newResizeRecommendation(appName,
 			"200m", "512Mi", "200m", "512Mi",

--- a/internal/controller/hpa.go
+++ b/internal/controller/hpa.go
@@ -25,7 +25,87 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
+
+// retuneHPAAfterResize rebases auto-tune HPA CPU targets from this-cycle
+// successful in-place CPU apply (dest-clamped), not the raw recommendation.
+func (r *AttunePolicyReconciler) retuneHPAAfterResize(
+	ctx context.Context,
+	policy *attunev1alpha1.AttunePolicy,
+	mode attunev1alpha1.UpdateType,
+	history []attunev1alpha1.ResizeHistoryEntry,
+	recommendations []attunev1alpha1.WorkloadRecommendation,
+	hpas []autoscalingv2.HorizontalPodAutoscaler,
+	podsByWorkload map[string][]corev1.Pod,
+) {
+	if r == nil || len(hpas) == 0 {
+		return
+	}
+	for _, rec := range recommendations {
+		if mode == attunev1alpha1.UpdateTypeCanary && policy != nil && !policy.Status.Canary.AllowsHPARetune(rec.Workload) {
+			continue
+		}
+		oldCPU, newCPU, ok := hpaCPUFromResizeHistory(history, rec.Workload)
+		if !ok {
+			continue
+		}
+		if oldCPU.Equal(newCPU) {
+			continue
+		}
+		var pods []corev1.Pod
+		if podsByWorkload != nil {
+			pods = podsByWorkload[rec.Workload]
+		}
+		cpuLimit := destCPULimitFromPods(pods)
+		if cpuLimit.IsZero() {
+			cpuLimit = newCPU.DeepCopy()
+		}
+		r.adjustHPATargets(ctx, hpas, rec.Workload, rec.Kind, oldCPU, newCPU, cpuLimit)
+	}
+}
+
+// hpaCPUFromResizeHistory sums From/To on this-cycle successful in-place
+// CPU rows for workload. ok is false when no parseable rows exist.
+func hpaCPUFromResizeHistory(history []attunev1alpha1.ResizeHistoryEntry, workload string) (oldCPU, newCPU resource.Quantity, ok bool) {
+	var oldMilli, newMilli int64
+	found := false
+	for _, h := range history {
+		if h.Workload != workload || h.Resource != "cpu" || !isSuccessfulInPlaceHistory(h) {
+			continue
+		}
+		from, fromErr := resource.ParseQuantity(h.From)
+		to, toErr := resource.ParseQuantity(h.To)
+		if fromErr != nil || toErr != nil {
+			continue
+		}
+		oldMilli += from.MilliValue()
+		newMilli += to.MilliValue()
+		found = true
+	}
+	if !found {
+		return resource.Quantity{}, resource.Quantity{}, false
+	}
+	return *resource.NewMilliQuantity(oldMilli, resource.DecimalSI),
+		*resource.NewMilliQuantity(newMilli, resource.DecimalSI), true
+}
+
+// destCPULimitFromPods sums leftover dest CPU limits across listed pods.
+func destCPULimitFromPods(pods []corev1.Pod) resource.Quantity {
+	var total int64
+	for i := range pods {
+		for _, c := range pods[i].Spec.Containers {
+			if lim, ok := c.Resources.Limits[corev1.ResourceCPU]; ok && !lim.IsZero() {
+				total += lim.MilliValue()
+			}
+		}
+	}
+	if total == 0 {
+		return resource.Quantity{}
+	}
+	return *resource.NewMilliQuantity(total, resource.DecimalSI)
+}
 
 // their resource-based target utilization to maintain the same absolute resource
 // threshold after a resize changes the request baseline.

--- a/internal/controller/hpa_test.go
+++ b/internal/controller/hpa_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
+)
+
+func TestHPACPUFromResizeHistory(t *testing.T) {
+	t.Parallel()
+	history := []attunev1alpha1.ResizeHistoryEntry{
+		{
+			Workload:  "api-server",
+			Container: "main",
+			Resource:  "cpu",
+			From:      "100m",
+			To:        "200m",
+			Method:    "InPlace",
+			Result:    attunev1alpha1.ResizeResultSuccess,
+		},
+		{
+			Workload:  "api-server",
+			Container: "sidecar",
+			Resource:  "cpu",
+			From:      "50m",
+			To:        "50m",
+			Method:    "InPlace",
+			Result:    attunev1alpha1.ResizeResultSuccess,
+		},
+		{
+			Workload:  "api-server",
+			Container: "main",
+			Resource:  "memory",
+			From:      "256Mi",
+			To:        "256Mi",
+			Method:    "InPlace",
+			Result:    attunev1alpha1.ResizeResultSuccess,
+		},
+		{
+			Workload:  "other",
+			Container: "main",
+			Resource:  "cpu",
+			From:      "1",
+			To:        "2",
+			Method:    "InPlace",
+			Result:    attunev1alpha1.ResizeResultSuccess,
+		},
+	}
+
+	oldCPU, newCPU, ok := hpaCPUFromResizeHistory(history, "api-server")
+	require.True(t, ok)
+	assert.Equal(t, int64(150), oldCPU.MilliValue())
+	assert.Equal(t, int64(250), newCPU.MilliValue())
+
+	_, _, ok = hpaCPUFromResizeHistory(nil, "api-server")
+	assert.False(t, ok)
+
+	_, _, ok = hpaCPUFromResizeHistory(history, "missing")
+	assert.False(t, ok)
+}
+
+func TestRetuneHPAAfterResize_UsesAppliedCPU(t *testing.T) {
+	t.Parallel()
+	scheme := testScheme()
+	oldTarget := int32(80)
+	hpa := autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api-server-hpa",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationHPAAutoTune: "true",
+			},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: "Deployment",
+				Name: "api-server",
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: &oldTarget,
+						},
+					},
+				},
+			},
+		},
+	}
+	pod := newResizePod("api-server", "100m", "256Mi", "200m", "256Mi")
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&hpa).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api-server",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "main",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("100m"),
+				CPULimit:      resource.MustParse("200m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+				MemoryLimit:   resource.MustParse("256Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				CPULimit:      resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+				MemoryLimit:   resource.MustParse("256Mi"),
+			},
+		}},
+	}}
+	history := []attunev1alpha1.ResizeHistoryEntry{{
+		Workload:  "api-server",
+		Container: "main",
+		Resource:  "cpu",
+		From:      "100m",
+		To:        "200m",
+		Method:    "InPlace",
+		Result:    attunev1alpha1.ResizeResultSuccess,
+	}}
+
+	r.retuneHPAAfterResize(context.Background(), policy, attunev1alpha1.UpdateTypeAuto,
+		history, recs, []autoscalingv2.HorizontalPodAutoscaler{hpa},
+		map[string][]corev1.Pod{"api-server": {*pod}})
+
+	var updated autoscalingv2.HorizontalPodAutoscaler
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server-hpa", Namespace: "default",
+	}, &updated))
+	require.NotNil(t, updated.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	assert.Equal(t, int32(40), *updated.Spec.Metrics[0].Resource.Target.AverageUtilization,
+		"HPA target must be 80*100/200=40 from dest-clamped apply, not 80*100/500=16")
+}

--- a/internal/controller/memory_usage_floor_test.go
+++ b/internal/controller/memory_usage_floor_test.go
@@ -41,11 +41,16 @@ func TestApplyMemoryUsageFloor_GuaranteedRaisesRequestToFlooredLimit(t *testing.
 	require.NoError(t, corev1.AddToScheme(scheme))
 
 	margin := int32(10)
+	cv := attunev1alpha1.ControlledRequestsAndLimits
 	policy := &attunev1alpha1.AttunePolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "p-qos", Namespace: "default"},
 		Spec: attunev1alpha1.AttunePolicySpec{
+			CPU: attunev1alpha1.ResourceConfig{
+				ControlledValues: &cv,
+			},
 			Memory: attunev1alpha1.ResourceConfig{
 				DecreaseUsageMarginPercent: &margin,
+				ControlledValues:           &cv,
 			},
 		},
 	}
@@ -237,11 +242,16 @@ func TestApplyMemoryUsageFloor_UsesLiveContainerLimit(t *testing.T) {
 	require.NoError(t, corev1.AddToScheme(scheme))
 
 	margin := int32(10)
+	cv := attunev1alpha1.ControlledRequestsAndLimits
 	policy := &attunev1alpha1.AttunePolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "p-live", Namespace: "default"},
 		Spec: attunev1alpha1.AttunePolicySpec{
+			CPU: attunev1alpha1.ResourceConfig{
+				ControlledValues: &cv,
+			},
 			Memory: attunev1alpha1.ResourceConfig{
 				DecreaseUsageMarginPercent: &margin,
+				ControlledValues:           &cv,
 			},
 		},
 	}

--- a/internal/controller/resize.go
+++ b/internal/controller/resize.go
@@ -136,8 +136,9 @@ type liveResizeApplyMeta struct {
 
 // applyLiveResizeTarget applies ClampMemoryLimitForPolicy, the Guaranteed
 // request raise when platform-clamped, the usage floor otherwise, then
-// leftover dest limits (same overlay as mergeResources) and
-// ClampRequestsToLimits. OneShot compare and resizeContainer must share
+// leftover dest limits (RequestsOnly overwrites template limits; RequestsAndLimits
+// fills omitted keys) and ClampRequestsToLimits. OneShot compare and
+// resizeContainer must share
 // this so they cannot drift.
 func (r *AttunePolicyReconciler) applyLiveResizeTarget(
 	policy *attunev1alpha1.AttunePolicy,
@@ -177,23 +178,52 @@ func (r *AttunePolicyReconciler) applyLiveResizeTarget(
 		meta.FloorEqualsCurrent = resMeta.FloorToLimit.Equal(current)
 	}
 	if dest := findContainerByName(pod, containerRec.Name); dest != nil {
-		// Keep dest leftover limits when the rec blob omitted that resource.
+		// RequestsOnly must keep dest leftover limits even when the rec
+		// copied template limits onto Recommended.*Limit. RequestsAndLimits
+		// still fills only omitted keys.
 		if len(dest.Resources.Limits) > 0 {
 			if applied.Limits == nil {
 				applied.Limits = corev1.ResourceList{}
 			}
 			for _, res := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+				destLim, ok := dest.Resources.Limits[res]
+				if !ok || destLim.IsZero() {
+					continue
+				}
+				if resourceControlledRequestsOnly(policy, res) {
+					applied.Limits[res] = destLim.DeepCopy()
+					continue
+				}
 				if _, set := applied.Limits[res]; set {
 					continue
 				}
-				if destLim, ok := dest.Resources.Limits[res]; ok && !destLim.IsZero() {
-					applied.Limits[res] = destLim.DeepCopy()
-				}
+				applied.Limits[res] = destLim.DeepCopy()
 			}
 		}
 		meta.DestClamped = resize.ClampRequestsToLimits(&applied)
 	}
 	return applied, meta
+}
+
+// resourceControlledRequestsOnly is true when the policy does not manage
+// that resource's limits (unset, empty, or RequestsOnly).
+func resourceControlledRequestsOnly(policy *attunev1alpha1.AttunePolicy, res corev1.ResourceName) bool {
+	if policy == nil {
+		return true
+	}
+	var cv *string
+	switch res {
+	case corev1.ResourceCPU:
+		cv = policy.Spec.CPU.ControlledValues
+	case corev1.ResourceMemory:
+		cv = policy.Spec.Memory.ControlledValues
+	default:
+		return true
+	}
+	if cv == nil || *cv == "" || *cv == attunev1alpha1.DefaultControlledValues || *cv == attunev1alpha1.ControlledRequestsOnly {
+		return true
+	}
+	return false
 }
 
 // appliedResizeTarget is the clamp + Guaranteed QoS raise + usage floor that

--- a/internal/controller/resize_plan_test.go
+++ b/internal/controller/resize_plan_test.go
@@ -137,6 +137,9 @@ func TestPlanPodActions_UsesAppliedTargetAndSkipsAtTarget(t *testing.T) {
 	pod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = resource.MustParse("256Mi")
 	r := NewAttunePolicyReconciler()
 	policy := newTestPolicy("p", "default")
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy.Spec.CPU.ControlledValues = &cv
+	policy.Spec.Memory.ControlledValues = &cv
 	rec := attunev1alpha1.WorkloadRecommendation{
 		Workload: "api-server",
 		Containers: []attunev1alpha1.ContainerRecommendation{{
@@ -204,6 +207,40 @@ func TestPlanPodActions_ClampsToLiveLeftoverLimit(t *testing.T) {
 	require.Len(t, at, 1)
 	assert.True(t, at[0].AtTarget)
 	assert.Equal(t, int64(0), at[0].CPUIncrease)
+}
+
+func TestPlanPodActions_RequestsOnlyKeepsLiveLeftoverLimit(t *testing.T) {
+	t.Parallel()
+	// Production recs copy template limits onto Recommended.*Limit.
+	// RequestsOnly must still overwrite those with dest leftover limits.
+	pod := newResizePod("api-server", "100m", "256Mi", "200m", "256Mi")
+	r := NewAttunePolicyReconciler()
+	policy := newTestPolicy("p", "default")
+	rec := attunev1alpha1.WorkloadRecommendation{
+		Workload: "api-server",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "main",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("100m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+				CPULimit:      resource.MustParse("200m"),
+				MemoryLimit:   resource.MustParse("256Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+				CPULimit:      resource.MustParse("500m"),
+			},
+		}},
+	}
+
+	actions := r.planPodActions(policy, pod, rec)
+	require.Len(t, actions, 1)
+	assert.Equal(t, int64(200), actions[0].Target.Requests.Cpu().MilliValue(),
+		"plan target request must dest-clamp 500m to leftover live limit 200m")
+	assert.Equal(t, int64(200), actions[0].Target.Limits.Cpu().MilliValue(),
+		"RequestsOnly must keep dest leftover limit 200m, not template 500m")
+	assert.Contains(t, actions[0].Clamped, "cpu")
 }
 
 func TestObserveAndPlanPod_SkipsLiveGetWhenListedAtTarget(t *testing.T) {


### PR DESCRIPTION
After dest leftover clamp (#721), three follow-through holes and one CLI hole remained.

## Problem

1. Dest overlay only copied leftover limits when the rec blob omitted that key. Production recs copy template limits into `Recommended.*Limit`, so RequestsOnly still wrote those template limits onto live pods and raised LimitRange leftovers.
2. HPA auto-tune summed raw `Recommended.CPURequest` after a dest-clamped apply. Live request stayed at the leftover cap (200m) while the target was computed as if the request became 500m. Utilization is `usage / liveRequest`, so the cluster scaled up too early.
3. `kubectl attune wizard` used the first Service port and `http://name.ns:port`. Thanos Query exposes gRPC first. Doctor also did not treat that host as in-cluster.
4. `kubectl attune status --all-contexts` exited 0 when every context failed and printed "No AttunePolicies found."

## Change

- RequestsOnly overwrites dest leftover CPU/memory limits even when the rec already set the key, then clamps the request.
- HPA retune uses this-cycle successful in-place CPU history From/To (the applied dest-clamped request). No parseable CPU rows: skip (no fallback to the raw rec).
- Wizard prefers HTTP-named ports (then 9090/9091/8080/80) and writes `http://name.ns.svc:port`.
- Multi-cluster commands exit 1 when every context errors.

## Validation

- `go test ./internal/controller/... ./cmd/kubectl-attune/... -race -count=1`
- Red: dest overlay left request/limit at 500m; HPA target was 16 (80*100/500). Green: dest 200m/200m; HPA target 40 (80*100/200).

Ref #721
