### PR TITLE
fix: inherit metrics source, guaranteed boost dest, budget remainder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Report a bug in Attune
 title: "[Bug] "
-labels: kind/bug
+labels: bug
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest a feature for Attune
 title: "[Feature] "
-labels: kind/feature
+labels: enhancement
 assignees: ""
 ---
 

--- a/api/v1alpha1/attunepolicy_types.go
+++ b/api/v1alpha1/attunepolicy_types.go
@@ -95,7 +95,11 @@ type AttunePolicySpec struct {
 	TargetRef TargetRef `json:"targetRef"`
 
 	// MetricsSource configures where and how to collect metrics.
-	MetricsSource MetricsSource `json:"metricsSource"`
+	// Omit to inherit the provider from AttuneDefaults or
+	// AttuneNamespaceDefaults. Admission accepts an empty source;
+	// reconcile MergeDefaults fills the provider before queries.
+	// +optional
+	MetricsSource MetricsSource `json:"metricsSource,omitempty"`
 
 	// CPU configures CPU resource recommendations.
 	CPU ResourceConfig `json:"cpu"`

--- a/charts/attune/crds/attune.io_attunepolicies.yaml
+++ b/charts/attune/crds/attune.io_attunepolicies.yaml
@@ -376,7 +376,11 @@ spec:
                     type: object
                 type: object
               metricsSource:
-                description: MetricsSource configures where and how to collect metrics.
+                description: |-
+                  MetricsSource configures where and how to collect metrics.
+                  Omit to inherit the provider from AttuneDefaults or
+                  AttuneNamespaceDefaults. Admission accepts an empty source;
+                  reconcile MergeDefaults fills the provider before queries.
                 properties:
                   cloudwatch:
                     description: CloudWatch configures an Amazon CloudWatch Container
@@ -1021,7 +1025,6 @@ spec:
             required:
             - cpu
             - memory
-            - metricsSource
             - targetRef
             type: object
           status:

--- a/cmd/kubectl-attune/wizard_test.go
+++ b/cmd/kubectl-attune/wizard_test.go
@@ -19,6 +19,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"sigs.k8s.io/yaml"
 
 	attunev1alpha1 "github.com/attune-io/attune/api/v1alpha1"
 )
