### PR TITLE
fix: persist dest-clamped apply after successful resize

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -493,7 +493,7 @@ Built-in known names include `istio-proxy`, `linkerd-proxy`, `consul-dataplane`,
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `updateStrategy.templatePersistence.enabled` | bool | `false` | When true, write recommended resources into Deployment/StatefulSet pod templates so new pods start correctly sized. **Opt-in only.** Do not enable under unmanaged GitOps without adopting recommendations in Git; prefer `export` or `initialSizing` instead. |
-| `updateStrategy.templatePersistence.when` | string | `AfterSuccessfulResize` | `AfterSuccessfulResize`: patch template after a successful in-place resize or a successful Eviction (`InPlaceOrRecreate`) so replacement pods start from the new requests. `OnRecommendation`: patch when a recommendation is accepted (works in Recommend mode). |
+| `updateStrategy.templatePersistence.when` | string | `AfterSuccessfulResize` | `AfterSuccessfulResize`: patch template after a successful in-place resize or a successful Eviction (`InPlaceOrRecreate`) so replacement pods start from the new requests. The write uses dest-clamped apply `To` from resize history, not the raw rec, so leftover dest limits do not land 500m on the template after live applied 200m. `OnRecommendation`: patch when a recommendation is accepted (works in Recommend mode). |
 
 Template changes trigger a rolling update. The operator no-ops when the template already matches and skips patches mid-rollout. **Observe mode never patches.** **Canary** defers template writes until `FullRollout` so a partial canary resize does not roll the whole fleet via the template. Requests are clamped to limits the same way as live resize.
 

--- a/internal/controller/template_persistence.go
+++ b/internal/controller/template_persistence.go
@@ -23,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,6 +53,49 @@ func templatePersistenceWhen(us *attunev1alpha1.UpdateStrategy) attunev1alpha1.T
 		return attunev1alpha1.TemplatePersistenceAfterSuccessfulResize
 	}
 	return us.TemplatePersistence.When
+}
+
+// overlayAppliedResizeOnWant replaces want requests with the latest successful
+// in-place To from history. After dest leftover clamp, To is the live apply
+// (200m) and the raw rec (500m) must not be written to the template.
+func overlayAppliedResizeOnWant(
+	want *corev1.ResourceRequirements,
+	history []attunev1alpha1.ResizeHistoryEntry,
+	workload, container string,
+) {
+	if want == nil {
+		return
+	}
+	var cpuTo, memTo *resource.Quantity
+	for i := range history {
+		h := history[i]
+		if h.Workload != workload || h.Container != container || !isSuccessfulInPlaceHistory(h) {
+			continue
+		}
+		q, err := resource.ParseQuantity(h.To)
+		if err != nil || q.IsZero() {
+			continue
+		}
+		qq := q
+		switch h.Resource {
+		case "cpu":
+			cpuTo = &qq
+		case "memory":
+			memTo = &qq
+		}
+	}
+	if cpuTo == nil && memTo == nil {
+		return
+	}
+	if want.Requests == nil {
+		want.Requests = corev1.ResourceList{}
+	}
+	if cpuTo != nil {
+		want.Requests[corev1.ResourceCPU] = *cpuTo
+	}
+	if memTo != nil {
+		want.Requests[corev1.ResourceMemory] = *memTo
+	}
 }
 
 // materializeContainerResources builds ResourceRequirements from a recommendation,
@@ -326,6 +370,9 @@ func (r *AttunePolicyReconciler) applyTemplatePersistence(
 				continue
 			}
 			want := materializeContainerResources(policy, c)
+			if mode == attunev1alpha1.TemplatePersistenceAfterSuccessfulResize {
+				overlayAppliedResizeOnWant(&want, policy.Status.ResizeHistory, rec.Workload, c.Name)
+			}
 			if recLim, ok := want.Limits[corev1.ResourceMemory]; ok &&
 				!c.Recommended.MemoryLimit.IsZero() && recLim.Cmp(c.Recommended.MemoryLimit) > 0 {
 				logger.V(1).Info("Template persist memory limit floored above usage",

--- a/internal/controller/template_persistence_test.go
+++ b/internal/controller/template_persistence_test.go
@@ -487,6 +487,83 @@ func TestApplyTemplatePersistence_AfterSuccessfulResize_OnlyResizedWorkloads(t *
 		"default AllowDecrease=false keeps template memory 512Mi")
 }
 
+func TestApplyTemplatePersistence_AfterSuccessfulResize_UsesAppliedDestCPU(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, attunev1alpha1.AddToScheme(scheme))
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "nginx",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = cl
+	r.Scheme = scheme
+
+	policy := newTestPolicy("p", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeAuto
+	policy.Spec.UpdateStrategy.TemplatePersistence = &attunev1alpha1.TemplatePersistence{
+		Enabled: boolPtr(true),
+		When:    attunev1alpha1.TemplatePersistenceAfterSuccessfulResize,
+	}
+	policy.Status.ResizeHistory = []attunev1alpha1.ResizeHistoryEntry{{
+		Workload:  "api",
+		Container: "app",
+		Resource:  "cpu",
+		From:      "100m",
+		To:        "200m",
+		Method:    "InPlace",
+		Result:    attunev1alpha1.ResizeResultSuccess,
+	}}
+
+	recs := []attunev1alpha1.WorkloadRecommendation{{
+		Workload: "api",
+		Kind:     "Deployment",
+		Containers: []attunev1alpha1.ContainerRecommendation{{
+			Name: "app",
+			Current: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("100m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+			},
+			Recommended: attunev1alpha1.ResourceValues{
+				CPURequest:    resource.MustParse("500m"),
+				MemoryRequest: resource.MustParse("256Mi"),
+			},
+		}},
+	}}
+
+	history := r.applyTemplatePersistence(context.Background(), policy, []client.Object{deploy}, recs,
+		attunev1alpha1.TemplatePersistenceAfterSuccessfulResize, map[string]bool{"api": true})
+	require.Len(t, history, 1)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(deploy), &updated))
+	got := updated.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
+	assert.Equal(t, int64(200), got,
+		"persist must write dest-clamped apply To 200m, not raw rec 500m")
+}
+
 func TestApplyTemplatePersistence_StatefulSet(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, appsv1.AddToScheme(scheme))


### PR DESCRIPTION
Persist dest-clamped apply `To` after a successful resize, not the raw rec.

## Problem

`AfterSuccessfulResize` wrote the raw recommendation onto the Deployment template. Live dest leftover clamp applies 200m while the rec stays 500m. The next rollout then admits 500m against a 200m LimitRange dest and fails (or starts oversized until CREATE leftover clamp).

## Change

When persisting after a successful resize, overlay the latest successful in-place `To` from resize history onto the persist want. `OnRecommendation` is unchanged.

## Validation

Red (unfixed): `TestApplyTemplatePersistence_AfterSuccessfulResize_UsesAppliedDestCPU` wrote 500m, want 200m.

Green: `go test ./internal/controller/ -count=1 -run 'TestApplyTemplatePersistence_'` pass.

No issue closes this change.
