### PR TITLE
docs: document ResizeDeferred after dest clamp and floor

### DIFF
--- a/docs/architecture/safety.md
+++ b/docs/architecture/safety.md
@@ -193,6 +193,7 @@ The controller emits Kubernetes Events for visibility:
 | Event type | Reason | When |
 |-----------|--------|------|
 | Normal | `Resized` | A container was successfully resized |
+| Normal | `ResizeDeferred` | Applied target already matches live after filtering, dest clamp, or usage floor |
 | Warning | `ResizeFailed` | The resize API call returned an error |
 | Warning | `ResizeSkipped` | A resize was skipped (QoS change, node capacity, quota) |
 | Warning | `Reverted` | A resize was reverted due to a safety violation |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -253,6 +253,7 @@ View them with `kubectl describe attunepolicy <name>` or
 | `Evicted` | Warning | A pod was evicted as a fallback when in-place resize was not possible |
 | `StaleRecommendation` | Warning | Recommendations are stale (no fresh Prometheus data) |
 | `CooldownActive` | Normal | Resize deferred because the cooldown period has not elapsed |
+| `ResizeDeferred` | Normal | Live resources already match the applied target after change filtering, dest-limit clamp, or usage floor |
 | `HPAConflict` | Warning | An HPA targets the same workload and may conflict with resizing |
 | `VPAConflict` | Warning | A VPA targets the same workload |
 | `ConfigClamped` | Warning | A policy field was clamped to its allowed range at runtime |


### PR DESCRIPTION
#722 made dest-CPU clamp AtTarget emit `ResizeDeferred`. The event was missing from the API and safety event tables, so dest-limit converge looked like a silent V(1) skip.

Adds the Normal `ResizeDeferred` row next to the other resize events.