@@ -418,6 +421,29 @@ func TestBuildPolicyObject_OmitsMetricsWhenInherited(t *testing.T) {
 	_, found, err := unstructured.NestedMap(obj.Object, "spec", "metricsSource")
 	require.NoError(t, err)
 	assert.False(t, found)
+}
+
+func TestCRD_MetricsSourceNotRequired(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("..", "..", "config", "crd", "bases", "attune.io_attunepolicies.yaml"))
+	require.NoError(t, err)
+	var doc map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &doc))
+	versions, found, err := unstructured.NestedSlice(doc, "spec", "versions")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotEmpty(t, versions)
+	ver, ok := versions[0].(map[string]interface{})
+	require.True(t, ok)
+	required, found, err := unstructured.NestedStringSlice(ver,
+		"schema", "openAPIV3Schema", "properties", "spec", "required")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.NotContains(t, required, "metricsSource",
+		"omit metricsSource must be schema-valid so wizard inherit is accepted")
+	assert.Contains(t, required, "targetRef")
+	assert.Contains(t, required, "cpu")
+	assert.Contains(t, required, "memory")
 }
 
 func TestKindToGVR(t *testing.T) {

--- a/config/crd/bases/attune.io_attunepolicies.yaml
+++ b/config/crd/bases/attune.io_attunepolicies.yaml
@@ -376,7 +376,11 @@ spec:
                     type: object
                 type: object
               metricsSource:
-                description: MetricsSource configures where and how to collect metrics.
+                description: |-
+                  MetricsSource configures where and how to collect metrics.
+                  Omit to inherit the provider from AttuneDefaults or
+                  AttuneNamespaceDefaults. Admission accepts an empty source;
+                  reconcile MergeDefaults fills the provider before queries.
                 properties:
                   cloudwatch:
                     description: CloudWatch configures an Amazon CloudWatch Container
@@ -1021,7 +1025,6 @@ spec:
             required:
             - cpu
             - memory
-            - metricsSource
             - targetRef
             type: object
           status:

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -2223,7 +2223,11 @@ spec:
                     type: object
                 type: object
               metricsSource:
-                description: MetricsSource configures where and how to collect metrics.
+                description: |-
+                  MetricsSource configures where and how to collect metrics.
+                  Omit to inherit the provider from AttuneDefaults or
+                  AttuneNamespaceDefaults. Admission accepts an empty source;
+                  reconcile MergeDefaults fills the provider before queries.
                 properties:
                   cloudwatch:
                     description: CloudWatch configures an Amazon CloudWatch Container
@@ -2868,7 +2872,6 @@ spec:
             required:
             - cpu
             - memory
-            - metricsSource
             - targetRef
             type: object
           status:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2222,7 +2222,11 @@ spec:
                     type: object
                 type: object
               metricsSource:
-                description: MetricsSource configures where and how to collect metrics.
+                description: |-
+                  MetricsSource configures where and how to collect metrics.
+                  Omit to inherit the provider from AttuneDefaults or
+                  AttuneNamespaceDefaults. Admission accepts an empty source;
+                  reconcile MergeDefaults fills the provider before queries.
                 properties:
                   cloudwatch:
                     description: CloudWatch configures an Amazon CloudWatch Container
@@ -2867,7 +2871,6 @@ spec:
             required:
             - cpu
             - memory
-            - metricsSource
             - targetRef
             type: object
           status:

--- a/docs/guides/startup-boost.md
+++ b/docs/guides/startup-boost.md
@@ -8,19 +8,34 @@ that expires after a configurable duration.
 
 ## How it works
 
-1. The operator detects a newly created pod whose age (`now` minus
-   `pod.CreationTimestamp`) is still within `startupBoost.duration`.
-   Container start time is not used.
-2. It resizes each eligible container's CPU request to
-   `recommended_cpu * multiplier`. Native sidecars (init containers with
-   `restartPolicy: Always`) are included. Known sidecar names such as
-   `istio-proxy` stay excluded via `EffectiveExcludedContainers`.
-3. After a successful apply, the operator writes
-   `attune.io/startup-boost-at`. The boost expires when that timestamp
-   plus `duration` elapses. Container Ready is not checked.
-4. If the boosted CPU would exceed the container's CPU limit,
-   `maxAllowed`, or the node's allocatable CPU, the boost is capped
-   automatically.
+Startup boost has two apply paths.
+
+**CREATE webhook.** When a matching policy has a recommendation and
+`initialSizing` is on, the mutating webhook writes
+`recommended_cpu * multiplier` onto the new pod. Recommend mode
+CREATE is limited to CronJob and Job owners (those pods cannot be
+resized in place). In `RequestsAndLimits` mode the webhook also
+raises the CPU dest with the boosted request so Guaranteed pods
+still get headroom.
+
+**In-place resize.** After the pod is running, the operator detects a
+newly created pod whose age (`now` minus `pod.CreationTimestamp`) is
+still within `startupBoost.duration`. Container start time is not used.
+It resizes each eligible container's CPU request to
+`recommended_cpu * multiplier`. Native sidecars (init containers with
+`restartPolicy: Always`) are included. Known sidecar names such as
+`istio-proxy` stay excluded via `EffectiveExcludedContainers`.
+`RequestsAndLimits` raises dest with the boosted request the same way
+CREATE does.
+
+After a successful apply, the operator writes
+`attune.io/startup-boost-at`. The boost expires when that timestamp
+plus `duration` elapses and dest returns to the steady-state
+recommendation. Container Ready is not checked.
+
+If the boosted CPU would exceed `maxAllowed` or the node's allocatable
+CPU, the boost is capped. `RequestsOnly` also dest-caps leftover dest
+and does not raise dest.
 
 ### Native sidecars
 
@@ -87,7 +102,10 @@ container startup time in your monitoring to calibrate duration.
 The boost is applied **after** bounds clamping. If the boosted value exceeds
 the configured `maxAllowed`, it is capped at `maxAllowed`. Set `maxAllowed`
 high enough to accommodate the boosted value if you want the full multiplier
-effect.
+effect. With `cpu.controlledValues: RequestsAndLimits`, dest is raised
+with the boosted request so Guaranteed pods keep request equal to dest
+and still receive headroom. `RequestsOnly` dest-caps leftover dest and
+does not raise dest.
 
 For example, with a 500m recommendation, 3.0x multiplier, and maxAllowed of
 1000m, the boosted request will be 1000m (capped), not 1500m.
@@ -116,9 +134,9 @@ includes a Startup Boost panel that visualizes this metric.
   operator is down during a deployment, pods start with their current
   requests and receive the boost on the next reconcile (if still within
   the duration window).
-- Only applies when the operator is in a resize-capable mode (Auto,
-  OneShot, or Canary). Startup boost is a live in-place CPU overlay on
-  the pod, not a field on the recommendation object. Recommend and
-  Observe modes compute the steady-state recommendation only.
+- In-place boost requires a resize-capable mode (Auto, OneShot, or
+  Canary). CREATE webhook boost also applies in Recommend mode when
+  the pod owner is a CronJob or Job, because those pods cannot be
+  resized in place. Observe mode never applies a boost.
 
 See [`examples/14-startup-boost.yaml`](https://github.com/attune-io/attune/blob/main/examples/14-startup-boost.yaml) for a complete example.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -12,7 +12,8 @@ appears in the stored spec when omitted by the user (it is a CRD schema
 default). All other defaultable fields (`type`, `controlledValues`,
 `cooldown`, `historyWindow`, `minimumDataPoints`, `queryStep`, `rateWindow`, `podAggregation`, `autoRevert`,
 `resizeMethod`, `cpu.maxChangePercent`, `memory.maxChangePercent`,
-`safetyObservationPeriod`, `excludeKnownSidecars`, `maxConcurrentResizes`) are applied
+`safetyObservationPeriod`, `excludeKnownSidecars`, `maxConcurrentResizes`,
+`metricsSource`) are applied
 by the controller at reconcile time so that cluster-wide `AttuneDefaults`
 and namespace-scoped `AttuneNamespaceDefaults` can override them. These
 fields will appear empty in `kubectl get attunepolicy -o yaml` but still control runtime

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -410,7 +410,10 @@ By default, Attune queries Prometheus for CPU and memory usage data.
 The CRD also supports Datadog, CloudWatch Container Insights, and VPA
 as alternative metrics sources. **At most one** of `prometheus`,
 `datadog`, `cloudwatch`, or `vpa` may be set on a policy or on
