### PR TITLE
fix: cap hpa dest leftover from applied cpu

### DIFF
--- a/docs/guides/hpa-coexistence.md
+++ b/docs/guides/hpa-coexistence.md
@@ -70,7 +70,10 @@ The upper cap on this target depends on the pod's QoS class:
   limit, so utilization above 100% of request is achievable. This preserves
   the absolute threshold without triggering premature scale-outs.
 - **Guaranteed** (limit == request): targets are capped at 100%. Utilization
-  cannot exceed 100% when cgroups enforce `limit == request`.
+  cannot exceed 100% when cgroups enforce `limit == request`. After a
+  `RequestsAndLimits` apply, dest leftover is the applied CPU (`To`), not
+  the pre-resize leftover, so the cap stays 100% instead of a stale
+  higher dest that live pods can never reach.
 - **BestEffort** (no requests/limits): not applicable; HPA resource metrics
   require requests to be set.
 

--- a/internal/controller/hpa.go
+++ b/internal/controller/hpa.go
@@ -59,7 +59,11 @@ func (r *AttunePolicyReconciler) retuneHPAAfterResize(
 			pods = podsByWorkload[rec.Workload]
 		}
 		cpuLimit := destCPULimitFromPods(pods)
-		if cpuLimit.IsZero() {
+		if !resourceControlledRequestsOnly(policy, corev1.ResourceCPU) {
+			// After RequestsAndLimits apply, leftover dest is the applied To.
+			// podsByWorkload is the pre-resize list and still has old limits.
+			cpuLimit = newCPU.DeepCopy()
+		} else if cpuLimit.IsZero() {
 			cpuLimit = newCPU.DeepCopy()
 		}
 		r.adjustHPATargets(ctx, hpas, rec.Workload, rec.Kind, oldCPU, newCPU, cpuLimit)

--- a/internal/controller/hpa_test.go
+++ b/internal/controller/hpa_test.go
@@ -165,3 +165,72 @@ func TestRetuneHPAAfterResize_UsesAppliedCPU(t *testing.T) {
 	assert.Equal(t, int32(40), *updated.Spec.Metrics[0].Resource.Target.AverageUtilization,
 		"HPA target must be 80*100/200=40 from dest-clamped apply, not 80*100/500=16")
 }
+
+func TestRetuneHPAAfterResize_RequestsAndLimitsCapsAtAppliedLimit(t *testing.T) {
+	t.Parallel()
+	scheme := testScheme()
+	oldTarget := int32(80)
+	hpa := autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api-server-hpa",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationHPAAutoTune: "true",
+			},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: "Deployment",
+				Name: "api-server",
+			},
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: &oldTarget,
+						},
+					},
+				},
+			},
+		},
+	}
+	// Pre-resize list still has the old Guaranteed 500m limit.
+	pod := newResizePod("api-server", "500m", "256Mi", "500m", "256Mi")
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&hpa).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+
+	cv := attunev1alpha1.ControlledRequestsAndLimits
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.CPU.ControlledValues = &cv
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api-server",
+		Kind:     "Deployment",
+	}}
+	history := []attunev1alpha1.ResizeHistoryEntry{{
+		Workload:  "api-server",
+		Container: "main",
+		Resource:  "cpu",
+		From:      "500m",
+		To:        "200m",
+		Method:    "InPlace",
+		Result:    attunev1alpha1.ResizeResultSuccess,
+	}}
+
+	r.retuneHPAAfterResize(context.Background(), policy, attunev1alpha1.UpdateTypeAuto,
+		history, recs, []autoscalingv2.HorizontalPodAutoscaler{hpa},
+		map[string][]corev1.Pod{"api-server": {*pod}})
+
+	var updated autoscalingv2.HorizontalPodAutoscaler
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "api-server-hpa", Namespace: "default",
+	}, &updated))
+	require.NotNil(t, updated.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	assert.Equal(t, int32(100), *updated.Spec.Metrics[0].Resource.Target.AverageUtilization,
+		"R+L apply dest is the new 200m limit; 80*500/200=200 must cap at 100, not 200")
+}


### PR DESCRIPTION
Cap auto-tune HPA dest leftover from the applied CPU after `RequestsAndLimits`.

## Problem

`retuneHPAAfterResize` summed leftover dest CPU limits from the pre-resize pod list. After a `RequestsAndLimits` apply, live dest is the applied `To`. A Guaranteed 500m to 200m rebase used dest 500m, so `maxTarget` was 250 and the target became 200%. Live pods cannot exceed 100% of the new 200m limit, so HPA never scales.

## Change

When CPU `controlledValues` is `RequestsAndLimits`, dest leftover is the applied `To` (`newCPU`). RequestsOnly still uses the pre-resize leftover dest (limits do not change).

## Validation

Red (unfixed): `TestRetuneHPAAfterResize_RequestsAndLimitsCapsAtAppliedLimit` got target 200, want 100.

Green: `go test ./internal/controller/ -count=1 -run 'TestRetuneHPAAfterResize_|TestHPACPUFromResizeHistory'` pass.

Draft while [#725](https://github.com/attune-io/attune/pull/725) occupies the ready slot.
