### PR TITLE
fix: inherit attune defaults provider in wizard

### DIFF
--- a/cmd/kubectl-attune/wizard.go
+++ b/cmd/kubectl-attune/wizard.go
@@ -175,8 +175,9 @@ func wizardCreate(ctx context.Context, dynClient dynamic.Interface, namespace st
 		return err
 	}
 
-	// 4. Prometheus auto-detection.
-	promAddr, err := detectOrPromptPrometheus(ctx, dynClient, p)
+	// 4. Metrics source: inherit AttuneDefaults when a provider is set,
+	// otherwise detect or prompt for Prometheus.
+	promAddr, err := detectOrPromptPrometheus(ctx, dynClient, ns, p)
 	if err != nil {
 		return err
 	}
@@ -456,14 +457,34 @@ func kindToGVR(kind string) schema.GroupVersionResource {
 	}
 }
 
-// detectOrPromptPrometheus auto-detects Prometheus services and falls back to manual input.
-func detectOrPromptPrometheus(ctx context.Context, dynClient dynamic.Interface, p prompter) (string, error) {
+// detectOrPromptPrometheus auto-detects Prometheus services and falls back to
+// manual input. When AttuneDefaults already sets a metrics provider, the
+// first option is inherit (empty address) so MergeDefaults keeps that
+// provider instead of a wizard Prometheus block.
+func detectOrPromptPrometheus(ctx context.Context, dynClient dynamic.Interface, namespace string, p prompter) (string, error) {
+	inherit := inheritedMetricsProviderLabel(ctx, dynClient, namespace)
 	detected := detectPrometheus(ctx, dynClient)
-	if len(detected) > 0 {
-		options := append(detected, "Enter manually")
-		idx, err := p.Select("Prometheus address (auto-detected):", options)
+
+	if inherit != "" || len(detected) > 0 {
+		var options []string
+		if inherit != "" {
+			options = append(options, "Inherit from AttuneDefaults ("+inherit+")")
+		}
+		options = append(options, detected...)
+		options = append(options, "Enter manually")
+		label := "Prometheus address (auto-detected):"
+		if inherit != "" {
+			label = "Metrics source:"
+		}
+		idx, err := p.Select(label, options)
 		if err != nil {
 			return "", err
+		}
+		if inherit != "" {
+			if idx == 0 {
+				return "", nil
+			}
+			idx--
 		}
 		if idx < len(detected) {
 			return detected[idx], nil
@@ -477,6 +498,26 @@ func detectOrPromptPrometheus(ctx context.Context, dynClient dynamic.Interface, 
 		return "", fmt.Errorf("prometheus address is required")
 	}
 	return addr, nil
+}
+
+func inheritedMetricsProviderLabel(ctx context.Context, dynClient dynamic.Interface, namespace string) string {
+	selected, err := fetchSelectedDefaults(ctx, dynClient, namespace)
+	if err != nil || selected.defaults == nil || selected.defaults.Spec.MetricsSource == nil {
+		return ""
+	}
+	ms := selected.defaults.Spec.MetricsSource
+	switch {
+	case ms.Datadog != nil:
+		return "Datadog"
+	case ms.CloudWatch != nil:
+		return "CloudWatch"
+	case ms.VPA != nil:
+		return "VPA"
+	case ms.Prometheus != nil:
+		return "Prometheus"
+	default:
+		return ""
+	}
 }
 
 // detectPrometheus scans cluster services for Prometheus-like endpoints.
@@ -574,11 +615,6 @@ func buildPolicyObject(namespace, name, kind, workloadName, promAddr string, cpu
 					"kind": kind,
 					"name": workloadName,
 				},
-				"metricsSource": map[string]interface{}{
-					"prometheus": map[string]interface{}{
-						"address": promAddr,
-					},
-				},
 				"cpu": map[string]interface{}{
 					"percentile": int64(cpuPercentile),
 					"overhead":   attunev1alpha1.DefaultCPUOverhead,
@@ -590,6 +626,14 @@ func buildPolicyObject(namespace, name, kind, workloadName, promAddr string, cpu
 				"updateStrategy": buildUpdateStrategy(mode, initialSizing),
 			},
 		},
+	}
+	if promAddr != "" {
+		spec, _ := obj.Object["spec"].(map[string]interface{})
+		spec["metricsSource"] = map[string]interface{}{
+			"prometheus": map[string]interface{}{
+				"address": promAddr,
+			},
+		}
 	}
 	return obj
 }

--- a/cmd/kubectl-attune/wizard_test.go
+++ b/cmd/kubectl-attune/wizard_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,12 +78,14 @@ func newFakeDynClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient 
 	scheme := runtime.NewScheme()
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 		map[schema.GroupVersionResource]string{
-			namespacesGVR:   "NamespaceList",
-			deploymentsGVR:  "DeploymentList",
-			statefulsetsGVR: "StatefulSetList",
-			daemonsetsGVR:   "DaemonSetList",
-			servicesGVR:     "ServiceList",
-			gvr:             "AttunePolicyList",
+			namespacesGVR:        "NamespaceList",
+			deploymentsGVR:       "DeploymentList",
+			statefulsetsGVR:      "StatefulSetList",
+			daemonsetsGVR:        "DaemonSetList",
+			servicesGVR:          "ServiceList",
+			gvr:                  "AttunePolicyList",
+			defaultsGVR:          "AttuneDefaultsList",
+			namespaceDefaultsGVR: "AttuneNamespaceDefaultsList",
 		},
 		objects...,
 	)
@@ -338,6 +341,61 @@ func TestDetectPrometheus_NoMatches(t *testing.T) {
 	assert.Empty(t, results)
 }
 
+func unstructuredClusterDefaultsDatadog(t *testing.T, name string) *unstructured.Unstructured {
+	t.Helper()
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&attunev1alpha1.AttuneDefaults{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "attune.io/v1alpha1", Kind: "AttuneDefaults"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: attunev1alpha1.AttuneDefaultsSpec{
+			MetricsSource: &attunev1alpha1.MetricsSource{
+				Datadog: &attunev1alpha1.DatadogConfig{
+					Site: "datadoghq.com",
+					APIKeySecretRef: attunev1alpha1.SecretKeyRef{
+						Name: "datadog",
+						Key:  "api-key",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func TestWizardCreate_InheritsDefaultsDatadog(t *testing.T) {
+	dynClient := newFakeDynClient(
+		unstructuredDeployment("api-server", "default", 3),
+		unstructuredService("prometheus-server", "monitoring", int64(9090)),
+	)
+	_, err := dynClient.Resource(defaultsGVR).Create(context.Background(),
+		unstructuredClusterDefaultsDatadog(t, "cluster"), metav1.CreateOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "Datadog", inheritedMetricsProviderLabel(context.Background(), dynClient, "default"))
+
+	p := &scriptedPrompter{
+		selectAnswers: []int{
+			0, // kind: Deployment
+			0, // workload: api-server
+			0, // inherit Datadog
+			0, // CPU: P95
+			0, // Memory: P99
+			0, // mode: Recommend
+			0, // action: Apply
+		},
+	}
+
+	err = wizardCreate(context.Background(), dynClient, "default", p)
+	require.NoError(t, err)
+
+	created, err := dynClient.Resource(gvr).Namespace("default").Get(
+		context.Background(), "api-server-attune", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	_, found, err := unstructured.NestedMap(created.Object, "spec", "metricsSource")
+	require.NoError(t, err)
+	assert.False(t, found, "wizard must omit metricsSource so MergeDefaults keeps AttuneDefaults Datadog")
+}
+
 func TestBuildPolicyObject(t *testing.T) {
 	obj := buildPolicyObject("prod", "api-attune", "Deployment", "api-server",
 		"http://prom:9090", 95, 99, "Recommend", false)
@@ -349,6 +407,16 @@ func TestBuildPolicyObject(t *testing.T) {
 
 	mode := getNestedString(*obj, "spec", "updateStrategy", "type")
 	assert.Equal(t, "Recommend", mode)
+	addr := getNestedString(*obj, "spec", "metricsSource", "prometheus", "address")
+	assert.Equal(t, "http://prom:9090", addr)
+}
+
+func TestBuildPolicyObject_OmitsMetricsWhenInherited(t *testing.T) {
+	obj := buildPolicyObject("prod", "api-attune", "Deployment", "api-server",
+		"", 95, 99, "Recommend", false)
+	_, found, err := unstructured.NestedMap(obj.Object, "spec", "metricsSource")
+	require.NoError(t, err)
+	assert.False(t, found)
 }
 
 func TestKindToGVR(t *testing.T) {

--- a/cmd/kubectl-attune/wizard_test.go
+++ b/cmd/kubectl-attune/wizard_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"testing"
 
-	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
 
 // scriptedPrompter returns pre-programmed answers for testing.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -233,8 +233,12 @@ kubectl attune wizard promote        # promote an existing policy's mode
 ```
 
 **Create flow**: selects namespace, workload kind, workload name,
-auto-detects Prometheus, asks for CPU/memory percentiles and starting mode,
-then offers to apply directly or save the YAML to a file.
+then metrics source. When `AttuneDefaults` or `AttuneNamespaceDefaults`
+already set a provider (Datadog, CloudWatch, VPA, or Prometheus), the
+first option is inherit so the policy does not write a Prometheus
+block that would block `MergeDefaults`. Otherwise it auto-detects
+Prometheus. Then it asks for CPU/memory percentiles and starting
+mode, and offers to apply directly or save the YAML to a file.
 
 **Promote flow**: lists existing policies with their current mode and
 status, shows the recommendation summary, and updates the mode after


### PR DESCRIPTION
Let `kubectl attune wizard` inherit an existing AttuneDefaults metrics provider.

## Problem

The wizard always wrote `spec.metricsSource.prometheus`. `MergeDefaults` then skipped cluster Datadog, CloudWatch, or VPA (and default bearer or headers). New policies queried unauthenticated Prometheus and never produced recommendations.

## Change

When `AttuneDefaults` or `AttuneNamespaceDefaults` already set a provider, the first metrics option is inherit. Inherit omits `metricsSource` so merge keeps that provider. Users can still pick a detected Prometheus address or enter one manually.

## Validation

Red (unfixed): `TestWizardCreate_InheritsDefaultsDatadog` still wrote `prometheus-server.monitoring.svc:9090`.

Green: `go test ./cmd/kubectl-attune/ -count=1 -run 'TestWizard|TestBuildPolicy|TestDetectPrometheus|TestPickPrometheus|TestInitialSizing'` pass.

No issue closes this change.