-`AttuneDefaults` / `AttuneNamespaceDefaults`.
+`AttuneDefaults` / `AttuneNamespaceDefaults`. Omitting
+`spec.metricsSource` on an `AttunePolicy` is valid; `MergeDefaults`
+copies the provider from namespace or cluster defaults before the
+operator queries. The wizard inherit option uses that omit shape.
 
 > The Datadog collector queries the `/api/v1/query` endpoint and converts
 > nanocores to cores automatically. The CloudWatch collector uses the

--- a/internal/controller/attunepolicy_controller.go
+++ b/internal/controller/attunepolicy_controller.go
@@ -673,6 +673,8 @@ func (r *AttunePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if applyFrozen {
 		r.markNamespaceFrozen(&policy, freezeErr)
+	} else {
+		r.clearNamespaceFrozen(&policy)
 	}
 
 	// Set Ready condition (surface series cap as degraded data quality note).
@@ -923,6 +925,15 @@ func (r *AttunePolicyReconciler) markNamespaceFrozen(policy *attunev1alpha1.Attu
 		Message:            msg,
 		ObservedGeneration: policy.Generation,
 	})
+}
+
+// clearNamespaceFrozen drops ResizeBlocked only when it was set for a
+// namespace freeze. Deferred and Infeasible blockers stay.
+func (r *AttunePolicyReconciler) clearNamespaceFrozen(policy *attunev1alpha1.AttunePolicy) {
+	cond := meta.FindStatusCondition(policy.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+	if cond != nil && cond.Reason == attunev1alpha1.ReasonNamespaceFrozen {
+		meta.RemoveStatusCondition(&policy.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+	}
 }
 
 // processWorkloads processes discovered workloads in parallel, checking for

--- a/internal/controller/attunepolicy_controller_test.go
+++ b/internal/controller/attunepolicy_controller_test.go
@@ -14310,6 +14310,86 @@ func TestApplyStartupBoosts_ExpiresBoostAfterDuration(t *testing.T) {
 	assert.True(t, foundResize, "expected a resize action for boost expiry")
 }
 
+func TestApplyStartupBoosts_ExpiryRestoresRequestsAndLimitsDest(t *testing.T) {
+	t.Parallel()
+	scheme := testScheme()
+	now := time.Date(2026, 1, 1, 0, 5, 0, 0, time.UTC)
+	boostTime := now.Add(-3 * time.Minute)
+	both := attunev1alpha1.ControlledRequestsAndLimits
+	policy := &attunev1alpha1.AttunePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Namespace: "default"},
+		Spec: attunev1alpha1.AttunePolicySpec{
+			CPU: attunev1alpha1.ResourceConfig{
+				ControlledValues: &both,
+				StartupBoost: &attunev1alpha1.StartupBoost{
+					Multiplier: "2.0",
+					Duration:   metav1.Duration{Duration: 2 * time.Minute},
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "qos-app-xyz",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(boostTime),
+			Annotations: map[string]string{
+				annotationStartupBoostAt: boostTime.UTC().Format(time.RFC3339),
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, QOSClass: corev1.PodQOSGuaranteed},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	clientset := kubefake.NewSimpleClientset(pod)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	r := NewAttunePolicyReconciler()
+	r.Client = fakeClient
+	r.Scheme = scheme
+	r.Clientset = clientset
+	r.SetNowFunc(func() time.Time { return now })
+
+	resizer := resize.NewPodResizer(clientset, ctrl.Log)
+	recs := []attunev1alpha1.WorkloadRecommendation{
+		{
+			Workload: "qos-app",
+			Kind:     "Deployment",
+			Containers: []attunev1alpha1.ContainerRecommendation{
+				{
+					Name: "main",
+					Recommended: attunev1alpha1.ResourceValues{
+						CPURequest: resource.MustParse("500m"),
+						CPULimit:   resource.MustParse("500m"),
+					},
+				},
+			},
+		},
+	}
+	r.applyStartupBoosts(context.Background(), policy, map[string][]corev1.Pod{"qos-app": {*pod}}, recs, resizer, nil)
+
+	got, err := clientset.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(500), got.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(),
+		"expiry must restore CPU request to rec dest")
+	assert.Equal(t, int64(500), got.Spec.Containers[0].Resources.Limits.Cpu().MilliValue(),
+		"expiry must restore CPU dest to rec dest")
+}
+
 func TestApplyStartupBoosts_MalformedAnnotationSkipsGracefully(t *testing.T) {
 	scheme := testScheme()
 	now := time.Date(2026, 1, 1, 0, 5, 0, 0, time.UTC)
@@ -17132,6 +17212,15 @@ func TestApplyStartupBoosts_DestCap(t *testing.T) {
 			wantReq:  "1",
 			wantDest: "1",
 		},
+		{
+			name:     "RequestsAndLimits Guaranteed rec dest equals rec request raises dest with boost",
+			cv:       &both,
+			leftover: "500m",
+			recReq:   "500m",
+			recDest:  "500m",
+			wantReq:  "1",
+			wantDest: "1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -17168,15 +17257,14 @@ func TestApplyStartupBoosts_DestCap(t *testing.T) {
 				recVals.CPULimit = recDest
 			}
 
-			// dest==request leftover: dest-capping leftover dest is a no-op
-			// unless RequestsAndLimits dest-caps the rec dest and raises dest.
+			// dest==request leftover is Guaranteed. PreservesQoS needs memory dest.
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "dest-app-abc",
 					Namespace:         "default",
 					CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Second)),
 				},
-				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning, QOSClass: corev1.PodQOSGuaranteed},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -17187,7 +17275,8 @@ func TestApplyStartupBoosts_DestCap(t *testing.T) {
 									corev1.ResourceMemory: memReq,
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU: leftover.DeepCopy(),
+									corev1.ResourceCPU:    leftover.DeepCopy(),
+									corev1.ResourceMemory: memReq.DeepCopy(),
 								},
 							},
 						},

--- a/internal/controller/increase_budget.go
+++ b/internal/controller/increase_budget.go
@@ -80,7 +80,10 @@ func refillResource(tokens, rate, cap int64, last time.Time, now time.Time) (int
 	if tokens > cap {
 		tokens = cap
 	}
-	return tokens, now
+	// Advance last only by the whole tokens produced so leftover
+	// milliseconds carry into the next tick.
+	consumedMs := add * 60000 / rate
+	return tokens, last.Add(time.Duration(consumedMs) * time.Millisecond)
 }
 
 func (b *increaseRateBucket) refillLocked(now time.Time) {

--- a/internal/controller/increase_budget_test.go
+++ b/internal/controller/increase_budget_test.go
@@ -70,7 +70,20 @@ func TestIncreaseRateBucket_BothRatesDoNotStarveCPU(t *testing.T) {
 		tick = tick.Add(time.Second)
 		b.tryDraw(0, 0, tick)
 	}
-	assert.True(t, b.tryDraw(960, 0, tick), "CPU must refill across mem-driven 1s ticks")
+	assert.True(t, b.tryDraw(1000, 0, tick), "CPU must refill a full minute across 1s ticks")
+}
+
+func TestIncreaseRateBucket_SmallRateOneSecondTicksDeliverConfiguredRate(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	b := newIncreaseRateBucket(100, -1, now)
+	assert.True(t, b.tryDraw(100, 0, now))
+	tick := now
+	for i := 0; i < 60; i++ {
+		tick = tick.Add(time.Second)
+		b.tryDraw(0, 0, tick)
+	}
+	assert.True(t, b.tryDraw(100, 0, tick), "100m/min must refill 100m across 60 one-second ticks")
 }
 
 func TestIncreaseRateBucket_LongIdleFillsToCap(t *testing.T) {

--- a/internal/controller/namespace_freeze_test.go
+++ b/internal/controller/namespace_freeze_test.go
@@ -577,6 +577,59 @@ func TestReconcile_NamespaceFreeze_RecheckBeforeExecuteResizes(t *testing.T) {
 	assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
 }
 
+func TestReconcile_NamespaceFreeze_ClearsConditionAfterUnfreezeDuringBlockerHold(t *testing.T) {
+	t.Parallel()
+
+	policy := newTestPolicy("test-policy", "default")
+	policy.Spec.UpdateStrategy.Type = attunev1alpha1.UpdateTypeRecommend
+	deploy := newTestDeployment("api-server", "default", map[string]string{"app": "api-server"})
+	pod := newResizePod("api-server", "500m", "512Mi", "1000m", "1Gi")
+	ns := newTestNamespace("default", map[string]string{conflict.AnnotationFreeze: "true"})
+	mc := &mockCollector{
+		queryRangeFunc: func(_ context.Context, _ string, _, _ time.Time, _ time.Duration) ([]rsmetrics.Sample, error) {
+			return generateSamples(200, 0.1), nil
+		},
+	}
+
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy, deploy, pod, ns).
+		WithStatusSubresource(&attunev1alpha1.AttunePolicy{}).
+		Build()
+	reconciler := newReconcilerForReconcileWithClient(mc, fakeClient, scheme)
+	reconciler.Clientset = kubefake.NewSimpleClientset(pod.DeepCopy())
+	reconciler.BlockerRefreshInterval = 5 * time.Minute
+	now := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	reconciler.SetNowFunc(func() time.Time { return now })
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	var frozen attunev1alpha1.AttunePolicy
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, &frozen))
+	cond := meta.FindStatusCondition(frozen.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+	require.NotNil(t, cond)
+	assert.Equal(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason)
+
+	var liveNS corev1.Namespace
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "default"}, &liveNS))
+	liveNS.Annotations = map[string]string{}
+	require.NoError(t, fakeClient.Update(context.Background(), &liveNS))
+
+	_, err = reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	var thawed attunev1alpha1.AttunePolicy
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, &thawed))
+	cond = meta.FindStatusCondition(thawed.Status.Conditions, attunev1alpha1.ConditionResizeBlocked)
+	if cond != nil {
+		assert.NotEqual(t, attunev1alpha1.ReasonNamespaceFrozen, cond.Reason,
+			"NamespaceFrozen must clear on the next reconcile after unfreeze, even inside BlockerRefreshInterval")
+	}
+}
+
 // capturingEventRecorder records the last Eventf reason and formatted note.
 type capturingEventRecorder struct {
 	reason *string

--- a/internal/controller/startupboost.go
+++ b/internal/controller/startupboost.go
@@ -167,15 +167,17 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 					if policy.Spec.CPU.MaxAllowed != nil && boostedCPU.Cmp(*policy.Spec.CPU.MaxAllowed) > 0 {
 						boostedCPU = policy.Spec.CPU.MaxAllowed.DeepCopy()
 					}
-					// RequestsAndLimits dest-caps rec dest so leftover dest
-					// cannot skip the boost. RequestsOnly keeps leftover dest.
+					// RequestsAndLimits raises dest with the boosted request
+					// so Guaranteed (request==dest at rec dest) still gets
+					// headroom. RequestsOnly dest-caps leftover dest.
 					cpuCV := policy.Spec.CPU.ControlledValues
 					raiseDest := cpuCV != nil &&
 						*cpuCV == attunev1alpha1.ControlledRequestsAndLimits &&
 						!recCPU.dest.IsZero()
+					boostDest := boostedCPU.DeepCopy()
 					if raiseDest {
-						if boostedCPU.Cmp(recCPU.dest) > 0 {
-							boostedCPU = recCPU.dest.DeepCopy()
+						if boostDest.Cmp(recCPU.dest) < 0 {
+							boostDest = recCPU.dest.DeepCopy()
 						}
 					} else if cpuLim, hasLim := c.Resources.Limits[corev1.ResourceCPU]; hasLim && boostedCPU.Cmp(cpuLim) > 0 {
 						boostedCPU = cpuLim.DeepCopy()
@@ -207,9 +209,17 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 						},
 					}
 					if raiseDest {
-						boostRec.Recommended.CPULimit = recCPU.dest.DeepCopy()
+						boostRec.Recommended.CPULimit = boostDest.DeepCopy()
 						boostTarget.Limits = corev1.ResourceList{
-							corev1.ResourceCPU: recCPU.dest.DeepCopy(),
+							corev1.ResourceCPU: boostDest.DeepCopy(),
+						}
+						// PreservesQoS on Guaranteed requires memory dest too.
+						if memLim, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
+							boostRec.Recommended.MemoryLimit = memLim.DeepCopy()
+							boostTarget.Limits[corev1.ResourceMemory] = memLim.DeepCopy()
+						} else if memReq, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+							boostRec.Recommended.MemoryLimit = memReq.DeepCopy()
+							boostTarget.Limits[corev1.ResourceMemory] = memReq.DeepCopy()
 						}
 					}
 					if skip, reason := r.shouldSkipResize(ctx, pod, boostRec, boostTarget, checks); skip {
@@ -315,6 +325,22 @@ func (r *AttunePolicyReconciler) applyStartupBoosts(
 								corev1.ResourceCPU:    recCPU.request.DeepCopy(),
 								corev1.ResourceMemory: c.Resources.Requests.Memory().DeepCopy(),
 							},
+						}
+						cpuCV := policy.Spec.CPU.ControlledValues
+						if cpuCV != nil &&
+							*cpuCV == attunev1alpha1.ControlledRequestsAndLimits &&
+							!recCPU.dest.IsZero() {
+							expireRec.Recommended.CPULimit = recCPU.dest.DeepCopy()
+							expireTarget.Limits = corev1.ResourceList{
+								corev1.ResourceCPU: recCPU.dest.DeepCopy(),
+							}
+							if memLim, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
+								expireRec.Recommended.MemoryLimit = memLim.DeepCopy()
+								expireTarget.Limits[corev1.ResourceMemory] = memLim.DeepCopy()
+							} else if memReq, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+								expireRec.Recommended.MemoryLimit = memReq.DeepCopy()
+								expireTarget.Limits[corev1.ResourceMemory] = memReq.DeepCopy()
+							}
 						}
 						if skip, reason := r.shouldSkipResize(ctx, pod, expireRec, expireTarget, checks); skip {
 							if reason == "" {

--- a/internal/webhook/pod_mutating.go
+++ b/internal/webhook/pod_mutating.go
@@ -442,8 +442,10 @@ func (h *PodMutatingHandler) mutateContainer(
 }
 
 // applyCreateStartupBoost raises the CREATE CPU request by the policy
-// multiplier, capped at maxAllowed and leftover dest limit. Returns true
-// when the request was raised so Handle can stamp startup-boost-at.
+// multiplier, capped at maxAllowed. RequestsAndLimits raises dest with
+// the boosted request so Guaranteed pods still get headroom.
+// RequestsOnly dest-caps leftover dest. Returns true when the request
+// was raised so Handle can stamp startup-boost-at.
 func applyCreateStartupBoost(container *corev1.Container, policy *attunev1alpha1.AttunePolicy) bool {
 	if policy == nil || policy.Spec.CPU.StartupBoost == nil {
 		return false
@@ -461,7 +463,18 @@ func applyCreateStartupBoost(container *corev1.Container, policy *attunev1alpha1
 	if policy.Spec.CPU.MaxAllowed != nil && boosted.Cmp(*policy.Spec.CPU.MaxAllowed) > 0 {
 		boosted = policy.Spec.CPU.MaxAllowed.DeepCopy()
 	}
-	if lim, hasLim := container.Resources.Limits[corev1.ResourceCPU]; hasLim && boosted.Cmp(lim) > 0 {
+	cpuCV := policy.Spec.CPU.ControlledValues
+	raiseDest := cpuCV != nil && *cpuCV == attunev1alpha1.ControlledRequestsAndLimits
+	if raiseDest {
+		// Raise dest with the boosted request so Guaranteed (request==dest)
+		// still gets startup headroom. RequestsOnly dest-caps leftover dest.
+		if container.Resources.Limits == nil {
+			container.Resources.Limits = corev1.ResourceList{}
+		}
+		if lim, hasLim := container.Resources.Limits[corev1.ResourceCPU]; !hasLim || boosted.Cmp(lim) > 0 {
+			container.Resources.Limits[corev1.ResourceCPU] = boosted.DeepCopy()
+		}
+	} else if lim, hasLim := container.Resources.Limits[corev1.ResourceCPU]; hasLim && boosted.Cmp(lim) > 0 {
 		boosted = lim.DeepCopy()
 	}
 	if boosted.Cmp(cpu) <= 0 {

--- a/internal/webhook/pod_mutating_test.go
+++ b/internal/webhook/pod_mutating_test.go
@@ -805,6 +805,7 @@ func TestPodMutatingHandler_StartupBoostDestClamp(t *testing.T) {
 		recDest     string
 		maxAllowed  string
 		wantCPU     string
+		wantDest    string
 		wantBoostAt bool
 	}{
 		{
@@ -812,6 +813,7 @@ func TestPodMutatingHandler_StartupBoostDestClamp(t *testing.T) {
 			cv:          &only,
 			leftover:    "200m",
 			wantCPU:     "200m",
+			wantDest:    "200m",
 			wantBoostAt: false,
 		},
 		{
@@ -819,6 +821,7 @@ func TestPodMutatingHandler_StartupBoostDestClamp(t *testing.T) {
 			cv:          &only,
 			leftover:    "800m",
 			wantCPU:     "800m",
+			wantDest:    "800m",
 			wantBoostAt: true,
 		},
 		{
@@ -827,6 +830,16 @@ func TestPodMutatingHandler_StartupBoostDestClamp(t *testing.T) {
 			leftover:    "200m",
 			recDest:     "1",
 			wantCPU:     "1",
+			wantDest:    "1",
+			wantBoostAt: true,
+		},
+		{
+			name:        "RequestsAndLimits Guaranteed rec dest equals rec request raises dest with boost",
+			cv:          &both,
+			leftover:    "500m",
+			recDest:     "500m",
+			wantCPU:     "1",
+			wantDest:    "1",
 			wantBoostAt: true,
 		},
 		{
@@ -835,6 +848,7 @@ func TestPodMutatingHandler_StartupBoostDestClamp(t *testing.T) {
 			leftover:    "800m",
 			maxAllowed:  "600m",
 			wantCPU:     "600m",
+			wantDest:    "800m",
 			wantBoostAt: true,
 		},
 	}
@@ -881,6 +895,13 @@ func TestPodMutatingHandler_StartupBoostDestClamp(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, wantCPU.MilliValue(), got.MilliValue(),
 				"CREATE CPU request dest-clamp")
+			if tt.wantDest != "" {
+				wantDest, destErr := resource.ParseQuantity(tt.wantDest)
+				require.NoError(t, destErr)
+				gotDest := mutatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
+				assert.Equal(t, wantDest.MilliValue(), gotDest.MilliValue(),
+					"CREATE CPU dest")
+			}
 			assert.Equal(t, tt.wantBoostAt, mutatedPod.Annotations[AnnotationStartupBoostAt] != "")
 		})
 	}


### PR DESCRIPTION
Make wizard inherit, Guaranteed startup boost, per-minute budgets, and freeze status match what operators actually see.

## Problem

Six review findings on current main:

- Wizard inherit omitted required `spec.metricsSource`, so apply was rejected before `MergeDefaults`.
- The inherit test asserted that invalid shape against a fake client with no CRD schema.
- CREATE and live startup boost dest-capped at rec dest. For Guaranteed (`request == dest`) that made boost a silent no-op.
- The startup-boost guide still said Recommend never applies a boost.
- `maxCpuIncreasePerMinute` / `maxMemoryIncreasePerMinute` threw away the refill remainder on every tick.
- `ResizeBlocked=NamespaceFrozen` stayed set after unfreeze until the blocker-refresh hold expired.

## Change

- `metricsSource` is optional on `AttunePolicy`. Omit means inherit. The wizard keep-omit path is now schema-valid. A CRD test locks `spec.required` without `metricsSource`.
- `RequestsAndLimits` raises CPU dest with the boosted request on CREATE and live resize. Live targets also copy memory dest so `PreservesQoS` accepts Guaranteed pods. Expiry restores dest to rec dest.
- Token-bucket refill advances `last` only by the whole tokens produced, so 60 one-second ticks deliver the configured rate.
- When the namespace is not frozen, drop `ResizeBlocked` only if the reason is `NamespaceFrozen`.
- Issue templates now use `bug` and `enhancement` (the repo has no `kind/bug` / `kind/feature`).

## Validation

- `go test ./cmd/kubectl-attune/ ./internal/webhook/ ./internal/controller/ -race -count=1`
- Targeted cases: inherit omit, CRD required list, CREATE/live Guaranteed dest raise, expiry dest restore, 1000m/min and 100m/min 1s ticks, freeze then unfreeze inside `BlockerRefreshInterval`
- `make lint` and `make verify-quick` (2626 tests, CRD freshness, Helm)

## Reviewer

Local review found that live dest raise omitted memory dest, so `PreservesQoS` skipped real Guaranteed pods. Fixed before push. CREATE docs now say initial sizing is still required.

Closes #735
Closes #736
Closes #737
Closes #738
Closes #739
Closes #740
